### PR TITLE
feat: compare solver output against known optimal tour (--optimal-tour flag, closes #39)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,13 @@ fn main() {
                 .action(ArgAction::SetTrue)
                 .required(false),
         )
+        .arg(
+            Arg::new("optimal_tour")
+                .long("optimal-tour")
+                .value_name("FILE_PATH")
+                .help("Path to a .opt.tour file; overlays optimal route on visualization and prints gap to stderr")
+                .required(false),
+        )
         .get_matches();
 
     let solver_type =
@@ -133,6 +140,28 @@ fn main() {
 
     // eframe (winit) requires the event loop on the main thread,
     // so the solver runs in a background thread and the window stays on main.
+    // MUST construct ProgressPlot first — new() calls init_channels() which
+    // sets up the global mpsc channel before any send_progress calls.
+    let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
+
+    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
+        let opt_path = Path::new(opt_path_str.as_str());
+        match teeline::tsp::opt_tour::read_from_file(opt_path) {
+            Ok(opt) => {
+                if opt.dimension == tsp_data.len() {
+                    progress::send_progress(progress::ProgressMessage::OptimalTour(opt.route));
+                } else {
+                    eprintln!(
+                        "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                        opt.dimension,
+                        tsp_data.len()
+                    );
+                }
+            }
+            Err(e) => eprintln!("--optimal-tour: {e}"),
+        }
+    }
+
     let cities_for_solver = cities.clone();
     let distances_for_solver = distances.clone();
     let span = tracing::info_span!("solver", algorithm = ?solver_type);
@@ -141,12 +170,16 @@ fn main() {
         let tour = solve(solver_type, &cities_for_solver, &distances_for_solver, &options.clone());
         tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
+        tour
     });
 
-    let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
     progress_display.run(show_progress);
 
-    solver_handle.join().expect("Solver thread failed");
+    let tour = solver_handle.join().expect("Solver thread failed");
+
+    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
+        print_optimal_comparison(&tour, &distances, opt_path_str);
+    }
 }
 
 fn solve(
@@ -175,6 +208,47 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
         print!("{} ", city_id);
     }
     println!();
