### PR TITLE
refactor: deduplicate shared helpers after FPA merge (GH #69)

### DIFF
--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -2,15 +2,10 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
+use super::probability::levy_step;
 use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
-
-// Lévy exponent β=1.5 (Yang & Deb 2009 recommendation for CS).
-// σ_u from Mantegna (1994): (Γ(1+β)·sin(πβ/2) / (Γ((1+β)/2)·β·2^((β-1)/2)))^(1/β)
-// Numerically: (0.8862·0.9816 / (0.8862·1.5·1.2247))^(0.667) ≈ 0.6966
-const BETA: f64 = 1.5;
-const SIGMA_U: f64 = 0.6966;
 const DEFAULT_N_NESTS: usize = 25;
 
 /// Greedy nearest-neighbour tour starting from the first city.
@@ -36,24 +31,6 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
         tour.push(current);
     }
     tour
-}
-
-fn normal_sample(rng: &mut impl Rng) -> f64 {
-    // Box-Muller transform; guard against ln(0) with MIN_POSITIVE floor.
-    let u1: f64 = rng.random::<f64>().max(f64::MIN_POSITIVE);
-    let u2: f64 = rng.random();
-    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
-}
-
-fn levy_step(rng: &mut impl Rng) -> f64 {
-    // Mantegna's algorithm: step = u*σ_u / |v|^(1/β).
-    // Resample v when it's too close to zero to avoid divide-by-zero -> inf.
-    let u = normal_sample(rng) * SIGMA_U;
-    let mut v = normal_sample(rng);
-    while v.abs() < f64::MIN_POSITIVE {
-        v = normal_sample(rng);
-    }
-    u / v.abs().powf(1.0 / BETA)
 }
 
 fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usize> {
@@ -166,24 +143,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 mod tests {
     use super::*;
     use crate::tsp::{distance_matrix, kdtree};
-
-    #[test]
-    fn test_normal_sample_is_finite() {
-        let mut rng = rand::rng();
-        for _ in 0..100 {
-            let s = normal_sample(&mut rng);
-            assert!(s.is_finite(), "normal_sample returned non-finite: {s}");
-        }
-    }
-
-    #[test]
-    fn test_levy_step_is_finite() {
-        let mut rng = rand::rng();
-        for _ in 0..10_000 {
-            let s = levy_step(&mut rng);
-            assert!(s.is_finite(), "levy_step produced non-finite: {s}");
-        }
-    }
 
     #[test]
     fn test_apply_k_random_2opt_preserves_cities() {

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
+use super::probability::probability;
 use super::progress::ProgressMessage;
 use super::route::{random_position_pair, Route};
 use super::{Solution, SolverOptions};
@@ -156,12 +157,6 @@ fn ordered_crossover_genes(
     }
 
     (gene1, gene2)
-}
-
-// returns true with given probability
-fn probability(p: f32) -> bool {
-    let mut rng = rand::rng();
-    p > rng.random::<f32>()
 }
 
 #[derive(Debug, Clone)]

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
-use super::route::Route;
+use super::route::{apply_swaps, swap_sequence, Route};
 use super::{Solution, SolverOptions};
 
 type Swap = (usize, usize);
@@ -42,39 +42,6 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
         tour.push(current);
     }
     tour
-}
-
-/// Greedy swap sequence that converts `from` into `to`.
-///
-/// Iterates positions 0..n-1; the last position auto-aligns, so no
-/// out-of-bounds slice access occurs on valid permutations.
-fn swap_sequence(from: &[usize], to: &[usize]) -> Velocity {
-    let n = from.len();
-    let mut tmp = from.to_vec();
-    let mut seq = Vec::new();
-
-    for i in 0..n.saturating_sub(1) {
-        if tmp[i] != to[i] {
-            // to[i] must exist at some j > i because positions 0..i already match
-            let j = tmp[i + 1..]
-                .iter()
-                .position(|&x| x == to[i])
-                .map(|p| p + i + 1)
-                .expect("swap_sequence: permutations must share the same elements");
-            seq.push((i, j));
-            tmp.swap(i, j);
-        }
-    }
-    seq
-}
-
-/// Apply an ordered list of swaps to a position, returning the new position.
-fn apply_swaps(position: &[usize], velocity: &[Swap]) -> Vec<usize> {
-    let mut pos = position.to_vec();
-    for &(i, j) in velocity {
-        pos.swap(i, j);
-    }
-    pos
 }
 
 /// Scalar-multiply a velocity: keep the first `keep` swaps (clamped to length).
