### PR TITLE
feat: edge-comparison viz + GA bug fix + coverage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,36 @@ Resources:
 
 ## Visualising Results
 
-While solving, Teeline opens a Piston window that shows the current best route updating in real time. Pass `--disable_progress` to suppress it (required in headless / CI environments).
+While solving, Teeline opens a window that shows the current best route updating in real time. Pass `--disable_progress` to suppress it (required in headless / CI environments).
+
+### Comparing against a known-optimal tour
+
+Pass `--optimal-tour <FILE>` with a TSPLIB `.opt.tour` file to overlay the optimal route on the visualisation and print a gap comparison to stderr after solving.
+
+```bash
+teeline ga -i data/tsplib/berlin52.tsp \
+    --optimal-tour data/tsplib/berlin52.opt.tour
+```
+
+Example output (stderr):
+
+```
+--- Comparison ---
+Optimal  : 7544.36572  (from BERLIN52.OPT.TOUR)
+Solver   : 7953.25830
+Gap      : +5.42 %
+```
+
+The visualisation window uses colour to show how the solver's best tour compares to the optimal:
+
+| Colour | Meaning |
+|--------|---------|
+| Very dark green (thick) | Edge appears in **both** the optimal tour and the solver's best — correctly found |
+| Light gray | Edge is in the optimal tour but **missed** by the solver |
+| Dark green | Solver's best route |
+| Blue | Current route being explored |
+
+Optimal tour files for the TSPLIB benchmark instances are included in `data/tsplib/` (e.g. `berlin52.opt.tour`).
 
 You can also upload your input file and the solution output to the [Discrete Optimization visualiser](https://discreteoptimization.github.io/vis/tsp/) to inspect tours interactively.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,13 @@ fn main() {
                 .action(ArgAction::SetTrue)
                 .required(false),
         )
+        .arg(
+            Arg::new("optimal_tour")
+                .long("optimal-tour")
+                .value_name("FILE_PATH")
+                .help("Path to a .opt.tour file; overlays optimal route on visualization and prints gap to stderr")
+                .required(false),
+        )
         .get_matches();
 
     let solver_type =
@@ -133,6 +140,28 @@ fn main() {
 
     // eframe (winit) requires the event loop on the main thread,
     // so the solver runs in a background thread and the window stays on main.
+    // MUST construct ProgressPlot first — new() calls init_channels() which
+    // sets up the global mpsc channel before any send_progress calls.
+    let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
+
+    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
+        let opt_path = Path::new(opt_path_str.as_str());
+        match teeline::tsp::opt_tour::read_from_file(opt_path) {
+            Ok(opt) => {
+                if opt.dimension == tsp_data.len() {
+                    progress::send_progress(progress::ProgressMessage::OptimalTour(opt.route));
+                } else {
+                    eprintln!(
+                        "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                        opt.dimension,
+                        tsp_data.len()
+                    );
+                }
+            }
+            Err(e) => eprintln!("--optimal-tour: {e}"),
+        }
+    }
+
     let cities_for_solver = cities.clone();
     let distances_for_solver = distances.clone();
     let span = tracing::info_span!("solver", algorithm = ?solver_type);
@@ -141,12 +170,16 @@ fn main() {
         let tour = solve(solver_type, &cities_for_solver, &distances_for_solver, &options.clone());
         tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
+        tour
     });
 
-    let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
     progress_display.run(show_progress);
 
-    solver_handle.join().expect("Solver thread failed");
+    let tour = solver_handle.join().expect("Solver thread failed");
+
+    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
+        print_optimal_comparison(&tour, &distances, opt_path_str);
+    }
 }
 
 fn solve(
@@ -175,6 +208,47 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
         print!("{} ", city_id);
     }
     println!();
