### PR TITLE
feat(flower_pollination): Flower Pollination Algorithm solver (GH #43)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -37,6 +37,8 @@ representative, not as a guarantee.
 | **Particle Swarm (PSO)** | `--epochs=10000` (default) | 8 874.46 | +17.6 % | 0.84 s | 100 % | 7.9 MB |
 | **Particle Swarm (PSO)** | `--epochs=10000 --n_nearest=50` | 8 663.69 | +14.8 % | 1.42 s | 100 % | 8.1 MB |
 | **Cuckoo Search** | default (`--epochs=10000 --n_nearest=25`) | 7 877.84 | +4.4 % | 0.72 s | 100 % | 7.9 MB |
+| **Flower Pollination (FPA)** | default (`--epochs=10000 --n_nearest=25`) | 8 867.93 | +17.5 % | 0.53 s | 100 % | 7.2 MB |
+| **Flower Pollination (FPA)** | `--epochs=10000 --n_nearest=50` | 8 950.21 | +18.6 % | 1.13 s | 99 % | 7.2 MB |
 
 *Wall time* = elapsed wall-clock time. *CPU* = percentage of one core used (>100% would indicate parallelism). *Peak RSS* = maximum resident set size reported by GNU `time -v`.
 
@@ -71,6 +73,8 @@ Gap from optimal
  11%  Stochastic Hill/10k (0.02 s)  ← best value for time
  15%  PSO/50p (1.42 s)
  17%  PSO/default (0.84 s)
+ 18%  FPA/default (0.53 s)
+ 19%  FPA/50 flowers (1.13 s)
  19%  NN (0.01 s)
  23%  Tabu/10k (0.47 s)
  24%  2-opt (0.01 s)
@@ -100,6 +104,13 @@ as a sanity check.
 **PSO** sits in the middle of the pack. More particles (`--n_nearest=50`) improve quality at
 the cost of proportionally more wall time. Default of 30 particles is a reasonable starting
 point.
+
+**Flower Pollination (FPA)** lands mid-table (~17–19 % gap), broadly level with PSO. With the
+default 25 flowers it converges in under 0.6 s; scaling to 50 flowers roughly doubles wall time
+without improving quality on this instance. The greedy acceptance rule (update only if
+`new_cost < current`) means the population converges very quickly — tracing shows only 1–2
+global-best improvements across 10 000 epochs. Adding a Metropolis acceptance or elitism would
+likely push quality closer to SA/CS.
 
 **Tabu Search** underperforms relative to its wall time budget; the current implementation
 does not improve much beyond 1 000 epochs on this instance.

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,7 @@ fn solve(
         Solvers::BellmanKarp => tsp::bellman_karp::solve(cities, distances, options),
         Solvers::BranchBound => tsp::branch_bound::solve(cities, distances, options),
         Solvers::CuckooSearch => tsp::cuckoo_search::solve(cities, distances, options),
+        Solvers::FlowerPollination => tsp::flower_pollination::solve(cities, distances, options),
         Solvers::NearestNeighbor => tsp::nearest_neighbor::solve(cities, distances, options),
         Solvers::TwoOpt => tsp::two_opt::solve(cities, distances, options),
         Solvers::StochasticHill => tsp::stochastic_hill::solve(cities, distances, options),

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -148,7 +148,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                         Route::new(&gbest),
                         gbest_cost,
                     ));
