### PR TITLE
feat(pso): Discrete Particle Swarm Optimization solver (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/bin nn
 | `simulated_annealing.rs` | Simulated annealing | `sa` |
 | `tabu_search.rs` | Tabu search | — |
 | `genetic_algorithm.rs` | Genetic algorithm | `ga` |
+| `particle_swarm.rs` | Discrete PSO (velocity-capped, linearly decaying inertia, NN-seeded) | `pso` |
 
 **Tests:**
 - Unit tests live inline in each source file (`#[cfg(test)]`)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,35 @@ Resources:
 - [Genetic algorithm (Wikipedia)](https://en.wikipedia.org/wiki/Genetic_algorithm)
 - *AIMA*, Section 4.1.4 — Genetic Algorithms
 
+#### Particle Swarm Optimisation (`particle_swarm`, `pso`)
+
+Swarm metaheuristic: each particle is a candidate tour that moves through the search space pulled toward its own personal best and the global best tour found so far. The velocity is an ordered list of position swaps rather than a continuous vector.
+
+**TSP-specific adaptations** (deviations from the textbook Clerc 2004 algorithm):
+
+| Adaptation | Why |
+|---|---|
+| Velocity cap at `⌈0.35 · n⌉` swaps | Without a cap, steady-state velocity grows to ~5 n swaps, scrambling the tour into noise |
+| Linear inertia decay W: 0.9 → 0.4 | High inertia early for broad exploration; decays like a cooling schedule so late epochs fine-tune around the best region found |
+| Particle 0 seeded with a greedy NN tour | Gives the swarm a good starting neighbourhood; remaining particles are random for diversity |
+
+Options:
+| Flag | Description | Default |
+|---|---|---|
+| `--epochs` | Maximum iterations | 10 000 |
+| `--n_nearest` | Number of particles (floored at 30) | 30 |
+
+```bash
+teeline pso -i ./data/tsplib/berlin52.tsp
+teeline particle_swarm -i ./data/tsplib/berlin52.tsp --epochs=500
+teeline pso -i ./data/tsplib/berlin52.tsp --n_nearest=50
+```
+
+Resources:
+- [Particle swarm optimisation (Wikipedia)](https://en.wikipedia.org/wiki/Particle_swarm_optimization)
+- Kennedy & Eberhart (1995) — *Particle Swarm Optimization*
+- Clerc (2004) — *Discrete Particle Swarm Optimization, illustrated by the Traveling Salesman Problem*
+
 ---
 
 ## Visualising Results

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ fn solve(
         Solvers::SimulatedAnnealing => tsp::simulated_annealing::solve(cities, distances, options),
         Solvers::TabuSearch => tsp::tabu_search::solve(cities, distances, options),
         Solvers::GeneticAlgorithm => tsp::genetic_algorithm::solve(cities, distances, options),
+        Solvers::ParticleSwarmOptimization => tsp::particle_swarm::solve(cities, distances, options),
         _ => panic!("Unspecified solver"),
     }
 }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -10,6 +10,7 @@ pub mod simulated_annealing;
 pub mod stochastic_hill;
 pub mod tabu_search;
 pub mod opt_tour;
+pub mod particle_swarm;
 pub mod tsplib;
 pub mod two_opt;
 
@@ -29,6 +30,7 @@ pub enum Solvers {
     BranchBound,
     NearestNeighbor,
     GeneticAlgorithm,
+    ParticleSwarmOptimization,
     SimulatedAnnealing,
     StochasticHill,
     TabuSearch,
@@ -46,6 +48,8 @@ impl Solvers {
             "nn",
             "genetic_algorithm",
             "ga",
+            "particle_swarm",
+            "pso",
             "simulated_annealing",
             "sa",
             "stochastic_hill",
@@ -65,6 +69,7 @@ impl FromStr for Solvers {
             "branch_bound" => Ok(Solvers::BranchBound),
             "nn" | "nearest_neighbor" => Ok(Solvers::NearestNeighbor),
             "ga" | "genetic_algorithm" => Ok(Solvers::GeneticAlgorithm),
+            "pso" | "particle_swarm" => Ok(Solvers::ParticleSwarmOptimization),
             "sa" | "simulated_annealing" => Ok(Solvers::SimulatedAnnealing),
             "stochastic_hill" => Ok(Solvers::StochasticHill),
             "tabu_search" => Ok(Solvers::TabuSearch),

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -9,11 +9,40 @@ use super::{Solution, SolverOptions};
 type Swap = (usize, usize);
 type Velocity = Vec<Swap>;
 
-// PSO hyper-parameters (Clerc 2004 recommendations)
-const W: f64 = 0.7;  // inertia weight
-const C1: f64 = 1.5; // cognitive coefficient
-const C2: f64 = 1.5; // social coefficient
+// PSO hyper-parameters
+const W_MAX: f64 = 0.9; // inertia at epoch 0 (exploration)
+const W_MIN: f64 = 0.4; // inertia at final epoch (exploitation)
+const C1: f64 = 1.5;    // cognitive coefficient
+const C2: f64 = 1.5;    // social coefficient
 const DEFAULT_N_PARTICLES: usize = 30;
+// Without a velocity cap, steady-state swap-list length ≈ (C1+C2)*0.5*(n−1)/(1−W) ≈ 5n,
+// which scrambles the tour completely.  Capping at ~n/3 gives directional movement.
+const V_MAX_FACTOR: f64 = 0.35;
+
+/// Greedy nearest-neighbour tour starting from the first city in `city_ids`.
+/// Used to seed particle 0 so the swarm starts from a reasonable neighbourhood.
+fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
+    let n = city_ids.len();
+    let mut unvisited: Vec<usize> = city_ids.to_vec();
+    let mut tour = Vec::with_capacity(n);
+    let mut current = unvisited.swap_remove(0);
+    tour.push(current);
+    while !unvisited.is_empty() {
+        let best_pos = unvisited
+            .iter()
+            .enumerate()
+            .min_by(|(_, &a), (_, &b)| {
+                let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
+                let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        current = unvisited.swap_remove(best_pos);
+        tour.push(current);
+    }
+    tour
+}
 
 /// Greedy swap sequence that converts `from` into `to`.
 ///
@@ -57,19 +86,26 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let n_cities = cities.len();
     // n_nearest is repurposed as n_particles; floor at DEFAULT_N_PARTICLES
     let n_particles = options.n_nearest.max(DEFAULT_N_PARTICLES);
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    let v_max = ((n_cities as f64 * V_MAX_FACTOR).ceil() as usize).max(1);
 
     let mut rng = rand::rng();
     let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
 
-    // Initialise: each particle gets a Fisher-Yates shuffled tour
+    // Particle 0 is seeded with a greedy NN tour so gbest starts from a good neighbourhood.
+    // The rest are random Fisher-Yates shuffles to maintain diversity.
     let mut positions: Vec<Vec<usize>> = (0..n_particles)
-        .map(|_| {
-            let mut p = city_ids.clone();
-            for i in (1..n_cities).rev() {
-                let j = rng.random_range(0..=i);
-                p.swap(i, j);
+        .map(|idx| {
+            if idx == 0 {
+                nn_seed(&city_ids, distances)
+            } else {
+                let mut p = city_ids.clone();
+                for i in (1..n_cities).rev() {
+                    let j = rng.random_range(0..=i);
+                    p.swap(i, j);
+                }
+                p
             }
-            p
         })
         .collect();
 
@@ -88,14 +124,21 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
     send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
 
-    for epoch in 0..options.epochs {
+    let epochs = options.epochs;
+    for epoch in 0..epochs {
+        // Linearly decay inertia weight from W_MAX (exploration) to W_MIN (exploitation).
+        // Mirrors simulated annealing's cooling schedule: high randomness early,
+        // fine-tuning near convergence.
+        #[allow(clippy::cast_precision_loss)]
+        let w = W_MAX - (W_MAX - W_MIN) * (epoch as f64 / epochs.max(1) as f64);
+
         for i in 0..n_particles {
             let r1: f64 = rng.random();
             let r2: f64 = rng.random();
 
             // Inertia: keep first round(w * |v|) swaps of current velocity
             #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-            let inertia_keep = (W * velocities[i].len() as f64).round() as usize;
+            let inertia_keep = (w * velocities[i].len() as f64).round() as usize;
 
             // Cognitive: toward personal best
             let cog_diff = swap_sequence(&positions[i], &pbest[i]);
@@ -107,10 +150,13 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
             let soc_keep = (C2 * r2 * soc_diff.len() as f64).round() as usize;
 
-            // New velocity = inertia + cognitive + social
+            // New velocity = inertia + cognitive + social, capped at v_max.
+            // The cap is the discrete analogue of v_max in continuous PSO:
+            // without it the swap list grows to ~5n and scrambles the tour.
             let mut new_vel = trim_velocity(&velocities[i], inertia_keep);
             new_vel.extend(trim_velocity(&cog_diff, cog_keep));
             new_vel.extend(trim_velocity(&soc_diff, soc_keep));
+            new_vel.truncate(v_max);
 
             // Update position and velocity
             let new_pos = apply_swaps(&positions[i], &new_vel);
@@ -169,6 +215,23 @@ mod tests {
         assert_eq!(trim_velocity(&v, 2), vec![(0, 1), (1, 2)]);
         assert_eq!(trim_velocity(&v, 0), vec![]);
         assert_eq!(trim_velocity(&v, 10), v);
+    }
+
+    #[test]
+    fn test_nn_seed_visits_all_cities() {
+        let ids = vec![0, 1, 2, 3];
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.0],
+            vec![0.0, 1.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let tour = nn_seed(&city_ids, &dm);
+        let mut sorted = tour.clone();
+        sorted.sort();
+        assert_eq!(sorted, ids);
     }
 
     #[test]

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -1,0 +1,192 @@
+use rand::Rng;
+
+use super::distance_matrix::DistanceMatrix;
+use super::kdtree::KDPoint;
+use super::progress::{send_progress, ProgressMessage};
+use super::route::Route;
+use super::{Solution, SolverOptions};
+
+type Swap = (usize, usize);
+type Velocity = Vec<Swap>;
+
+// PSO hyper-parameters (Clerc 2004 recommendations)
+const W: f64 = 0.7;  // inertia weight
+const C1: f64 = 1.5; // cognitive coefficient
+const C2: f64 = 1.5; // social coefficient
+const DEFAULT_N_PARTICLES: usize = 30;
+
+/// Greedy swap sequence that converts `from` into `to`.
+///
+/// Iterates positions 0..n-1; the last position auto-aligns, so no
+/// out-of-bounds slice access occurs on valid permutations.
+fn swap_sequence(from: &[usize], to: &[usize]) -> Velocity {
+    let n = from.len();
+    let mut tmp = from.to_vec();
+    let mut seq = Vec::new();
+
+    for i in 0..n.saturating_sub(1) {
+        if tmp[i] != to[i] {
+            // to[i] must exist at some j > i because positions 0..i already match
+            let j = tmp[i + 1..]
+                .iter()
+                .position(|&x| x == to[i])
+                .map(|p| p + i + 1)
+                .expect("swap_sequence: permutations must share the same elements");
+            seq.push((i, j));
+            tmp.swap(i, j);
+        }
+    }
+    seq
+}
+
+/// Apply an ordered list of swaps to a position, returning the new position.
+fn apply_swaps(position: &[usize], velocity: &[Swap]) -> Vec<usize> {
+    let mut pos = position.to_vec();
+    for &(i, j) in velocity {
+        pos.swap(i, j);
+    }
+    pos
+}
+
+/// Scalar-multiply a velocity: keep the first `keep` swaps (clamped to length).
+fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
+    v.iter().take(keep).copied().collect()
+}
+
+pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+    let n_cities = cities.len();
+    // n_nearest is repurposed as n_particles; floor at DEFAULT_N_PARTICLES
+    let n_particles = options.n_nearest.max(DEFAULT_N_PARTICLES);
+
+    let mut rng = rand::rng();
+    let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+
+    // Initialise: each particle gets a Fisher-Yates shuffled tour
+    let mut positions: Vec<Vec<usize>> = (0..n_particles)
+        .map(|_| {
+            let mut p = city_ids.clone();
+            for i in (1..n_cities).rev() {
+                let j = rng.random_range(0..=i);
+                p.swap(i, j);
+            }
+            p
+        })
+        .collect();
+
+    let mut velocities: Vec<Velocity> = vec![Vec::new(); n_particles];
+    let mut pbest: Vec<Vec<usize>> = positions.clone();
+    let mut pbest_cost: Vec<f32> = pbest.iter().map(|p| distances.tour_length(p)).collect();
+
+    // Global best
+    let (best_idx, _) = pbest_cost
+        .iter()
+        .enumerate()
+        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .unwrap();
+    let mut gbest: Vec<usize> = pbest[best_idx].clone();
+    let mut gbest_cost: f32 = pbest_cost[best_idx];
+
+    send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+
+    for epoch in 0..options.epochs {
+        for i in 0..n_particles {
+            let r1: f64 = rng.random();
+            let r2: f64 = rng.random();
+
+            // Inertia: keep first round(w * |v|) swaps of current velocity
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let inertia_keep = (W * velocities[i].len() as f64).round() as usize;
+
+            // Cognitive: toward personal best
+            let cog_diff = swap_sequence(&positions[i], &pbest[i]);
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let cog_keep = (C1 * r1 * cog_diff.len() as f64).round() as usize;
+
+            // Social: toward global best
+            let soc_diff = swap_sequence(&positions[i], &gbest);
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let soc_keep = (C2 * r2 * soc_diff.len() as f64).round() as usize;
+
+            // New velocity = inertia + cognitive + social
+            let mut new_vel = trim_velocity(&velocities[i], inertia_keep);
+            new_vel.extend(trim_velocity(&cog_diff, cog_keep));
+            new_vel.extend(trim_velocity(&soc_diff, soc_keep));
+
+            // Update position and velocity
+            let new_pos = apply_swaps(&positions[i], &new_vel);
+            positions[i] = new_pos;
+            velocities[i] = new_vel;
+
+            // Evaluate and update bests
+            let cost = distances.tour_length(&positions[i]);
+
+            if cost < pbest_cost[i] {
+                pbest[i] = positions[i].clone();
+                pbest_cost[i] = cost;
+            }
+            if cost < gbest_cost {
+                gbest = positions[i].clone();
+                gbest_cost = cost;
+                send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+            }
+        }
+
+        send_progress(ProgressMessage::EpochUpdate(epoch));
+    }
+
+    send_progress(ProgressMessage::Done);
+    Solution::new(&gbest, cities, distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{distance_matrix, kdtree};
+
+    #[test]
+    fn test_swap_sequence_converts_from_to_to() {
+        let from = vec![1, 2, 3, 4];
+        let to = vec![1, 3, 2, 4];
+        let seq = swap_sequence(&from, &to);
+        assert_eq!(apply_swaps(&from, &seq), to);
+    }
+
+    #[test]
+    fn test_swap_sequence_identity_returns_empty() {
+        let v = vec![1, 2, 3, 4];
+        assert!(swap_sequence(&v, &v).is_empty());
+    }
+
+    #[test]
+    fn test_apply_swaps_empty_velocity_is_identity() {
+        let pos = vec![1, 2, 3];
+        assert_eq!(apply_swaps(&pos, &[]), pos);
+    }
+
+    #[test]
+    fn test_trim_velocity_truncates_and_clamps() {
+        let v: Velocity = vec![(0, 1), (1, 2), (2, 3)];
+        assert_eq!(trim_velocity(&v, 2), vec![(0, 1), (1, 2)]);
+        assert_eq!(trim_velocity(&v, 0), vec![]);
+        assert_eq!(trim_velocity(&v, 10), v);
+    }
+
+    #[test]
+    fn test_solve_returns_valid_tour_on_small_instance() {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.0],
+            vec![0.0, 1.0],
+        ]);
+        let distances = distance_matrix::from_cities(&cities);
+        let options = SolverOptions {
+            epochs: 20,
+            n_nearest: 5,
+            ..SolverOptions::default()
+        };
+        let sol = solve(&cities, &distances, &options);
+        assert_eq!(sol.route().len(), cities.len());
+        assert!(sol.total > 0.0);
+    }
+}

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -13,7 +13,8 @@
 use std::path::Path;
 use teeline::tsp::{
     bellman_karp, branch_bound, distance_matrix, genetic_algorithm, kdtree, nearest_neighbor,
-    simulated_annealing, stochastic_hill, tabu_search, two_opt, tsplib, SolverOptions,
+    particle_swarm, simulated_annealing, stochastic_hill, tabu_search, two_opt, tsplib,
+    SolverOptions,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -145,6 +146,19 @@ fn genetic_algorithm_valid_tour_berlin52() {
     let tour = genetic_algorithm::solve(&cities, &build_dm(&cities), &opts);
 
     assert!(is_valid_tour(tour.route(), &cities), "GA tour is not valid on berlin52");
+}
+
+// ─── particle swarm optimisation ─────────────────────────────────────────────
+
+#[test]
+fn particle_swarm_valid_tour_berlin52() {
+    let cities = load_berlin52();
+    let tour = particle_swarm::solve(&cities, &build_dm(&cities), &stochastic_options(200));
+
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "PSO tour is not valid on berlin52"
+    );
 }
 
 // ─── exact solvers (small instance only) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `src/tsp/particle_swarm.rs` with a Discrete PSO solver: position = tour permutation `Vec<usize>`, velocity = ordered list of index-swap pairs
- Hyper-parameters follow Clerc 2004 recommendations: w=0.7, c1=c2=1.5, n_particles floored at 30 (controlled via `--n_nearest`)
- Registered as `pso` / `particle_swarm` in the `Solvers` enum and CLI dispatcher

## Implementation notes

- `swap_sequence(from, to)` builds the minimal greedy swap list converting one permutation to another; iterates `0..n-1` so the last city auto-aligns without risk of out-of-bounds access
- Velocity update: `new_vel = trim(inertia) + trim(cognitive toward pbest) + trim(social toward gbest)` with per-particle, per-epoch random scalars r1, r2
- Sends `ProgressMessage::PathUpdate` on every gbest improvement, compatible with `--gui` visualization

## Test plan

- [x] 5 unit tests in `src/tsp/particle_swarm.rs` (swap_sequence, apply_swaps, trim_velocity, end-to-end on 4-city instance)
- [x] Integration test `particle_swarm_valid_tour_berlin52` in `tests/solvers_integration.rs`
- [x] `cargo test` — all 19 integration tests + all unit tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Headless smoke test on berlin52: produces two-line output, no panic