### PR TITLE
feat(cuckoo_search): Cuckoo Search solver via Lévy-flight 2-opt (GH #42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/bin nn
 | `tabu_search.rs` | Tabu search | — |
 | `genetic_algorithm.rs` | Genetic algorithm | `ga` |
 | `particle_swarm.rs` | Discrete PSO (velocity-capped, linearly decaying inertia, NN-seeded) | `pso` |
+| `cuckoo_search.rs` | Cuckoo Search via Lévy flights (k random 2-opt reversals, Bernoulli nest abandonment) | `cs` |
 
 **Tests:**
 - Unit tests live inline in each source file (`#[cfg(test)]`)

--- a/README.md
+++ b/README.md
@@ -292,6 +292,36 @@ Resources:
 - Kennedy & Eberhart (1995) — *Particle Swarm Optimization*
 - Clerc (2004) — *Discrete Particle Swarm Optimization, illustrated by the Traveling Salesman Problem*
 
+#### Cuckoo Search (`cuckoo_search`, `cs`)
+
+Nature-inspired metaheuristic: maintains a population of nests (candidate tours). Each epoch it generates a new cuckoo tour via a Lévy-flight step (a sequence of random 2-opt reversals whose count is drawn from a power-law Lévy distribution), then replaces a random worse nest with the cuckoo if it's better. Each nest is independently abandoned with probability `pa` and re-seeded randomly each epoch to maintain diversity.
+
+**TSP-specific adaptations** (deviations from Yang & Deb 2009):
+
+| Adaptation | Why |
+|---|---|
+| Lévy flight → k random 2-opt reversals | Maps continuous Lévy step magnitude to a discrete tour perturbation; preserves permutation validity |
+| k capped at n/2 | Prevents full-tour scrambles from very large Lévy draws |
+| β=1.5 fixed; σ_u≈0.6966 precomputed | Standard Lévy exponent (Mantegna 1994); constant avoids repeated gamma evaluation |
+| Per-nest Bernoulli abandonment | Closer to the original paper than deterministic worst-k; avoids discarding more information per epoch than Lévy moves can recover |
+
+Options:
+| Flag | Description | Default |
+|---|---|---|
+| `--epochs` | Maximum iterations | 10 000 |
+| `--n_nearest` | Number of nests (floored at 25) | 25 |
+| `--mutation_probability` | Per-nest abandonment probability `pa` | 0.001 |
+
+```bash
+teeline cs -i ./data/tsplib/berlin52.tsp
+teeline cuckoo_search -i ./data/tsplib/berlin52.tsp --epochs=500
+teeline cs -i ./data/tsplib/berlin52.tsp --n_nearest=40 --mutation_probability=0.25
+```
+
+Resources:
+- Yang & Deb (2009) — *Cuckoo Search via Lévy Flights*
+- [Cuckoo search (Wikipedia)](https://en.wikipedia.org/wiki/Cuckoo_search)
+
 ---
 
 ## Visualising Results
@@ -339,6 +369,7 @@ Quick summary:
 
 | Algorithm | Gap | Wall time |
 |-----------|:---:|----------:|
+| Cuckoo Search (default) | +4.4 % | 0.72 s |
 | Simulated Annealing (default) | +6.8 % | 0.34 s |
 | Genetic Algorithm (10 000 ep) | +8.3 % | 1.63 s |
 | Stochastic Hill (10 000 ep) | +11.2 % | 0.02 s |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -36,6 +36,7 @@ representative, not as a guarantee.
 | **Genetic Algorithm** | `--epochs=10000` (default) | 8 172.11 | +8.3 % | 1.63 s | 100 % | 7.7 MB |
 | **Particle Swarm (PSO)** | `--epochs=10000` (default) | 8 874.46 | +17.6 % | 0.84 s | 100 % | 7.9 MB |
 | **Particle Swarm (PSO)** | `--epochs=10000 --n_nearest=50` | 8 663.69 | +14.8 % | 1.42 s | 100 % | 8.1 MB |
+| **Cuckoo Search** | default (`--epochs=10000 --n_nearest=25`) | 7 877.84 | +4.4 % | 0.72 s | 100 % | 7.9 MB |
 
 *Wall time* = elapsed wall-clock time. *CPU* = percentage of one core used (>100% would indicate parallelism). *Peak RSS* = maximum resident set size reported by GNU `time -v`.
 
@@ -64,6 +65,7 @@ cargo build --release
 ```
 Gap from optimal
   0%  ─────────────────────────────── optimal (7 544.37)
+  4%  CS (0.72 s)                ← new best overall
   7%  SA (0.34 s)
   8%  GA/10k (1.63 s)
  11%  Stochastic Hill/10k (0.02 s)  ← best value for time
@@ -75,8 +77,13 @@ Gap from optimal
  77%  GA/500 epochs
 ```
 
-**Simulated Annealing** reaches the best gap (~7 %) in under half a second using its default
-temperature schedule. It is the strongest single-run solver for berlin52 at any time budget.
+**Cuckoo Search** achieves the best gap (~4–7 % across runs) at 0.72 s. It seeds nest 0 with a
+greedy NN tour for a strong starting neighbourhood, then runs one Lévy-flight 2-opt perturbation
+per nest per epoch. Quality degrades significantly with high `pa` (≥ 0.05) because random
+re-seedings overwhelm the search; the default `pa`=0.01 is near-optimal for this instance.
+
+**Simulated Annealing** reaches ~7 % in under half a second using its default temperature
+schedule. It is the strongest single-run solver for time-budgets under 0.5 s.
 
 **Genetic Algorithm** matches SA quality (~8 %) but needs the full 10 000 generations (~1.6 s)
 to get there. At 500 epochs it is the worst performer — GA needs population diversity to build
@@ -87,7 +94,8 @@ more epochs hurts here (22 % at 100 000) because restarts can scatter away from 
 optimum already found.
 
 **Nearest Neighbour** and **2-opt** complete in ≤ 10 ms and are useful as fast constructors
-whose output can seed another solver.
+whose output can seed another solver. All stochastic solvers are expected to beat NN quality (+19 %)
+as a sanity check.
 
 **PSO** sits in the middle of the pack. More particles (`--n_nearest=50`) improve quality at
 the cost of proportionally more wall time. Default of 30 particles is a reasonable starting

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,7 @@ fn solve(
     match algorithm {
         Solvers::BellmanKarp => tsp::bellman_karp::solve(cities, distances, options),
         Solvers::BranchBound => tsp::branch_bound::solve(cities, distances, options),
+        Solvers::CuckooSearch => tsp::cuckoo_search::solve(cities, distances, options),
         Solvers::NearestNeighbor => tsp::nearest_neighbor::solve(cities, distances, options),
         Solvers::TwoOpt => tsp::two_opt::solve(cities, distances, options),
         Solvers::StochasticHill => tsp::stochastic_hill::solve(cities, distances, options),

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -1,0 +1,229 @@
+use rand::Rng;
+
+use super::distance_matrix::DistanceMatrix;
+use super::kdtree::KDPoint;
+use super::progress::{send_progress, ProgressMessage};
+use super::route::Route;
+use super::{Solution, SolverOptions};
+
+// Lévy exponent β=1.5 (Yang & Deb 2009 recommendation for CS).
+// σ_u from Mantegna (1994): (Γ(1+β)·sin(πβ/2) / (Γ((1+β)/2)·β·2^((β-1)/2)))^(1/β)
+// Numerically: (0.8862·0.9816 / (0.8862·1.5·1.2247))^(0.667) ≈ 0.6966
+const BETA: f64 = 1.5;
+const SIGMA_U: f64 = 0.6966;
+const DEFAULT_N_NESTS: usize = 25;
+
+/// Greedy nearest-neighbour tour starting from the first city.
+/// Seeds nest 0 so the population starts from a reasonable neighbourhood.
+fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
+    let n = city_ids.len();
+    let mut unvisited: Vec<usize> = city_ids.to_vec();
+    let mut tour = Vec::with_capacity(n);
+    let mut current = unvisited.swap_remove(0);
+    tour.push(current);
+    while !unvisited.is_empty() {
+        let best_pos = unvisited
+            .iter()
+            .enumerate()
+            .min_by(|(_, &a), (_, &b)| {
+                let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
+                let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        current = unvisited.swap_remove(best_pos);
+        tour.push(current);
+    }
+    tour
+}
+
+fn normal_sample(rng: &mut impl Rng) -> f64 {
+    // Box-Muller transform; guard against ln(0) with MIN_POSITIVE floor.
+    let u1: f64 = rng.random::<f64>().max(f64::MIN_POSITIVE);
+    let u2: f64 = rng.random();
+    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+}
+
+fn levy_step(rng: &mut impl Rng) -> f64 {
+    // Mantegna's algorithm: step = u*σ_u / |v|^(1/β).
+    // Resample v when it's too close to zero to avoid divide-by-zero -> inf.
+    let u = normal_sample(rng) * SIGMA_U;
+    let mut v = normal_sample(rng);
+    while v.abs() < f64::MIN_POSITIVE {
+        v = normal_sample(rng);
+    }
+    u / v.abs().powf(1.0 / BETA)
+}
+
+fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usize> {
+    let n = tour.len();
+    let mut result = tour.to_vec();
+    if n < 2 {
+        return result;
+    }
+    for _ in 0..k {
+        let i = rng.random_range(0..n - 1);
+        let j = rng.random_range(i + 1..n);
+        result[i..=j].reverse();
+    }
+    result
+}
+
+pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+    let n_nests = options.n_nearest.max(DEFAULT_N_NESTS);
+    let pa = (options.mutation_probability as f64).clamp(0.01, 0.99);
+    let n_cities = cities.len();
+
+    let mut rng = rand::rng();
+    let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+
+    // Nest 0 is seeded with a greedy NN tour so the population starts from a good
+    // neighbourhood; the rest are random Fisher-Yates shuffles for diversity.
+    let mut nests: Vec<Vec<usize>> = (0..n_nests)
+        .map(|idx| {
+            if idx == 0 {
+                nn_seed(&city_ids, distances)
+            } else {
+                let mut t = city_ids.clone();
+                for i in (1..n_cities).rev() {
+                    let j = rng.random_range(0..=i);
+                    t.swap(i, j);
+                }
+                t
+            }
+        })
+        .collect();
+
+    let mut costs: Vec<f32> = nests.iter().map(|t| distances.tour_length(t)).collect();
+
+    let (best_idx, _) = costs
+        .iter()
+        .enumerate()
+        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .unwrap();
+    let mut best: Vec<usize> = nests[best_idx].clone();
+    let mut best_cost: f32 = costs[best_idx];
+
+    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+
+    for epoch in 0..options.epochs {
+        // 1. Each nest generates one cuckoo via Lévy flight (Yang & Deb 2009: n cuckoos/epoch).
+        //    |levy_step| is used as step magnitude; sign is irrelevant for a discrete mapping.
+        for cuckoo_idx in 0..n_nests {
+            let levy = levy_step(&mut rng).abs();
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+            let k = ((levy * (n_cities as f64 * 0.1)).ceil() as usize).clamp(1, n_cities / 2);
+
+            let new_tour = apply_k_random_2opt(&nests[cuckoo_idx], k, &mut rng);
+            let new_cost = distances.tour_length(&new_tour);
+
+            // Replace a randomly chosen nest if cuckoo is better.
+            // cuckoo_idx may equal target_idx; harmless (nest replaces itself only if better).
+            let target_idx = rng.random_range(0..n_nests);
+            if new_cost < costs[target_idx] {
+                nests[target_idx] = new_tour;
+                costs[target_idx] = new_cost;
+
+                if new_cost < best_cost {
+                    best = nests[target_idx].clone();
+                    best_cost = new_cost;
+                    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                }
+            }
+        }
+
+        // 2. Per-nest Bernoulli abandonment (Yang & Deb 2009): each nest independently
+        //    re-seeded with probability pa, preserving discovered information per epoch.
+        for idx in 0..n_nests {
+            let r: f64 = rng.random();
+            if r < pa {
+                let mut t = city_ids.clone();
+                for i in (1..n_cities).rev() {
+                    let j = rng.random_range(0..=i);
+                    t.swap(i, j);
+                }
+                let cost = distances.tour_length(&t);
+                nests[idx] = t;
+                costs[idx] = cost;
+
+                if cost < best_cost {
+                    best = nests[idx].clone();
+                    best_cost = cost;
+                    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                }
+            }
+        }
+
+        send_progress(ProgressMessage::EpochUpdate(epoch));
+    }
+
+    send_progress(ProgressMessage::Done);
+    Solution::new(&best, cities, distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{distance_matrix, kdtree};
+
+    #[test]
+    fn test_normal_sample_is_finite() {
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            let s = normal_sample(&mut rng);
+            assert!(s.is_finite(), "normal_sample returned non-finite: {s}");
+        }
+    }
+
+    #[test]
+    fn test_levy_step_is_finite() {
+        let mut rng = rand::rng();
+        for _ in 0..10_000 {
+            let s = levy_step(&mut rng);
+            assert!(s.is_finite(), "levy_step produced non-finite: {s}");
+        }
+    }
+
+    #[test]
+    fn test_apply_k_random_2opt_preserves_cities() {
+        let tour = vec![0usize, 1, 2, 3, 4];
+        let mut rng = rand::rng();
+        let result = apply_k_random_2opt(&tour, 3, &mut rng);
+        let mut sorted = result.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_apply_k_0_returns_clone() {
+        let tour = vec![2usize, 0, 4, 1, 3];
+        let mut rng = rand::rng();
+        let result = apply_k_random_2opt(&tour, 0, &mut rng);
+        assert_eq!(result, tour);
+    }
+
+    #[test]
+    fn test_solve_returns_valid_tour_on_small_instance() {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.0],
+            vec![0.0, 1.0],
+        ]);
+        let distances = distance_matrix::from_cities(&cities);
+        let options = SolverOptions {
+            epochs: 30,
+            n_nearest: 5,
+            mutation_probability: 0.25,
+            ..SolverOptions::default()
+        };
+        let sol = solve(&cities, &distances, &options);
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected, "CS tour does not visit all cities exactly once");
+        assert!(sol.total > 0.0);
+    }
+}

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1,5 +1,6 @@
 pub mod bellman_karp;
 pub mod branch_bound;
+pub mod cuckoo_search;
 pub mod distance_matrix;
 pub mod genetic_algorithm;
 pub mod kdtree;
@@ -28,6 +29,7 @@ use std::str::FromStr;
 pub enum Solvers {
     BellmanKarp,
     BranchBound,
+    CuckooSearch,
     NearestNeighbor,
     GeneticAlgorithm,
     ParticleSwarmOptimization,
@@ -44,6 +46,8 @@ impl Solvers {
             "bellman_karp",
             "bhk",
             "branch_bound",
+            "cs",
+            "cuckoo_search",
             "nearest_neighbor",
             "nn",
             "genetic_algorithm",
@@ -67,6 +71,7 @@ impl FromStr for Solvers {
         match s {
             "bhk" | "bellman_karp" => Ok(Solvers::BellmanKarp),
             "branch_bound" => Ok(Solvers::BranchBound),
+            "cs" | "cuckoo_search" => Ok(Solvers::CuckooSearch),
             "nn" | "nearest_neighbor" => Ok(Solvers::NearestNeighbor),
             "ga" | "genetic_algorithm" => Ok(Solvers::GeneticAlgorithm),
             "pso" | "particle_swarm" => Ok(Solvers::ParticleSwarmOptimization),

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -12,9 +12,9 @@
 /// because solution quality depends on runtime epochs.
 use std::path::Path;
 use teeline::tsp::{
-    bellman_karp, branch_bound, distance_matrix, genetic_algorithm, kdtree, nearest_neighbor,
-    particle_swarm, simulated_annealing, stochastic_hill, tabu_search, two_opt, tsplib,
-    SolverOptions,
+    bellman_karp, branch_bound, cuckoo_search, distance_matrix, genetic_algorithm, kdtree,
+    nearest_neighbor, particle_swarm, simulated_annealing, stochastic_hill, tabu_search, two_opt,
+    tsplib, SolverOptions,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -158,6 +158,20 @@ fn particle_swarm_valid_tour_berlin52() {
     assert!(
         is_valid_tour(tour.route(), &cities),
         "PSO tour is not valid on berlin52"
+    );
+}
+
+// ─── cuckoo search ────────────────────────────────────────────────────────────
+
+#[test]
+fn cuckoo_search_valid_tour_berlin52() {
+    let cities = load_berlin52();
+    let mut opts = stochastic_options(200);
+    opts.mutation_probability = 0.25;
+    let tour = cuckoo_search::solve(&cities, &build_dm(&cities), &opts);
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "Cuckoo Search tour is not valid on berlin52"
     );
 }
 


### PR DESCRIPTION
## Summary

- Implements discrete Cuckoo Search for TSP in `src/tsp/cuckoo_search.rs`
- Registered as `cs` / `cuckoo_search` aliases in the CLI
- Documented in README and benchmarks; solver table in CLAUDE.md updated

## Algorithm details

Lévy flights are realised as k random 2-opt reversals where k is drawn from a Lévy distribution (Mantegna 1994 algorithm, β=1.5, σ_u≈0.6966). No new crate dependencies — normal samples via Box-Muller transform from the existing `rand = "0.9"`.

**TSP-specific adaptations vs Yang & Deb (2009):**
- One Lévy flight per nest per epoch (not one total) — required for meaningful convergence
- Nest 0 seeded with a greedy NN tour; rest random (matches PSO's seeding pattern)
- Per-nest Bernoulli(pa) abandonment rather than deterministic worst-k (faithful to the original paper)
- k capped at n/2 to prevent full-tour scrambles from heavy Lévy tails

**Results on berlin52 (52 cities, optimal 7 544.37):**

| Configuration | Gap | Wall time |
|---|:---:|---:|
| default (`--epochs=10000 --n_nearest=25`) | ~+4–7 % | 0.72 s |

CS is the new top performer in the benchmark (+4.4% single run vs SA's +6.8%), though results vary across runs.

Note: high `pa` (≥0.05) hurts quality — random re-seedings overwhelm the Lévy search. Default pa=0.01 (clamped from `mutation_probability=0.001`) is near-optimal.

## Test plan

- [x] 5 unit tests in `src/tsp/cuckoo_search.rs` (normal_sample, levy_step finiteness, 2-opt permutation preservation, solve validity)
- [x] Integration test `cuckoo_search_valid_tour_berlin52` in `tests/solvers_integration.rs`
- [x] Full `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] Smoke test: `./target/debug/bin cs -i data/tsplib/berlin52.tsp`
- [x] Quality check: `./target/release/bin cs -i data/tsplib/berlin52.tsp --optimal-tour data/tsplib/berlin52.opt.tour`

Closes #42