### PR TITLE
chore: migrate workspace to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 name = "teeline"
 version = "0.3.0"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "teeline"

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,17 +189,17 @@ fn run_solve(args: &ArgMatches) {
             }
         });
 
-    if let Some(ref ot) = opt_tour {
-        if let Some(ref tx) = options.progress_tx {
-            if ot.dimension == tsp_data.len() {
-                let _ = tx.send(progress::ProgressMessage::OptimalTour(ot.route.clone()));
-            } else {
-                eprintln!(
-                    "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
-                    ot.dimension,
-                    tsp_data.len()
-                );
-            }
+    if let Some(ref ot) = opt_tour
+        && let Some(ref tx) = options.progress_tx
+    {
+        if ot.dimension == tsp_data.len() {
+            let _ = tx.send(progress::ProgressMessage::OptimalTour(ot.route.clone()));
+        } else {
+            eprintln!(
+                "--optimal-tour: dimension mismatch ({} vs {}); skipping visualization overlay",
+                ot.dimension,
+                tsp_data.len()
+            );
         }
     }
 

--- a/src/tsp/convert.rs
+++ b/src/tsp/convert.rs
@@ -55,10 +55,10 @@ pub fn convert_file(input: &Path, output: &Path) -> Result<(), String> {
         .to_string_lossy()
         .into_owned();
 
-    if let Some(parent) = output.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-        }
+    if let Some(parent) = output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
 
     let mut f = fs::File::create(output).map_err(|e| e.to_string())?;

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -20,7 +20,7 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
         let best_pos = unvisited
             .iter()
             .enumerate()
-            .min_by(|(_, &a), (_, &b)| {
+            .min_by(|&(_, &a), &(_, &b)| {
                 let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
                 let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
                 da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -20,7 +20,7 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
         let best_pos = unvisited
             .iter()
             .enumerate()
-            .min_by(|(_, &a), (_, &b)| {
+            .min_by(|&(_, &a), &(_, &b)| {
                 let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
                 let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
                 da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)

--- a/src/tsp/kdtree.rs
+++ b/src/tsp/kdtree.rs
@@ -136,8 +136,7 @@ impl KDTree {
 
         self.walk(|n| pts.borrow_mut().push(n.coords().to_vec()));
 
-        let res = pts.borrow().to_vec();
-        res
+        pts.borrow().to_vec()
     }
 }
 
@@ -219,12 +218,12 @@ impl KDNode {
 
         // check distance from split line
         let split_dist = self.point.split_distance(target_point, self.level_coord());
-        if nearest_result.closest_distance() > split_dist {
-            if let Some(branch) = futher_branch {
-                let further_result = branch.nearest(target_point, nearest_result.clone());
-                let pt_distance = further_result.closest_distance();
-                nearest_result.add(further_result.point, pt_distance);
-            }
+        if nearest_result.closest_distance() > split_dist
+            && let Some(branch) = futher_branch
+        {
+            let further_result = branch.nearest(target_point, nearest_result.clone());
+            let pt_distance = further_result.closest_distance();
+            nearest_result.add(further_result.point, pt_distance);
         }
 
         nearest_result

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -31,7 +31,7 @@ fn nn_seed(city_ids: &[usize], distances: &DistanceMatrix) -> Vec<usize> {
         let best_pos = unvisited
             .iter()
             .enumerate()
-            .min_by(|(_, &a), (_, &b)| {
+            .min_by(|&(_, &a), &(_, &b)| {
                 let da = distances.distance_between(current, a).unwrap_or(f32::MAX);
                 let db = distances.distance_between(current, b).unwrap_or(f32::MAX);
                 da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)

--- a/teeline-wasm/Cargo.toml
+++ b/teeline-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teeline-wasm"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Closes #74

## Summary

- Set `edition = "2024"` in both `Cargo.toml` files (root + `teeline-wasm`)
- Ran `cargo fix --edition` — rewrote closure capture patterns in 3 solver files (`cuckoo_search`, `flower_pollination`, `particle_swarm`) to use edition 2024 field-granular capture
- Fixed 4 latent clippy warnings that surface under `-D warnings`: two collapsible-if in `convert.rs` and `kdtree.rs`/`main.rs`, one let-and-return in `kdtree.rs` (now uses if-let chains, stable in 2024)
- `teeline-wasm/src/bindings.rs` required no changes — wit-bindgen 0.41.0 already emits explicit `unsafe {}` blocks inside `unsafe fn`, which is what edition 2024 requires

## Manual checklist (issue #74)

- [x] No variable named `gen` — confirmed clean
- [x] `unsafe` blocks inside `unsafe fn` are explicit — bindings.rs already compliant
- [x] Closure capture behaviour unchanged — `cargo fix` handled automatically, logic identical
- [x] All tests pass: `cargo test --no-default-features` (12 WASM component + unit + integration)
- [x] Clippy clean: `cargo clippy -- -D warnings`