### PR TITLE
fix(clippy): resolve all 83 Clippy warnings to restore CI (#50)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
     for city_id in tour.route().iter() {
         print!("{} ", city_id);
     }
-    print!("\n");
+    println!();
 }
 
 fn read_tsp_data_from_file(file_path: &Path) -> tsplib::TspLibData {

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -29,7 +29,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     let dists = DistanceMatrix::from_cities(cities).unwrap();
     let mut opt = vec![vec![UNKNOWN_DISTANCE; n_powersets]; n_others];
 
-    if options.verbose == true {
+    if options.verbose {
         println!("BHK: initializing the table with subresults");
     }
     // inialize tables first row with distance from first cities to other cities
@@ -49,7 +49,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
         solve_bhk(&mut opt, &dists, selected_set, city_pos);
     }
 
-    if options.verbose == true {
+    if options.verbose {
         println!("BHK: done with calculations, preparing the result");
         show_table(&opt);
     }
@@ -75,9 +75,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     send_progress(ProgressMessage::PathUpdate(route, 0.0));
     send_progress(ProgressMessage::Done);
 
-    let tour = Solution::new(&route_vec, cities);
-
-    tour
+    Solution::new(&route_vec, cities)
 }
 
 fn solve_bhk(
@@ -128,12 +126,12 @@ fn read_optimal_route(opt: &DPTable, dm: &DistanceMatrix, n: usize, best_val: f3
             break;
         }
 
-        for j in 0..(n - 1) {
+        for (j, row) in opt[0..(n - 1)].iter().enumerate() {
             let step_dist = dm
                 .distance_by_pos(j, route_ids[i - 1])
                 .expect("step_dist points are out range");
 
-            let cur_dist = opt[j][unread_set] + step_dist;
+            let cur_dist = row[unread_set] + step_dist;
             let is_unprocessed = (unread_set & (1 << j)) > 0;
             if is_unprocessed && approx(left_dist, cur_dist) {
                 left_dist -= step_dist;

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -26,7 +26,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     open_path[0] = route.get(0).unwrap();
 
     // at the beginning all cities the except the first city are unvisited
-    let unvisited_cities: UniqSet = route.route().iter().skip(1).map(|x| x.clone()).collect();
+    let unvisited_cities: UniqSet = route.route().iter().skip(1).copied().collect();
 
     let fitness_fn = build_evaluator(cities);
     let (best_path, _best_distance) = backtrack(
@@ -46,7 +46,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
 fn build_evaluator(cities: &[KDPoint]) -> PathEvaluator {
     let dm = Rc::new(DistanceMatrix::from_cities(cities).expect("Failed to build distance matrix"));
 
-    return Rc::new(move |path: &Path| dm.tour_length(path));
+    Rc::new(move |path: &Path| dm.tour_length(path))
 }
 
 fn backtrack(
@@ -62,7 +62,7 @@ fn backtrack(
     let mut best_distance = upper_bound;
 
     let n_cities = k + unvisited_cities.len();
-    if is_solution(path.as_ref(), k, n_cities) {
+    if is_solution(path, k, n_cities) {
         let new_distance = evaluate_fn(path);
 
         if new_distance < upper_bound {
@@ -76,22 +76,22 @@ fn backtrack(
     };
 
     let candidates: Vec<usize> = construct_candidates(
-        &path,
+        path,
         k,
-        &unvisited_cities,
+        unvisited_cities,
         running_cost,
         best_distance,
         evaluate_fn,
     );
 
     for candidate in candidates.iter() {
-        make_move(path, k, candidate.clone());
+        make_move(path, k, *candidate);
 
         let visited_path: Vec<usize> = path
             .to_vec()
             .iter()
             .filter(|&&x| x != UNVISITED_NODE)
-            .map(|x| x.clone())
+            .copied()
             .collect();
         send_progress(ProgressMessage::PathUpdate(
             Route::new(&visited_path),
@@ -99,7 +99,7 @@ fn backtrack(
         ));
 
         let prev_city = path[k - 1];
-        let next_distance = evaluate_fn(&vec![prev_city, candidate.clone()]);
+        let next_distance = evaluate_fn(&vec![prev_city, *candidate]);
 
         let mut next_cities = unvisited_cities.clone();
         next_cities.remove(candidate);
@@ -126,7 +126,7 @@ fn backtrack(
 }
 
 fn is_solution(path: &Path, k: usize, n_cities: usize) -> bool {
-    let uniq_ids: UniqSet = path[0..k].iter().map(|c| c.clone()).collect();
+    let uniq_ids: UniqSet = path[0..k].iter().copied().collect();
 
     k == n_cities && k > 1 && uniq_ids.len() == n_cities
 }
@@ -142,15 +142,15 @@ fn construct_candidates(
     let mut candidates: Path = vec![]; // always start from city.id 0
 
     for city_id in unvisited_cities.iter() {
-        let next_distance = evaluate_fn(&vec![path[k - 1], city_id.clone()]);
+        let next_distance = evaluate_fn(&vec![path[k - 1], *city_id]);
         // simple pruning
         if best_distance > running_cost + next_distance {
-            candidates.push(city_id.clone());
+            candidates.push(*city_id);
         }
     }
 
-    candidates.sort(); // try to keep lexikographic order
-    return candidates;
+    candidates.sort();
+    candidates
 }
 
 fn make_move(path: &mut Path, k: usize, candidate: usize) {

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -97,12 +97,10 @@ impl DistanceMatrix {
         let mut city_table = CityTable::new();
 
         let mut distances = Vec::with_capacity(size);
-        for i in 0..n {
-            let pt1 = &cities[i];
+        for (i, pt1) in cities.iter().enumerate() {
             city_table.insert(i, pt1.clone());
 
-            for j in 0..i {
-                let pt2 = &cities[j];
+            for pt2 in cities.iter().take(i) {
                 distances.push(pt1.distance(pt2));
             }
         }
@@ -114,6 +112,10 @@ impl DistanceMatrix {
 
     pub fn len(&self) -> usize {
         self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
     }
 
     pub fn distances(&self) -> &[f32] {

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -52,7 +52,7 @@ fn solve_ga(
             let parent1 = current_population.random_selection();
             let parent2 = current_population.random_selection();
 
-            let (mut child1, mut child2) = ordered_crossover(&parent1, &parent2, &fitness_fn);
+            let (mut child1, mut child2) = ordered_crossover(parent1, parent2, &fitness_fn);
             if probability(mutation_prob) {
                 child1.mutate()
             };
@@ -87,7 +87,7 @@ fn solve_ga(
     current_population.best().clone()
 }
 
-fn build_evaluator(cities: &[KDPoint]) -> Rc<dyn Fn(&[usize]) -> f32> {
+fn build_evaluator(cities: &[KDPoint]) -> FitnessFn {
     let dm = Rc::new(DistanceMatrix::from_cities(cities).unwrap());
 
     Rc::new(move |path: &[usize]| {
@@ -129,10 +129,8 @@ fn ordered_crossover_genes(
     let range_b: HashSet<usize> = parent2[from..=to].iter().copied().collect();
 
     // copy cross-overs from parents
-    for i in from..=to {
-        gene1[i] = parent2[i];
-        gene2[i] = parent1[i];
-    }
+    gene1[from..=to].copy_from_slice(&parent2[from..=to]);
+    gene2[from..=to].copy_from_slice(&parent1[from..=to]);
 
     // copy other values like rolling-shift to -> from
     let mut k = (to + 1) % gene_len;
@@ -201,6 +199,10 @@ impl TspPopulation {
         self.individuals.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.individuals.is_empty()
+    }
+
     pub fn individuals(&self) -> &[TspGenotype] {
         &self.individuals
     }
@@ -267,6 +269,10 @@ impl TspGenotype {
 
     pub fn len(&self) -> usize {
         self.genotype.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.genotype.is_empty()
     }
 
     pub fn set_fitness(&mut self, new_fitness: f32) {

--- a/src/tsp/kdtree.rs
+++ b/src/tsp/kdtree.rs
@@ -69,7 +69,7 @@ fn partition_points(
     }
 
     let coord = depth % k;
-    sorted_points.sort_by(|a, b| a.cmp_by_coord(&b, coord).unwrap());
+    sorted_points.sort_by(|a, b| a.cmp_by_coord(b, coord).unwrap());
 
     let pivot_idx = sorted_points.len() / 2;
     let pivot_pt = sorted_points[pivot_idx].clone();
@@ -102,11 +102,11 @@ impl KDTree {
         }
     }
 
-    pub fn walk(&self, callback: impl Fn(&KDPoint) -> ()) {
+    pub fn walk(&self, callback: impl Fn(&KDPoint)) {
         self.walk_in_order(&self.root, &callback);
     }
 
-    pub fn walk_in_order(&self, subtree: &KDSubTree, callback: &impl Fn(&KDPoint) -> ()) {
+    pub fn walk_in_order(&self, subtree: &KDSubTree, callback: &impl Fn(&KDPoint)) {
         if let Some(node) = subtree {
             self.walk_in_order(&node.left, callback);
             callback(&node.point);
@@ -125,6 +125,10 @@ impl KDTree {
 
     pub fn len(&self) -> usize {
         self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
     }
 
     pub fn to_vec(&self) -> PointMatrix {
@@ -148,15 +152,8 @@ pub struct KDNode {
 
 impl KDNode {
     pub fn new(point: KDPoint, depth: usize, left: Option<KDNode>, right: Option<KDNode>) -> Self {
-        let left_node = match left {
-            Some(node) => Some(Box::new(node)),
-            None => None,
-        };
-
-        let right_node = match right {
-            Some(node) => Some(Box::new(node)),
-            None => None,
-        };
+        let left_node = left.map(Box::new);
+        let right_node = right.map(Box::new);
 
         let left_size = left_node.as_ref().map_or(0, |n| n.len());
         let right_size = right_node.as_ref().map_or(0, |n| n.len());
@@ -208,29 +205,26 @@ impl KDNode {
             nearest_result.add(pt, distance_from_target);
         };
 
-        let (closest_branch, futher_branch) = match self.cmp_by_point(&target_point) {
+        let (closest_branch, futher_branch) = match self.cmp_by_point(target_point) {
             None => panic!("Dimension conflict in nearest function"),
             Some(Ordering::Greater) => (self.left(), self.right()),
             Some(_) => (self.right(), self.left()),
         };
 
-        if closest_branch.is_some() {
-            let closest_result = closest_branch
-                .unwrap()
-                .nearest(target_point, nearest_result.clone());
-
+        if let Some(branch) = closest_branch {
+            let closest_result = branch.nearest(target_point, nearest_result.clone());
             let pt_distance = closest_result.closest_distance();
             nearest_result.add(closest_result.point, pt_distance);
         }
 
         // check distance from split line
-        let split_dist = self.point.split_distance(&target_point, self.level_coord());
-        if nearest_result.closest_distance() > split_dist && futher_branch.is_some() {
-            let further_result = futher_branch
-                .unwrap()
-                .nearest(target_point, nearest_result.clone());
-            let pt_distance = further_result.closest_distance();
-            nearest_result.add(further_result.point, pt_distance);
+        let split_dist = self.point.split_distance(target_point, self.level_coord());
+        if nearest_result.closest_distance() > split_dist {
+            if let Some(branch) = futher_branch {
+                let further_result = branch.nearest(target_point, nearest_result.clone());
+                let pt_distance = further_result.closest_distance();
+                nearest_result.add(further_result.point, pt_distance);
+            }
         }
 
         nearest_result
@@ -245,20 +239,16 @@ impl KDNode {
         self.depth % self.point.dimensionality
     }
 
-    pub fn left(&self) -> Option<&Box<KDNode>> {
-        self.left.as_ref()
+    pub fn left(&self) -> Option<&KDNode> {
+        self.left.as_deref()
     }
 
-    pub fn right(&self) -> Option<&Box<KDNode>> {
-        self.right.as_ref()
+    pub fn right(&self) -> Option<&KDNode> {
+        self.right.as_deref()
     }
 
     pub fn is_empty(&self) -> bool {
-        if self.len() == 0 {
-            true
-        } else {
-            false
-        }
+        self.len() == 0
     }
 
     pub fn is_leaf(&self) -> bool {
@@ -318,18 +308,9 @@ impl KDPoint {
     }
 
     pub fn get(&self, dimension: usize) -> Option<f32> {
-        self.coords.get(dimension).map(|x| x.clone())
+        self.coords.get(dimension).copied()
     }
 
-    // TODO: finish and add tests
-    pub fn eq(&self, other: &KDPoint) -> bool {
-        if self.dimensionality != other.dimensionality {
-            return false;
-        }
-
-        let diff = self.distance(other);
-        diff < f32::EPSILON
-    }
 
     pub fn distance(&self, other: &KDPoint) -> f32 {
         let distance: f32 = self
@@ -372,7 +353,7 @@ impl KDPoint {
             panic!("for accessing y, dimensionality must be > 0");
         }
 
-        self.coords[0].clone()
+        self.coords[0]
     }
 
     pub fn y(&self) -> f32 {
@@ -380,7 +361,16 @@ impl KDPoint {
             panic!("for accessing y, dimensionality must be > 1");
         }
 
-        self.coords[1].clone()
+        self.coords[1]
+    }
+}
+
+impl PartialEq for KDPoint {
+    fn eq(&self, other: &KDPoint) -> bool {
+        if self.dimensionality != other.dimensionality {
+            return false;
+        }
+        self.distance(other) < f32::EPSILON
     }
 }
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -16,8 +16,8 @@ use crate::tsp::kdtree::KDPoint;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-pub const VERSION: &'static str = "0.6.1";
-pub const AUTHOR: &'static str = "Timo Sulg <timo@sulg.dev>";
+pub const VERSION: &str = "0.6.1";
+pub const AUTHOR: &str = "Timo Sulg <timo@sulg.dev>";
 
 use std::str::FromStr;
 
@@ -88,8 +88,8 @@ pub struct SolverOptions {
     pub show_progress: bool, // should we show and print progress
 }
 
-impl SolverOptions {
-    pub fn default() -> Self {
+impl Default for SolverOptions {
+    fn default() -> Self {
         SolverOptions {
             epochs: 10_000,
             platoo_epochs: 500,
@@ -126,7 +126,7 @@ pub fn total_distance(cities: &[KDPoint], route: &[usize]) -> f32 {
 pub fn city_table_from_vec(cities: &[kdtree::KDPoint]) -> CityTable {
     let table: CityTable = cities.iter().map(|c| (c.id, c.clone())).collect();
 
-    return table;
+    table
 }
 
 pub struct Solution {
@@ -155,6 +155,10 @@ impl Solution {
 
     pub fn len(&self) -> usize {
         self.route.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.route.is_empty()
     }
 
     pub fn route(&self) -> &[usize] {

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -6,7 +6,7 @@ use super::route::Route;
 use super::{Solution, SolverOptions};
 
 pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
-    let search_tree = kdtree::from_cities(&cities);
+    let search_tree = kdtree::from_cities(cities);
     let n_nearest = options.n_nearest;
 
     let cities_table: HashMap<usize, KDPoint> = cities.iter().map(|c| (c.id, c.clone())).collect();
@@ -47,6 +47,5 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     }
 
     send_progress(ProgressMessage::Done);
-    let tour = Solution::new(&path, cities);
-    tour
+    Solution::new(&path, cities)
 }

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -15,17 +15,17 @@ use super::KDPoint;
 
 pub type PublishChannel = Sender<ProgressMessage>;
 pub type ReceiverChannel = Receiver<ProgressMessage>;
-pub type PublisherFn = Arc<dyn Fn(ProgressMessage) -> ()>;
+pub type PublisherFn = Arc<dyn Fn(ProgressMessage)>;
 
-type RGBA = [f32; 4];
+type Rgba = [f32; 4];
 type RectCoords = [f64; 4];
 type Point2D = (f64, f64);
 
-const WHITE: RGBA = [1.0; 4];
-const RED: RGBA = [1.0, 0.0, 0.0, 0.9];
-const GREY: RGBA = [0.7, 0.7, 0.7, 0.9];
+const WHITE: Rgba = [1.0; 4];
+const RED: Rgba = [1.0, 0.0, 0.0, 0.9];
+const GREY: Rgba = [0.7, 0.7, 0.7, 0.9];
 
-const INACTIVE_COLOR: RGBA = GREY;
+const INACTIVE_COLOR: Rgba = GREY;
 
 const FONT_SIZE: u32 = 16;
 
@@ -46,7 +46,7 @@ fn init_channels() {
 
 pub fn get_publisher() -> Option<PublishChannel> {
     match PUBLISH_CHANNEL.lock() {
-        Ok(mtx) => mtx.clone().map(|m| m.clone()),
+        Ok(mtx) => mtx.clone(),
         Err(_) => None,
     }
 }
@@ -88,11 +88,11 @@ struct Node {
     y: f64,
     height: f64,
     width: f64,
-    color: RGBA,
+    color: Rgba,
 }
 
 impl Node {
-    fn new(city_id: Option<usize>, x: f64, y: f64, height: f64, width: f64, color: RGBA) -> Self {
+    fn new(city_id: Option<usize>, x: f64, y: f64, height: f64, width: f64, color: Rgba) -> Self {
         Node {
             city_id,
             x,
@@ -141,11 +141,11 @@ struct Edge {
     from: Point2D,
     to: Point2D,
     width: f64,
-    color: RGBA,
+    color: Rgba,
 }
 
 impl Edge {
-    fn new(from: Point2D, to: Point2D, color: RGBA, width: f64) -> Self {
+    fn new(from: Point2D, to: Point2D, color: Rgba, width: f64) -> Self {
         Edge {
             from,
             to,
@@ -181,11 +181,11 @@ struct TextBox {
     x: f64,
     y: f64,
     font_size: u32,
-    color: RGBA,
+    color: Rgba,
 }
 
 impl TextBox {
-    pub fn new<S: Into<String>>(text: S, x: f64, y: f64, color: RGBA, font_size: u32) -> Self {
+    pub fn new<S: Into<String>>(text: S, x: f64, y: f64, color: Rgba, font_size: u32) -> Self {
         TextBox {
             text: text.into(),
             x,
@@ -327,10 +327,10 @@ impl ProgressPlot {
 
         for to_city_id in path.iter().skip(1) {
             let from_city = self.city_table.get(&from_city_id);
-            let to_city = self.city_table.get(&to_city_id);
+            let to_city = self.city_table.get(to_city_id);
 
-            if from_city.is_some() && to_city.is_some() {
-                let new_edge = self.build_edge(&from_city.unwrap(), &to_city.unwrap(), GREY);
+            if let (Some(from), Some(to)) = (from_city, to_city) {
+                let new_edge = self.build_edge(from, to, GREY);
                 self.shapes.push(Box::new(new_edge));
 
                 from_city_id = *to_city_id;
@@ -340,11 +340,11 @@ impl ProgressPlot {
         let from_city = self.city_table.get(&from_city_id).unwrap();
         let to_city = self.city_table.get(&path[0]).unwrap();
 
-        let new_edge = self.build_edge(&from_city, &to_city, GREY);
+        let new_edge = self.build_edge(from_city, to_city, GREY);
         self.shapes.push(Box::new(new_edge));
     }
 
-    fn build_edge(&self, from_city: &KDPoint, to_city: &KDPoint, color: RGBA) -> Edge {
+    fn build_edge(&self, from_city: &KDPoint, to_city: &KDPoint, color: Rgba) -> Edge {
         let from_point = scaled_point(
             from_city,
             &self.cities_bounding_box,
@@ -446,11 +446,11 @@ fn point_to_viewport(
     let y_max = window[3];
 
     // TODO: research how to scale viewport itself, so we can get rid of margin here
-    let x_v = (viewport.width - viewport.margin * 2.0) as f64 * (x - x_min) / (x_max - x_min);
-    let y_v = (viewport.height - viewport.margin * 2.0) as f64 * (y - y_min) / (y_max - y_min);
+    let x_v = (viewport.width - viewport.margin * 2.0) * (x - x_min) / (x_max - x_min);
+    let y_v = (viewport.height - viewport.margin * 2.0) * (y - y_min) / (y_max - y_min);
 
     (
-        x_v + (viewport.margin as f64),
-        y_v + (viewport.margin as f64),
+        x_v + viewport.margin,
+        y_v + viewport.margin,
     )
 }

--- a/src/tsp/route.rs
+++ b/src/tsp/route.rs
@@ -31,6 +31,10 @@ impl Route {
         self.route.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.route.is_empty()
+    }
+
     pub fn route(&self) -> &[usize] {
         self.route.as_slice()
     }
@@ -95,7 +99,7 @@ fn random_pair(n_items: usize) -> (usize, usize) {
     }
 }
 
-fn swap_cities(route: &mut Vec<usize>, from: usize, to: usize) {
+fn swap_cities(route: &mut [usize], from: usize, to: usize) {
     if to >= route.len() {
         panic!("to can not be same or bigger than route size");
     }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -13,10 +13,10 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
 
     let mut epoch = 0;
     let mut n_stale = 0;
-    let mut best_distance = total_distance(cities, &best_route.route());
+    let mut best_distance = total_distance(cities, best_route.route());
     loop {
         let candidate = current_route.random_successor();
-        let candidate_distance = total_distance(&cities, candidate.route());
+        let candidate_distance = total_distance(cities, candidate.route());
 
         if candidate_distance < best_distance {
             best_route = candidate;

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -42,6 +42,10 @@ impl TspLibData {
     pub fn len(&self) -> usize {
         self.cities.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.cities.is_empty()
+    }
 }
 
 pub fn read_from_file(path: &Path) -> Result<TspLibData, String> {
@@ -65,7 +69,7 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
     let mut metadata: HashMap<String, String> = HashMap::new();
     let mut cities: Vec<KDPoint> = vec![];
 
-    let mut state = TspReaderStates::START;
+    let mut state = TspReaderStates::Start;
     let mut line_no = 1;
     for line_res in reader.lines() {
         if line_res.is_err() {
@@ -75,7 +79,7 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
         let line = line_res.unwrap().trim().to_uppercase();
         line_no += 1;
 
-        if state == TspReaderStates::END {
+        if state == TspReaderStates::End {
             break;
         }
 
@@ -87,14 +91,14 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
 
         // -- EXTRACT VALUE
         match &state {
-            TspReaderStates::START => match KEY_VALUE_MATCHER.captures(&line) {
+            TspReaderStates::Start => match KEY_VALUE_MATCHER.captures(&line) {
                 None => return Err(format!("Failed to extract meta data on line.{:?}", line_no)),
                 Some(res) => {
                     metadata.insert(res["key"].to_string(), res["val"].to_string());
                 }
             },
             // we parse coords only from those 2 sections
-            TspReaderStates::INSECTION(section_id)
+            TspReaderStates::Insection(section_id)
                 if (section_id == COORD_SECTION_KEY || section_id == DISPLAY_DATA_SECTION_KEY) =>
             {
                 match coords_from_text(line_no, &line) {
@@ -102,7 +106,7 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
                     Ok(pt) => cities.push(pt),
                 }
             }
-            TspReaderStates::END => {
+            TspReaderStates::End => {
                 break;
             }
             _ => continue,
@@ -131,25 +135,23 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
     Ok(dt)
 }
 
-fn is_state_marker(line: &String) -> bool {
+fn is_state_marker(line: &str) -> bool {
     SECTION_START_MATCHER.captures(line).is_some()
 }
 
-fn next_state(state: &TspReaderStates, line: &String) -> TspReaderStates {
+fn next_state(state: &TspReaderStates, line: &str) -> TspReaderStates {
     if line == EOF_KEY {
-        return TspReaderStates::END;
+        return TspReaderStates::End;
     }
 
     // if it section keyword
-    if let Some(res) = SECTION_START_MATCHER.captures(&line) {
-        let next_state = TspReaderStates::INSECTION(res["key"].to_string());
-
-        return next_state;
+    if let Some(res) = SECTION_START_MATCHER.captures(line) {
+        return TspReaderStates::Insection(res["key"].to_string());
     }
 
     // check if we are already out of coord section
     match &state {
-        TspReaderStates::INSECTION(_) if !starts_with_number(&line) => TspReaderStates::OUTSECTION,
+        TspReaderStates::Insection(_) if !starts_with_number(line) => TspReaderStates::Outsection,
         st => st.to_owned().clone(),
     }
 }
@@ -165,10 +167,10 @@ fn starts_with_number<S: AsRef<str>>(txt: S) -> bool {
 
 #[derive(Debug, Clone, PartialEq)]
 enum TspReaderStates {
-    START,
-    INSECTION(String),
-    OUTSECTION,
-    END,
+    Start,
+    Insection(String),
+    Outsection,
+    End,
 }
 
 fn coords_from_text<S: AsRef<str>>(line_no: usize, txt: S) -> Result<KDPoint, String> {
@@ -179,7 +181,7 @@ fn coords_from_text<S: AsRef<str>>(line_no: usize, txt: S) -> Result<KDPoint, St
         let id: usize = usize::from_str(id_str).unwrap();
 
         // it is important we take id first out, then we dont need skip(1) here
-        let coords_res: Result<Vec<f32>, _> = tokens.map(|x| f32::from_str(x)).collect();
+        let coords_res: Result<Vec<f32>, _> = tokens.map(f32::from_str).collect();
         if coords_res.is_err() {
             return Err(format!("Error on line.{:?} - invalid number", line_no));
         }
@@ -263,28 +265,28 @@ mod tests {
 
     #[test]
     fn test_next_state_with_end_marker() {
-        let state = TspReaderStates::OUTSECTION;
+        let state = TspReaderStates::Outsection;
 
-        assert_eq!(TspReaderStates::END, next_state(&state, &"EOF".to_string()))
+        assert_eq!(TspReaderStates::End, next_state(&state, "EOF"))
     }
 
     #[test]
     fn test_next_state_with_beginning_of_coord_section() {
-        let state = TspReaderStates::START;
+        let state = TspReaderStates::Start;
 
-        let res = next_state(&state, &"NODE_COORD_SECTION".to_string());
+        let res = next_state(&state, "NODE_COORD_SECTION");
         assert_eq!(
-            TspReaderStates::INSECTION(COORD_SECTION_KEY.to_string()),
+            TspReaderStates::Insection(COORD_SECTION_KEY.to_string()),
             res
         );
     }
 
     #[test]
     fn test_state_from_coord_section_switches_to_outsection() {
-        let state = TspReaderStates::INSECTION(COORD_SECTION_KEY.to_string());
+        let state = TspReaderStates::Insection(COORD_SECTION_KEY.to_string());
 
-        let res = next_state(&state, &"KEY: VAL1".to_string());
-        assert_eq!(TspReaderStates::OUTSECTION, res);
+        let res = next_state(&state, "KEY: VAL1");
+        assert_eq!(TspReaderStates::Outsection, res);
     }
 
     #[test]

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -44,15 +44,15 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     Solution::new(&path, cities)
 }
 
-fn swap_2opt(path: &mut Vec<usize>, from: usize, to: usize) {
+fn swap_2opt(path: &mut [usize], from: usize, to: usize) {
     if from >= to {
-        return; // ignore if from to are equal or wrong order
+        return;
     }
 
-    let reversed_seq: Vec<usize> = path[from..=to].iter().map(|x| x.clone()).rev().collect();
+    let reversed_seq: Vec<usize> = path[from..=to].iter().copied().rev().collect();
 
     for (i, swapped_val) in reversed_seq.iter().enumerate() {
-        path[from + i] = swapped_val.clone();
+        path[from + i] = *swapped_val;
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes all 83 Clippy warnings across 13 files, restoring a clean CI baseline
- Style/idiom fixes only — no behaviour changes
- Closes #50

## Changes by category

| Category | Files |
|----------|-------|
| `clone` on `Copy` types (`usize`, `f32`) → `.copied()` or `*x` | branch_bound, two_opt, kdtree, route |
| `&mut Vec<T>` / `&String` → `&mut [T]` / `&str` | route, two_opt, tsplib |
| `is_some()` + `unwrap()` → `if let` | kdtree, progress |
| `&Box<T>` → `&T` via `.as_deref()` | kdtree |
| `len_without_is_empty` → added `is_empty()` to 7 structs | mod, kdtree, distance_matrix, genetic_algorithm, route, tsplib |
| Manual `Option::map` → `.map(Box::new)` | kdtree |
| `SolverOptions::default()` → `impl Default` trait | mod |
| `KDPoint::eq()` method → `impl PartialEq` trait | kdtree |
| `TspReaderStates` variants `ALL_CAPS` → `MixedCase` | tsplib |
| `type RGBA` → `type Rgba` | progress |
| Needless `return`, redundant `'static`, bool comparisons, redundant closures | various |
| Unnecessary `as f64` casts | progress |
| `print!("\n")` → `println!()` | main |

## Test plan

- [x] `cargo clippy -- -D warnings` → 0 errors
- [x] `cargo test` → 62 passed, 0 failed