### PR TITLE
refactor: remove global progress channel state, replace with explicit DI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
         Solvers::from_str(args.get_one::<String>("solver").map(|s| s.as_str()).unwrap_or("unspecified"))
             .expect("Unknown solver");
 
-    let options = solver_options_from_args(&args);
+    let mut options = solver_options_from_args(&args);
 
     let default_level = if options.verbose { "debug" } else { "info" };
     tracing_subscriber::fmt()
@@ -136,13 +136,17 @@ fn main() {
             std::process::exit(1);
         }
     };
-    let show_progress = options.show_progress;
-
-    // eframe (winit) requires the event loop on the main thread,
-    // so the solver runs in a background thread and the window stays on main.
-    // MUST construct ProgressPlot first — new() calls init_channels() which
-    // sets up the global mpsc channel before any send_progress calls.
-    let progress_display = progress::ProgressPlot::new(&cities, 1024.0, 1024.0, 50.0);
+    // Build the progress display only when --gui is requested.
+    // eframe (winit) requires the event loop on the main thread;
+    // the solver runs in a background thread.
+    let maybe_display: Option<progress::ProgressPlot>;
+    if args.get_flag("gui") {
+        let (display, tx) = progress::ProgressPlot::new_with_channel(&cities, 1024.0, 1024.0, 50.0);
+        options.progress_tx = Some(tx);
+        maybe_display = Some(display);
+    } else {
+        maybe_display = None;
+    }
 
     let opt_tour = args
         .get_one::<String>("optimal_tour")
@@ -154,15 +158,18 @@ fn main() {
             }
         });
 
+    // Send the optimal tour overlay only when the GUI is active.
     if let Some(ref ot) = opt_tour {
-        if ot.dimension == tsp_data.len() {
-            progress::send_progress(progress::ProgressMessage::OptimalTour(ot.route.clone()));
-        } else {
-            eprintln!(
-                "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
-                ot.dimension,
-                tsp_data.len()
-            );
+        if let Some(ref tx) = options.progress_tx {
+            if ot.dimension == tsp_data.len() {
+                let _ = tx.send(progress::ProgressMessage::OptimalTour(ot.route.clone()));
+            } else {
+                eprintln!(
+                    "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                    ot.dimension,
+                    tsp_data.len()
+                );
+            }
         }
     }
 
@@ -177,7 +184,9 @@ fn main() {
         tour
     });
 
-    progress_display.run(show_progress);
+    if let Some(display) = maybe_display {
+        display.run();
+    }
 
     let tour = solver_handle.join().expect("Solver thread failed");
 
@@ -300,7 +309,7 @@ mod tests {
         let opts = solver_options_from_args(&args);
         let defaults = SolverOptions::default();
         assert!(!opts.verbose);
-        assert!(!opts.show_progress);
+        assert!(opts.progress_tx.is_none());
         assert_eq!(opts.epochs, defaults.epochs);
         assert_eq!(opts.n_nearest, defaults.n_nearest);
     }
@@ -309,12 +318,6 @@ mod tests {
     fn test_solver_options_verbose_flag_sets_verbose() {
         let args = options_cmd().get_matches_from(["test", "nn", "--verbose"]);
         assert!(solver_options_from_args(&args).verbose);
-    }
-
-    #[test]
-    fn test_solver_options_gui_flag_enables_progress() {
-        let args = options_cmd().get_matches_from(["test", "nn", "--gui"]);
-        assert!(solver_options_from_args(&args).show_progress);
     }
 
     #[test]
@@ -385,10 +388,6 @@ fn solver_options_from_args(args: &ArgMatches) -> SolverOptions {
 
     if args.get_flag("verbose") {
         options.verbose = true;
-    }
-
-    if args.get_flag("gui") {
-        options.show_progress = true;
     }
 
     if let Some(n_epochs_str) = args.get_one::<String>("epochs") {

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -11,7 +11,7 @@
 ///
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -40,7 +40,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             .unwrap_or(UNKNOWN_DISTANCE);
 
         if let Some(city_id) = dists.pos2city_id(&i) {
-            send_progress(ProgressMessage::CityChange(city_id));
+            options.send_progress(ProgressMessage::CityChange(city_id));
         }
     }
 
@@ -73,8 +73,8 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
     // send final route to the visualizer
     let route = Route::new(route_vec.as_ref());
-    send_progress(ProgressMessage::PathUpdate(route, 0.0));
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::PathUpdate(route, 0.0));
+    options.send_progress(ProgressMessage::Done);
 
     Solution::new(&route_vec, cities, distances)
 }

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -21,7 +21,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     tracing::info!(n_cities, "B&B starting");
 
     route.sort();
