### PR TITLE
feat: visualization off by default; --gui flag to enable it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/bin nn
 
 - The binary is named `bin` (not `teeline`) — set by `[[bin]] name = "bin"` in `Cargo.toml`.
 - `bellman_karp` and `branch_bound` are exact algorithms with factorial/exponential complexity — don't use them on datasets larger than ~30 cities.
-- The progress window (Piston) always opens unless `--disable_progress` is passed. In headless/CI environments this will fail; the CI workflow (`cargo test`) avoids running the binary directly.
+- The visualization window is **off by default**. Pass `--gui` to open it. In headless/CI environments never pass `--gui`; the CI workflow (`cargo test`) avoids running the binary directly.
 - TSPLIB parsing normalizes all keys to uppercase and lowercases metadata values; city coordinates are stored as `f32`.
 - `convert2tsplib.py` converts raw coordinate lists to TSPLIB format; `download_data.sh` fetches benchmark datasets.
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ teeline nn -i ./data/tsplib/berlin52.tsp
 # from stdin
 cat ./data/tsplib/berlin52.tsp | teeline nn
 
-# headless / CI — skip the visualisation window
-teeline nn -i ./data/tsplib/berlin52.tsp --disable_progress
+# with the visualization window
+teeline nn -i ./data/tsplib/berlin52.tsp --gui
 ```
 
 Output format:
@@ -267,7 +267,7 @@ Resources:
 
 ## Visualising Results
 
-While solving, Teeline opens a window that shows the current best route updating in real time. Pass `--disable_progress` to suppress it (required in headless / CI environments).
+While solving, Teeline runs headless by default. Pass `--gui` to open a window that shows the current best route updating in real time.
 
 ### Comparing against a known-optimal tour
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,9 +86,9 @@ fn main() {
                 .required(false),
         )
         .arg(
-            Arg::new("disable_progress")
-                .long("disable_progress")
-                .help("Doesnt show any progress or visualization, default false")
+            Arg::new("gui")
+                .long("gui")
+                .help("Open the visualization window while solving")
                 .action(ArgAction::SetTrue)
                 .required(false),
         )
@@ -281,7 +281,7 @@ mod tests {
         Command::new("test")
             .arg(Arg::new("solver").index(1).required(true))
             .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue))
-            .arg(Arg::new("disable_progress").long("disable_progress").action(ArgAction::SetTrue))
+            .arg(Arg::new("gui").long("gui").action(ArgAction::SetTrue))
             .arg(Arg::new("epochs").long("epochs"))
             .arg(Arg::new("platoo_epochs").long("platoo_epochs"))
             .arg(Arg::new("n_nearest").long("n_nearest"))
@@ -298,7 +298,7 @@ mod tests {
         let opts = solver_options_from_args(&args);
         let defaults = SolverOptions::default();
         assert!(!opts.verbose);
-        assert!(opts.show_progress);
+        assert!(!opts.show_progress);
         assert_eq!(opts.epochs, defaults.epochs);
         assert_eq!(opts.n_nearest, defaults.n_nearest);
     }
@@ -310,9 +310,9 @@ mod tests {
     }
 
     #[test]
-    fn test_solver_options_disable_progress_clears_show_progress() {
-        let args = options_cmd().get_matches_from(["test", "nn", "--disable_progress"]);
-        assert!(!solver_options_from_args(&args).show_progress);
+    fn test_solver_options_gui_flag_enables_progress() {
+        let args = options_cmd().get_matches_from(["test", "nn", "--gui"]);
+        assert!(solver_options_from_args(&args).show_progress);
     }
 
     #[test]
@@ -385,8 +385,8 @@ fn solver_options_from_args(args: &ArgMatches) -> SolverOptions {
         options.verbose = true;
     }
 
-    if args.get_flag("disable_progress") {
-        options.show_progress = false;
+    if args.get_flag("gui") {
+        options.show_progress = true;
     }
 
     if let Some(n_epochs_str) = args.get_one::<String>("epochs") {

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -102,7 +102,7 @@ impl Default for SolverOptions {
             cooling_rate: 0.0001,
             min_temperature: 0.001,
             max_temperature: 1_000.0,
-            show_progress: true,
+            show_progress: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Visualization window is now **off by default** — the solver runs headless unless `--gui` is passed
- `--disable_progress` flag removed; replaced by `--gui` (opposite polarity)
- `SolverOptions::default()` `show_progress` flipped from `true` → `false`
- Tests, CLAUDE.md, and README updated

## Test plan

- [x] `cargo test` — 135 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp` — runs headless, prints result, no window
- [x] `./target/debug/bin nn -i data/tsplib/berlin52.tsp --gui` — opens visualization window