+}
+
+fn print_optimal_comparison(
+    solver_tour: &Solution,
+    distances: &distance_matrix::DistanceMatrix,
+    opt_path_str: &str,
+) {
+    let opt_path = Path::new(opt_path_str);
+    let opt_tour = match teeline::tsp::opt_tour::read_from_file(opt_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("--optimal-tour: {e}");
+            return;
+        }
+    };
+
+    if opt_tour.dimension != distances.len() {
+        eprintln!(
+            "--optimal-tour: dimension mismatch ({} vs {}); skipping comparison",
+            opt_tour.dimension,
+            distances.len()
+        );
+        return;
+    }
+
+    let optimal_cost = distances.tour_length(&opt_tour.route);
+    let solver_cost = solver_tour.total;
+    let gap_pct = if optimal_cost > 0.0 {
+        (solver_cost - optimal_cost) / optimal_cost * 100.0
+    } else {
+        0.0
+    };
+
+    eprintln!("--- Comparison ---");
+    eprintln!("Optimal  : {:.5}  (from {})", optimal_cost, opt_tour.name);
+    eprintln!("Solver   : {:.5}", solver_cost);
+    if gap_pct.abs() < 0.001 {
+        eprintln!("Gap      : 0.00 % (matches optimal)");
+    } else {
+        eprintln!("Gap      : {:+.2} %", gap_pct);
+    }
 }
 
 fn read_tsp_data_from_file(file_path: &Path) -> tsplib::TspLibData {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,21 +144,25 @@ fn main() {
     // sets up the global mpsc channel before any send_progress calls.
     let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
 
-    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
-        let opt_path = Path::new(opt_path_str.as_str());
-        match teeline::tsp::opt_tour::read_from_file(opt_path) {
-            Ok(opt) => {
-                if opt.dimension == tsp_data.len() {
-                    progress::send_progress(progress::ProgressMessage::OptimalTour(opt.route));
-                } else {
-                    eprintln!(
-                        "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
-                        opt.dimension,
-                        tsp_data.len()
-                    );
-                }
+    let opt_tour = args
+        .get_one::<String>("optimal_tour")
+        .and_then(|p| match teeline::tsp::opt_tour::read_from_file(Path::new(p.as_str())) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                eprintln!("--optimal-tour: {e}");
+                None
             }
-            Err(e) => eprintln!("--optimal-tour: {e}"),
+        });
+
+    if let Some(ref ot) = opt_tour {
+        if ot.dimension == tsp_data.len() {
+            progress::send_progress(progress::ProgressMessage::OptimalTour(ot.route.clone()));
+        } else {
+            eprintln!(
+                "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                ot.dimension,
+                tsp_data.len()
+            );
         }
     }
 
@@ -177,8 +181,8 @@ fn main() {
 
     let tour = solver_handle.join().expect("Solver thread failed");
 
-    if let Some(opt_path_str) = args.get_one::<String>("optimal_tour") {
-        print_optimal_comparison(&tour, &distances, opt_path_str);
+    if let Some(ot) = opt_tour {
+        print_optimal_comparison(&tour, &distances, tsp_data.len(), &ot);
     }
 }
 
@@ -213,22 +217,14 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
 fn print_optimal_comparison(
     solver_tour: &Solution,
     distances: &distance_matrix::DistanceMatrix,
-    opt_path_str: &str,
+    n_cities: usize,
+    opt_tour: &teeline::tsp::opt_tour::OptTour,
 ) {
-    let opt_path = Path::new(opt_path_str);
-    let opt_tour = match teeline::tsp::opt_tour::read_from_file(opt_path) {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("--optimal-tour: {e}");
-            return;
-        }
-    };
-
-    if opt_tour.dimension != distances.len() {
+    if opt_tour.dimension != n_cities {
         eprintln!(
             "--optimal-tour: dimension mismatch ({} vs {}); skipping comparison",
             opt_tour.dimension,
-            distances.len()
+            n_cities
         );
         return;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,112 @@ fn read_tsp_data_from_stdin() -> tsplib::TspLibData {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal clap Command that mirrors the args read by `solver_options_from_args`.
+    fn options_cmd() -> Command {
+        Command::new("test")
+            .arg(Arg::new("solver").index(1).required(true))
+            .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue))
+            .arg(Arg::new("disable_progress").long("disable_progress").action(ArgAction::SetTrue))
+            .arg(Arg::new("epochs").long("epochs"))
+            .arg(Arg::new("platoo_epochs").long("platoo_epochs"))
+            .arg(Arg::new("n_nearest").long("n_nearest"))
+            .arg(Arg::new("n_elite").long("n_elite"))
+            .arg(Arg::new("mutation_probability").long("mutation_probability"))
+            .arg(Arg::new("cooling_rate").long("cooling_rate"))
+            .arg(Arg::new("min_temperature").long("min_temperature"))
+            .arg(Arg::new("max_temperature").long("max_temperature"))
+    }
+
+    #[test]
+    fn test_solver_options_defaults_preserved_when_no_args() {
+        let args = options_cmd().get_matches_from(["test", "nn"]);
+        let opts = solver_options_from_args(&args);
+        let defaults = SolverOptions::default();
+        assert!(!opts.verbose);
+        assert!(opts.show_progress);
+        assert_eq!(opts.epochs, defaults.epochs);
+        assert_eq!(opts.n_nearest, defaults.n_nearest);
+    }
+
+    #[test]
+    fn test_solver_options_verbose_flag_sets_verbose() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--verbose"]);
+        assert!(solver_options_from_args(&args).verbose);
+    }
+
+    #[test]
+    fn test_solver_options_disable_progress_clears_show_progress() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--disable_progress"]);
+        assert!(!solver_options_from_args(&args).show_progress);
+    }
+
+    #[test]
+    fn test_solver_options_epochs_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "500"]);
+        assert_eq!(solver_options_from_args(&args).epochs, 500);
+    }
+
+    #[test]
+    fn test_solver_options_invalid_epochs_defaults_to_zero() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "bad"]);
+        assert_eq!(solver_options_from_args(&args).epochs, 0);
+    }
+
+    #[test]
+    fn test_solver_options_platoo_epochs_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--platoo_epochs", "200"]);
+        assert_eq!(solver_options_from_args(&args).platoo_epochs, 200);
+    }
+
+    #[test]
+    fn test_solver_options_n_nearest_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--n_nearest", "5"]);
+        assert_eq!(solver_options_from_args(&args).n_nearest, 5);
+    }
+
+    #[test]
+    fn test_solver_options_n_elite_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--n_elite", "7"]);
+        assert_eq!(solver_options_from_args(&args).n_elite, 7);
+    }
+
+    #[test]
+    fn test_solver_options_mutation_probability_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--mutation_probability", "0.05"]);
+        let opts = solver_options_from_args(&args);
+        assert!((opts.mutation_probability - 0.05).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_solver_options_invalid_mutation_probability_defaults_to_zero() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--mutation_probability", "nope"]);
+        assert!((solver_options_from_args(&args).mutation_probability - 0.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_solver_options_cooling_rate_parsed() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--cooling_rate", "0.001"]);
+        let opts = solver_options_from_args(&args);
+        assert!((opts.cooling_rate - 0.001).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_solver_options_temperature_bounds_parsed() {
+        let args = options_cmd().get_matches_from([
+            "test", "nn",
+            "--min_temperature", "0.5",
+            "--max_temperature", "500.0",
+        ]);
+        let opts = solver_options_from_args(&args);
+        assert!((opts.min_temperature - 0.5).abs() < 1e-5);
+        assert!((opts.max_temperature - 500.0).abs() < 1e-3);
+    }
+}
+
 fn solver_options_from_args(args: &ArgMatches) -> SolverOptions {
     let mut options = SolverOptions::default();
 

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -16,12 +16,12 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
     let population_size = cities.len();
     let population = TspPopulation::from_cities(cities, population_size, &evaluator);
-    let best_candidate = solve_ga(&population, evaluator, options);
+    let best_candidate = solve_ga(&population, evaluator, distances, options);
 
     let best_route = Route::new(best_candidate.genotype());
     send_progress(ProgressMessage::PathUpdate(
         best_route,
-        best_candidate.fitness(),
+        distances.tour_length(best_candidate.genotype()),
     ));
     send_progress(ProgressMessage::Done);
     Solution::new(best_candidate.genotype(), cities, distances)
@@ -30,6 +30,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 fn solve_ga(
     population: &TspPopulation,
     fitness_fn: FitnessFn,
+    distances: &DistanceMatrix,
     options: &SolverOptions,
 ) -> TspGenotype {
     let population_size = population.len();
@@ -77,7 +78,7 @@ fn solve_ga(
         let best_route = Route::new(best_candidate.genotype());
         send_progress(ProgressMessage::PathUpdate(
             best_route,
-            best_candidate.fitness(),
+            distances.tour_length(best_candidate.genotype()),
         ));
 
         tracing::debug!(epoch, fitness = current_population.best().fitness(), "GA: generation");
@@ -295,6 +296,44 @@ impl TspGenotype {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tsp::{distance_matrix, kdtree};
+
+    // Regression test: GA's internal fitness is 1/tour_length (used for selection).
+    // The PathUpdate messages and Solution::total must carry the real tour_length,
+    // not the inverted fitness. If this regresses, solution.total would be ~0.00025
+    // instead of ~4.0 for a unit square.
+    #[test]
+    fn test_solve_returns_real_tour_length_not_inverted_fitness() {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![0.0, 1.0],
+            vec![1.0, 1.0],
+            vec![1.0, 0.0],
+        ]);
+        let distances = distance_matrix::from_cities(&cities);
+        let options = SolverOptions {
+            epochs: 100,
+            ..SolverOptions::default()
+        };
+
+        let solution = solve(&cities, &distances, &options);
+
+        // Real tour for a unit square visits all 4 sides: total >= 4.0.
+        // Inverted fitness would be 1/4.0 = 0.25 — far below this threshold.
+        assert!(
+            solution.total >= 3.9,
+            "GA solution.total = {} looks like inverted fitness; expected >= 4.0",
+            solution.total
+        );
+        // Also verify the stored total matches a fresh computation on the route.
+        let recomputed = distances.tour_length(solution.route());
+        assert!(
+            (solution.total - recomputed).abs() < 0.01,
+            "solution.total ({}) != distances.tour_length ({}) — inconsistent",
+            solution.total,
+            recomputed
+        );
+    }
 
     #[test]
     fn test_ordered_crossover_genes_with_example_from_book() {

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -9,6 +9,7 @@ pub mod route;
 pub mod simulated_annealing;
 pub mod stochastic_hill;
 pub mod tabu_search;
+pub mod opt_tour;
 pub mod tsplib;
 pub mod two_opt;
 

--- a/src/tsp/opt_tour.rs
+++ b/src/tsp/opt_tour.rs
@@ -181,4 +181,55 @@ EOF";
             "error should mention dimension mismatch, got: {msg}"
         );
     }
+
+    #[test]
+    fn test_parse_tour_eof_terminates_without_minus_one() {
+        let input = "\
+NAME : eof.opt.tour
+TYPE : TOUR
+DIMENSION : 2
+TOUR_SECTION
+1
+2
+EOF";
+        let result = parse_from_str(input).unwrap();
+        assert_eq!(result.dimension, 2);
+        assert_eq!(result.route, vec![1usize, 2]);
+    }
+
+    #[test]
+    fn test_parse_tour_missing_name_defaults_to_unknown() {
+        let input = "\
+TYPE : TOUR
+DIMENSION : 2
+TOUR_SECTION
+1
+2
+-1
+EOF";
+        let result = parse_from_str(input).unwrap();
+        assert_eq!(result.name, "unknown");
+    }
+
+    #[test]
+    fn test_parse_tour_invalid_dimension_returns_error() {
+        let input = "\
+NAME : bad.opt.tour
+TYPE : TOUR
+DIMENSION : NOT_A_NUMBER
+TOUR_SECTION
+1
+2
+-1
+EOF";
+        let result = parse_from_str(input);
+        assert!(result.is_err(), "expected error for non-numeric DIMENSION");
+    }
+
+    #[test]
+    fn test_read_from_file_nonexistent_path_returns_error() {
+        let result = read_from_file(std::path::Path::new("/no/such/file.opt.tour"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("opt_tour: cannot open file"));
+    }
 }

--- a/src/tsp/opt_tour.rs
+++ b/src/tsp/opt_tour.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static KEY_VALUE_MATCHER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?P<key>\w+)\s*:\s*(?P<val>.+)$").unwrap());
+
+#[derive(Debug, Clone)]
+pub struct OptTour {
+    pub name: String,
+    pub comment: String,
+    pub dimension: usize,
+    pub route: Vec<usize>,
+}
+
+#[derive(Debug, PartialEq)]
+enum ParseState {
+    Header,
+    TourSection,
+    End,
+}
+
+pub fn read_from_file(path: &Path) -> Result<OptTour, String> {
+    let f = File::open(path).map_err(|e| format!("opt_tour: cannot open file: {e}"))?;
+    parse_from_reader(BufReader::new(f))
+}
+
+#[cfg(test)]
+pub(crate) fn parse_from_str(text: &str) -> Result<OptTour, String> {
+    parse_from_reader(text.as_bytes())
+}
+
+fn parse_from_reader<R: BufRead>(reader: R) -> Result<OptTour, String> {
+    let mut metadata: HashMap<String, String> = HashMap::new();
+    let mut route: Vec<usize> = Vec::new();
+    let mut state = ParseState::Header;
+
+    for line_result in reader.lines() {
+        let raw = line_result.map_err(|e| format!("opt_tour: read error: {e}"))?;
+        let line = raw.trim().to_uppercase();
+
+        if line == "EOF" || state == ParseState::End {
+            break;
+        }
+
+        match state {
+            ParseState::Header => {
+                if line == "TOUR_SECTION" {
+                    state = ParseState::TourSection;
+                } else if let Some(caps) = KEY_VALUE_MATCHER.captures(&line) {
+                    metadata.insert(caps["key"].to_string(), caps["val"].trim().to_string());
+                }
+            }
+            ParseState::TourSection => {
+                for token in line.split_whitespace() {
+                    match isize::from_str(token) {
+                        Ok(-1) => {
+                            state = ParseState::End;
+                            break;
+                        }
+                        Ok(id) if id > 0 => route.push(id as usize),
+                        _ => {}
+                    }
+                }
+            }
+            ParseState::End => break,
+        }
+    }
+
+    let doc_type = metadata.get("TYPE").map(|s| s.as_str()).unwrap_or("");
+    if doc_type != "TOUR" {
+        return Err(format!(
+            "opt_tour: expected TYPE : TOUR, found TYPE : {doc_type}"
+        ));
+    }
+
+    let dimension: usize = metadata
+        .get("DIMENSION")
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0);
+
+    if route.len() != dimension {
+        return Err(format!(
+            "opt_tour: dimension mismatch — DIMENSION={dimension} but parsed {} cities",
+            route.len()
+        ));
+    }
+
+    Ok(OptTour {
+        name: metadata
+            .get("NAME")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string()),
+        comment: metadata.get("COMMENT").cloned().unwrap_or_default(),
+        dimension,
+        route,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_TOUR: &str = "\
+NAME : test3.opt.tour
+COMMENT : three-city test
+TYPE : TOUR
+DIMENSION : 3
+TOUR_SECTION
+1
+2
+3
+-1
+EOF";
+
+    const MULTI_ID_LINE_TOUR: &str = "\
+NAME : test4.opt.tour
+TYPE : TOUR
+DIMENSION : 4
+TOUR_SECTION
+1 2
+3 4
+-1
+EOF";
+
+    const WRONG_TYPE_TOUR: &str = "\
+NAME : bad.tsp
+TYPE : TSP
+DIMENSION : 3
+TOUR_SECTION
+1 2 3
+-1
+EOF";
+
+    const DIMENSION_MISMATCH_TOUR: &str = "\
+NAME : bad.opt.tour
+TYPE : TOUR
+DIMENSION : 5
+TOUR_SECTION
+1
+2
+3
+-1
+EOF";
+
+    #[test]
+    fn test_parse_valid_tour() {
+        let result = parse_from_str(VALID_TOUR).unwrap();
+        assert_eq!(result.name, "TEST3.OPT.TOUR");
+        assert_eq!(result.dimension, 3);
+        assert_eq!(result.route, vec![1usize, 2, 3]);
+    }
+
+    #[test]
+    fn test_parse_tour_multiple_ids_per_line() {
+        let result = parse_from_str(MULTI_ID_LINE_TOUR).unwrap();
+        assert_eq!(result.dimension, 4);
+        assert_eq!(result.route, vec![1usize, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_parse_returns_error_on_wrong_type() {
+        let result = parse_from_str(WRONG_TYPE_TOUR);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("TYPE"), "error should mention TYPE, got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_returns_error_on_dimension_mismatch() {
+        let result = parse_from_str(DIMENSION_MISMATCH_TOUR);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("dimension") || msg.contains("3") || msg.contains("5"),
+            "error should mention dimension mismatch, got: {msg}"
+        );
+    }
+}

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -424,7 +424,7 @@ fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: b
 
     let mut entries: Vec<(Color32, &str)> = Vec::new();
     if show_optimal {
-        entries.push((SHARED_EDGE_COLOR, "Shared (optimal ∩ solver)"));
+        entries.push((SHARED_EDGE_COLOR, "Shared (optimal + solver)"));
         entries.push((UNIQUE_OPT_COLOR,  "Optimal only (missed)"));
     }
     entries.push((BEST_EDGE_COLOR, "Solver best"));

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -24,6 +24,7 @@ const WHITE:              Color32 = Color32::from_rgb(255, 255, 255);
 const CITY_COLOR:         Color32 = Color32::from_rgb(30,  30,  30);   // near-black nodes
 const CURRENT_CITY_COLOR: Color32 = Color32::from_rgb(220, 30,  30);   // red — active city
 const BEST_EDGE_COLOR:    Color32 = Color32::from_rgb(34,  139, 34);   // green — best route
+const OPTIMAL_EDGE_COLOR: Color32 = Color32::from_rgb(50,  205, 50);   // lime — known-optimal route
 const CURRENT_EDGE_COLOR: Color32 = Color32::from_rgb(30,  100, 220);  // blue — exploring route
 const ACTIVE_EDGE_COLOR:  Color32 = Color32::from_rgb(255, 140, 0);    // orange — current step
 const STATUS_COLOR:       Color32 = Color32::from_rgb(220, 30,  30);   // red — status text
@@ -73,6 +74,7 @@ pub enum ProgressMessage {
     EpochUpdate(usize),
     Done,
     Restart,
+    OptimalTour(Vec<usize>),
 }
 
 struct NodeData {
@@ -84,6 +86,7 @@ pub struct ProgressPlot {
     city_table: HashMap<usize, KDPoint>,
     nodes: Vec<NodeData>,
     best_edges: Vec<EdgeData>,    // shown in green after Done
+    optimal_edges: Vec<EdgeData>, // lime green — known-optimal tour overlay
     current_edges: Vec<EdgeData>, // shown in blue while solving
     current_city_id: Option<usize>,
     prev_city_id: Option<usize>,
@@ -103,6 +106,7 @@ impl ProgressPlot {
             city_table: HashMap::new(),
             nodes: Vec::new(),
             best_edges: Vec::new(),
+            optimal_edges: Vec::new(),
             current_edges: Vec::new(),
             current_city_id: None,
             prev_city_id: None,
@@ -181,6 +185,10 @@ impl ProgressPlot {
                 self.current_city_id = Some(*id);
                 self.status = "Solving...".to_string();
             }
+            ProgressMessage::OptimalTour(city_ids) => {
+                let route = Route::new(city_ids.as_slice());
+                self.optimal_edges = self.build_route_edges(&route);
+            }
             _ => {}
         }
     }
@@ -239,8 +247,12 @@ impl eframe::App for ProgressPlot {
             .show(ctx, |ui| {
                 let painter = ui.painter();
 
-                // While solving: current exploring route in blue.
-                // After Done: best route in green (replaces live view).
+                // Layer 0: optimal tour (lime green) — always visible as reference
+                for (from, to) in &self.optimal_edges {
+                    painter.line_segment([*from, *to], Stroke::new(2.0, OPTIMAL_EDGE_COLOR));
+                }
+
+                // Layer 1: solver route
                 if self.is_solved {
                     for (from, to) in &self.best_edges {
                         painter.line_segment([*from, *to], Stroke::new(2.5, BEST_EDGE_COLOR));
@@ -251,7 +263,7 @@ impl eframe::App for ProgressPlot {
                     }
                 }
 
-                // Orange edge from previous city to current city (B&B active step)
+                // Layer 2: active step edge (B&B orange)
                 if let (Some(prev_id), Some(curr_id)) = (self.prev_city_id, self.current_city_id) {
                     let prev_pos = self.nodes.iter().find(|n| n.city_id == prev_id).map(|n| n.pos);
                     let curr_pos = self.nodes.iter().find(|n| n.city_id == curr_id).map(|n| n.pos);
@@ -260,7 +272,7 @@ impl eframe::App for ProgressPlot {
                     }
                 }
 
-                // Layer 4: city nodes (black; current city = red)
+                // Layer 3: city nodes (black; current city = red)
                 for node in &self.nodes {
                     let color = if self.current_city_id == Some(node.city_id) {
                         CURRENT_CITY_COLOR
@@ -281,6 +293,7 @@ impl eframe::App for ProgressPlot {
                     );
                 }
 
+                // Status line (top-left)
                 let margin = self.viewport_dimensions.margin as f32;
                 painter.text(
                     Pos2::new(margin, margin / 2.0),
@@ -289,6 +302,9 @@ impl eframe::App for ProgressPlot {
                     FontId::proportional(FONT_SIZE),
                     STATUS_COLOR,
                 );
+
+                // Legend (bottom-left); painter is already &Painter — do NOT add &
+                draw_legend(painter, &self.viewport_dimensions, !self.optimal_edges.is_empty());
             });
 
         // Poll at ~60fps while solver runs; avoids burning a full CPU core.
@@ -356,6 +372,38 @@ fn cities_bounding_box(cities: &[KDPoint]) -> RectCoords {
     }
 
     [x_min as f64, y_min as f64, x_max as f64, y_max as f64]
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: bool) {
+    let x0 = vp.margin as f32;
+    let y0 = vp.height as f32 - vp.margin as f32 - 80.0;
+    let line_len = 24.0_f32;
+    let row_h = 20.0_f32;
+    let label_x = x0 + line_len + 6.0;
+
+    let mut entries: Vec<(Color32, &str)> = Vec::new();
+    if show_optimal {
+        entries.push((OPTIMAL_EDGE_COLOR, "Optimal tour"));
+    }
+    entries.push((BEST_EDGE_COLOR, "Solver best"));
+    entries.push((CURRENT_EDGE_COLOR, "Solver current"));
+    entries.push((ACTIVE_EDGE_COLOR, "Active edge"));
+
+    for (i, (color, label)) in entries.iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let y = y0 + i as f32 * row_h;
+        let p0 = Pos2::new(x0, y);
+        let p1 = Pos2::new(x0 + line_len, y);
+        painter.line_segment([p0, p1], Stroke::new(2.5, *color));
+        painter.text(
+            Pos2::new(label_x, y - FONT_SIZE / 2.0),
+            Align2::LEFT_TOP,
+            *label,
+            FontId::proportional(FONT_SIZE - 2.0),
+            *color,
+        );
+    }
 }
 
 // converts EUC2D space into GUI coords [0..self.height, 0..self.width]

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -247,15 +247,15 @@ impl eframe::App for ProgressPlot {
             .show(ctx, |ui| {
                 let painter = ui.painter();
 
-                // Layer 0: optimal tour (lime green) — always visible as reference
+                // Layer 0: optimal tour (lime green, thin) — always visible as reference
                 for (from, to) in &self.optimal_edges {
-                    painter.line_segment([*from, *to], Stroke::new(2.0, OPTIMAL_EDGE_COLOR));
+                    painter.line_segment([*from, *to], Stroke::new(1.5, OPTIMAL_EDGE_COLOR));
                 }
 
                 // Layer 1: solver route
                 if self.is_solved {
                     for (from, to) in &self.best_edges {
-                        painter.line_segment([*from, *to], Stroke::new(2.5, BEST_EDGE_COLOR));
+                        painter.line_segment([*from, *to], Stroke::new(4.0, BEST_EDGE_COLOR));
                     }
                 } else {
                     for (from, to) in &self.current_edges {

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -450,6 +450,84 @@ fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: b
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::kdtree::build_points;
+    use crate::tsp::route::Route;
+
+    #[test]
+    fn test_route_edge_keys_triangle() {
+        let route = Route::new(&[1, 2, 3]);
+        let keys = ProgressPlot::route_edge_keys(&route);
+        // Edges: 1-2, 2-3, 3-1 (closing)
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&(1, 2)));
+        assert!(keys.contains(&(2, 3)));
+        assert!(keys.contains(&(1, 3))); // normalized from (3, 1)
+    }
+
+    #[test]
+    fn test_route_edge_keys_normalizes_direction() {
+        // Route 5 → 2 should produce key (2, 5), not (5, 2)
+        let route = Route::new(&[5, 2]);
+        let keys = ProgressPlot::route_edge_keys(&route);
+        assert!(keys.contains(&(2, 5)));
+        assert!(!keys.contains(&(5, 2)));
+    }
+
+    #[test]
+    fn test_cities_bounding_box_basic() {
+        let cities = build_points(&[
+            vec![0.0, 5.0],
+            vec![10.0, 0.0],
+            vec![3.0, 8.0],
+        ]);
+        let bbox = cities_bounding_box(&cities);
+        assert!((bbox[0] - 0.0).abs() < 0.01);  // x_min
+        assert!((bbox[1] - 0.0).abs() < 0.01);  // y_min
+        assert!((bbox[2] - 10.0).abs() < 0.01); // x_max
+        assert!((bbox[3] - 8.0).abs() < 0.01);  // y_max
+    }
+
+    #[test]
+    fn test_cities_bounding_box_single_city() {
+        let cities = build_points(&[vec![7.0, 3.0]]);
+        let bbox = cities_bounding_box(&cities);
+        assert!((bbox[0] - 7.0).abs() < 0.01);
+        assert!((bbox[2] - 7.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_point_to_viewport_corner() {
+        let window = [0.0, 0.0, 10.0, 10.0];
+        let vp = ViewportDimensions::new(100.0, 100.0, 10.0);
+        // The origin of the city space should map to the margin offset
+        let (vx, vy) = point_to_viewport(0.0, 0.0, &window, &vp);
+        assert!((vx - 10.0).abs() < 0.01);
+        assert!((vy - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_point_to_viewport_far_corner() {
+        let window = [0.0, 0.0, 10.0, 10.0];
+        let vp = ViewportDimensions::new(100.0, 100.0, 10.0);
+        // The far corner of city space maps to width - margin
+        let (vx, vy) = point_to_viewport(10.0, 10.0, &window, &vp);
+        assert!((vx - 90.0).abs() < 0.01);
+        assert!((vy - 90.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_point_to_viewport_centre() {
+        let window = [0.0, 0.0, 10.0, 10.0];
+        let vp = ViewportDimensions::new(100.0, 100.0, 0.0);
+        let (vx, vy) = point_to_viewport(5.0, 5.0, &window, &vp);
+        assert!((vx - 50.0).abs() < 0.01);
+        assert!((vy - 50.0).abs() < 0.01);
+    }
+}
+
 // converts EUC2D space into GUI coords [0..self.height, 0..self.width]
 fn point_to_viewport(
     x: f64,

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 use eframe;
 use eframe::egui::{self, Align2, Color32, FontId, Pos2, Rect, Stroke};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 
@@ -24,7 +24,8 @@ const WHITE:              Color32 = Color32::from_rgb(255, 255, 255);
 const CITY_COLOR:         Color32 = Color32::from_rgb(30,  30,  30);   // near-black nodes
 const CURRENT_CITY_COLOR: Color32 = Color32::from_rgb(220, 30,  30);   // red — active city
 const BEST_EDGE_COLOR:    Color32 = Color32::from_rgb(34,  139, 34);   // green — best route
-const OPTIMAL_EDGE_COLOR: Color32 = Color32::from_rgb(50,  205, 50);   // lime — known-optimal route
+const SHARED_EDGE_COLOR:  Color32 = Color32::from_rgb(0,   100, 0);    // very dark green — shared optimal+solver
+const UNIQUE_OPT_COLOR:   Color32 = Color32::from_rgb(180, 180, 180);  // light gray — optimal only (solver missed)
 const CURRENT_EDGE_COLOR: Color32 = Color32::from_rgb(30,  100, 220);  // blue — exploring route
 const ACTIVE_EDGE_COLOR:  Color32 = Color32::from_rgb(255, 140, 0);    // orange — current step
 const STATUS_COLOR:       Color32 = Color32::from_rgb(220, 30,  30);   // red — status text
@@ -85,9 +86,10 @@ struct NodeData {
 pub struct ProgressPlot {
     city_table: HashMap<usize, KDPoint>,
     nodes: Vec<NodeData>,
-    best_edges: Vec<EdgeData>,    // shown in green after Done
-    optimal_edges: Vec<EdgeData>, // lime green — known-optimal tour overlay
-    current_edges: Vec<EdgeData>, // shown in blue while solving
+    best_edges: Vec<EdgeData>,                          // shown in green after Done
+    best_edge_keys: HashSet<(usize, usize)>,            // normalized city-id pairs for solver's best route
+    optimal_edge_data: Vec<((usize, usize), EdgeData)>, // (normalized city-id pair, screen coords)
+    current_edges: Vec<EdgeData>,                       // shown in blue while solving
     current_city_id: Option<usize>,
     prev_city_id: Option<usize>,
     best_distance: f32,
@@ -106,7 +108,8 @@ impl ProgressPlot {
             city_table: HashMap::new(),
             nodes: Vec::new(),
             best_edges: Vec::new(),
-            optimal_edges: Vec::new(),
+            best_edge_keys: HashSet::new(),
+            optimal_edge_data: Vec::new(),
             current_edges: Vec::new(),
             current_city_id: None,
             prev_city_id: None,
@@ -176,6 +179,7 @@ impl ProgressPlot {
                 if *distance > 0.0 && *distance < self.best_distance {
                     self.best_distance = *distance;
                     self.best_edges = self.current_edges.clone();
+                    self.best_edge_keys = Self::route_edge_keys(route);
                 }
 
                 self.status = format!("Solving... | best: {:.2}", self.best_distance);
@@ -187,7 +191,7 @@ impl ProgressPlot {
             }
             ProgressMessage::OptimalTour(city_ids) => {
                 let route = Route::new(city_ids.as_slice());
-                self.optimal_edges = self.build_route_edges(&route);
+                self.optimal_edge_data = self.build_route_edge_data(&route);
             }
             _ => {}
         }
@@ -208,6 +212,36 @@ impl ProgressPlot {
                 pos: Pos2::new(sx as f32, sy as f32),
             });
         }
+    }
+
+    fn route_edge_keys(route: &Route) -> HashSet<(usize, usize)> {
+        let path = route.route();
+        let n = path.len();
+        (0..n)
+            .map(|i| {
+                let a = path[i];
+                let b = path[(i + 1) % n];
+                (a.min(b), a.max(b))
+            })
+            .collect()
+    }
+
+    fn build_route_edge_data(&self, route: &Route) -> Vec<((usize, usize), EdgeData)> {
+        let path = route.route().to_vec();
+        let n = path.len();
+        let mut data = Vec::new();
+        for i in 0..n {
+            let a = path[i];
+            let b = path[(i + 1) % n];
+            if let (Some(from), Some(to)) = (
+                self.city_table.get(&a).cloned(),
+                self.city_table.get(&b).cloned(),
+            ) {
+                let edge = build_edge(&from, &to, &self.cities_bounding_box, &self.viewport_dimensions);
+                data.push(((a.min(b), a.max(b)), edge));
+            }
+        }
+        data
     }
 
     fn build_route_edges(&self, route: &Route) -> Vec<EdgeData> {
@@ -247,9 +281,16 @@ impl eframe::App for ProgressPlot {
             .show(ctx, |ui| {
                 let painter = ui.painter();
 
-                // Layer 0: optimal tour (lime green, thin) — always visible as reference
-                for (from, to) in &self.optimal_edges {
-                    painter.line_segment([*from, *to], Stroke::new(1.5, OPTIMAL_EDGE_COLOR));
+                // Layer 0: optimal tour — shared edges (very dark green, thick) vs. missed (light gray)
+                if !self.optimal_edge_data.is_empty() {
+                    for ((a, b), (from, to)) in &self.optimal_edge_data {
+                        let key = (*a, *b);
+                        if !self.best_edge_keys.is_empty() && self.best_edge_keys.contains(&key) {
+                            painter.line_segment([*from, *to], Stroke::new(6.0, SHARED_EDGE_COLOR));
+                        } else {
+                            painter.line_segment([*from, *to], Stroke::new(1.5, UNIQUE_OPT_COLOR));
+                        }
+                    }
                 }
 
                 // Layer 1: solver route
@@ -304,7 +345,7 @@ impl eframe::App for ProgressPlot {
                 );
 
                 // Legend (bottom-left); painter is already &Painter — do NOT add &
-                draw_legend(painter, &self.viewport_dimensions, !self.optimal_edges.is_empty());
+                draw_legend(painter, &self.viewport_dimensions, !self.optimal_edge_data.is_empty());
             });
 
         // Poll at ~60fps while solver runs; avoids burning a full CPU core.
@@ -377,18 +418,21 @@ fn cities_bounding_box(cities: &[KDPoint]) -> RectCoords {
 #[allow(clippy::cast_possible_truncation)]
 fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: bool) {
     let x0 = vp.margin as f32;
-    let y0 = vp.height as f32 - vp.margin as f32 - 80.0;
     let line_len = 24.0_f32;
     let row_h = 20.0_f32;
     let label_x = x0 + line_len + 6.0;
 
     let mut entries: Vec<(Color32, &str)> = Vec::new();
     if show_optimal {
-        entries.push((OPTIMAL_EDGE_COLOR, "Optimal tour"));
+        entries.push((SHARED_EDGE_COLOR, "Shared (optimal ∩ solver)"));
+        entries.push((UNIQUE_OPT_COLOR,  "Optimal only (missed)"));
     }
     entries.push((BEST_EDGE_COLOR, "Solver best"));
     entries.push((CURRENT_EDGE_COLOR, "Solver current"));
     entries.push((ACTIVE_EDGE_COLOR, "Active edge"));
+
+    #[allow(clippy::cast_precision_loss)]
+    let y0 = vp.height as f32 - vp.margin as f32 - entries.len() as f32 * row_h - 4.0;
 
     for (i, (color, label)) in entries.iter().enumerate() {
         #[allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
## Summary

- **Bug fix**: GA was sending `1/tour_length` (inverted fitness) as the `distance` field in `PathUpdate`. `progress.rs` interprets smaller distance as better, so GA improvements never updated `best_edges`. Visualization locked on the first random-population route showing a zig-zag with "Done | best: 0.00". Fixed by passing `distances` into `solve_ga` and sending `distances.tour_length(genotype)`.
- **Visualization**: Replaced flat lime-green optimal-tour overlay with a two-color edge comparison — shared edges (in both optimal and solver best) drawn as very dark green (6px); edges only in optimal drawn as light gray (1.5px). Legend updated with dynamic row height.
- **Coverage**: Added 24 new unit tests across `opt_tour.rs`, `progress.rs`, and `main.rs` covering EOF termination, missing header fields, pure coordinate math functions, and all `solver_options_from_args` branches.

## Test plan

- [x] `cargo test` — 135 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] GA visualization regression: `Done | best:` now shows real tour length, not `0.00`
- [x] Edge comparison: shared edges appear dark green thick, missed edges appear light gray