+}
+
+fn print_optimal_comparison(
+    solver_tour: &Solution,
+    distances: &distance_matrix::DistanceMatrix,
+    opt_path_str: &str,
+) {
+    let opt_path = Path::new(opt_path_str);
+    let opt_tour = match teeline::tsp::opt_tour::read_from_file(opt_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("--optimal-tour: {e}");
+            return;
+        }
+    };
+
+    if opt_tour.dimension != distances.len() {
+        eprintln!(
+            "--optimal-tour: dimension mismatch ({} vs {}); skipping comparison",
+            opt_tour.dimension,
+            distances.len()
+        );
+        return;
+    }
+
+    let optimal_cost = distances.tour_length(&opt_tour.route);
+    let solver_cost = solver_tour.total;
+    let gap_pct = if optimal_cost > 0.0 {
+        (solver_cost - optimal_cost) / optimal_cost * 100.0
+    } else {
+        0.0
+    };
+
+    eprintln!("--- Comparison ---");
+    eprintln!("Optimal  : {:.5}  (from {})", optimal_cost, opt_tour.name);
+    eprintln!("Solver   : {:.5}", solver_cost);
+    if gap_pct.abs() < 0.001 {
+        eprintln!("Gap      : 0.00 % (matches optimal)");
+    } else {
+        eprintln!("Gap      : {:+.2} %", gap_pct);
+    }
 }
 
 fn read_tsp_data_from_file(file_path: &Path) -> tsplib::TspLibData {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,21 +144,25 @@ fn main() {
     // sets up the global mpsc channel before any send_progress calls.
     let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
 
-    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
-        let opt_path = Path::new(opt_path_str.as_str());
-        match teeline::tsp::opt_tour::read_from_file(opt_path) {
-            Ok(opt) => {
-                if opt.dimension == tsp_data.len() {
-                    progress::send_progress(progress::ProgressMessage::OptimalTour(opt.route));
-                } else {
-                    eprintln!(
-                        "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
-                        opt.dimension,
-                        tsp_data.len()
-                    );
-                }
+    let opt_tour = args
+        .get_one::<String>("optimal_tour")
+        .and_then(|p| match teeline::tsp::opt_tour::read_from_file(Path::new(p.as_str())) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                eprintln!("--optimal-tour: {e}");
+                None
             }
-            Err(e) => eprintln!("--optimal-tour: {e}"),
+        });
+
+    if let Some(ref ot) = opt_tour {
+        if ot.dimension == tsp_data.len() {
+            progress::send_progress(progress::ProgressMessage::OptimalTour(ot.route.clone()));
+        } else {
+            eprintln!(
+                "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                ot.dimension,
+                tsp_data.len()
+            );
         }
     }
 
@@ -177,8 +181,8 @@ fn main() {
 
     let tour = solver_handle.join().expect("Solver thread failed");
 
-    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
-        print_optimal_comparison(&tour, &distances, opt_path_str);
+    if let Some(ot) = opt_tour {
+        print_optimal_comparison(&tour, &distances, tsp_data.len(), &ot);
     }
 }
 
@@ -213,22 +217,14 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
 fn print_optimal_comparison(
     solver_tour: &Solution,
     distances: &distance_matrix::DistanceMatrix,
-    opt_path_str: &str,
+    n_cities: usize,
+    opt_tour: &teeline::tsp::opt_tour::OptTour,
 ) {
-    let opt_path = Path::new(opt_path_str);
-    let opt_tour = match teeline::tsp::opt_tour::read_from_file(opt_path) {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("--optimal-tour: {e}");
-            return;
-        }
-    };
-
-    if opt_tour.dimension != distances.len() {
+    if opt_tour.dimension != n_cities {
         eprintln!(
             "--optimal-tour: dimension mismatch ({} vs {}); skipping comparison",
             opt_tour.dimension,
-            distances.len()
+            n_cities
         );
         return;
     }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -9,6 +9,7 @@ pub mod route;
 pub mod simulated_annealing;
 pub mod stochastic_hill;
 pub mod tabu_search;
+pub mod opt_tour;
 pub mod tsplib;
 pub mod two_opt;
 

--- a/src/tsp/opt_tour.rs
+++ b/src/tsp/opt_tour.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static KEY_VALUE_MATCHER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?P<key>\w+)\s*:\s*(?P<val>.+)$").unwrap());
+
+#[derive(Debug, Clone)]
+pub struct OptTour {
+    pub name: String,
+    pub comment: String,
+    pub dimension: usize,
+    pub route: Vec<usize>,
+}
+
+#[derive(Debug, PartialEq)]
+enum ParseState {
+    Header,
+    TourSection,
+    End,
+}
+
+pub fn read_from_file(path: &Path) -> Result<OptTour, String> {
+    let f = File::open(path).map_err(|e| format!("opt_tour: cannot open file: {e}"))?;
+    parse_from_reader(BufReader::new(f))
+}
+
+#[cfg(test)]
+pub(crate) fn parse_from_str(text: &str) -> Result<OptTour, String> {
+    parse_from_reader(text.as_bytes())
+}
+
+fn parse_from_reader<R: BufRead>(reader: R) -> Result<OptTour, String> {
+    let mut metadata: HashMap<String, String> = HashMap::new();
+    let mut route: Vec<usize> = Vec::new();
+    let mut state = ParseState::Header;
+
+    for line_result in reader.lines() {
+        let raw = line_result.map_err(|e| format!("opt_tour: read error: {e}"))?;
+        let line = raw.trim().to_uppercase();
+
+        if line == "EOF" || state == ParseState::End {
+            break;
+        }
+
+        match state {
+            ParseState::Header => {
+                if line == "TOUR_SECTION" {
+                    state = ParseState::TourSection;
+                } else if let Some(caps) = KEY_VALUE_MATCHER.captures(&line) {
+                    metadata.insert(caps["key"].to_string(), caps["val"].trim().to_string());
+                }
+            }
+            ParseState::TourSection => {
+                for token in line.split_whitespace() {
+                    match isize::from_str(token) {
+                        Ok(-1) => {
+                            state = ParseState::End;
+                            break;
+                        }
+                        Ok(id) if id > 0 => route.push(id as usize),
+                        _ => {}
+                    }
+                }
+            }
+            ParseState::End => break,
+        }
+    }
+
+    let doc_type = metadata.get("TYPE").map(|s| s.as_str()).unwrap_or("");
+    if doc_type != "TOUR" {
+        return Err(format!(
+            "opt_tour: expected TYPE : TOUR, found TYPE : {doc_type}"
+        ));
+    }
+
+    let dimension: usize = metadata
+        .get("DIMENSION")
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0);
+
+    if route.len() != dimension {
+        return Err(format!(
+            "opt_tour: dimension mismatch — DIMENSION={dimension} but parsed {} cities",
+            route.len()
+        ));
+    }
+
+    Ok(OptTour {
+        name: metadata
+            .get("NAME")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string()),
+        comment: metadata.get("COMMENT").cloned().unwrap_or_default(),
+        dimension,
+        route,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_TOUR: &str = "\
+NAME : test3.opt.tour
+COMMENT : three-city test
+TYPE : TOUR
+DIMENSION : 3
+TOUR_SECTION
+1
+2
+3
+-1
+EOF";
+
+    const MULTI_ID_LINE_TOUR: &str = "\
+NAME : test4.opt.tour
+TYPE : TOUR
+DIMENSION : 4
+TOUR_SECTION
+1 2
+3 4
+-1
+EOF";
+
+    const WRONG_TYPE_TOUR: &str = "\
+NAME : bad.tsp
+TYPE : TSP
+DIMENSION : 3
+TOUR_SECTION
+1 2 3
+-1
+EOF";
+
+    const DIMENSION_MISMATCH_TOUR: &str = "\
+NAME : bad.opt.tour
+TYPE : TOUR
+DIMENSION : 5
+TOUR_SECTION
+1
+2
+3
+-1
+EOF";
+
+    #[test]
+    fn test_parse_valid_tour() {
+        let result = parse_from_str(VALID_TOUR).unwrap();
+        assert_eq!(result.name, "TEST3.OPT.TOUR");
+        assert_eq!(result.dimension, 3);
+        assert_eq!(result.route, vec![1usize, 2, 3]);
+    }
+
+    #[test]
+    fn test_parse_tour_multiple_ids_per_line() {
+        let result = parse_from_str(MULTI_ID_LINE_TOUR).unwrap();
+        assert_eq!(result.dimension, 4);
+        assert_eq!(result.route, vec![1usize, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_parse_returns_error_on_wrong_type() {
+        let result = parse_from_str(WRONG_TYPE_TOUR);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("TYPE"), "error should mention TYPE, got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_returns_error_on_dimension_mismatch() {
+        let result = parse_from_str(DIMENSION_MISMATCH_TOUR);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("dimension") || msg.contains("3") || msg.contains("5"),
+            "error should mention dimension mismatch, got: {msg}"
+        );
+    }
+}

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -24,6 +24,7 @@ const WHITE:              Color32 = Color32::from_rgb(255, 255, 255);
 const CITY_COLOR:         Color32 = Color32::from_rgb(30,  30,  30);   // near-black nodes
 const CURRENT_CITY_COLOR: Color32 = Color32::from_rgb(220, 30,  30);   // red — active city
 const BEST_EDGE_COLOR:    Color32 = Color32::from_rgb(34,  139, 34);   // green — best route
+const OPTIMAL_EDGE_COLOR: Color32 = Color32::from_rgb(50,  205, 50);   // lime — known-optimal route
 const CURRENT_EDGE_COLOR: Color32 = Color32::from_rgb(30,  100, 220);  // blue — exploring route
 const ACTIVE_EDGE_COLOR:  Color32 = Color32::from_rgb(255, 140, 0);    // orange — current step
 const STATUS_COLOR:       Color32 = Color32::from_rgb(220, 30,  30);   // red — status text
@@ -73,6 +74,7 @@ pub enum ProgressMessage {
     EpochUpdate(usize),
     Done,
     Restart,
+    OptimalTour(Vec<usize>),
 }
 
 struct NodeData {
@@ -84,6 +86,7 @@ pub struct ProgressPlot {
     city_table: HashMap<usize, KDPoint>,
     nodes: Vec<NodeData>,
     best_edges: Vec<EdgeData>,    // shown in green after Done
+    optimal_edges: Vec<EdgeData>, // lime green — known-optimal tour overlay
     current_edges: Vec<EdgeData>, // shown in blue while solving
     current_city_id: Option<usize>,
     prev_city_id: Option<usize>,
@@ -103,6 +106,7 @@ impl ProgressPlot {
             city_table: HashMap::new(),
             nodes: Vec::new(),
             best_edges: Vec::new(),
+            optimal_edges: Vec::new(),
             current_edges: Vec::new(),
             current_city_id: None,
             prev_city_id: None,
@@ -181,6 +185,10 @@ impl ProgressPlot {
                 self.current_city_id = Some(*id);
                 self.status = "Solving...".to_string();
             }
+            ProgressMessage::OptimalTour(city_ids) => {
+                let route = Route::new(city_ids.as_slice());
+                self.optimal_edges = self.build_route_edges(&route);
+            }
             _ => {}
         }
     }
@@ -239,8 +247,12 @@ impl eframe::App for ProgressPlot {
             .show(ctx, |ui| {
                 let painter = ui.painter();
 
-                // While solving: current exploring route in blue.
-                // After Done: best route in green (replaces live view).
+                // Layer 0: optimal tour (lime green) — always visible as reference
+                for (from, to) in &self.optimal_edges {
+                    painter.line_segment([*from, *to], Stroke::new(2.0, OPTIMAL_EDGE_COLOR));
+                }
+
+                // Layer 1: solver route
                 if self.is_solved {
                     for (from, to) in &self.best_edges {
                         painter.line_segment([*from, *to], Stroke::new(2.5, BEST_EDGE_COLOR));
@@ -251,7 +263,7 @@ impl eframe::App for ProgressPlot {
                     }
                 }
 
-                // Orange edge from previous city to current city (B&B active step)
+                // Layer 2: active step edge (B&B orange)
                 if let (Some(prev_id), Some(curr_id)) = (self.prev_city_id, self.current_city_id) {
                     let prev_pos = self.nodes.iter().find(|n| n.city_id == prev_id).map(|n| n.pos);
                     let curr_pos = self.nodes.iter().find(|n| n.city_id == curr_id).map(|n| n.pos);
@@ -260,7 +272,7 @@ impl eframe::App for ProgressPlot {
                     }
                 }
 
-                // Layer 4: city nodes (black; current city = red)
+                // Layer 3: city nodes (black; current city = red)
                 for node in &self.nodes {
                     let color = if self.current_city_id == Some(node.city_id) {
                         CURRENT_CITY_COLOR
@@ -281,6 +293,7 @@ impl eframe::App for ProgressPlot {
                     );
                 }
 
+                // Status line (top-left)
                 let margin = self.viewport_dimensions.margin as f32;
                 painter.text(
                     Pos2::new(margin, margin / 2.0),
@@ -289,6 +302,9 @@ impl eframe::App for ProgressPlot {
                     FontId::proportional(FONT_SIZE),
                     STATUS_COLOR,
                 );
+
+                // Legend (bottom-left); painter is already &Painter — do NOT add &
+                draw_legend(painter, &self.viewport_dimensions, !self.optimal_edges.is_empty());
             });
 
         // Poll at ~60fps while solver runs; avoids burning a full CPU core.
@@ -356,6 +372,38 @@ fn cities_bounding_box(cities: &[KDPoint]) -> RectCoords {
     }
 
     [x_min as f64, y_min as f64, x_max as f64, y_max as f64]
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: bool) {
+    let x0 = vp.margin as f32;
+    let y0 = vp.height as f32 - vp.margin as f32 - 80.0;
+    let line_len = 24.0_f32;
+    let row_h = 20.0_f32;
+    let label_x = x0 + line_len + 6.0;
+
+    let mut entries: Vec<(Color32, &str)> = Vec::new();
+    if show_optimal {
+        entries.push((OPTIMAL_EDGE_COLOR, "Optimal tour"));
+    }
+    entries.push((BEST_EDGE_COLOR, "Solver best"));
+    entries.push((CURRENT_EDGE_COLOR, "Solver current"));
+    entries.push((ACTIVE_EDGE_COLOR, "Active edge"));
+
+    for (i, (color, label)) in entries.iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let y = y0 + i as f32 * row_h;
+        let p0 = Pos2::new(x0, y);
+        let p1 = Pos2::new(x0 + line_len, y);
+        painter.line_segment([p0, p1], Stroke::new(2.5, *color));
+        painter.text(
+            Pos2::new(label_x, y - FONT_SIZE / 2.0),
+            Align2::LEFT_TOP,
+            *label,
+            FontId::proportional(FONT_SIZE - 2.0),
+            *color,
+        );
+    }
 }
 
 // converts EUC2D space into GUI coords [0..self.height, 0..self.width]

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -247,15 +247,15 @@ impl eframe::App for ProgressPlot {
             .show(ctx, |ui| {
                 let painter = ui.painter();
 
-                // Layer 0: optimal tour (lime green) — always visible as reference
+                // Layer 0: optimal tour (lime green, thin) — always visible as reference
                 for (from, to) in &self.optimal_edges {
-                    painter.line_segment([*from, *to], Stroke::new(2.0, OPTIMAL_EDGE_COLOR));
+                    painter.line_segment([*from, *to], Stroke::new(1.5, OPTIMAL_EDGE_COLOR));
                 }
 
                 // Layer 1: solver route
                 if self.is_solved {
                     for (from, to) in &self.best_edges {
-                        painter.line_segment([*from, *to], Stroke::new(2.5, BEST_EDGE_COLOR));
+                        painter.line_segment([*from, *to], Stroke::new(4.0, BEST_EDGE_COLOR));
                     }
                 } else {
                     for (from, to) in &self.current_edges {


### PR DESCRIPTION
## Summary

- Adds `--optimal-tour <FILE>` CLI flag to load a TSPLIB `.opt.tour` file and compare it against the solver's output
- Prints a `--- Comparison ---` block (Optimal / Solver / Gap %) to stderr after solving; stdout format is unchanged
- Overlays the optimal route as a **lime-green** background layer in the egui visualization window; adds a color legend at the bottom-left

## Changes

- `src/tsp/opt_tour.rs` (new) — state-machine parser for TSPLIB TOUR format; validates `TYPE=TOUR` and dimension; supports multiple city IDs per line
- `src/tsp/progress.rs` — adds `ProgressMessage::OptimalTour(Vec<usize>)`, `optimal_edges` field, lime-green drawing layer, and `draw_legend` function
- `src/main.rs` — wires the flag end-to-end; `ProgressPlot::new()` now precedes `send_progress` to guarantee channel is initialised before use; solver thread returns `Solution` for post-join comparison

## Test Plan

- [x] `cargo test` — 111 tests pass (4 new unit tests in `opt_tour.rs`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp --optimal-tour data/tsplib/berlin52.opt.tour --disable_progress` — stderr shows `--- Comparison ---` block with Gap ~+194%
- [x] Without `--optimal-tour`: stdout format byte-identical
- [x] Bad file path: single clean error line on stderr, no duplicate message