### PR TITLE
feat(logging): structured tracing to all solvers (GH #51)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1399,6 +1414,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2458,6 +2482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2644,8 @@ dependencies = [
  "piston_window",
  "rand",
  "regex",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2660,6 +2695,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2738,7 +2782,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2746,6 +2802,39 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "ttf-parser"
@@ -2793,6 +2882,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vecmath"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ rand = "0.9"
 regex = "1.12.3"
 piston = "1.0.0"
 piston_window = "0.147.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::thread;
 
 use teeline::tsp::{self, kdtree, progress, tsplib, Solution, SolverOptions, Solvers};
+use tracing_subscriber::EnvFilter;
 
 fn main() {
     let args = Command::new("Teeline")
@@ -98,9 +99,17 @@ fn main() {
             .expect("Unknown solver");
 
     let options = solver_options_from_args(&args);
-    if options.verbose {
-        println!("Selected solver: {:?}", solver_type);
-    }
+
+    let default_level = if options.verbose { "debug" } else { "info" };
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive(format!("teeline={default_level}").parse().unwrap()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    tracing::info!(algorithm = ?solver_type, "solver selected");
 
     let tsp_data = if let Some(input_file_path) = args.get_one::<String>("input") {
         let file_path = Path::new(input_file_path.as_str());
@@ -109,22 +118,19 @@ fn main() {
         read_tsp_data_from_stdin()
     };
 
-    if options.verbose {
-        println!(
-            "Problem details:\n\tname:{:?}\n\tcomment:{:?}\n\tcities:{:?}",
-            tsp_data.name,
-            tsp_data.comment,
-            tsp_data.len()
-        );
-    }
+    tracing::info!(name = %tsp_data.name, comment = %tsp_data.comment,
+                   cities = tsp_data.len(), "problem loaded");
 
     let cities = tsp_data.cities().to_vec();
     let show_progress = options.show_progress;
 
     // winit (used by piston_window) requires the event loop on the main thread,
     // so the solver runs in a background thread and the window stays on main.
+    let span = tracing::info_span!("solver", algorithm = ?solver_type);
     let solver_handle = thread::spawn(move || {
+        let _enter = span.entered();
         let tour = solve(solver_type, tsp_data.cities(), &options.clone());
+        tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
     });
 

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -26,12 +26,12 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     let n_others = n_cities - 1; // we start from last city
     let n_powersets = 1 << n_others;
 
+    tracing::info!(n_cities, n_subsets = n_powersets, "BHK starting");
+
     let dists = DistanceMatrix::from_cities(cities).unwrap();
     let mut opt = vec![vec![UNKNOWN_DISTANCE; n_powersets]; n_others];
 
-    if options.verbose {
-        println!("BHK: initializing the table with subresults");
-    }
+    tracing::info!("BHK: initialising DP table");
     // inialize tables first row with distance from first cities to other cities
     let last_pos = n_others;
     for i in 0..n_others {
@@ -49,8 +49,8 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
         solve_bhk(&mut opt, &dists, selected_set, city_pos);
     }
 
+    tracing::info!("BHK: DP complete");
     if options.verbose {
-        println!("BHK: done with calculations, preparing the result");
         show_table(&opt);
     }
 
@@ -68,6 +68,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
         })
         .fold(f32::MAX, f32::min);
 
+    tracing::info!(optimal_distance, "BHK: optimal tour found");
     let route_vec = read_optimal_route(&opt, &dists, n_cities, optimal_distance);
 
     // send final route to the visualizer

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -18,6 +18,8 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     let mut route = Route::from_cities(cities);
     let n_cities = route.len();
 
+    tracing::info!(n_cities, "B&B starting");
+
     // we will start from city with smallest ID
     route.sort();
     send_progress(ProgressMessage::PathUpdate(route.clone(), 0.0));
@@ -49,6 +51,7 @@ fn build_evaluator(cities: &[KDPoint]) -> PathEvaluator {
     Rc::new(move |path: &Path| dm.tour_length(path))
 }
 
+#[allow(clippy::only_used_in_recursion)]
 fn backtrack(
     evaluate_fn: &PathEvaluator,
     path: &mut Path,
@@ -69,9 +72,7 @@ fn backtrack(
             best_path = path.clone();
             best_distance = new_distance;
 
-            if options.verbose {
-                println!("B&B: epoch.{:?}, new best distance {:?}", k, best_distance);
-            }
+            tracing::info!(depth = k, tour_length = best_distance, "B&B: new best");
         }
     };
 

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -36,6 +36,13 @@ fn solve_ga(
     let mutation_prob = options.mutation_probability;
     let elite_size = options.n_elite;
 
+    tracing::info!(
+        population_size,
+        elite_size = options.n_elite,
+        mutation_prob = options.mutation_probability,
+        "GA starting"
+    );
+
     let mut epoch = 0;
     let mut current_population = population.clone();
 
@@ -73,13 +80,7 @@ fn solve_ga(
             best_candidate.fitness(),
         ));
 
-        if options.verbose {
-            println!(
-                "GA: epoch.{:?} - best individual:\n{:?}",
-                epoch,
-                current_population.best()
-            );
-        }
+        tracing::debug!(epoch, fitness = current_population.best().fitness(), "GA: generation");
 
         epoch += 1;
     }

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -6,6 +6,8 @@ use super::route::Route;
 use super::{Solution, SolverOptions};
 
 pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
+    tracing::info!(n_nearest = options.n_nearest, cities = cities.len(), "NN starting");
+
     let search_tree = kdtree::from_cities(cities);
     let n_nearest = options.n_nearest;
 
@@ -26,10 +28,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
 
         let search_result = frontier.nearest();
         if search_result.is_empty() {
-            if options.verbose {
-                println!("No nearest for city: #{:?}", id1);
-            }
-
+            tracing::debug!(city_id = id1, "NN: no nearest found");
             continue;
         }
 
@@ -39,6 +38,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
         if next_distance < current_distance {
             let nearest_city_id = closest_item.point.id;
             if let Some(nearest_pos) = path.iter().position(|&x| x == nearest_city_id) {
+                tracing::debug!(from = id2, to = nearest_city_id, "NN: swap");
                 path.swap(i + 1, nearest_pos);
 
                 send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -9,6 +9,13 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     let cooling_rate = options.cooling_rate;
     let mut epoch = 0;
 
+    tracing::info!(
+        epochs = options.epochs,
+        max_temp = options.max_temperature,
+        cooling_rate = options.cooling_rate,
+        "SA starting"
+    );
+
     let mut best_route = Route::from_cities(cities);
     let mut best_distance = total_distance(cities, best_route.route());
 
@@ -30,14 +37,10 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
                 best_route.clone(),
                 best_distance,
             ));
-            if options.verbose {
-                println!(
-                    "SA: epoch.{:?} new best distance: {:?}",
-                    epoch, best_distance
-                );
-            }
+            tracing::info!(epoch, tour_length = best_distance, "SA: new best");
         }
 
+        tracing::debug!(epoch, temperature, "SA: tick");
         temperature = cooling(temperature, cooling_rate);
         epoch += 1;
     }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -4,6 +4,12 @@ use super::route::Route;
 use super::{total_distance, Solution, SolverOptions};
 
 pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