-                    tracing::debug!(epoch, tour_length = gbest_cost, "FPA: new best");
+                    tracing::info!(epoch, tour_length = gbest_cost, "FPA: new best");
                 }
             }
         }

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -1,0 +1,207 @@
+use rand::Rng;
+
+use super::distance_matrix::DistanceMatrix;
+use super::kdtree::KDPoint;
+use super::probability::{bernoulli, levy_step};
+use super::progress::ProgressMessage;
+use super::route::{apply_swaps, swap_sequence, Route};
+use super::{Solution, SolverOptions};
+
+const DEFAULT_N_FLOWERS: usize = 25;
+
+/// Greedy nearest-neighbour tour starting from the first city.
+fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
+    let n = city_ids.len();
+    let mut unvisited: Vec<usize> = city_ids.to_vec();
+    let mut tour = Vec::with_capacity(n);
+    let mut current = unvisited.swap_remove(0);
+    tour.push(current);
+    while !unvisited.is_empty() {
+        let best_pos = unvisited
+            .iter()
+            .enumerate()
+            .min_by(|(_, &a), (_, &b)| {
+                let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
+                let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        current = unvisited.swap_remove(best_pos);
+        tour.push(current);
+    }
+    tour
+}
+
+/// Pick a random index in `0..n` that is not in `excluded`.
+fn pick_other(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
+    loop {
+        let idx = rng.random_range(0..n);
+        if !excluded.contains(&idx) {
+            return idx;
+        }
+    }
+}
+
+pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+    let n_flowers = options.n_nearest.max(DEFAULT_N_FLOWERS);
+    let n_cities = cities.len();
+    // default mutation_probability 0.001 → 99.9% local, which defeats global search;
+    // floor to 0.8 so a bare `bin fpa` run is meaningful without extra flags.
+    let switch_prob = if options.mutation_probability < 0.01 {
+        0.8_f64
+    } else {
+        options.mutation_probability as f64
+    };
+
+    tracing::info!(
+        n_flowers,
+        switch_prob,
+        epochs = options.epochs,
+        "FPA starting"
+    );
+
+    let mut rng = rand::rng();
+    let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+
+    // Flower 0 seeded with greedy NN for a warm start; rest are random shuffles.
+    let mut flowers: Vec<Vec<usize>> = (0..n_flowers)
+        .map(|idx| {
+            if idx == 0 {
+                nn_seed(&city_ids, distances)
+            } else {
+                let mut t = city_ids.clone();
+                for i in (1..n_cities).rev() {
+                    let j = rng.random_range(0..=i);
+                    t.swap(i, j);
+                }
+                t
+            }
+        })
+        .collect();
+
+    let mut costs: Vec<f32> = flowers.iter().map(|t| distances.tour_length(t)).collect();
+
+    let (best_idx, _) = costs
+        .iter()
+        .enumerate()
+        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .unwrap();
+    let mut gbest: Vec<usize> = flowers[best_idx].clone();
+    let mut gbest_cost: f32 = costs[best_idx];
+
+    options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+
+    for epoch in 0..options.epochs {
+        for i in 0..n_flowers {
+            let new_x = if bernoulli(&mut rng, switch_prob) {
+                // --- global pollination ---
+                // swap_sequence toward gbest is the permutation analogue of γ·L·(g* − x_i)
+                let seq = swap_sequence(&flowers[i], &gbest);
+                if seq.is_empty() {
+                    flowers[i].clone()
+                } else {
+                    let levy = levy_step(&mut rng).abs();
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        clippy::cast_precision_loss
+                    )]
+                    let n_swaps =
+                        ((levy * seq.len() as f64 * 0.5).ceil() as usize).clamp(1, seq.len());
+                    apply_swaps(&flowers[i], &seq[..n_swaps])
+                }
+            } else {
+                // --- local pollination ---
+                // need at least 3 flowers to pick j ≠ i and k ≠ i, j ≠ k
+                if n_flowers < 3 {
+                    flowers[i].clone()
+                } else {
+                    let j = pick_other(&mut rng, n_flowers, &[i]);
+                    let k = pick_other(&mut rng, n_flowers, &[i, j]);
+                    let seq = swap_sequence(&flowers[j], &flowers[k]);
+                    if seq.is_empty() {
+                        flowers[i].clone()
+                    } else {
+                        let epsilon: f64 = rng.random();
+                        #[allow(
+                            clippy::cast_possible_truncation,
+                            clippy::cast_sign_loss,
+                            clippy::cast_precision_loss
+                        )]
+                        let n_swaps = ((epsilon * seq.len() as f64).ceil() as usize)
+                            .clamp(1, seq.len());
+                        apply_swaps(&flowers[i], &seq[..n_swaps])
+                    }
+                }
+            };
+
+            let new_cost = distances.tour_length(&new_x);
+            if new_cost < costs[i] {
+                flowers[i] = new_x;
+                costs[i] = new_cost;
+
+                if new_cost < gbest_cost {
+                    gbest = flowers[i].clone();
+                    gbest_cost = new_cost;
+                    options.send_progress(ProgressMessage::PathUpdate(
+                        Route::new(&gbest),
+                        gbest_cost,
+                    ));
+                    tracing::debug!(epoch, tour_length = gbest_cost, "FPA: new best");
+                }
+            }
+        }
+
+        options.send_progress(ProgressMessage::EpochUpdate(epoch));
+    }
+
+    options.send_progress(ProgressMessage::Done);
+    Solution::new(&gbest, cities, distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{distance_matrix, kdtree};
+
+    fn four_city_setup() -> (Vec<KDPoint>, DistanceMatrix) {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.0],
+            vec![0.0, 1.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        (cities, dm)
+    }
+
+    #[test]
+    fn test_nn_seed_visits_all_cities() {
+        let (cities, dm) = four_city_setup();
+        let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let tour = nn_seed(&city_ids, &dm);
+        let mut sorted = tour.clone();
+        sorted.sort();
+        assert_eq!(sorted, city_ids);
+    }
+
+    #[test]
+    fn test_solve_returns_valid_tour() {
+        let (cities, dm) = four_city_setup();
+        let options = SolverOptions {
+            epochs: 30,
+            n_nearest: 5,
+            mutation_probability: 0.8,
+            ..SolverOptions::default()
+        };
+        let sol = solve(&cities, &dm, &options);
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected, "FPA tour does not visit all cities exactly once");
+        assert!(sol.total > 0.0);
+        assert!(sol.total.is_finite());
+    }
+}

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::probability::{bernoulli, levy_step, sample_with_exclude};
+use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
 use super::{Solution, SolverOptions};