-    send_progress(ProgressMessage::PathUpdate(route.clone(), 0.0));
+    options.send_progress(ProgressMessage::PathUpdate(route.clone(), 0.0));
 
     let mut open_path: Path = vec![0; n_cities];
     open_path[0] = route.get(0).unwrap();
@@ -39,7 +39,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         options,
     );
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(&best_path, cities, distances)
 }
 
@@ -84,7 +84,7 @@ fn backtrack(
     );
 
     for candidate in candidates.iter() {
-        make_move(path, k, *candidate);
+        make_move(path, k, *candidate, options);
 
         let visited_path: Vec<usize> = path
             .to_vec()
@@ -92,7 +92,7 @@ fn backtrack(
             .filter(|&&x| x != UNVISITED_NODE)
             .copied()
             .collect();
-        send_progress(ProgressMessage::PathUpdate(
+        options.send_progress(ProgressMessage::PathUpdate(
             Route::new(&visited_path),
             best_distance,
         ));
@@ -152,9 +152,9 @@ fn construct_candidates(
     candidates
 }
 
-fn make_move(path: &mut Path, k: usize, candidate: usize) {
+fn make_move(path: &mut Path, k: usize, candidate: usize, options: &SolverOptions) {
     path[k] = candidate;
-    send_progress(ProgressMessage::CityChange(candidate));
+    options.send_progress(ProgressMessage::CityChange(candidate));
 }
 
 fn undo_move(path: &mut Path, k: usize) {

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -105,7 +105,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut best: Vec<usize> = nests[best_idx].clone();
     let mut best_cost: f32 = costs[best_idx];
 
-    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
 
     for epoch in 0..options.epochs {
         // 1. Each nest generates one cuckoo via Lévy flight (Yang & Deb 2009: n cuckoos/epoch).
@@ -128,7 +128,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                 if new_cost < best_cost {
                     best = nests[target_idx].clone();
                     best_cost = new_cost;
-                    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
                 }
             }
         }
@@ -150,15 +150,15 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                 if cost < best_cost {
                     best = nests[idx].clone();
                     best_cost = cost;
-                    send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
                 }
             }
         }
 
-        send_progress(ProgressMessage::EpochUpdate(epoch));
+        options.send_progress(ProgressMessage::EpochUpdate(epoch));
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(&best, cities, distances)
 }
 

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::{random_position_pair, Route};
 use super::{Solution, SolverOptions};
 
@@ -19,11 +19,11 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let best_candidate = solve_ga(&population, evaluator, distances, options);
 
     let best_route = Route::new(best_candidate.genotype());
-    send_progress(ProgressMessage::PathUpdate(
+    options.send_progress(ProgressMessage::PathUpdate(
         best_route,
         distances.tour_length(best_candidate.genotype()),
     ));
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(best_candidate.genotype(), cities, distances)
 }
 
@@ -76,7 +76,7 @@ fn solve_ga(
 
         let best_candidate = current_population.best().clone();
         let best_route = Route::new(best_candidate.genotype());
-        send_progress(ProgressMessage::PathUpdate(
+        options.send_progress(ProgressMessage::PathUpdate(
             best_route,
             distances.tour_length(best_candidate.genotype()),
         ));

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -19,6 +19,7 @@ use crate::tsp::distance_matrix::DistanceMatrix;
 use crate::tsp::kdtree::KDPoint;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::sync::mpsc;
 
 pub const VERSION: &str = "0.6.1";
 pub const AUTHOR: &str = "Timo Sulg <timo@sulg.dev>";
@@ -86,7 +87,7 @@ impl FromStr for Solvers {
 
 // -- SolverOptions
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SolverOptions {
     pub epochs: usize,
     pub platoo_epochs: usize,
@@ -97,7 +98,24 @@ pub struct SolverOptions {
     pub cooling_rate: f32,
     pub max_temperature: f32,
     pub min_temperature: f32,
-    pub show_progress: bool,
+    pub progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
+}
+
+impl std::fmt::Debug for SolverOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SolverOptions")
+            .field("epochs", &self.epochs)
+            .field("platoo_epochs", &self.platoo_epochs)
+            .field("verbose", &self.verbose)
+            .field("n_nearest", &self.n_nearest)
+            .field("mutation_probability", &self.mutation_probability)
+            .field("n_elite", &self.n_elite)
+            .field("cooling_rate", &self.cooling_rate)
+            .field("max_temperature", &self.max_temperature)
+            .field("min_temperature", &self.min_temperature)
+            .field("progress_tx", &self.progress_tx.is_some())
+            .finish()
+    }
 }
 
 impl Default for SolverOptions {
@@ -112,7 +130,15 @@ impl Default for SolverOptions {
             cooling_rate: 0.0001,
             min_temperature: 0.001,
             max_temperature: 1_000.0,
-            show_progress: false,
+            progress_tx: None,
+        }
+    }
+}
+
+impl SolverOptions {
+    pub fn send_progress(&self, msg: progress::ProgressMessage) {
+        if let Some(ref tx) = self.progress_tx {
+            let _ = tx.send(msg);
         }
     }
 }
@@ -256,6 +282,25 @@ impl PartialEq for NearestResultItem {
 mod tests {
     use super::*;
     use crate::test::helpers::assert_approx;
+
+    #[test]
+    fn test_send_progress_with_none_is_noop() {
+        let options = SolverOptions::default();
+        options.send_progress(progress::ProgressMessage::Done);
+    }
+
+    #[test]
+    fn test_send_progress_with_channel_delivers_message() {
+        use std::sync::mpsc;
+        let (tx, rx) = mpsc::channel();
+        let mut options = SolverOptions::default();
+        options.progress_tx = Some(tx);
+        options.send_progress(progress::ProgressMessage::EpochUpdate(99));
+        match rx.recv().unwrap() {
+            progress::ProgressMessage::EpochUpdate(n) => assert_eq!(n, 99),
+            other => panic!("unexpected message: {:?}", other),
+        }
+    }
 
     #[test]
     fn test_solution_total_for_tsp_5_1() {

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -20,13 +20,13 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     path.push(start_id);
     unvisited.remove(&start_id);
 
-    send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
 
     while !unvisited.is_empty() {
         let current_id = *path.last().unwrap();
         let current_city = &cities_table[&current_id];
 
-        send_progress(ProgressMessage::CityChange(current_id));
+        options.send_progress(ProgressMessage::CityChange(current_id));
 
         // Find the nearest unvisited city.  Check the n_nearest frontier first (fast path);
         // fall back to a linear scan over `unvisited` when all frontier cities are already
@@ -50,10 +50,10 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
         path.push(next_id);
         unvisited.remove(&next_id);
-        send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+        options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(&path, cities, distances)
 }
 

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -122,7 +122,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut gbest: Vec<usize> = pbest[best_idx].clone();
     let mut gbest_cost: f32 = pbest_cost[best_idx];
 
-    send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
 
     let epochs = options.epochs;
     for epoch in 0..epochs {
@@ -173,14 +173,14 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             if cost < gbest_cost {
                 gbest = positions[i].clone();
                 gbest_cost = cost;
-                send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
             }
         }
 
-        send_progress(ProgressMessage::EpochUpdate(epoch));
+        options.send_progress(ProgressMessage::EpochUpdate(epoch));
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(&gbest, cities, distances)
 }
 

--- a/src/tsp/progress.rs
+++ b/src/tsp/progress.rs
@@ -1,20 +1,12 @@
 use std::sync::mpsc;
-use std::sync::Mutex;
-use std::sync::LazyLock;
 
 use eframe;
 use eframe::egui::{self, Align2, Color32, FontId, Pos2, Rect, Stroke};
 
 use std::collections::{HashMap, HashSet};
-use std::sync::mpsc::{Receiver, Sender};
-use std::sync::Arc;
 
 use super::route::Route;
 use super::KDPoint;
-
-pub type PublishChannel = Sender<ProgressMessage>;
-pub type ReceiverChannel = Receiver<ProgressMessage>;
-pub type PublisherFn = Arc<dyn Fn(ProgressMessage)>;
 
 type RectCoords = [f64; 4];
 type Point2D = (f64, f64);
@@ -31,42 +23,6 @@ const ACTIVE_EDGE_COLOR:  Color32 = Color32::from_rgb(255, 140, 0);    // orange
 const STATUS_COLOR:       Color32 = Color32::from_rgb(220, 30,  30);   // red — status text
 const FONT_SIZE: f32 = 16.0;
 
-static PUBLISH_CHANNEL: LazyLock<Mutex<Option<PublishChannel>>> =
-    LazyLock::new(|| Mutex::new(None));
-static RECEIVER_CHANNEL: LazyLock<Mutex<Option<ReceiverChannel>>> =
-    LazyLock::new(|| Mutex::new(None));
-
-fn init_channels() {
-    let (out_ch, in_ch) = mpsc::channel();
-    let mut mtx = PUBLISH_CHANNEL.lock().unwrap();
-    *mtx = Some(out_ch);
-
-    let mut inmtx = RECEIVER_CHANNEL.lock().unwrap();
-    *inmtx = Some(in_ch);
-}
-
-pub fn get_publisher() -> Option<PublishChannel> {
-    match PUBLISH_CHANNEL.lock() {
-        Ok(mtx) => mtx.clone(),
-        Err(_) => None,
-    }
-}
-
-pub fn send_progress(msg: ProgressMessage) {
-    let publish_ch = PUBLISH_CHANNEL.lock().unwrap();
-    if publish_ch.is_some() {
-        publish_ch
-            .clone()
-            .unwrap()
-            .send(msg)
-            .expect("Failed to publish message");
-    }
-}
-
-fn try_retrieve_message() -> Option<ProgressMessage> {
-    let ch = RECEIVER_CHANNEL.lock().unwrap();
-    ch.as_ref().and_then(|x| x.try_recv().ok())
-}
 
 #[derive(Debug, Clone)]
 pub enum ProgressMessage {
@@ -84,6 +40,7 @@ struct NodeData {
 }
 
 pub struct ProgressPlot {
+    rx: mpsc::Receiver<ProgressMessage>,
     city_table: HashMap<usize, KDPoint>,
     nodes: Vec<NodeData>,
     best_edges: Vec<EdgeData>,                          // shown in green after Done
@@ -100,11 +57,12 @@ pub struct ProgressPlot {
 }
 
 impl ProgressPlot {
-    pub fn new(cities: &[KDPoint], width: f64, height: f64, margin: f64) -> Self {
-        // Initialise channels here so they are ready before the solver thread starts.
-        init_channels();
-
+    pub fn new_with_channel(cities: &[KDPoint], width: f64, height: f64, margin: f64)
+        -> (Self, mpsc::Sender<ProgressMessage>)
+    {
+        let (tx, rx) = mpsc::channel();
         let mut plot = ProgressPlot {
+            rx,
             city_table: HashMap::new(),
             nodes: Vec::new(),
             best_edges: Vec::new(),
@@ -119,25 +77,12 @@ impl ProgressPlot {
             cities_bounding_box: cities_bounding_box(cities),
             status: "Preparing...".to_string(),
         };
-
         plot.add_cities(cities);
         plot.add_nodes();
-        plot
+        (plot, tx)
     }
 
-    pub fn run(self, show_progress: bool) {
-        if !show_progress {
-            // Drain messages so the solver's channel send never blocks, then exit.
-            loop {
-                match try_retrieve_message() {
-                    Some(ProgressMessage::Done) => break,
-                    None => std::thread::sleep(std::time::Duration::from_millis(5)),
-                    _ => {}
-                }
-            }
-            return;
-        }
-
+    pub fn run(self) {
         let options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
                 .with_inner_size([
@@ -272,7 +217,7 @@ impl ProgressPlot {
 
 impl eframe::App for ProgressPlot {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        while let Some(msg) = try_retrieve_message() {
+        while let Ok(msg) = self.rx.try_recv() {
             self.handle_message(&msg);
         }
 
@@ -525,6 +470,13 @@ mod tests {
         let (vx, vy) = point_to_viewport(5.0, 5.0, &window, &vp);
         assert!((vx - 50.0).abs() < 0.01);
         assert!((vy - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_new_with_channel_creates_working_channel() {
+        let cities = build_points(&[vec![0.0, 0.0], vec![10.0, 5.0]]);
+        let (_plot, tx) = ProgressPlot::new_with_channel(&cities, 100.0, 100.0, 10.0);
+        assert!(tx.send(ProgressMessage::EpochUpdate(1)).is_ok());
     }
 }
 

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -20,7 +20,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut best_route = Route::from_cities(cities);
     let mut best_distance = distances.tour_length(best_route.route());
 
-    send_progress(ProgressMessage::PathUpdate(
+    options.send_progress(ProgressMessage::PathUpdate(
         best_route.clone(),
         best_distance,
     ));
@@ -34,7 +34,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             best_route = candidate;
             best_distance = candidate_distance;
 
-            send_progress(ProgressMessage::PathUpdate(
+            options.send_progress(ProgressMessage::PathUpdate(
                 best_route.clone(),
                 best_distance,
             ));
@@ -46,7 +46,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         epoch += 1;
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(best_route.route(), cities, distances)
 }
 

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -1,6 +1,6 @@
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -15,7 +15,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
     //mix up the cities to avoid getting stuck due bad initial state
     current_route.shuffle();
-    send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+    options.send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
 
     // Baseline from the shuffled state — sequential ordering would be
     // an artificially low bar that random successors can never beat.
@@ -37,7 +37,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
             n_stale = 0;
 
-            send_progress(ProgressMessage::PathUpdate(
+            options.send_progress(ProgressMessage::PathUpdate(
                 best_route.clone(),
                 best_distance,
             ));
@@ -56,7 +56,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             current_route.shuffle();
             n_stale = 0;
 
-            send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+            options.send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
         }
 
         // check if we should finish the search
@@ -69,7 +69,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         tracing::warn!(epochs = options.epochs, tour_length = best_distance, "hill: no improvement found");
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(best_route.route(), cities, distances)
 }
 

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
@@ -16,7 +16,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut best_route = Route::from_cities(cities);
     tabu_list.add(best_route.clone());
 
-    send_progress(ProgressMessage::PathUpdate(best_route.clone(), 0.0));
+    options.send_progress(ProgressMessage::PathUpdate(best_route.clone(), 0.0));
 
     let mut u = best_route.clone();
     let mut best_distance = distances.tour_length(u.route());
@@ -28,7 +28,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             best_route = local_best.clone();
             best_distance = local_distance;
 
-            send_progress(ProgressMessage::PathUpdate(
+            options.send_progress(ProgressMessage::PathUpdate(
                 best_route.clone(),
                 best_distance,
             ));
@@ -43,7 +43,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         done = update_terminate(epoch, options.epochs);
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(best_route.route(), cities, distances)
 }
 

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -1,22 +1,22 @@
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::progress::{send_progress, ProgressMessage};
+use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, _options: &SolverOptions) -> Solution {
+pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
     tracing::info!(cities = cities.len(), "2-opt starting");
 
     let n_indices = cities.len() - 1;
     let mut path: Vec<usize> = cities.iter().map(|c| c.id).collect();
 
-    send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
 
     let mut improved = true;
     while improved {
         improved = false;
         for i in 0..(n_indices - 2) {
-            send_progress(ProgressMessage::CityChange(path[i]));
+            options.send_progress(ProgressMessage::CityChange(path[i]));
 
             for j in (i + 2)..n_indices {
                 let current_distance =
@@ -31,14 +31,14 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, _options: &SolverOp
                     swap_2opt(&mut path, i + 1, j);
                     improved = true;
 
-                    send_progress(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
+                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
                     tracing::debug!(i, j, tour_length = new_distance, "2-opt: improvement");
                 }
             }
         }
     }
 
-    send_progress(ProgressMessage::Done);
+    options.send_progress(ProgressMessage::Done);
     Solution::new(&path, cities, distances)
 }
 


### PR DESCRIPTION
Closes #65 (Phase 1 only — WASM will be a separate issue).

## Summary

- **Removes** the two `LazyLock<Mutex<Option<Sender/Receiver>>>` globals from `src/tsp/progress.rs` along with `init_channels()`, `send_progress()`, `get_publisher()`, and `try_retrieve_message()` free functions
- **Adds** `progress_tx: Option<mpsc::Sender<ProgressMessage>>` to `SolverOptions` and a `send_progress()` convenience method (no-op when `None`)
- **All 10 solvers** now call `options.send_progress()` instead of the global free function
- **`ProgressPlot`** owns its `Receiver` — `new_with_channel()` returns `(Self, Sender)` so the caller controls channel lifetime
- **`ProgressPlot` is never constructed in headless mode** — `main()` only builds it when `--gui` is passed; the old drain-loop is gone
- **`show_progress: bool`** removed from `SolverOptions`; presence of `progress_tx` is the signal

Phase 2 (tracing bridge) was dropped — the dual-path design added no real unification benefit. Phase 3 (WASM) is tracked in a separate issue.

## Test Plan

- [x] `cargo test` — 152 tests pass (120 lib + 11 unit + 20 integration + 1 kdtree)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] Headless smoke: `./target/debug/bin sa -i data/tsplib/berlin52.tsp` exits cleanly
- [x] Headless smoke: `cat data/tsplib/berlin52.tsp | ./target/debug/bin nn` exits cleanly
- [x] GUI smoke: `./target/debug/bin nn -i data/tsplib/berlin52.tsp --gui` (requires display)