+    tracing::info!(
+        epochs = options.epochs,
+        platoo_epochs = options.platoo_epochs,
+        "hill climbing starting"
+    );
+
     let mut current_route = Route::from_cities(cities);
     let mut best_route = current_route.clone();
 
@@ -29,9 +35,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
                 best_distance,
             ));
 
-            if options.verbose {
-                println!("Epoch: {:?}, new best distance: {:}", epoch, best_distance);
-            }
+            tracing::info!(epoch, tour_length = best_distance, "hill: new best");
         } else {
             n_stale += 1; // to measure how long we have been walking around on the platoo
         }
@@ -40,12 +44,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
 
         // restart search if been wandering too long on the platoo
         if n_stale > options.platoo_epochs && options.platoo_epochs > 0 {
-            if options.verbose {
-                println!(
-                    "Epoch: {:?}, got stuck after {:?} steps, going to restart search",
-                    epoch, options.platoo_epochs
-                );
-            }
+            tracing::warn!(epoch, plateau_epochs = options.platoo_epochs, "hill: plateau, restarting");
 
             current_route.shuffle();
             n_stale = 0;

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -8,6 +8,8 @@ use super::{total_distance, Solution, SolverOptions};
 pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
     let tabu_capacity = cities.len();
 
+    tracing::info!(epochs = options.epochs, tabu_capacity, "tabu search starting");
+
     let mut tabu_list = TabuList::new(tabu_capacity);
 
     let mut best_route = Route::from_cities(cities);
@@ -30,12 +32,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
                 best_distance,
             ));
 
-            if options.verbose {
-                println!(
-                    "Tabusearch: epoch.{:?} new best {:?}",
-                    epoch, local_distance
-                );
-            }
+            tracing::info!(epoch, tour_length = local_distance, "tabu: new best");
         }
 
         // refine tabu list

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -3,7 +3,9 @@ use super::progress::{send_progress, ProgressMessage};
 use super::route::Route;
 use super::{city_table_from_vec, Solution, SolverOptions};
 
-pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
+pub fn solve(cities: &[KDPoint], _options: &SolverOptions) -> Solution {
+    tracing::info!(cities = cities.len(), "2-opt starting");
+
     let n_indices = cities.len() - 1;
     let cities_table = city_table_from_vec(cities);
     let mut path: Vec<usize> = cities.iter().map(|c| c.id).collect();
@@ -28,13 +30,7 @@ pub fn solve(cities: &[KDPoint], options: &SolverOptions) -> Solution {
                     improved = true;
 
                     send_progress(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
-
-                    if options.verbose {
-                        println!(
-                            "2OPT: cities(i: {:?}, j: {:?}) new best {:?}",
-                            i, j, new_distance
-                        );
-                    }
+                    tracing::debug!(i, j, tour_length = new_distance, "2-opt: improvement");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Replaces all `if options.verbose { println!() }` blocks with `tracing` calls across 8 solvers and `main.rs`
- Subscriber writes to **stderr**, keeping stdout clean for piping
- `--verbose` sets default level to `debug`; `RUST_LOG` overrides both
- Added ADR-001 in GitKB documenting the logging decision

## Changes

- `Cargo.toml` — add `tracing = "0.1"` and `tracing-subscriber = { version = "0.3", features = ["env-filter"] }`
- `src/main.rs` — init subscriber after arg parsing, `info!` for solver/problem, `info_span!` around solver thread
- All 8 solvers — `info!` at start/improvement, `debug!` for per-iteration detail, `warn!` for plateau restarts (stochastic hill)

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 62 tests passing
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp 2>logs.txt` — INFO lines on stderr, tour on stdout
- [x] `./target/debug/bin -v nn -i data/tsplib/berlin52.tsp 2>&1 | grep NN:` — debug lines visible
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp 2>/dev/null` — stdout still has solution
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp | wc -w` — piping works, no log noise on stdout