@@ -60,8 +60,8 @@ fn local_pollination(
     if n_flowers < 3 {
         return flower.to_vec();
     }
-    let j = sample_with_exclude(rng, n_flowers, &[flower_idx]);
-    let k = sample_with_exclude(rng, n_flowers, &[flower_idx, j]);
+    let j = sample_without_replacement(rng, n_flowers, &[flower_idx]);
+    let k = sample_without_replacement(rng, n_flowers, &[flower_idx, j]);
     let seq = swap_sequence(&flowers[j], &flowers[k]);
     if seq.is_empty() {
         return flower.to_vec();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::probability::{bernoulli, levy_step};
+use super::probability::{bernoulli, levy_step, sample_with_exclude};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
 use super::{Solution, SolverOptions};
@@ -33,16 +33,6 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
     tour
 }
 
-/// Pick a random index in `0..n` that is not in `excluded`.
-fn pick_other(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
-    loop {
-        let idx = rng.random_range(0..n);
-        if !excluded.contains(&idx) {
-            return idx;
-        }
-    }
-}
-
 /// Global pollination: move `flower` toward `gbest` by a Lévy-scaled fraction of the swap
 /// sequence between them — the permutation analogue of `x + γ·L·(g* − x)` (Yang 2012).
 /// Returns the current flower unchanged if it already equals `gbest`.
@@ -70,8 +60,8 @@ fn local_pollination(
     if n_flowers < 3 {
         return flower.to_vec();
     }
-    let j = pick_other(rng, n_flowers, &[flower_idx]);
-    let k = pick_other(rng, n_flowers, &[flower_idx, j]);
+    let j = sample_with_exclude(rng, n_flowers, &[flower_idx]);
+    let k = sample_with_exclude(rng, n_flowers, &[flower_idx, j]);
     let seq = swap_sequence(&flowers[j], &flowers[k]);
     if seq.is_empty() {
         return flower.to_vec();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -43,6 +43,45 @@ fn pick_other(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
     }
 }
 
+/// Global pollination: move `flower` toward `gbest` by a Lévy-scaled fraction of the swap
+/// sequence between them — the permutation analogue of `x + γ·L·(g* − x)` (Yang 2012).
+/// Returns the current flower unchanged if it already equals `gbest`.
+fn global_pollination(flower: &[usize], gbest: &[usize], rng: &mut impl Rng) -> Vec<usize> {
+    let seq = swap_sequence(flower, gbest);
+    if seq.is_empty() {
+        return flower.to_vec();
+    }
+    let levy = levy_step(rng).abs();
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    let n_swaps = ((levy * seq.len() as f64 * 0.5).ceil() as usize).clamp(1, seq.len());
+    apply_swaps(flower, &seq[..n_swaps])
+}
+
+/// Local pollination: apply an ε-scaled fraction of the displacement between two randomly
+/// chosen flowers `j` and `k` to `flower` — the permutation analogue of `x + ε·(x_j − x_k)`.
+/// Returns the current flower unchanged when `n_flowers < 3` or `flowers[j] == flowers[k]`.
+fn local_pollination(
+    flower: &[usize],
+    flowers: &[Vec<usize>],
+    flower_idx: usize,
+    rng: &mut impl Rng,
+) -> Vec<usize> {
+    let n_flowers = flowers.len();
+    if n_flowers < 3 {
+        return flower.to_vec();
+    }
+    let j = pick_other(rng, n_flowers, &[flower_idx]);
+    let k = pick_other(rng, n_flowers, &[flower_idx, j]);
+    let seq = swap_sequence(&flowers[j], &flowers[k]);
+    if seq.is_empty() {
+        return flower.to_vec();
+    }
+    let epsilon: f64 = rng.random();
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    let n_swaps = ((epsilon * seq.len() as f64).ceil() as usize).clamp(1, seq.len());
+    apply_swaps(flower, &seq[..n_swaps])
+}
+
 pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
     let n_flowers = options.n_nearest.max(DEFAULT_N_FLOWERS);
     let n_cities = cities.len();
@@ -95,45 +134,9 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     for epoch in 0..options.epochs {
         for i in 0..n_flowers {
             let new_x = if bernoulli(&mut rng, switch_prob) {
-                // --- global pollination ---
-                // swap_sequence toward gbest is the permutation analogue of γ·L·(g* − x_i)
-                let seq = swap_sequence(&flowers[i], &gbest);
-                if seq.is_empty() {
-                    flowers[i].clone()
-                } else {
-                    let levy = levy_step(&mut rng).abs();
-                    #[allow(
-                        clippy::cast_possible_truncation,
-                        clippy::cast_sign_loss,
-                        clippy::cast_precision_loss
-                    )]
-                    let n_swaps =
-                        ((levy * seq.len() as f64 * 0.5).ceil() as usize).clamp(1, seq.len());
-                    apply_swaps(&flowers[i], &seq[..n_swaps])
-                }
+                global_pollination(&flowers[i], &gbest, &mut rng)
             } else {
-                // --- local pollination ---
-                // need at least 3 flowers to pick j ≠ i and k ≠ i, j ≠ k
-                if n_flowers < 3 {
-                    flowers[i].clone()
-                } else {
-                    let j = pick_other(&mut rng, n_flowers, &[i]);
-                    let k = pick_other(&mut rng, n_flowers, &[i, j]);
-                    let seq = swap_sequence(&flowers[j], &flowers[k]);
-                    if seq.is_empty() {
-                        flowers[i].clone()
-                    } else {
-                        let epsilon: f64 = rng.random();
-                        #[allow(
-                            clippy::cast_possible_truncation,
-                            clippy::cast_sign_loss,
-                            clippy::cast_precision_loss
-                        )]
-                        let n_swaps = ((epsilon * seq.len() as f64).ceil() as usize)
-                            .clamp(1, seq.len());
-                        apply_swaps(&flowers[i], &seq[..n_swaps])
-                    }
-                }
+                local_pollination(&flowers[i], &flowers, i, &mut rng)
             };
 
             let new_cost = distances.tour_length(&new_x);

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1,6 +1,7 @@
 pub mod bellman_karp;
 pub mod branch_bound;
 pub mod cuckoo_search;