@@ -188,26 +155,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 mod tests {
     use super::*;
     use crate::tsp::{distance_matrix, kdtree};
-
-    #[test]
-    fn test_swap_sequence_converts_from_to_to() {
-        let from = vec![1, 2, 3, 4];
-        let to = vec![1, 3, 2, 4];
-        let seq = swap_sequence(&from, &to);
-        assert_eq!(apply_swaps(&from, &seq), to);
-    }
-
-    #[test]
-    fn test_swap_sequence_identity_returns_empty() {
-        let v = vec![1, 2, 3, 4];
-        assert!(swap_sequence(&v, &v).is_empty());
-    }
-
-    #[test]
-    fn test_apply_swaps_empty_velocity_is_identity() {
-        let pos = vec![1, 2, 3];
-        assert_eq!(apply_swaps(&pos, &[]), pos);
-    }
 
     #[test]
     fn test_trim_velocity_truncates_and_clamps() {

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
+use super::probability::{cooling, metropolis};
 use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{Solution, SolverOptions};
@@ -50,10 +51,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     Solution::new(best_route.route(), cities, distances)
 }
 
-fn cooling(temperature: f32, cooling_rate: f32) -> f32 {
-    temperature - cooling_rate * temperature
-}
-
 fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool {
     if new_distance < old_distance {
         return true;
@@ -71,67 +68,9 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
     p < criteria
 }
 
-// Boltzmann acceptance probability: exp(-(e2 - e1) / t)
-// For worsening moves (e2 > e1): result is in (0, 1) and decreases as temperature drops.
-// For improving moves (e2 < e1): result would be > 1, but is_acceptable handles those before
-// calling metropolis.
-fn metropolis(t: f32, e1: f32, e2: f32) -> f32 {
-    (-(e2 - e1) / t).exp()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const APPROX_EPSILON: f32 = 1e-5;
-
-    fn approx_eq(a: f32, b: f32) -> bool {
-        (a - b).abs() < APPROX_EPSILON
-    }
-
-    // metropolis(t, e1, e2) = exp(-(e2-e1)/t)
-    // For e2 > e1 (worsening): result is in (0,1)
-    // For e2 == e1: result is exp(0) = 1.0
-    // For e2 < e1 (improving): result is > 1.0 (handled by is_acceptable before reaching here)
-
-    #[test]
-    fn test_metropolis_equal_energies_returns_one() {
-        // exp(-(10-10)/100) = exp(0) = 1.0
-        let result = metropolis(100.0, 10.0, 10.0);
-        assert!(approx_eq(1.0, result), "got {result}");
-    }
-
-    #[test]
-    fn test_metropolis_worsening_move_at_high_temperature() {
-        // exp(-(11-10)/100) = exp(-0.01) ≈ 0.99005
-        let result = metropolis(100.0, 10.0, 11.0);
-        assert!(result > 0.0 && result < 1.0, "expected (0,1), got {result}");
-        assert!(approx_eq((-0.01_f32).exp(), result), "got {result}");
-    }
-
-    #[test]
-    fn test_metropolis_worsening_move_at_low_temperature() {
-        // exp(-(11-10)/0.1) = exp(-10) ≈ 0.0000454
-        let result = metropolis(0.1, 10.0, 11.0);
-        assert!(result > 0.0 && result < 1.0, "expected (0,1), got {result}");
-        assert!(approx_eq((-10.0_f32).exp(), result), "got {result}");
-    }
-
-    #[test]
-    fn test_metropolis_higher_temperature_gives_higher_acceptance() {
-        // At higher temperature we accept worse solutions more readily
-        let hot = metropolis(1000.0, 10.0, 15.0);
-        let cold = metropolis(1.0, 10.0, 15.0);
-        assert!(hot > cold, "hot={hot}, cold={cold}");
-    }
-
-    #[test]
-    fn test_metropolis_larger_worsening_gives_lower_acceptance() {
-        // A bigger step backward should be less likely to be accepted
-        let small_step = metropolis(100.0, 10.0, 11.0);
-        let large_step = metropolis(100.0, 10.0, 20.0);
-        assert!(small_step > large_step, "small={small_step}, large={large_step}");
-    }
 
     #[test]
     fn test_is_acceptable_always_accepts_improvement() {


### PR DESCRIPTION
## Summary

Removes private copies of helpers that were intentionally left in place during the FPA PR (#70) to keep that diff minimal. All four files now import from the canonical modules.

| File | Removed | Now imports from |
|------|---------|-----------------|
| `cuckoo_search.rs` | `BETA`, `SIGMA_U`, `normal_sample`, `levy_step` | `probability::levy_step` |
| `simulated_annealing.rs` | `cooling`, `metropolis` | `probability::{cooling, metropolis}` |
| `genetic_algorithm.rs` | `probability` fn | `probability::probability` |
| `particle_swarm.rs` | `swap_sequence`, `apply_swaps` | `route::{swap_sequence, apply_swaps}` |

Duplicate unit tests removed alongside each function (10 tests total). All canonical tests remain in `probability.rs` and `route.rs`.

Net change: **−164 lines / +4 lines**.

Closes #69

## Test Plan

- [x] `cargo test cuckoo_search` — 3 tests pass
- [x] `cargo test simulated_annealing` — 4 tests pass
- [x] `cargo test genetic_algorithm` — 3 tests pass
- [x] `cargo test particle_swarm` — 3 tests pass
- [x] `cargo test` — 158 tests, all pass