+pub mod flower_pollination;
 pub mod distance_matrix;
 pub mod genetic_algorithm;
 pub mod kdtree;
@@ -12,6 +13,7 @@ pub mod stochastic_hill;
 pub mod tabu_search;
 pub mod opt_tour;
 pub mod particle_swarm;
+pub mod probability;
 pub mod tsplib;
 pub mod two_opt;
 
@@ -31,6 +33,7 @@ pub enum Solvers {
     BellmanKarp,
     BranchBound,
     CuckooSearch,
+    FlowerPollination,
     NearestNeighbor,
     GeneticAlgorithm,
     ParticleSwarmOptimization,
@@ -49,6 +52,8 @@ impl Solvers {
             "branch_bound",
             "cs",
             "cuckoo_search",
+            "fpa",
+            "flower_pollination",
             "nearest_neighbor",
             "nn",
             "genetic_algorithm",
@@ -73,6 +78,7 @@ impl FromStr for Solvers {
             "bhk" | "bellman_karp" => Ok(Solvers::BellmanKarp),
             "branch_bound" => Ok(Solvers::BranchBound),
             "cs" | "cuckoo_search" => Ok(Solvers::CuckooSearch),
+            "fpa" | "flower_pollination" => Ok(Solvers::FlowerPollination),
             "nn" | "nearest_neighbor" => Ok(Solvers::NearestNeighbor),
             "ga" | "genetic_algorithm" => Ok(Solvers::GeneticAlgorithm),
             "pso" | "particle_swarm" => Ok(Solvers::ParticleSwarmOptimization),

--- a/src/tsp/probability.rs
+++ b/src/tsp/probability.rs
@@ -43,7 +43,7 @@ pub fn bernoulli(rng: &mut impl Rng, p: f64) -> bool {
 }
 
 /// Sample a random index in `0..n` that is not in `excluded`. Panics if no valid index exists.
-pub fn sample_with_exclude(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
+pub fn sample_without_replacement(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
     loop {
         let idx = rng.random_range(0..n);
         if !excluded.contains(&idx) {

--- a/src/tsp/probability.rs
+++ b/src/tsp/probability.rs
@@ -1,0 +1,115 @@
+use rand::Rng;
+
+pub const BETA: f64 = 1.5;
+// Mantegna (1994) σ_u for β=1.5: (Γ(1+β)·sin(πβ/2)/(Γ((1+β)/2)·β·2^((β-1)/2)))^(1/β)
+pub const SIGMA_U: f64 = 0.6966;
+
+/// Box-Muller normal sample; guards ln(0) with MIN_POSITIVE floor.
+pub fn normal_sample(rng: &mut impl Rng) -> f64 {
+    let u1: f64 = rng.random::<f64>().max(f64::MIN_POSITIVE);
+    let u2: f64 = rng.random();
+    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+}
+
+/// Mantegna's Lévy-stable step (β=1.5). Resamples v to avoid ÷0 → inf.
+pub fn levy_step(rng: &mut impl Rng) -> f64 {
+    let u = normal_sample(rng) * SIGMA_U;
+    let mut v = normal_sample(rng);
+    while v.abs() < f64::MIN_POSITIVE {
+        v = normal_sample(rng);
+    }
+    u / v.abs().powf(1.0 / BETA)
+}
+
+/// Boltzmann acceptance: exp(-(e2-e1)/t). Caller handles the e2<e1 case.
+pub fn metropolis(t: f32, e1: f32, e2: f32) -> f32 {
+    (-(e2 - e1) / t).exp()
+}
+
+/// Geometric cooling: temperature × (1 - cooling_rate).
+pub fn cooling(temperature: f32, cooling_rate: f32) -> f32 {
+    temperature - cooling_rate * temperature
+}
+
+/// Bernoulli trial — returns true with probability p. Constructs its own RNG; for hot loops use `bernoulli`.
+pub fn probability(p: f32) -> bool {
+    let mut rng = rand::rng();
+    p > rng.random::<f32>()
+}
+
+/// Bernoulli trial using a caller-supplied RNG — zero allocation, suitable for inner loops.
+pub fn bernoulli(rng: &mut impl Rng, p: f64) -> bool {
+    rng.random::<f64>() < p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normal_sample_is_finite() {
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            let s = normal_sample(&mut rng);
+            assert!(s.is_finite(), "normal_sample returned non-finite: {s}");
+        }
+    }
+
+    #[test]
+    fn test_levy_step_is_finite() {
+        let mut rng = rand::rng();
+        for _ in 0..10_000 {
+            let s = levy_step(&mut rng);
+            assert!(s.is_finite(), "levy_step produced non-finite: {s}");
+        }
+    }
+
+    #[test]
+    fn test_metropolis_equal_energies_returns_one() {
+        let result = metropolis(100.0, 10.0, 10.0);
+        assert!((result - 1.0).abs() < 1e-5, "expected 1.0, got {result}");
+    }
+
+    #[test]
+    fn test_metropolis_worsening_returns_in_0_1() {
+        let result = metropolis(100.0, 10.0, 11.0);
+        assert!(result > 0.0 && result < 1.0, "expected (0,1), got {result}");
+    }
+
+    #[test]
+    fn test_cooling_reduces_temperature() {
+        let t = cooling(100.0, 0.01);
+        assert!(t < 100.0, "cooling should reduce temperature, got {t}");
+        assert!((t - 99.0).abs() < 1e-4, "expected ~99.0, got {t}");
+    }
+
+    #[test]
+    fn test_probability_always_false_at_zero() {
+        for _ in 0..100 {
+            assert!(!probability(0.0));
+        }
+    }
+
+    #[test]
+    fn test_probability_always_true_above_one() {
+        for _ in 0..100 {
+            assert!(probability(1.1));
+        }
+    }
+
+    #[test]
+    fn test_bernoulli_always_false_at_zero() {
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            assert!(!bernoulli(&mut rng, 0.0));
+        }
+    }
+
+    #[test]
+    fn test_bernoulli_always_true_above_one() {
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            assert!(bernoulli(&mut rng, 1.1));
+        }
+    }
+}

--- a/src/tsp/probability.rs
+++ b/src/tsp/probability.rs
@@ -42,6 +42,16 @@ pub fn bernoulli(rng: &mut impl Rng, p: f64) -> bool {
     rng.random::<f64>() < p
 }
 
+/// Sample a random index in `0..n` that is not in `excluded`. Panics if no valid index exists.
+pub fn sample_with_exclude(rng: &mut impl Rng, n: usize, excluded: &[usize]) -> usize {
+    loop {
+        let idx = rng.random_range(0..n);
+        if !excluded.contains(&idx) {
+            return idx;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tsp/route.rs
+++ b/src/tsp/route.rs
@@ -112,6 +112,36 @@ fn swap_cities(route: &mut [usize], from: usize, to: usize) {
     }
 }
 
+/// Greedy swap sequence that transforms `from` into `to`.
+/// Returns `Vec<(pos_i, pos_j)>` of swaps to apply in order.
+/// Both slices must be permutations of the same elements.
+pub fn swap_sequence(from: &[usize], to: &[usize]) -> Vec<(usize, usize)> {
+    let n = from.len();
+    let mut tmp = from.to_vec();
+    let mut seq: Vec<(usize, usize)> = Vec::new();
+    for i in 0..n.saturating_sub(1) {
+        if tmp[i] != to[i] {
+            let j = tmp[i + 1..]
+                .iter()
+                .position(|&x| x == to[i])
+                .map(|p| p + i + 1)
+                .expect("swap_sequence: permutations must share the same elements");
+            seq.push((i, j));
+            tmp.swap(i, j);
+        }
+    }
+    seq
+}
+
+/// Apply an ordered list of `(i, j)` swaps to `position`, returning the result.
+pub fn apply_swaps(position: &[usize], swaps: &[(usize, usize)]) -> Vec<usize> {
+    let mut pos = position.to_vec();
+    for &(i, j) in swaps {
+        pos.swap(i, j);
+    }
+    pos
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,6 +164,25 @@ mod tests {
         assert_eq!(2, route.len());
         assert_eq!(Some(0), route.get(0));
         assert_eq!(Some(1), route.get(1));
+    }
+
+    #[test]
+    fn test_swap_sequence_converts_from_to_to() {
+        let from = vec![1, 2, 3, 4];
+        let to = vec![1, 3, 2, 4];
+        assert_eq!(apply_swaps(&from, &swap_sequence(&from, &to)), to);
+    }
+
+    #[test]
+    fn test_swap_sequence_identity_is_empty() {
+        let v = vec![1, 2, 3];
+        assert!(swap_sequence(&v, &v).is_empty());
+    }
+
+    #[test]
+    fn test_apply_swaps_empty_is_identity() {
+        let pos = vec![1, 2, 3];
+        assert_eq!(apply_swaps(&pos, &[]), pos);
     }
 
     #[test]

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -12,9 +12,9 @@
 /// because solution quality depends on runtime epochs.
 use std::path::Path;
 use teeline::tsp::{
-    bellman_karp, branch_bound, cuckoo_search, distance_matrix, genetic_algorithm, kdtree,
-    nearest_neighbor, particle_swarm, simulated_annealing, stochastic_hill, tabu_search, two_opt,
-    tsplib, SolverOptions,
+    bellman_karp, branch_bound, cuckoo_search, distance_matrix, flower_pollination,
+    genetic_algorithm, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
+    stochastic_hill, tabu_search, two_opt, tsplib, SolverOptions,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -295,4 +295,25 @@ fn bellman_karp_optimal_gr17() {
         "BHK should find optimal ~2085 on gr17, got {}",
         tour.total
     );
+}
+
+// ─── flower pollination algorithm ────────────────────────────────────────────
+
+#[test]
+fn flower_pollination_valid_tour_berlin52() {
+    let cities = load_berlin52();
+    let mut opts = stochastic_options(200);
+    opts.mutation_probability = 0.8;
+    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts);
+    assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
+}
+
+#[test]
+fn flower_pollination_tour_is_finite_and_positive() {
+    let cities = load_berlin52();
+    let mut opts = stochastic_options(200);
+    opts.mutation_probability = 0.8;
+    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts);
+    assert!(tour.total > 0.0);
+    assert!(tour.total.is_finite());
 }


### PR DESCRIPTION
## Summary

- Adds the Flower Pollination Algorithm (FPA) solver as `fpa` / `flower_pollination` CLI alias
- Introduces `src/tsp/probability.rs` with shared math (`normal_sample`, `levy_step`, `metropolis`, `cooling`, `probability`, `bernoulli`)
- Adds public `swap_sequence` / `apply_swaps` to `route.rs` (FPA's permutation operations)
- Registers FPA in `Solvers` enum, `variants()`, `FromStr`, and `main.rs` dispatch

## Algorithm

FPA alternates between two modes per flower per epoch (Yang 2012):

- **Global pollination** (`bernoulli(rng, switch_prob)`): computes a swap sequence from the flower toward the global best, scales it by a Lévy step (`β = 1.5`, Mantegna's algorithm), and applies `n_swaps` of it
- **Local pollination** (else): picks two other random flowers `j`, `k` and applies an `ε`-scaled fraction of `swap_sequence(flowers[j], flowers[k])` to flower `i`

Greedy acceptance (update only if `new_cost < current cost`). `switch_prob` is floored to 0.8 when `mutation_probability < 0.01` (the default) to prevent degeneration into near-pure local search.

## Design Notes

- Existing private `levy_step`/`normal_sample` copies in `cuckoo_search.rs` and `metropolis`/`cooling` in `simulated_annealing.rs` are **left in place** for this PR. Deduplication is tracked in issue #69.
- `bernoulli(rng, p)` is the hot-loop variant; `probability(p)` constructs its own RNG and is preserved for existing GA callers.

## Verification

```bash
cargo test                                   # 154 tests, all pass
./target/debug/bin fpa -i data/tsplib/berlin52.tsp   # ~8700-9000, finite, exit 0
```

Closes #43

## Test Plan

- [x] `cargo test tsp::probability` — 9 unit tests (levy, normal, metropolis, cooling, bernoulli)
- [x] `cargo test tsp::route` — 3 new swap helper tests
- [x] `cargo test tsp::flower_pollination` — nn_seed + valid tour unit tests
- [x] `flower_pollination_valid_tour_berlin52` integration test
- [x] `flower_pollination_tour_is_finite_and_positive` integration test
- [x] Binary smoke test on berlin52