### PR TITLE
refactor: solver-specific options + PipelineStage as runtime object (#87)

### DIFF
--- a/configs/classic-tuned.toml
+++ b/configs/classic-tuned.toml
@@ -9,20 +9,21 @@
 #   ./target/debug/bin pipeline --config=configs/classic-tuned.toml \
 #       -i data/tsplib/berlin52.tsp
 
-[global]
-epochs       = 10000
-platoo_epochs = 500
-
 [[stage]]
 solver = "nn"
 
 [[stage]]
 solver = "2opt"
+
+[stage.heuristic]
 epochs = 2000
 
 [[stage]]
 solver = "sa"
+
+[stage.sa]
 max_temperature = 200.0   # lower start: 2-opt already cleaned up most crossings
 min_temperature = 0.001
 cooling_rate    = 0.0005  # faster cooling: already near a local optimum
 epochs          = 10000
+platoo_epochs   = 500

--- a/configs/thorough-tuned.toml
+++ b/configs/thorough-tuned.toml
@@ -11,20 +11,22 @@
 #   ./target/debug/bin pipeline --config=configs/thorough-tuned.toml \
 #       -i data/tsplib/berlin52.tsp
 
-[global]
-epochs        = 20000
-platoo_epochs = 1000
-
 [[stage]]
 solver = "nn"
 
 [[stage]]
 solver = "3opt"
-epochs = 5000   # 3-opt is expensive; keep passes bounded
+
+[stage.heuristic]
+epochs        = 5000   # 3-opt is expensive; keep passes bounded
+platoo_epochs = 1000
 
 [[stage]]
 solver = "sa"
+
+[stage.sa]
 max_temperature = 100.0   # very low start: 3-opt left little room for gross improvement
 min_temperature = 0.0001
 cooling_rate    = 0.0002  # slow cooling: take time to explore the tight basin
 epochs          = 20000
+platoo_epochs   = 1000

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::tsp::{AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions,
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
 /// Each provider takes a base and returns an overridden copy.
-pub trait OptionsProvider {
+pub trait AppOptionsProvider {
     fn provide(&self, base: AppOptions) -> Result<AppOptions, String>;
 }
 
@@ -14,7 +14,7 @@ pub trait OptionsProvider {
 /// Returns `Err` on unknown keys or mis-typed sub-tables.
 pub struct TomlTableProvider<'a>(pub &'a toml::Table);
 
-impl OptionsProvider for TomlTableProvider<'_> {
+impl AppOptionsProvider for TomlTableProvider<'_> {
     fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
         for (key, value) in self.0.iter() {
             match key.as_str() {
@@ -152,11 +152,11 @@ pub fn select_pipeline_source(
     }
 }
 
-/// A no-op `OptionsProvider` that leaves the base unchanged.
+/// A no-op `AppOptionsProvider` that leaves the base unchanged.
 /// Used in tests and config-file mode where no CLI overrides apply.
 pub struct IdentityProvider;
 
-impl OptionsProvider for IdentityProvider {
+impl AppOptionsProvider for IdentityProvider {
     fn provide(&self, base: AppOptions) -> Result<AppOptions, String> {
         Ok(base)
     }
@@ -164,7 +164,7 @@ impl OptionsProvider for IdentityProvider {
 
 /// Reads a pipeline config file and returns fully-resolved `(Solvers, AppOptions)` pairs.
 /// The `overrides` provider applies to the base before per-stage TOML keys are merged.
-pub fn resolve_config_file<P: OptionsProvider>(
+pub fn resolve_config_file<P: AppOptionsProvider>(
     path: &Path,
     overrides: &P,
 ) -> Result<Vec<(Solvers, AppOptions)>, String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,103 +1,47 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::tsp::pipeline::PipelineStage;
-use crate::tsp::{SolverOptions, Solvers};
+use crate::tsp::{AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers};
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
 /// Each provider takes a base and returns an overridden copy.
 pub trait OptionsProvider {
-    fn provide(&self, base: SolverOptions) -> Result<SolverOptions, String>;
+    fn provide(&self, base: AppOptions) -> Result<AppOptions, String>;
 }
 
-/// Applies all recognised fields from a `toml::Table` to the base `SolverOptions`.
-/// Returns `Err` on any unknown key; unknown-to-that-solver warnings are collected
-/// by the caller.
+/// Applies recognised sub-tables from a `toml::Table` to the base `AppOptions`.
+/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, and `heuristic` are valid top-level keys.
+/// Returns `Err` on unknown keys or mis-typed sub-tables.
 pub struct TomlTableProvider<'a>(pub &'a toml::Table);
 
 impl OptionsProvider for TomlTableProvider<'_> {
-    fn provide(&self, mut base: SolverOptions) -> Result<SolverOptions, String> {
+    fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
         for (key, value) in self.0.iter() {
             match key.as_str() {
-                "solver" => {} // consumed by the stage parser, not an options field
-                "epochs" => {
-                    base.epochs = value
-                        .as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {value}"))?
-                        as usize;
+                "solver" => {}
+                "sa" => {
+                    let t = value.as_table().ok_or("config: `sa` must be a table")?;
+                    base.sa = Some(SAOptions::from_toml(t)?);
                 }
-                "platoo_epochs" => {
-                    base.platoo_epochs = value
-                        .as_integer()
-                        .ok_or_else(|| {
-                            format!("config: `platoo_epochs` must be an integer, got {value}")
-                        })?
-                        as usize;
+                "ga" => {
+                    let t = value.as_table().ok_or("config: `ga` must be a table")?;
+                    base.ga = Some(GAOptions::from_toml(t)?);
                 }
-                "n_nearest" => {
-                    base.n_nearest = value
-                        .as_integer()
-                        .ok_or_else(|| {
-                            format!("config: `n_nearest` must be an integer, got {value}")
-                        })?
-                        as usize;
+                "cs" => {
+                    let t = value.as_table().ok_or("config: `cs` must be a table")?;
+                    base.cs = Some(CSOptions::from_toml(t)?);
                 }
-                "n_elite" => {
-                    base.n_elite = value
-                        .as_integer()
-                        .ok_or_else(|| {
-                            format!("config: `n_elite` must be an integer, got {value}")
-                        })?
-                        as usize;
+                "fpa" => {
+                    let t = value.as_table().ok_or("config: `fpa` must be a table")?;
+                    base.fpa = Some(FPAOptions::from_toml(t)?);
                 }
-                "mutation_probability" => {
-                    base.mutation_probability = value
-                        .as_float()
-                        .or_else(|| value.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| {
-                            format!(
-                                "config: `mutation_probability` must be a float, got {value}"
-                            )
-                        })?
-                        as f32;
-                }
-                "cooling_rate" => {
-                    base.cooling_rate = value
-                        .as_float()
-                        .or_else(|| value.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| {
-                            format!("config: `cooling_rate` must be a float, got {value}")
-                        })?
-                        as f32;
-                }
-                "max_temperature" => {
-                    base.max_temperature = value
-                        .as_float()
-                        .or_else(|| value.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| {
-                            format!("config: `max_temperature` must be a float, got {value}")
-                        })?
-                        as f32;
-                }
-                "min_temperature" => {
-                    base.min_temperature = value
-                        .as_float()
-                        .or_else(|| value.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| {
-                            format!("config: `min_temperature` must be a float, got {value}")
-                        })?
-                        as f32;
-                }
-                "verbose" => {
-                    base.verbose = value
-                        .as_bool()
-                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {value}"))?;
+                "heuristic" => {
+                    let t = value.as_table().ok_or("config: `heuristic` must be a table")?;
+                    base.heuristic = Some(HeuristicOptions::from_toml(t)?);
                 }
                 other => {
                     return Err(format!(
-                        "config: unknown field `{other}` — check for typos (valid fields: \
-                         epochs, platoo_epochs, n_nearest, n_elite, mutation_probability, \
-                         cooling_rate, max_temperature, min_temperature, verbose)"
+                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, heuristic"
                     ));
                 }
             }
@@ -106,28 +50,18 @@ impl OptionsProvider for TomlTableProvider<'_> {
     }
 }
 
-/// Parse a TOML string into a list of `PipelineStage`s, each with fully-merged options.
+/// Parse a TOML string into a list of `(Solvers, AppOptions)` pairs.
 ///
-/// `global_base` should already have [global] and CLI flags applied (in that order).
-/// Returns `(stages, warnings)` on success; warnings are soft advisories (irrelevant
-/// fields for a given solver). Hard errors are returned as `Err`.
+/// `base` is the starting `AppOptions` (usually `AppOptions::default()`).
+/// Per-stage `[stage.sa]`, `[stage.ga]`, etc. are merged on top of `base`.
+/// Returns `Err` on parse errors, unknown keys, or wrong sub-table for a solver.
 pub fn load_pipeline_config(
     source: &str,
-    global_base: SolverOptions,
-) -> Result<(Vec<PipelineStage>, Vec<String>), String> {
+    base: AppOptions,
+) -> Result<Vec<(Solvers, AppOptions)>, String> {
     let root: toml::Table = toml::from_str(source)
         .map_err(|e| format!("config: TOML parse error: {e}"))?;
 
-    // --- [global] section — already applied externally, but validate for unknown keys ---
-    if let Some(global_value) = root.get("global") {
-        let global_table = global_value
-            .as_table()
-            .ok_or("config: [global] must be a table")?;
-        // Re-run through TomlTableProvider for unknown-key validation only; ignore result.
-        TomlTableProvider(global_table).provide(SolverOptions::default())?;
-    }
-
-    // --- [[stage]] array ---
     let stage_array = root
         .get("stage")
         .ok_or("config: missing [[stage]] array — at least one stage is required")?
@@ -139,14 +73,12 @@ pub fn load_pipeline_config(
     }
 
     let mut stages = Vec::with_capacity(stage_array.len());
-    let mut warnings = Vec::new();
 
     for (i, entry) in stage_array.iter().enumerate() {
         let table = entry
             .as_table()
             .ok_or_else(|| format!("config: [[stage]] entry {i} is not a table"))?;
 
-        // solver is required
         let solver_name = table
             .get("solver")
             .ok_or_else(|| format!("config: [[stage]] entry {i} missing required `solver` field"))?
@@ -159,137 +91,29 @@ pub fn load_pipeline_config(
             format!("config: [[stage]] entry {i}: unknown solver `{solver_name}`")
         })?;
 
-        // Apply stage-level overrides on top of global_base
-        let stage_options = TomlTableProvider(table).provide(global_base.clone())?;
+        let stage_options = TomlTableProvider(table).provide(base.clone())?;
 
-        // Validate numeric constraints
-        validate_options(i, &stage_options)?;
-
-        // Collect soft warnings for irrelevant fields
-        collect_irrelevant_warnings(i, solver, table, &mut warnings);
-
-        // verbose in [[stage]] has no effect — tracing subscriber is init'd once globally
-        if table.contains_key("verbose") {
-            warnings.push(format!(
-                "config: [[stage]] {i} ({solver_name}): `verbose` in a stage block has no \
-                 effect — set it in [global] or via --verbose"
-            ));
-        }
-
-        stages.push(PipelineStage { solver, options: stage_options });
-    }
-
-    Ok((stages, warnings))
-}
-
-/// Validates numeric constraints on a fully-resolved `SolverOptions`.
-fn validate_options(stage_idx: usize, opts: &SolverOptions) -> Result<(), String> {
-    if opts.cooling_rate <= 0.0 {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: cooling_rate must be > 0 (got {})",
-            opts.cooling_rate
-        ));
-    }
-    if opts.cooling_rate >= 1.0 {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: cooling_rate must be < 1 (got {})",
-            opts.cooling_rate
-        ));
-    }
-    if opts.max_temperature <= 0.0 {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: max_temperature must be > 0 (got {})",
-            opts.max_temperature
-        ));
-    }
-    if opts.min_temperature < 0.0 {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: min_temperature must be >= 0 (got {})",
-            opts.min_temperature
-        ));
-    }
-    if opts.min_temperature >= opts.max_temperature {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: min_temperature ({}) must be < max_temperature ({})",
-            opts.min_temperature, opts.max_temperature
-        ));
-    }
-    if opts.mutation_probability < 0.0 || opts.mutation_probability > 1.0 {
-        return Err(format!(
-            "config: [[stage]] {stage_idx}: mutation_probability must be in [0, 1] (got {})",
-            opts.mutation_probability
-        ));
-    }
-    if opts.epochs == 0 {
-        warnings_push_degenerate(stage_idx, opts.epochs);
-    }
-    Ok(())
-}
-
-fn warnings_push_degenerate(_stage_idx: usize, _epochs: usize) {
-    // epochs == 0 means "run forever" for most solvers; it's degenerate but not an error.
-    // Surfaced as a warning by the caller collecting from validate_options.
-    // (We can't return warnings from validate_options without changing its signature;
-    //  the caller handles this separately below.)
-}
-
-/// Temperature-like fields that are only meaningful for SimulatedAnnealing.
-const TEMP_FIELDS: &[&str] = &["max_temperature", "min_temperature", "cooling_rate"];
-
-/// Mutation/elite fields meaningful for GA/CS/FPA.
-const GA_FIELDS: &[&str] = &["mutation_probability", "n_elite"];
-
-fn collect_irrelevant_warnings(
-    stage_idx: usize,
-    solver: Solvers,
-    table: &toml::Table,
-    warnings: &mut Vec<String>,
-) {
-    let uses_temperature = matches!(solver, Solvers::SimulatedAnnealing);
-    let uses_ga_fields = matches!(
-        solver,
-        Solvers::GeneticAlgorithm | Solvers::CuckooSearch | Solvers::FlowerPollination
-    );
-
-    if !uses_temperature {
-        for field in TEMP_FIELDS {
-            if table.contains_key(*field) {
-                warnings.push(format!(
-                    "config: [[stage]] {stage_idx} ({solver:?}): `{field}` has no effect on \
-                     this solver (only used by sa)"
+        // Hard error if a solver-specific sub-table is present for the wrong solver.
+        for (sub, belongs) in [
+            ("sa",        matches!(solver, Solvers::SimulatedAnnealing)),
+            ("ga",        matches!(solver, Solvers::GeneticAlgorithm)),
+            ("cs",        matches!(solver, Solvers::CuckooSearch)),
+            ("fpa",       matches!(solver, Solvers::FlowerPollination)),
+            ("heuristic", !matches!(solver,
+                Solvers::SimulatedAnnealing | Solvers::GeneticAlgorithm |
+                Solvers::CuckooSearch | Solvers::FlowerPollination)),
+        ] {
+            if table.contains_key(sub) && !belongs {
+                return Err(format!(
+                    "config: stage {i} ({solver_name}): `[stage.{sub}]` is not valid for this solver"
                 ));
             }
         }
+
+        stages.push((solver, stage_options));
     }
 
-    if !uses_ga_fields {
-        for field in GA_FIELDS {
-            if table.contains_key(*field) {
-                warnings.push(format!(
-                    "config: [[stage]] {stage_idx} ({solver:?}): `{field}` has no effect on \
-                     this solver (only used by ga/cs/fpa)"
-                ));
-            }
-        }
-    }
-}
-
-/// Apply a `[global]` TOML table to a base `SolverOptions`.
-/// Convenience wrapper used by `main.rs` before applying CLI overrides.
-pub fn apply_global(
-    source: &str,
-    base: SolverOptions,
-) -> Result<SolverOptions, String> {
-    let root: toml::Table = toml::from_str(source)
-        .map_err(|e| format!("config: TOML parse error: {e}"))?;
-
-    match root.get("global") {
-        Some(v) => {
-            let table = v.as_table().ok_or("config: [global] must be a table")?;
-            TomlTableProvider(table).provide(base)
-        }
-        None => Ok(base),
-    }
+    Ok(stages)
 }
 
 // ---------------------------------------------------------------------------
@@ -329,28 +153,26 @@ pub fn select_pipeline_source(
 }
 
 /// A no-op `OptionsProvider` that leaves the base unchanged.
-/// Used in tests that have no CLI arguments to apply.
+/// Used in tests and config-file mode where no CLI overrides apply.
 pub struct IdentityProvider;
 
 impl OptionsProvider for IdentityProvider {
-    fn provide(&self, base: SolverOptions) -> Result<SolverOptions, String> {
+    fn provide(&self, base: AppOptions) -> Result<AppOptions, String> {
         Ok(base)
     }
 }
 
-/// Reads a pipeline config file and returns fully-resolved stages.
-///
-/// Applies `[global]` first, then `overrides` (e.g. CLI flags), then per-stage keys.
+/// Reads a pipeline config file and returns fully-resolved `(Solvers, AppOptions)` pairs.
+/// The `overrides` provider applies to the base before per-stage TOML keys are merged.
 pub fn resolve_config_file<P: OptionsProvider>(
     path: &Path,
     overrides: &P,
-) -> Result<(Vec<PipelineStage>, Vec<String>), String> {
+) -> Result<Vec<(Solvers, AppOptions)>, String> {
     let source = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read config file '{}': {e}", path.display()))?;
 
-    let global_base = apply_global(&source, SolverOptions::default())?;
-    let merged_base = overrides.provide(global_base)?;
-    load_pipeline_config(&source, merged_base)
+    let base = overrides.provide(AppOptions::default())?;
+    load_pipeline_config(&source, base)
 }
 
 // ---------------------------------------------------------------------------
@@ -360,177 +182,181 @@ pub fn resolve_config_file<P: OptionsProvider>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::SolverOptions;
-
-    fn defaults() -> SolverOptions {
-        SolverOptions::default()
-    }
+    use crate::tsp::{AppOptions, HeuristicOptions, SAOptions};
 
     // --- TomlTableProvider ---
 
     #[test]
-    fn test_toml_provider_patches_epochs() {
-        let table: toml::Table = toml::from_str("epochs = 9999").unwrap();
-        let opts = TomlTableProvider(&table).provide(defaults()).unwrap();
-        assert_eq!(opts.epochs, 9999);
+    fn test_toml_provider_skips_solver_key() {
+        let table: toml::Table = toml::from_str("solver = \"nn\"").unwrap();
+        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        assert!(opts.sa.is_none());
+        assert!(opts.heuristic.is_none());
+    }
+
+    #[test]
+    fn test_toml_provider_sa_sub_table_works() {
+        let table: toml::Table = toml::from_str(
+            "solver = \"sa\"\n[sa]\nepochs = 5000\ncooling_rate = 0.0005\nmax_temperature = 200.0\nmin_temperature = 0.001"
+        ).unwrap();
+        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        let sa = opts.sa.unwrap();
+        assert_eq!(sa.heuristic.epochs, 5000);
+        assert!((sa.cooling_rate - 0.0005).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_toml_provider_heuristic_sub_table_works() {
+        let table: toml::Table =
+            toml::from_str("solver = \"2opt\"\n[heuristic]\nepochs = 500").unwrap();
+        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        assert_eq!(opts.heuristic.unwrap().epochs, 500);
     }
 
     #[test]
     fn test_toml_provider_unknown_key_errors() {
         let table: toml::Table = toml::from_str("epoch = 9999").unwrap();
-        let err = TomlTableProvider(&table).provide(defaults()).unwrap_err();
+        let err = TomlTableProvider(&table).provide(AppOptions::default()).unwrap_err();
         assert!(err.contains("unknown field"), "got: {err}");
         assert!(err.contains("epoch"), "got: {err}");
     }
 
     #[test]
-    fn test_toml_provider_skips_solver_key() {
-        let table: toml::Table = toml::from_str("solver = \"nn\"\nepochs = 500").unwrap();
-        let opts = TomlTableProvider(&table).provide(defaults()).unwrap();
-        assert_eq!(opts.epochs, 500);
-    }
-
-    #[test]
-    fn test_toml_provider_float_field() {
-        let table: toml::Table =
-            toml::from_str("max_temperature = 250.0\ncooling_rate = 0.001").unwrap();
-        let opts = TomlTableProvider(&table).provide(defaults()).unwrap();
-        assert!((opts.max_temperature - 250.0).abs() < 0.01);
-        assert!((opts.cooling_rate - 0.001).abs() < 1e-6);
+    fn test_toml_provider_flat_epochs_errors_as_unknown_key() {
+        let table: toml::Table = toml::from_str("solver = \"sa\"\nepochs = 9999").unwrap();
+        let err = TomlTableProvider(&table).provide(AppOptions::default()).unwrap_err();
+        assert!(err.contains("unknown field"), "got: {err}");
     }
 
     // --- load_pipeline_config ---
 
     #[test]
-    fn test_load_pipeline_config_global_patches_base() {
-        let toml = r#"
-[global]
-epochs = 5000
-
-[[stage]]
-solver = "nn"
-
-[[stage]]
-solver = "sa"
-"#;
-        // Pre-apply [global] (as run_pipeline does), then let load_pipeline_config
-        // handle per-stage overrides on top.
-        let base = apply_global(toml, defaults()).unwrap();
-        let (stages, warnings) = load_pipeline_config(toml, base).unwrap();
-        assert_eq!(stages.len(), 2);
-        assert_eq!(stages[0].options.epochs, 5000);
-        assert_eq!(stages[1].options.epochs, 5000);
-        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
-    }
-
-    #[test]
-    fn test_load_pipeline_config_stage_override_is_local() {
-        let toml = r#"
-[global]
-epochs = 5000
-
-[[stage]]
-solver = "nn"
-
-[[stage]]
-solver = "2opt"
-epochs = 500
-"#;
-        let base = apply_global(toml, defaults()).unwrap();
-        let (stages, _) = load_pipeline_config(toml, base).unwrap();
-        assert_eq!(stages[0].options.epochs, 5000); // from global
-        assert_eq!(stages[1].options.epochs, 500);  // overridden by stage
-    }
-
-    #[test]
     fn test_load_pipeline_config_empty_stages_errors() {
         let toml = "[global]\nepochs = 100\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("[[stage]]") || err.contains("stage"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_unknown_key_in_stage_errors() {
-        let toml = r#"
-[[stage]]
-solver = "nn"
-epoch = 999
-"#;
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let toml = "[[stage]]\nsolver = \"nn\"\nepoch = 999\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("unknown field"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_unknown_solver_errors() {
         let toml = "[[stage]]\nsolver = \"bogus\"\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("bogus"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_cooling_rate_zero_errors() {
-        let toml = "[[stage]]\nsolver = \"sa\"\ncooling_rate = 0.0\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let toml =
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("cooling_rate"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_cooling_rate_ge_one_errors() {
-        let toml = "[[stage]]\nsolver = \"sa\"\ncooling_rate = 1.5\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let toml =
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 1.5\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("cooling_rate"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_negative_max_temperature_errors() {
-        let toml = "[[stage]]\nsolver = \"sa\"\nmax_temperature = -1.0\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let toml =
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = -1.0\nmin_temperature = 0.001\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("max_temperature"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_min_ge_max_temperature_errors() {
         let toml =
-            "[[stage]]\nsolver = \"sa\"\nmin_temperature = 500.0\nmax_temperature = 100.0\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmin_temperature = 500.0\nmax_temperature = 100.0\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("min_temperature"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_mutation_probability_out_of_range_errors() {
-        let toml = "[[stage]]\nsolver = \"ga\"\nmutation_probability = 1.5\n";
-        let err = load_pipeline_config(toml, defaults()).unwrap_err();
+        let toml =
+            "[[stage]]\nsolver = \"ga\"\n\n[stage.ga]\nmutation_probability = 1.5\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("mutation_probability"), "got: {err}");
     }
 
     #[test]
-    fn test_load_pipeline_config_irrelevant_temp_on_nn_warns() {
-        let toml = "[[stage]]\nsolver = \"nn\"\nmax_temperature = 500.0\n";
-        let (stages, warnings) = load_pipeline_config(toml, defaults()).unwrap();
-        assert_eq!(stages.len(), 1);
-        assert!(!warnings.is_empty(), "expected at least one warning");
-        assert!(warnings[0].contains("max_temperature"), "got: {:?}", warnings);
+    fn test_load_pipeline_config_sa_sub_table_on_nn_errors() {
+        let toml =
+            "[[stage]]\nsolver = \"nn\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("sa"), "got: {err}");
     }
 
     #[test]
-    fn test_load_pipeline_config_verbose_in_stage_warns() {
-        let toml = "[[stage]]\nsolver = \"nn\"\nverbose = true\n";
-        let (_, warnings) = load_pipeline_config(toml, defaults()).unwrap();
-        assert!(!warnings.is_empty());
-        assert!(warnings.iter().any(|w| w.contains("verbose")));
+    fn test_load_pipeline_config_heuristic_sub_table_on_sa_errors() {
+        let toml =
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n\n[stage.heuristic]\nepochs = 5000\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("heuristic"), "got: {err}");
     }
 
     #[test]
-    fn test_apply_global_patches_base() {
-        let toml = "[global]\nepochs = 7777\n";
-        let opts = apply_global(toml, defaults()).unwrap();
-        assert_eq!(opts.epochs, 7777);
+    fn test_load_pipeline_config_irrelevant_temp_on_nn_errors() {
+        // top-level cooling_rate is unknown field, not a soft warning any more
+        let toml = "[[stage]]\nsolver = \"nn\"\ncooling_rate = 500.0\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("cooling_rate"), "got: {err}");
     }
 
     #[test]
-    fn test_apply_global_no_section_returns_base_unchanged() {
-        let toml = "[[stage]]\nsolver = \"nn\"\n";
-        let opts = apply_global(toml, defaults()).unwrap();
-        assert_eq!(opts.epochs, defaults().epochs);
+    fn test_load_pipeline_config_returns_tuples() {
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmin_temperature = 0.0001\nmax_temperature = 100.0\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0].0, Solvers::NearestNeighbor);
+        assert_eq!(stages[1].0, Solvers::SimulatedAnnealing);
+        let sa_opts = stages[1].1.sa.as_ref().unwrap();
+        assert!((sa_opts.cooling_rate - 0.001).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_load_pipeline_config_sa_epochs_in_sub_table() {
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\nepochs = 5000\ncooling_rate = 0.001\nmin_temperature = 0.001\nmax_temperature = 1000.0\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        assert_eq!(stages[0].1.sa.as_ref().unwrap().heuristic.epochs, 5000);
+    }
+
+    #[test]
+    fn test_load_pipeline_config_heuristic_epochs_for_generic_solver() {
+        let toml = "[[stage]]\nsolver = \"2opt\"\n\n[stage.heuristic]\nepochs = 200\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        assert_eq!(stages[0].1.heuristic.as_ref().unwrap().epochs, 200);
+    }
+
+    #[test]
+    fn test_load_pipeline_config_ga_mutation_in_sub_table() {
+        let toml =
+            "[[stage]]\nsolver = \"ga\"\n\n[stage.ga]\nmutation_probability = 0.05\nepochs = 100\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        let ga = stages[0].1.ga.as_ref().unwrap();
+        assert!((ga.mutation_probability - 0.05).abs() < 1e-6);
+        assert_eq!(ga.heuristic.epochs, 100);
+    }
+
+    #[test]
+    fn test_load_pipeline_config_sa_uses_from_toml_validation() {
+        // validate() is called inside SAOptions::from_toml()
+        let toml =
+            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0005\nmax_temperature = 200.0\nmin_temperature = 0.001\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        let sa = stages[0].1.sa.as_ref().unwrap();
+        assert!((sa.max_temperature - 200.0).abs() < 0.01);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,7 +354,7 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         }
     }
 
-    let mut stages: Vec<PipelineStage> = stage_configs
+    let stages: Vec<PipelineStage> = stage_configs
         .into_iter()
         .map(|(solver, options)| {
             PipelineStage::new(solver, options, TspProblem::new(cities.clone(), distances.clone()), progress_tx.clone())
@@ -365,7 +365,7 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
     let span = tracing::info_span!("solver", n_stages);
     let solver_handle = thread::spawn(move || {
         let _enter = span.entered();
-        let tour = run_pipeline(&mut stages).expect("solver failed");
+        let tour = run_pipeline(&stages).expect("solver failed");
         tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
         tour

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use teeline::config::{
 use teeline::tsp::{
     self, distance_matrix,
     pipeline::{run_pipeline, PipelineStage},
-    progress, progress_eframe, tsplib, AppOptions, Solution, Solvers,
+    progress, progress_eframe, tsplib, AppOptions, Solution, Solvers, TspProblem,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -357,7 +357,7 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
     let stages: Vec<PipelineStage> = stage_configs
         .into_iter()
         .map(|(solver, options)| {
-            PipelineStage::new(solver, options, cities.clone(), distances.clone(), progress_tx.clone())
+            PipelineStage::new(solver, options, TspProblem::new(cities.clone(), distances.clone()), progress_tx.clone())
         })
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::thread;
 
 use teeline::config::{
-    resolve_config_file, select_pipeline_source, IdentityProvider, OptionsProvider, PipelineSource,
+    resolve_config_file, select_pipeline_source, IdentityProvider, AppOptionsProvider, PipelineSource,
 };
 use teeline::tsp::{
     self, distance_matrix,
@@ -29,7 +29,7 @@ impl<'a> CliArgsProvider<'a> {
     }
 }
 
-impl OptionsProvider for CliArgsProvider<'_> {
+impl AppOptionsProvider for CliArgsProvider<'_> {
     fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
         use teeline::tsp::{CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions};
         match self.solver {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,59 +4,59 @@ use std::str::FromStr;
 use std::thread;
 
 use teeline::config::{
-    resolve_config_file, select_pipeline_source, OptionsProvider, PipelineSource,
+    resolve_config_file, select_pipeline_source, IdentityProvider, OptionsProvider, PipelineSource,
 };
 use teeline::tsp::{
-    self, distance_matrix, pipeline, pipeline::PipelineStage, progress, progress_eframe, tsplib,
-    Solution, SolverOptions, Solvers,
+    self, distance_matrix,
+    pipeline::{run_pipeline, PipelineStage},
+    progress, progress_eframe, tsplib, AppOptions, Solution, Solvers,
 };
 use tracing_subscriber::EnvFilter;
 
 // ---------------------------------------------------------------------------
-// CliArgsProvider — applies CLI tuning flags to a base SolverOptions.
-// Absent flags leave the base values intact, so CLI naturally overrides
-// whatever was set by the [global] TOML section.
+// CliArgsProvider — applies CLI tuning flags to a base AppOptions.
+// Solver-aware: routes args to the right XOptions slot based on the active solver.
 // ---------------------------------------------------------------------------
 
-struct CliArgsProvider<'a>(&'a ArgMatches);
+struct CliArgsProvider<'a> {
+    args: &'a ArgMatches,
+    solver: Solvers,
+}
+
+impl<'a> CliArgsProvider<'a> {
+    fn new(args: &'a ArgMatches, solver: Solvers) -> Self {
+        CliArgsProvider { args, solver }
+    }
+}
 
 impl OptionsProvider for CliArgsProvider<'_> {
-    fn provide(&self, mut base: SolverOptions) -> Result<SolverOptions, String> {
-        let args = self.0;
-        if args.get_flag("verbose") {
-            base.verbose = true;
-        }
-        if let Some(v) = args.get_one::<String>("epochs") {
-            base.epochs = usize::from_str(v).unwrap_or(0);
-        }
-        if let Some(v) = args.get_one::<String>("platoo_epochs") {
-            base.platoo_epochs = usize::from_str(v).unwrap_or(0);
-        }
-        if let Some(v) = args.get_one::<String>("n_nearest") {
-            base.n_nearest = usize::from_str(v).unwrap_or(0);
-        }
-        if let Some(v) = args.get_one::<String>("n_elite") {
-            base.n_elite = usize::from_str(v).unwrap_or(0);
-        }
-        if let Some(v) = args.get_one::<String>("mutation_probability") {
-            base.mutation_probability = f32::from_str(v).unwrap_or(0.0);
-        }
-        if let Some(v) = args.get_one::<String>("cooling_rate") {
-            base.cooling_rate = f32::from_str(v).unwrap_or(0.0);
-        }
-        if let Some(v) = args.get_one::<String>("min_temperature") {
-            base.min_temperature = f32::from_str(v).unwrap_or(0.0);
-        }
-        if let Some(v) = args.get_one::<String>("max_temperature") {
-            base.max_temperature = f32::from_str(v).unwrap_or(0.0);
+    fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
+        use teeline::tsp::{CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions};
+        match self.solver {
+            Solvers::SimulatedAnnealing => {
+                base.sa = Some(SAOptions::from_cli(self.args));
+            }
+            Solvers::GeneticAlgorithm => {
+                base.ga = Some(GAOptions::from_cli(self.args));
+            }
+            Solvers::CuckooSearch => {
+                base.cs = Some(CSOptions::from_cli(self.args));
+            }
+            Solvers::FlowerPollination => {
+                base.fpa = Some(FPAOptions::from_cli(self.args));
+            }
+            _ => {
+                base.heuristic = Some(HeuristicOptions::from_cli(self.args));
+            }
         }
         Ok(base)
     }
 }
 
-// Convenience wrapper for paths that don't use a config file.
-fn solver_options_from_args(args: &ArgMatches) -> SolverOptions {
-    CliArgsProvider(args).provide(SolverOptions::default()).unwrap()
+fn solver_options_from_args(args: &ArgMatches, solver: Solvers) -> AppOptions {
+    CliArgsProvider::new(args, solver)
+        .provide(AppOptions::default())
+        .unwrap_or_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -139,7 +139,7 @@ fn main() {
 
     match cli.subcommand() {
         Some(("solve", args)) => run_solve(args),
-        Some(("pipeline", args)) => run_pipeline(args),
+        Some(("pipeline", args)) => run_pipeline_cmd(args),
         Some(("convert", args)) => run_convert(args),
         _ => unreachable!("clap ensures a subcommand is always present"),
     }
@@ -250,7 +250,7 @@ fn run_solve(args: &ArgMatches) {
     }
 }
 
-fn run_pipeline(args: &ArgMatches) {
+fn run_pipeline_cmd(args: &ArgMatches) {
     let config_path: Option<PathBuf> = args.get_one::<String>("config").map(PathBuf::from);
     let steps_vec: Option<Vec<String>> = args
         .get_many::<String>("steps")
@@ -262,14 +262,14 @@ fn run_pipeline(args: &ArgMatches) {
             std::process::exit(1);
         }
         Ok(PipelineSource::Config(path)) => {
-            let (stages, warnings) = match resolve_config_file(&path, &CliArgsProvider(args)) {
+            let stage_configs = match resolve_config_file(&path, &IdentityProvider) {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("error: {e}");
                     std::process::exit(1);
                 }
             };
-            run_as_pipeline_stages(&stages, args, warnings);
+            run_as_pipeline_stages(stage_configs, args);
         }
         Ok(PipelineSource::Steps(solvers)) => {
             run_as_pipeline(&solvers, args);
@@ -277,15 +277,13 @@ fn run_pipeline(args: &ArgMatches) {
     }
 }
 
-// Thin wrapper: builds uniform PipelineStage vec from Solvers slice + CLI options.
 fn run_as_pipeline(steps: &[Solvers], args: &ArgMatches) {
-    let base = solver_options_from_args(args);
-    let stages: Vec<PipelineStage> =
-        steps.iter().map(|&s| PipelineStage { solver: s, options: base.clone() }).collect();
-    run_as_pipeline_stages(&stages, args, vec![]);
+    let stage_configs: Vec<(Solvers, AppOptions)> =
+        steps.iter().map(|&s| (s, solver_options_from_args(args, s))).collect();
+    run_as_pipeline_stages(stage_configs, args);
 }
 
-fn run_as_pipeline_stages(stages: &[PipelineStage], args: &ArgMatches, warnings: Vec<String>) {
+fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgMatches) {
     let verbose = args.get_flag("verbose");
     let default_level = if verbose { "debug" } else { "info" };
     let _ = tracing_subscriber::fmt()
@@ -296,13 +294,8 @@ fn run_as_pipeline_stages(stages: &[PipelineStage], args: &ArgMatches, warnings:
         .with_writer(std::io::stderr)
         .try_init();
 
-    // Emit config warnings now that the subscriber is initialised.
-    for w in &warnings {
-        tracing::warn!("{w}");
-    }
-
-    for (i, stage) in stages.iter().enumerate() {
-        if i > 0 && stage.solver == Solvers::NearestNeighbor {
+    for (i, (solver, _)) in stage_configs.iter().enumerate() {
+        if i > 0 && *solver == Solvers::NearestNeighbor {
             eprintln!("warning: nn at pipeline stage {i} discards the warm-start seed");
         }
     }
@@ -361,21 +354,18 @@ fn run_as_pipeline_stages(stages: &[PipelineStage], args: &ArgMatches, warnings:
         }
     }
 
-    let cities_for_solver = cities.clone();
-    let distances_for_solver = distances.clone();
-    let stages_owned = stages.to_vec();
-    let progress_tx_for_solver = progress_tx.clone();
+    let stages: Vec<PipelineStage> = stage_configs
+        .into_iter()
+        .map(|(solver, options)| {
+            PipelineStage::new(solver, options, cities.clone(), distances.clone(), progress_tx.clone())
+        })
+        .collect();
+
     let n_stages = stages.len();
     let span = tracing::info_span!("solver", n_stages);
     let solver_handle = thread::spawn(move || {
         let _enter = span.entered();
-        let tour = pipeline::solve(
-            &stages_owned,
-            &cities_for_solver,
-            &distances_for_solver,
-            progress_tx_for_solver,
-        )
-        .expect("solver failed");
+        let tour = run_pipeline(&stages).expect("solver failed");
         tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
         tour
@@ -500,6 +490,7 @@ fn read_tsp_data_from_stdin() -> tsplib::TspLibData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use teeline::tsp::HeuristicOptions;
 
     /// Minimal clap Command that mirrors the args read by `solver_options_from_args`.
     fn options_cmd() -> Command {
@@ -512,102 +503,115 @@ mod tests {
     #[test]
     fn test_solver_options_defaults_preserved_when_no_args() {
         let args = options_cmd().get_matches_from(["test", "nn"]);
-        let opts = solver_options_from_args(&args);
-        let defaults = SolverOptions::default();
-        assert!(!opts.verbose);
-        assert!(opts.progress_tx.is_none());
-        assert_eq!(opts.epochs, defaults.epochs);
-        assert_eq!(opts.n_nearest, defaults.n_nearest);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        let h = opts.heuristic.unwrap_or_default();
+        assert!(!h.verbose);
+        assert_eq!(h.epochs, HeuristicOptions::default().epochs);
+        assert_eq!(h.n_nearest, HeuristicOptions::default().n_nearest);
     }
 
     #[test]
     fn test_solver_options_verbose_flag_sets_verbose() {
         let args = options_cmd().get_matches_from(["test", "nn", "--verbose"]);
-        assert!(solver_options_from_args(&args).verbose);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        assert!(opts.heuristic.unwrap_or_default().verbose);
     }
 
     #[test]
     fn test_solver_options_epochs_parsed() {
         let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "500"]);
-        assert_eq!(solver_options_from_args(&args).epochs, 500);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        assert_eq!(opts.heuristic.unwrap_or_default().epochs, 500);
     }
 
     #[test]
-    fn test_solver_options_invalid_epochs_defaults_to_zero() {
+    fn test_solver_options_invalid_epochs_keeps_default() {
         let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "bad"]);
-        assert_eq!(solver_options_from_args(&args).epochs, 0);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        assert_eq!(opts.heuristic.unwrap_or_default().epochs, HeuristicOptions::default().epochs);
     }
 
     #[test]
     fn test_solver_options_platoo_epochs_parsed() {
         let args = options_cmd().get_matches_from(["test", "nn", "--platoo_epochs", "200"]);
-        assert_eq!(solver_options_from_args(&args).platoo_epochs, 200);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        assert_eq!(opts.heuristic.unwrap_or_default().platoo_epochs, 200);
     }
 
     #[test]
     fn test_solver_options_n_nearest_parsed() {
         let args = options_cmd().get_matches_from(["test", "nn", "--n_nearest", "5"]);
-        assert_eq!(solver_options_from_args(&args).n_nearest, 5);
+        let opts = solver_options_from_args(&args, Solvers::NearestNeighbor);
+        assert_eq!(opts.heuristic.unwrap_or_default().n_nearest, 5);
     }
 
     #[test]
     fn test_solver_options_n_elite_parsed() {
-        let args = options_cmd().get_matches_from(["test", "nn", "--n_elite", "7"]);
-        assert_eq!(solver_options_from_args(&args).n_elite, 7);
+        let args = options_cmd().get_matches_from(["test", "ga", "--n_elite", "7"]);
+        let opts = solver_options_from_args(&args, Solvers::GeneticAlgorithm);
+        assert_eq!(opts.ga.unwrap_or_default().n_elite, 7);
     }
 
     #[test]
     fn test_solver_options_mutation_probability_parsed() {
         let args = options_cmd()
-            .get_matches_from(["test", "nn", "--mutation_probability", "0.05"]);
-        let opts = solver_options_from_args(&args);
-        assert!((opts.mutation_probability - 0.05).abs() < 1e-5);
+            .get_matches_from(["test", "ga", "--mutation_probability", "0.05"]);
+        let opts = solver_options_from_args(&args, Solvers::GeneticAlgorithm);
+        assert!((opts.ga.unwrap_or_default().mutation_probability - 0.05).abs() < 1e-5);
     }
 
     #[test]
-    fn test_solver_options_invalid_mutation_probability_defaults_to_zero() {
+    fn test_solver_options_invalid_mutation_probability_keeps_default() {
         let args = options_cmd()
-            .get_matches_from(["test", "nn", "--mutation_probability", "nope"]);
-        assert!((solver_options_from_args(&args).mutation_probability - 0.0).abs() < 1e-5);
+            .get_matches_from(["test", "ga", "--mutation_probability", "nope"]);
+        let opts = solver_options_from_args(&args, Solvers::GeneticAlgorithm);
+        use teeline::tsp::GAOptions;
+        assert!((opts.ga.unwrap_or_default().mutation_probability
+            - GAOptions::default().mutation_probability)
+            .abs()
+            < 1e-5);
     }
 
     #[test]
     fn test_solver_options_cooling_rate_parsed() {
-        let args = options_cmd().get_matches_from(["test", "nn", "--cooling_rate", "0.001"]);
-        let opts = solver_options_from_args(&args);
-        assert!((opts.cooling_rate - 0.001).abs() < 1e-6);
+        let args = options_cmd().get_matches_from(["test", "sa", "--cooling_rate", "0.001"]);
+        let opts = solver_options_from_args(&args, Solvers::SimulatedAnnealing);
+        assert!((opts.sa.unwrap_or_default().cooling_rate - 0.001).abs() < 1e-6);
     }
 
     #[test]
     fn test_solver_options_temperature_bounds_parsed() {
         let args = options_cmd().get_matches_from([
             "test",
-            "nn",
+            "sa",
             "--min_temperature",
             "0.5",
             "--max_temperature",
             "500.0",
         ]);
-        let opts = solver_options_from_args(&args);
-        assert!((opts.min_temperature - 0.5).abs() < 1e-5);
-        assert!((opts.max_temperature - 500.0).abs() < 1e-3);
+        let opts = solver_options_from_args(&args, Solvers::SimulatedAnnealing);
+        let sa = opts.sa.unwrap_or_default();
+        assert!((sa.min_temperature - 0.5).abs() < 1e-5);
+        assert!((sa.max_temperature - 500.0).abs() < 1e-3);
     }
 
     #[test]
     fn test_cli_args_provider_overrides_base() {
-        let args =
-            options_cmd().get_matches_from(["test", "nn", "--epochs", "777"]);
-        let base = SolverOptions { epochs: 100, ..SolverOptions::default() };
-        let opts = CliArgsProvider(&args).provide(base).unwrap();
-        assert_eq!(opts.epochs, 777);
+        let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "777"]);
+        let base = AppOptions::default();
+        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor).provide(base).unwrap();
+        assert_eq!(opts.heuristic.unwrap_or_default().epochs, 777);
     }
 
     #[test]
-    fn test_cli_args_provider_leaves_unset_base_intact() {
+    fn test_cli_args_provider_no_args_uses_defaults() {
         let args = options_cmd().get_matches_from(["test", "nn"]);
-        let base = SolverOptions { epochs: 42, ..SolverOptions::default() };
-        let opts = CliArgsProvider(&args).provide(base).unwrap();
-        assert_eq!(opts.epochs, 42); // not overridden by CLI
+        let base = AppOptions::default();
+        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor).provide(base).unwrap();
+        assert_eq!(
+            opts.heuristic.unwrap_or_default().epochs,
+            HeuristicOptions::default().epochs
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,7 +354,7 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         }
     }
 
-    let stages: Vec<PipelineStage> = stage_configs
+    let mut stages: Vec<PipelineStage> = stage_configs
         .into_iter()
         .map(|(solver, options)| {
             PipelineStage::new(solver, options, TspProblem::new(cities.clone(), distances.clone()), progress_tx.clone())
@@ -365,7 +365,7 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
     let span = tracing::info_span!("solver", n_stages);
     let solver_handle = thread::spawn(move || {
         let _enter = span.entered();
-        let tour = run_pipeline(&stages).expect("solver failed");
+        let tour = run_pipeline(&mut stages).expect("solver failed");
         tracing::info!(tour_length = tour.total, "solver finished");
         print_solution(&tour, false);
         tour

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -45,10 +45,9 @@ pub fn solve(
             .distance_by_pos(i, last_pos)
             .unwrap_or(UNKNOWN_DISTANCE);
 
-        if let Some(city_id) = dists.pos2city_id(&i) {
-            if let Some(tx) = progress_tx {
-                let _ = tx.send(ProgressMessage::CityChange(city_id));
-            }
+        if let Some(city_id) = dists.pos2city_id(&i)
+            && let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::CityChange(city_id));
         }
     }
 

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -15,7 +15,7 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 type FlagSet = u64;
 type DPTable = Vec<Vec<f32>>;
@@ -25,11 +25,10 @@ const UNKNOWN_DISTANCE: f32 = f32::MAX;
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     _initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let n_cities = cities.len();
     let n_others = n_cities - 1;
     let n_powersets = 1 << n_others;
@@ -59,7 +58,7 @@ pub fn solve(
     }
 
     tracing::info!("BHK: DP complete");
-    if h.verbose {
+    if opts.verbose {
         show_table(&opt);
     }
 
@@ -184,7 +183,7 @@ fn show_table(opt: &DPTable) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     fn tsp_5_1_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
@@ -200,7 +199,7 @@ mod tests {
     fn test_solve_returns_all_cities() {
         let cities = tsp_5_1_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();
@@ -215,7 +214,7 @@ mod tests {
     fn test_solve_finds_optimal_tour_length() {
         let cities = tsp_5_1_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         assert!(
             (solution.total - 4.0).abs() < 1e-3,
@@ -232,7 +231,7 @@ mod tests {
             vec![0.0, 4.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -83,7 +83,7 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::Done);
     }
 
-    Solution::new(&route_vec, cities, distances)
+    Solution::from_parts(&route_vec, cities, distances)
 }
 
 fn solve_bhk(

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -9,21 +9,29 @@
 ///
 ///
 ///
+use std::sync::mpsc;
+
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-// 0-1 Set, where 1 means that city N is collected
 type FlagSet = u64;
 type DPTable = Vec<Vec<f32>>;
 
 const UNKNOWN_DISTANCE: f32 = f32::MAX;
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _initial_tour: Option<&[usize]>,
+) -> Solution {
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let n_cities = cities.len();
-    let n_others = n_cities - 1; // we start from last city
+    let n_others = n_cities - 1;
     let n_powersets = 1 << n_others;
 
     tracing::info!(n_cities, n_subsets = n_powersets, "BHK starting");
@@ -32,7 +40,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut opt = vec![vec![UNKNOWN_DISTANCE; n_powersets]; n_others];
 
     tracing::info!("BHK: initialising DP table");
-    // inialize tables first row with distance from first cities to other cities
     let last_pos = n_others;
     for i in 0..n_others {
         opt[i][1 << i] = dists
@@ -40,7 +47,9 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             .unwrap_or(UNKNOWN_DISTANCE);
 
         if let Some(city_id) = dists.pos2city_id(&i) {
-            options.send_progress(ProgressMessage::CityChange(city_id));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::CityChange(city_id));
+            }
         }
     }
 
@@ -50,12 +59,10 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     }
 
     tracing::info!("BHK: DP complete");
-    if options.verbose {
+    if h.verbose {
         show_table(&opt);
     }
 
-    // Find the actual optimal tour distance: min over all ending cities of
-    // (cost to visit all n_others cities ending at i) + (return edge to start city)
     let optimal_distance = (0..n_others)
         .filter_map(|i| {
             let return_dist = dists.distance_by_pos(i, last_pos).ok()?;
@@ -71,10 +78,11 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     tracing::info!(optimal_distance, "BHK: optimal tour found");
     let route_vec = read_optimal_route(&opt, dists, n_cities, optimal_distance);
 
-    // send final route to the visualizer
     let route = Route::new(route_vec.as_ref());
-    options.send_progress(ProgressMessage::PathUpdate(route, 0.0));
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(route, 0.0));
+        let _ = tx.send(ProgressMessage::Done);
+    }
 
     Solution::new(&route_vec, cities, distances)
 }
@@ -87,22 +95,18 @@ fn solve_bhk(
 ) -> f32 {
     let mut best_val = f32::MAX;
 
-    // distance is already calculated
     let selected_pos = selected_set as usize;
     if opt[city_pos][selected_pos] < UNKNOWN_DISTANCE {
         return opt[city_pos][selected_pos];
     }
 
-    // rest_selected R = S \ t , all other than city_id
     let rest_selected = selected_set & !(1 << city_pos);
-    let n_other = opt.len(); // one row per non-start city (positions 0..n_others)
+    let n_other = opt.len();
     for i in 0..n_other {
-        // if city i is not in rest_selected
         if (rest_selected & (1 << i)) == 0 {
             continue;
         }
 
-        // solve sub problem
         let step_dist = dm
             .distance_by_pos(i, city_pos)
             .expect("solve_bhk tried to access non-existent cities");
@@ -180,11 +184,7 @@ fn show_table(opt: &DPTable) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
-
-    fn default_options() -> SolverOptions {
-        SolverOptions::default()
-    }
+    use crate::tsp::{distance_matrix, kdtree, AppOptions};
 
     fn tsp_5_1_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
@@ -200,7 +200,7 @@ mod tests {
     fn test_solve_returns_all_cities() {
         let cities = tsp_5_1_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &default_options());
+        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();
@@ -215,9 +215,8 @@ mod tests {
     fn test_solve_finds_optimal_tour_length() {
         let cities = tsp_5_1_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &default_options());
+        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
 
-        // optimal tour: 0→1→2→3→4→0 = 0.5 + 0.5 + 1.0 + 1.0 + 1.0 = 4.0
         assert!(
             (solution.total - 4.0).abs() < 1e-3,
             "expected tour length ~4.0, got {}",
@@ -233,13 +232,12 @@ mod tests {
             vec![0.0, 4.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &default_options());
+        let solution = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();
         assert_eq!(visited, vec![0, 1, 2]);
 
-        // tour is 3 + 4 + 5 = 12.0
         assert!((solution.total - 12.0).abs() < 1e-3, "got {}", solution.total);
     }
 }

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -12,10 +12,9 @@
 use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 type FlagSet = u64;
 type DPTable = Vec<Vec<f32>>;
@@ -23,12 +22,12 @@ type DPTable = Vec<Vec<f32>>;
 const UNKNOWN_DISTANCE: f32 = f32::MAX;
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    _initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let n_cities = cities.len();
     let n_others = n_cities - 1;
     let n_powersets = 1 << n_others;
@@ -183,23 +182,24 @@ fn show_table(opt: &DPTable) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
-    fn tsp_5_1_cities() -> Vec<kdtree::KDPoint> {
-        kdtree::build_points(&[
+    fn tsp_5_1_problem() -> TspProblem {
+        let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![0.0, 0.5],
             vec![0.0, 1.0],
             vec![1.0, 1.0],
             vec![1.0, 0.0],
-        ])
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        TspProblem::new(cities, dm)
     }
 
     #[test]
     fn test_solve_returns_all_cities() {
-        let cities = tsp_5_1_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp_5_1_problem();
+        let solution = solve(&problem, &HeuristicOptions::default(), None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();
@@ -212,9 +212,8 @@ mod tests {
 
     #[test]
     fn test_solve_finds_optimal_tour_length() {
-        let cities = tsp_5_1_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp_5_1_problem();
+        let solution = solve(&problem, &HeuristicOptions::default(), None);
 
         assert!(
             (solution.total - 4.0).abs() < 1e-3,
@@ -231,7 +230,8 @@ mod tests {
             vec![0.0, 4.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let solution = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = TspProblem::new(cities, dm);
+        let solution = solve(&problem, &HeuristicOptions::default(), None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -25,6 +25,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -199,7 +200,7 @@ mod tests {
     #[test]
     fn test_solve_returns_all_cities() {
         let problem = tsp_5_1_problem();
-        let solution = solve(&problem, &HeuristicOptions::default(), None);
+        let solution = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();
@@ -213,7 +214,7 @@ mod tests {
     #[test]
     fn test_solve_finds_optimal_tour_length() {
         let problem = tsp_5_1_problem();
-        let solution = solve(&problem, &HeuristicOptions::default(), None);
+        let solution = solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(
             (solution.total - 4.0).abs() < 1e-3,
@@ -231,7 +232,7 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let solution = solve(&problem, &HeuristicOptions::default(), None);
+        let solution = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = solution.route().to_vec();
         visited.sort();

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -17,6 +17,7 @@ pub fn solve(
     problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -200,7 +201,7 @@ mod tests {
     #[test]
     fn test_solve_visits_all_cities() {
         let problem = tsp5_problem();
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -210,7 +211,7 @@ mod tests {
     #[test]
     fn test_solve_finds_optimal_tour_on_tsp5() {
         let problem = tsp5_problem();
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(
             (tour.total - 4.0).abs() < 1e-3,
@@ -222,8 +223,8 @@ mod tests {
     #[test]
     fn test_solve_matches_bellman_karp_on_tsp5() {
         let problem = tsp5_problem();
-        let bb_tour = solve(&problem, &HeuristicOptions::default(), None);
-        let bhk_tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
+        let bb_tour = solve(&problem, &HeuristicOptions::default(), None, None);
+        let bhk_tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(
             (bb_tour.total - bhk_tour.total).abs() < 1e-3,

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -6,7 +6,7 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 const UNVISITED_NODE: usize = 0;
 
@@ -17,7 +17,7 @@ type PathEvaluator = Rc<dyn Fn(&Path) -> f32>;
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    _opts: &AppOptions,
+    _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     _initial_tour: Option<&[usize]>,
 ) -> Solution {
@@ -184,7 +184,7 @@ fn undo_move(path: &mut Path, k: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{bellman_karp, distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{bellman_karp, distance_matrix, kdtree, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
@@ -200,7 +200,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -211,7 +211,7 @@ mod tests {
     fn test_solve_finds_optimal_tour_on_tsp5() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         assert!(
             (tour.total - 4.0).abs() < 1e-3,
@@ -224,8 +224,8 @@ mod tests {
     fn test_solve_matches_bellman_karp_on_tsp5() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let bb_tour = solve(&cities, &dm, &AppOptions::default(), None, None);
-        let bhk_tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
+        let bb_tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let bhk_tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         assert!(
             (bb_tour.total - bhk_tour.total).abs() < 1e-3,

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -50,7 +50,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&best_path, cities, distances)
+    Solution::from_parts(&best_path, cities, distances)
 }
 
 fn build_evaluator(distances: &DistanceMatrix) -> PathEvaluator {

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -3,10 +3,9 @@ use std::rc::Rc;
 use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 const UNVISITED_NODE: usize = 0;
 
@@ -15,12 +14,12 @@ type Path = Vec<usize>;
 type PathEvaluator = Rc<dyn Fn(&Path) -> f32>;
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    _initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let mut route = Route::from_cities(cities);
     let n_cities = route.len();
 
@@ -184,23 +183,24 @@ fn undo_move(path: &mut Path, k: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{bellman_karp, distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{bellman_karp, distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
-    fn tsp5_cities() -> Vec<kdtree::KDPoint> {
-        kdtree::build_points(&[
+    fn tsp5_problem() -> TspProblem {
+        let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![0.0, 0.5],
             vec![0.0, 1.0],
             vec![1.0, 1.0],
             vec![1.0, 0.0],
-        ])
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        TspProblem::new(cities, dm)
     }
 
     #[test]
     fn test_solve_visits_all_cities() {
-        let cities = tsp5_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp5_problem();
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -209,9 +209,8 @@ mod tests {
 
     #[test]
     fn test_solve_finds_optimal_tour_on_tsp5() {
-        let cities = tsp5_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp5_problem();
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         assert!(
             (tour.total - 4.0).abs() < 1e-3,
@@ -222,10 +221,9 @@ mod tests {
 
     #[test]
     fn test_solve_matches_bellman_karp_on_tsp5() {
-        let cities = tsp5_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let bb_tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
-        let bhk_tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp5_problem();
+        let bb_tour = solve(&problem, &HeuristicOptions::default(), None);
+        let bhk_tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
 
         assert!(
             (bb_tour.total - bhk_tour.total).abs() < 1e-3,

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -1,11 +1,12 @@
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
 const UNVISITED_NODE: usize = 0;
 
@@ -13,15 +14,22 @@ type UniqSet = HashSet<usize>;
 type Path = Vec<usize>;
 type PathEvaluator = Rc<dyn Fn(&Path) -> f32>;
 
-// TODO: add better strategy or constraints for Bounding step
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    _opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _initial_tour: Option<&[usize]>,
+) -> Solution {
     let mut route = Route::from_cities(cities);
     let n_cities = route.len();
 
     tracing::info!(n_cities, "B&B starting");
 
     route.sort();
-    options.send_progress(ProgressMessage::PathUpdate(route.clone(), 0.0));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(route.clone(), 0.0));
+    }
 
     let mut open_path: Path = vec![0; n_cities];
     open_path[0] = route.get(0).unwrap();
@@ -36,10 +44,12 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         1,
         0.0,
         f32::MAX,
-        options,
+        progress_tx,
     );
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&best_path, cities, distances)
 }
 
@@ -57,7 +67,7 @@ fn backtrack(
     k: usize,
     running_cost: f32,
     upper_bound: f32,
-    options: &SolverOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
 ) -> (Path, f32) {
     let mut best_path = path.clone();
     let mut best_distance = upper_bound;
@@ -84,7 +94,7 @@ fn backtrack(
     );
 
     for candidate in candidates.iter() {
-        make_move(path, k, *candidate, options);
+        make_move(path, k, *candidate, progress_tx);
 
         let visited_path: Vec<usize> = path
             .to_vec()
@@ -92,10 +102,12 @@ fn backtrack(
             .filter(|&&x| x != UNVISITED_NODE)
             .copied()
             .collect();
-        options.send_progress(ProgressMessage::PathUpdate(
-            Route::new(&visited_path),
-            best_distance,
-        ));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::PathUpdate(
+                Route::new(&visited_path),
+                best_distance,
+            ));
+        }
 
         let prev_city = path[k - 1];
         let next_distance = evaluate_fn(&vec![prev_city, *candidate]);
@@ -110,7 +122,7 @@ fn backtrack(
             k + 1,
             running_cost + next_distance,
             best_distance,
-            options,
+            progress_tx,
         );
 
         if sub_dist < best_distance {
@@ -138,11 +150,10 @@ fn construct_candidates(
     best_distance: f32,
     evaluate_fn: &PathEvaluator,
 ) -> Path {
-    let mut candidates: Path = vec![]; // always start from city.id 0
+    let mut candidates: Path = vec![];
 
     for city_id in unvisited_cities.iter() {
         let next_distance = evaluate_fn(&vec![path[k - 1], *city_id]);
-        // simple pruning
         if best_distance > running_cost + next_distance {
             candidates.push(*city_id);
         }
@@ -152,13 +163,19 @@ fn construct_candidates(
     candidates
 }
 
-fn make_move(path: &mut Path, k: usize, candidate: usize, options: &SolverOptions) {
+fn make_move(
+    path: &mut Path,
+    k: usize,
+    candidate: usize,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+) {
     path[k] = candidate;
-    options.send_progress(ProgressMessage::CityChange(candidate));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::CityChange(candidate));
+    }
 }
 
 fn undo_move(path: &mut Path, k: usize) {
-    // we wouldnt change the first city
     if k > 0 {
         path[k] = UNVISITED_NODE;
     }
@@ -167,7 +184,7 @@ fn undo_move(path: &mut Path, k: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{bellman_karp, distance_matrix, kdtree};
+    use crate::tsp::{bellman_karp, distance_matrix, kdtree, AppOptions};
 
     fn tsp5_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
@@ -183,7 +200,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -194,7 +211,7 @@ mod tests {
     fn test_solve_finds_optimal_tour_on_tsp5() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         assert!(
             (tour.total - 4.0).abs() < 1e-3,
@@ -207,8 +224,8 @@ mod tests {
     fn test_solve_matches_bellman_karp_on_tsp5() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let bb_tour = solve(&cities, &dm, &SolverOptions::default());
-        let bhk_tour = bellman_karp::solve(&cities, &dm, &SolverOptions::default());
+        let bb_tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let bhk_tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
 
         assert!(
             (bb_tour.total - bhk_tour.total).abs() < 1e-3,

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -130,7 +130,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&best, cities, distances)
+    Solution::from_parts(&best, cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
@@ -5,7 +7,8 @@ use super::kdtree::KDPoint;
 use super::probability::levy_step;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
+
 const DEFAULT_N_NESTS: usize = 25;
 
 
@@ -23,9 +26,16 @@ fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usiz
     result
 }
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
-    let n_nests = options.n_nearest.max(DEFAULT_N_NESTS);
-    let pa = (options.mutation_probability as f64).clamp(0.01, 0.99);
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let cs = opts.cs.as_ref().cloned().unwrap_or_default();
+    let n_nests = cs.heuristic.n_nearest.max(DEFAULT_N_NESTS);
+    let pa = (cs.mutation_probability as f64).clamp(0.01, 0.99);
     let n_cities = cities.len();
 
     let mut rng = rand::rng();
@@ -34,7 +44,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut nests: Vec<Vec<usize>> = (0..n_nests)
         .map(|idx| {
             if idx == 0 {
-                options.initial_tour.clone().unwrap_or_else(|| {
+                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -63,11 +73,11 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut best: Vec<usize> = nests[best_idx].clone();
     let mut best_cost: f32 = costs[best_idx];
 
-    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+    }
 
-    for epoch in 0..options.epochs {
-        // 1. Each nest generates one cuckoo via Lévy flight (Yang & Deb 2009: n cuckoos/epoch).
-        //    |levy_step| is used as step magnitude; sign is irrelevant for a discrete mapping.
+    for epoch in 0..cs.heuristic.epochs {
         for cuckoo_idx in 0..n_nests {
             let levy = levy_step(&mut rng).abs();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
@@ -76,8 +86,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             let new_tour = apply_k_random_2opt(&nests[cuckoo_idx], k, &mut rng);
             let new_cost = distances.tour_length(&new_tour);
 
-            // Replace a randomly chosen nest if cuckoo is better.
-            // cuckoo_idx may equal target_idx; harmless (nest replaces itself only if better).
             let target_idx = rng.random_range(0..n_nests);
             if new_cost < costs[target_idx] {
                 nests[target_idx] = new_tour;
@@ -86,13 +94,13 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                 if new_cost < best_cost {
                     best = nests[target_idx].clone();
                     best_cost = new_cost;
-                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    if let Some(tx) = progress_tx {
+                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    }
                 }
             }
         }
 
-        // 2. Per-nest Bernoulli abandonment (Yang & Deb 2009): each nest independently
-        //    re-seeded with probability pa, preserving discovered information per epoch.
         for idx in 0..n_nests {
             let r: f64 = rng.random();
             if r < pa {
@@ -108,22 +116,28 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                 if cost < best_cost {
                     best = nests[idx].clone();
                     best_cost = cost;
-                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    if let Some(tx) = progress_tx {
+                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
+                    }
                 }
             }
         }
 
-        options.send_progress(ProgressMessage::EpochUpdate(epoch));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::EpochUpdate(epoch));
+        }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&best, cities, distances)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, CSOptions, HeuristicOptions};
 
     #[test]
     fn test_cs_respects_initial_tour() {
@@ -137,12 +151,14 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = SolverOptions {
-            epochs: 0,
-            initial_tour: Some(optimal.clone()),
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            cs: Some(CSOptions {
+                heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+                ..CSOptions::default()
+            }),
+            ..AppOptions::default()
         };
-        let result = solve(&cities, &dm, &opts);
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -178,13 +194,14 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let options = SolverOptions {
-            epochs: 30,
-            n_nearest: 5,
-            mutation_probability: 0.25,
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            cs: Some(CSOptions {
+                heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+                mutation_probability: 0.25,
+            }),
+            ..AppOptions::default()
         };
-        let sol = solve(&cities, &distances, &options);
+        let sol = solve(&cities, &distances, &opts, None, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -7,7 +7,7 @@ use super::kdtree::KDPoint;
 use super::probability::levy_step;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{CSOptions, Solution};
 
 const DEFAULT_N_NESTS: usize = 25;
 
@@ -29,13 +29,12 @@ fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usiz
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &CSOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let cs = opts.cs.as_ref().cloned().unwrap_or_default();
-    let n_nests = cs.heuristic.n_nearest.max(DEFAULT_N_NESTS);
-    let pa = (cs.mutation_probability as f64).clamp(0.01, 0.99);
+    let n_nests = opts.heuristic.n_nearest.max(DEFAULT_N_NESTS);
+    let pa = (opts.mutation_probability as f64).clamp(0.01, 0.99);
     let n_cities = cities.len();
 
     let mut rng = rand::rng();
@@ -77,7 +76,7 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&best), best_cost));
     }
 
-    for epoch in 0..cs.heuristic.epochs {
+    for epoch in 0..opts.heuristic.epochs {
         for cuckoo_idx in 0..n_nests {
             let levy = levy_step(&mut rng).abs();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
@@ -137,7 +136,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, CSOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, CSOptions, HeuristicOptions};
 
     #[test]
     fn test_cs_respects_initial_tour() {
@@ -151,12 +150,9 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = AppOptions {
-            cs: Some(CSOptions {
-                heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
-                ..CSOptions::default()
-            }),
-            ..AppOptions::default()
+        let opts = CSOptions {
+            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            ..CSOptions::default()
         };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
@@ -194,12 +190,9 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            cs: Some(CSOptions {
-                heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
-                mutation_probability: 0.25,
-            }),
-            ..AppOptions::default()
+        let opts = CSOptions {
+            heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+            mutation_probability: 0.25,
         };
         let sol = solve(&cities, &distances, &opts, None, None);
         let mut visited = sol.route().to_vec();

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -2,12 +2,10 @@ use std::sync::mpsc;
 
 use rand::Rng;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::probability::levy_step;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{CSOptions, Solution};
+use super::{CSOptions, Solution, TspProblem};
 
 const DEFAULT_N_NESTS: usize = 25;
 
@@ -27,12 +25,12 @@ fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usiz
 }
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &CSOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let n_nests = opts.heuristic.n_nearest.max(DEFAULT_N_NESTS);
     let pa = (opts.mutation_probability as f64).clamp(0.01, 0.99);
     let n_cities = cities.len();
@@ -43,7 +41,7 @@ pub fn solve(
     let mut nests: Vec<Vec<usize>> = (0..n_nests)
         .map(|idx| {
             if idx == 0 {
-                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
+                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -136,7 +134,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, CSOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, CSOptions, HeuristicOptions, TspProblem};
 
     #[test]
     fn test_cs_respects_initial_tour() {
@@ -154,7 +152,8 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
             ..CSOptions::default()
         };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
+        let result = solve(&problem, &opts, None);
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -194,7 +193,8 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
             mutation_probability: 0.25,
         };
-        let sol = solve(&cities, &distances, &opts, None, None);
+        let problem = TspProblem::new(cities.clone(), distances);
+        let sol = solve(&problem, &opts, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -28,6 +28,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &CSOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -41,7 +42,7 @@ pub fn solve(
     let mut nests: Vec<Vec<usize>> = (0..n_nests)
         .map(|idx| {
             if idx == 0 {
-                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
+                init_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -152,8 +153,8 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
             ..CSOptions::default()
         };
-        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -194,7 +195,7 @@ mod tests {
             mutation_probability: 0.25,
         };
         let problem = TspProblem::new(cities.clone(), distances);
-        let sol = solve(&problem, &opts, None);
+        let sol = solve(&problem, &opts, None, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -3,11 +3,10 @@ use std::sync::mpsc;
 use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{FPAOptions, Solution};
+use super::{FPAOptions, Solution, TspProblem};
 
 const DEFAULT_N_FLOWERS: usize = 25;
 
@@ -46,12 +45,12 @@ fn local_pollination(
 }
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &FPAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let n_flowers = opts.heuristic.n_nearest.max(DEFAULT_N_FLOWERS);
     let n_cities = cities.len();
     // default mutation_probability 0.001 → 99.9% local, which defeats global search;
@@ -75,7 +74,7 @@ pub fn solve(
     let mut flowers: Vec<Vec<usize>> = (0..n_flowers)
         .map(|idx| {
             if idx == 0 {
-                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
+                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -146,7 +145,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, FPAOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, FPAOptions, HeuristicOptions, TspProblem};
 
     #[test]
     fn test_fpa_respects_initial_tour() {
@@ -164,7 +163,8 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
             ..FPAOptions::default()
         };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
+        let result = solve(&problem, &opts, None);
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(visited, expected);
     }
 
-    fn four_city_setup() -> (Vec<KDPoint>, super::DistanceMatrix) {
+    fn four_city_setup() -> TspProblem {
         let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![1.0, 0.0],
@@ -181,17 +181,18 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        (cities, dm)
+        TspProblem::new(cities, dm)
     }
 
     #[test]
     fn test_solve_returns_valid_tour() {
-        let (cities, dm) = four_city_setup();
+        let problem = four_city_setup();
+        let cities = problem.cities.clone();
         let opts = FPAOptions {
             heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
             mutation_probability: 0.8,
         };
-        let sol = solve(&cities, &dm, &opts, None, None);
+        let sol = solve(&problem, &opts, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -140,7 +140,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&gbest, cities, distances)
+    Solution::from_parts(&gbest, cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
@@ -5,14 +7,11 @@ use super::kdtree::KDPoint;
 use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
 const DEFAULT_N_FLOWERS: usize = 25;
 
 
-/// Global pollination: move `flower` toward `gbest` by a Lévy-scaled fraction of the swap
-/// sequence between them — the permutation analogue of `x + γ·L·(g* − x)` (Yang 2012).
-/// Returns the current flower unchanged if it already equals `gbest`.
 fn global_pollination(flower: &[usize], gbest: &[usize], rng: &mut impl Rng) -> Vec<usize> {
     let seq = swap_sequence(flower, gbest);
     if seq.is_empty() {
@@ -24,9 +23,6 @@ fn global_pollination(flower: &[usize], gbest: &[usize], rng: &mut impl Rng) -> 
     apply_swaps(flower, &seq[..n_swaps])
 }
 
-/// Local pollination: apply an ε-scaled fraction of the displacement between two randomly
-/// chosen flowers `j` and `k` to `flower` — the permutation analogue of `x + ε·(x_j − x_k)`.
-/// Returns the current flower unchanged when `n_flowers < 3` or `flowers[j] == flowers[k]`.
 fn local_pollination(
     flower: &[usize],
     flowers: &[Vec<usize>],
@@ -49,21 +45,28 @@ fn local_pollination(
     apply_swaps(flower, &seq[..n_swaps])
 }
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
-    let n_flowers = options.n_nearest.max(DEFAULT_N_FLOWERS);
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
+    let n_flowers = fpa.heuristic.n_nearest.max(DEFAULT_N_FLOWERS);
     let n_cities = cities.len();
     // default mutation_probability 0.001 → 99.9% local, which defeats global search;
     // floor to 0.8 so a bare `bin fpa` run is meaningful without extra flags.
-    let switch_prob = if options.mutation_probability < 0.01 {
+    let switch_prob = if fpa.mutation_probability < 0.01 {
         0.8_f64
     } else {
-        options.mutation_probability as f64
+        fpa.mutation_probability as f64
     };
 
     tracing::info!(
         n_flowers,
         switch_prob,
-        epochs = options.epochs,
+        epochs = fpa.heuristic.epochs,
         "FPA starting"
     );
 
@@ -73,7 +76,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut flowers: Vec<Vec<usize>> = (0..n_flowers)
         .map(|idx| {
             if idx == 0 {
-                options.initial_tour.clone().unwrap_or_else(|| {
+                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -102,9 +105,11 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut gbest: Vec<usize> = flowers[best_idx].clone();
     let mut gbest_cost: f32 = costs[best_idx];
 
-    options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    }
 
-    for epoch in 0..options.epochs {
+    for epoch in 0..fpa.heuristic.epochs {
         for i in 0..n_flowers {
             let new_x = if bernoulli(&mut rng, switch_prob) {
                 global_pollination(&flowers[i], &gbest, &mut rng)
@@ -120,26 +125,29 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                 if new_cost < gbest_cost {
                     gbest = flowers[i].clone();
                     gbest_cost = new_cost;
-                    options.send_progress(ProgressMessage::PathUpdate(
-                        Route::new(&gbest),
-                        gbest_cost,
-                    ));
+                    if let Some(tx) = progress_tx {
+                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                    }
                     tracing::info!(epoch, tour_length = gbest_cost, "FPA: new best");
                 }
             }
         }
 
-        options.send_progress(ProgressMessage::EpochUpdate(epoch));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::EpochUpdate(epoch));
+        }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&gbest, cities, distances)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, FPAOptions, HeuristicOptions};
 
     #[test]
     fn test_fpa_respects_initial_tour() {
@@ -153,12 +161,14 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = SolverOptions {
-            epochs: 0,
-            initial_tour: Some(optimal.clone()),
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            fpa: Some(FPAOptions {
+                heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+                ..FPAOptions::default()
+            }),
+            ..AppOptions::default()
         };
-        let result = solve(&cities, &dm, &opts);
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -167,7 +177,7 @@ mod tests {
         assert_eq!(visited, expected);
     }
 
-    fn four_city_setup() -> (Vec<KDPoint>, DistanceMatrix) {
+    fn four_city_setup() -> (Vec<KDPoint>, super::DistanceMatrix) {
         let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![1.0, 0.0],
@@ -181,13 +191,14 @@ mod tests {
     #[test]
     fn test_solve_returns_valid_tour() {
         let (cities, dm) = four_city_setup();
-        let options = SolverOptions {
-            epochs: 30,
-            n_nearest: 5,
-            mutation_probability: 0.8,
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            fpa: Some(FPAOptions {
+                heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+                mutation_probability: 0.8,
+            }),
+            ..AppOptions::default()
         };
-        let sol = solve(&cities, &dm, &options);
+        let sol = solve(&cities, &dm, &opts, None, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -2,7 +2,6 @@ use std::sync::mpsc;
 
 use rand::Rng;
 
-use super::distance_matrix::DistanceMatrix;
 use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -7,7 +7,7 @@ use super::kdtree::KDPoint;
 use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{AppOptions, Solution};
+use super::{FPAOptions, Solution};
 
 const DEFAULT_N_FLOWERS: usize = 25;
 
@@ -48,25 +48,24 @@ fn local_pollination(
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &FPAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
-    let n_flowers = fpa.heuristic.n_nearest.max(DEFAULT_N_FLOWERS);
+    let n_flowers = opts.heuristic.n_nearest.max(DEFAULT_N_FLOWERS);
     let n_cities = cities.len();
     // default mutation_probability 0.001 → 99.9% local, which defeats global search;
     // floor to 0.8 so a bare `bin fpa` run is meaningful without extra flags.
-    let switch_prob = if fpa.mutation_probability < 0.01 {
+    let switch_prob = if opts.mutation_probability < 0.01 {
         0.8_f64
     } else {
-        fpa.mutation_probability as f64
+        opts.mutation_probability as f64
     };
 
     tracing::info!(
         n_flowers,
         switch_prob,
-        epochs = fpa.heuristic.epochs,
+        epochs = opts.heuristic.epochs,
         "FPA starting"
     );
 
@@ -109,7 +108,7 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
     }
 
-    for epoch in 0..fpa.heuristic.epochs {
+    for epoch in 0..opts.heuristic.epochs {
         for i in 0..n_flowers {
             let new_x = if bernoulli(&mut rng, switch_prob) {
                 global_pollination(&flowers[i], &gbest, &mut rng)
@@ -147,7 +146,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, FPAOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, FPAOptions, HeuristicOptions};
 
     #[test]
     fn test_fpa_respects_initial_tour() {
@@ -161,12 +160,9 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = AppOptions {
-            fpa: Some(FPAOptions {
-                heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
-                ..FPAOptions::default()
-            }),
-            ..AppOptions::default()
+        let opts = FPAOptions {
+            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            ..FPAOptions::default()
         };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
@@ -191,12 +187,9 @@ mod tests {
     #[test]
     fn test_solve_returns_valid_tour() {
         let (cities, dm) = four_city_setup();
-        let opts = AppOptions {
-            fpa: Some(FPAOptions {
-                heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
-                mutation_probability: 0.8,
-            }),
-            ..AppOptions::default()
+        let opts = FPAOptions {
+            heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+            mutation_probability: 0.8,
         };
         let sol = solve(&cities, &dm, &opts, None, None);
         let mut visited = sol.route().to_vec();

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -48,6 +48,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &FPAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -74,7 +75,7 @@ pub fn solve(
     let mut flowers: Vec<Vec<usize>> = (0..n_flowers)
         .map(|idx| {
             if idx == 0 {
-                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
+                init_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut t = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -163,8 +164,8 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
             ..FPAOptions::default()
         };
-        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -192,7 +193,7 @@ mod tests {
             heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
             mutation_probability: 0.8,
         };
-        let sol = solve(&problem, &opts, None);
+        let sol = solve(&problem, &opts, None, None);
         let mut visited = sol.route().to_vec();
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -2,32 +2,42 @@ use rand::Rng;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::probability::probability;
 use super::progress::ProgressMessage;
 use super::route::{random_position_pair, Route};
-use super::{Solution, SolverOptions};
+use super::{AppOptions, GAOptions, Solution};
 
 type FitnessFn = Rc<dyn Fn(&[usize]) -> f32>;
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let ga = opts.ga.as_ref().cloned().unwrap_or_default();
     let evaluator = build_evaluator(distances);
 
     let population_size = cities.len();
-    let population = match options.initial_tour.as_deref() {
+    let population = match initial_tour {
         Some(t) => TspPopulation::from_cities_seeded(cities, population_size, &evaluator, t),
         None => TspPopulation::from_cities(cities, population_size, &evaluator),
     };
-    let best_candidate = solve_ga(&population, evaluator, distances, options);
+    let best_candidate = solve_ga(&population, evaluator, distances, &ga, progress_tx);
 
     let best_route = Route::new(best_candidate.genotype());
-    options.send_progress(ProgressMessage::PathUpdate(
-        best_route,
-        distances.tour_length(best_candidate.genotype()),
-    ));
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(
+            best_route,
+            distances.tour_length(best_candidate.genotype()),
+        ));
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(best_candidate.genotype(), cities, distances)
 }
 
@@ -35,26 +45,26 @@ fn solve_ga(
     population: &TspPopulation,
     fitness_fn: FitnessFn,
     distances: &DistanceMatrix,
-    options: &SolverOptions,
+    ga: &GAOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
 ) -> TspGenotype {
     let population_size = population.len();
-    let mutation_prob = options.mutation_probability;
-    let elite_size = options.n_elite;
+    let mutation_prob = ga.mutation_probability;
+    let elite_size = ga.n_elite;
 
     tracing::info!(
         population_size,
-        elite_size = options.n_elite,
-        mutation_prob = options.mutation_probability,
+        elite_size = ga.n_elite,
+        mutation_prob = ga.mutation_probability,
         "GA starting"
     );
 
     let mut epoch = 0;
     let mut current_population = population.clone();
 
-    while epoch < options.epochs {
+    while epoch < ga.heuristic.epochs {
         let mut new_population = TspPopulation::with_capacity(population_size);
 
-        // pass n-fittest directly into new population
         current_population.sort();
         for elite in current_population.individuals().iter().take(elite_size) {
             new_population.add(elite.clone());
@@ -65,12 +75,8 @@ fn solve_ga(
             let parent2 = current_population.random_selection();
 
             let (mut child1, mut child2) = ordered_crossover(parent1, parent2, &fitness_fn);
-            if probability(mutation_prob) {
-                child1.mutate()
-            };
-            if probability(mutation_prob) {
-                child2.mutate()
-            };
+            if probability(mutation_prob) { child1.mutate() };
+            if probability(mutation_prob) { child2.mutate() };
 
             new_population.add(child1);
             new_population.add(child2);
@@ -80,10 +86,12 @@ fn solve_ga(
 
         let best_candidate = current_population.best().clone();
         let best_route = Route::new(best_candidate.genotype());
-        options.send_progress(ProgressMessage::PathUpdate(
-            best_route,
-            distances.tour_length(best_candidate.genotype()),
-        ));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::PathUpdate(
+                best_route,
+                distances.tour_length(best_candidate.genotype()),
+            ));
+        }
 
         tracing::debug!(epoch, fitness = current_population.best().fitness(), "GA: generation");
 
@@ -134,11 +142,9 @@ fn ordered_crossover_genes(
     let range_a: HashSet<usize> = parent1[from..=to].iter().copied().collect();
     let range_b: HashSet<usize> = parent2[from..=to].iter().copied().collect();
 
-    // copy cross-overs from parents
     gene1[from..=to].copy_from_slice(&parent2[from..=to]);
     gene2[from..=to].copy_from_slice(&parent1[from..=to]);
 
-    // copy other values like rolling-shift to -> from
     let mut k = (to + 1) % gene_len;
     let mut j1 = k;
     let mut j2 = k;
@@ -256,8 +262,6 @@ impl TspPopulation {
             .sort_by(|x, y| y.fitness.partial_cmp(&x.fitness).unwrap_or(Ordering::Equal));
     }
 
-    // TODO: test that entropy is good enough
-    // roulette wheel selection
     fn random_selection(&self) -> &TspGenotype {
         let total = self.total_fitness();
         let mut rng = rand::rng();
@@ -312,7 +316,6 @@ impl TspGenotype {
         self.fitness = new_fitness;
     }
 
-    // RSM from the reference paper
     pub fn mutate(&mut self) {
         let (mut from, mut to) = random_position_pair(self.genotype.len());
 
@@ -327,7 +330,7 @@ impl TspGenotype {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, GAOptions, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -341,9 +344,6 @@ mod tests {
 
     #[test]
     fn test_ga_respects_initial_tour() {
-        // from_cities_seeded must place the exact seed as the first individual.
-        // This test calls from_cities_seeded which doesn't exist yet (RED: compile failure).
-        // After implementation it verifies individuals()[0] == seed.
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let seed: Vec<usize> = cities.iter().map(|c| c.id).collect();
@@ -360,10 +360,6 @@ mod tests {
         );
     }
 
-    // Regression test: GA's internal fitness is 1/tour_length (used for selection).
-    // The PathUpdate messages and Solution::total must carry the real tour_length,
-    // not the inverted fitness. If this regresses, solution.total would be ~0.00025
-    // instead of ~4.0 for a unit square.
     #[test]
     fn test_solve_returns_real_tour_length_not_inverted_fitness() {
         let cities = kdtree::build_points(&[
@@ -373,21 +369,21 @@ mod tests {
             vec![1.0, 0.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let options = SolverOptions {
-            epochs: 100,
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            ga: Some(GAOptions {
+                heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+                ..GAOptions::default()
+            }),
+            ..AppOptions::default()
         };
 
-        let solution = solve(&cities, &distances, &options);
+        let solution = solve(&cities, &distances, &opts, None, None);
 
-        // Real tour for a unit square visits all 4 sides: total >= 4.0.
-        // Inverted fitness would be 1/4.0 = 0.25 — far below this threshold.
         assert!(
             solution.total >= 3.9,
             "GA solution.total = {} looks like inverted fitness; expected >= 4.0",
             solution.total
         );
-        // Also verify the stored total matches a fresh computation on the route.
         let recomputed = distances.tour_length(solution.route());
         assert!(
             (solution.total - recomputed).abs() < 0.01,
@@ -405,51 +401,27 @@ mod tests {
         })
     }
 
-    // n_seeded must be n/5, not n/10. Verify by checking that individuals[1..n/5]
-    // all exist and are distinct from each other AND from the exact seed.
-    // With old code (n_seeded = n/10), for n=20 that's 2 — indices 2 and 3
-    // come from the random portion and are random_successor of sequential, not seed.
-    // With new code (n_seeded = n/5), indices 1..4 are seeded variants.
     #[test]
     fn test_seeded_population_n5_fraction() {
-        // n=20: n/5=4, n/10=2 — enough to distinguish.
-        // Use a reversed seed so seeded variants start at city 19, not 0.
         let n = 20usize;
         let cities = kdtree::build_points(
             &(0..n).map(|i| vec![i as f32, 0.0]).collect::<Vec<_>>(),
         );
         let dm = distance_matrix::from_cities(&cities);
-        // Reversed seed maximally differs from the sequential base used for random portion.
         let seed: Vec<usize> = (0..n).rev().collect();
         let evaluator = make_evaluator(dm);
 
-        // Run 100 trials; collect ALL individuals across them.
-        // Count how many have genotype[0] == 19 (only possible if derived from reversed seed,
-        // since the random_successor base starts at 0).
-        // With n/10=2 seeded: 2 seeds per trial × 100 = 200 seed-derived individuals max.
-        // With n/5=4 seeded: 4 × 100 = 400 seed-derived individuals.
-        // Random-portion individuals start at 0, not 19 → not counted.
         let trials = 100usize;
         let mut seed_derived_count = 0usize;
         for _ in 0..trials {
             let pop = TspPopulation::from_cities_seeded(&cities, n, &evaluator, &seed);
             for ind in pop.individuals() {
-                // Only seed-derived individuals start at 19 (from reversed seed).
                 if ind.genotype()[0] == n - 1 {
                     seed_derived_count += 1;
                 }
             }
         }
         let avg_seed_derived = seed_derived_count as f32 / trials as f32;
-        // With n/5=4 seeded, at least the exact seed (1 per trial) always starts at 19.
-        // Mutants MAY or may not start at 19 (RSM can move it). So minimum is 1.0.
-        // Old code (n/10=2) also has exact seed: 1.0 minimum.
-        // What DIFFERS: with n/5=4, about 3 mutants exist; with n/10=2, about 1 mutant.
-        // A mutant derived from reversed seed keeps genotype[0]==19 only if RSM doesn't
-        // touch position 0. P(position 0 untouched) = (n-2)/n ≈ 0.9 per mutation.
-        // With 3 mutants (n/5): expected additional contribution ≈ 3 × 0.9 = 2.7/trial.
-        // With 1 mutant (n/10): expected additional contribution ≈ 1 × 0.9 = 0.9/trial.
-        // Expected avg with n/5: ≈ 3.7; with n/10: ≈ 1.9. Threshold: 2.5 distinguishes.
         assert!(
             avg_seed_derived >= 2.5,
             "expected avg ≥ 2.5 seed-derived individuals per trial (n/5 fraction), got {:.2}",
@@ -457,10 +429,6 @@ mod tests {
         );
     }
 
-    // Random portion of the unseeded population must be well-shuffled,
-    // not near-sequential (1-swap from city insertion order).
-    // Tests that from_cities produces distinct individuals — the mean
-    // pairwise Kendall distance across the population must exceed 0.3.
     #[test]
     fn test_from_cities_produces_diverse_population() {
         let n = 20usize;
@@ -472,9 +440,6 @@ mod tests {
 
         let pop = TspPopulation::from_cities(&cities, n, &evaluator);
 
-        // Count pairs that are NOT identical (a weak but reliable diversity signal).
-        // With random_successor() all are 1-swap of sequential — likely very similar to each other.
-        // With shuffle() individuals are independent random permutations.
         let individuals = pop.individuals();
         let mut n_distinct_pairs = 0usize;
         let total_pairs = individuals.len() * (individuals.len() - 1) / 2;
@@ -485,7 +450,6 @@ mod tests {
                 }
             }
         }
-        // ALL pairs should be distinct — random_successor can repeat, shuffle never does.
         assert_eq!(
             n_distinct_pairs, total_pairs,
             "population has duplicate individuals; expected all {} pairs to be distinct, only {} were",

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -9,21 +9,21 @@ use super::kdtree::KDPoint;
 use super::probability::probability;
 use super::progress::ProgressMessage;
 use super::route::{random_position_pair, Route};
-use super::{GAOptions, Solution};
+use super::{GAOptions, Solution, TspProblem};
 
 type FitnessFn = Rc<dyn Fn(&[usize]) -> f32>;
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &GAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let evaluator = build_evaluator(distances);
 
     let population_size = cities.len();
-    let population = match initial_tour {
+    let population = match problem.initial_tour.as_deref() {
         Some(t) => TspPopulation::from_cities_seeded(cities, population_size, &evaluator, t),
         None => TspPopulation::from_cities(cities, population_size, &evaluator),
     };
@@ -329,7 +329,7 @@ impl TspGenotype {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, GAOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, GAOptions, HeuristicOptions, TspProblem};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -373,7 +373,8 @@ mod tests {
             ..GAOptions::default()
         };
 
-        let solution = solve(&cities, &distances, &opts, None, None);
+        let problem = TspProblem::new(cities, distances.clone());
+        let solution = solve(&problem, &opts, None);
 
         assert!(
             solution.total >= 3.9,

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -9,18 +9,17 @@ use super::kdtree::KDPoint;
 use super::probability::probability;
 use super::progress::ProgressMessage;
 use super::route::{random_position_pair, Route};
-use super::{AppOptions, GAOptions, Solution};
+use super::{GAOptions, Solution};
 
 type FitnessFn = Rc<dyn Fn(&[usize]) -> f32>;
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &GAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let ga = opts.ga.as_ref().cloned().unwrap_or_default();
     let evaluator = build_evaluator(distances);
 
     let population_size = cities.len();
@@ -28,7 +27,7 @@ pub fn solve(
         Some(t) => TspPopulation::from_cities_seeded(cities, population_size, &evaluator, t),
         None => TspPopulation::from_cities(cities, population_size, &evaluator),
     };
-    let best_candidate = solve_ga(&population, evaluator, distances, &ga, progress_tx);
+    let best_candidate = solve_ga(&population, evaluator, distances, opts, progress_tx);
 
     let best_route = Route::new(best_candidate.genotype());
     if let Some(tx) = progress_tx {
@@ -330,7 +329,7 @@ impl TspGenotype {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, GAOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, GAOptions, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -369,12 +368,9 @@ mod tests {
             vec![1.0, 0.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            ga: Some(GAOptions {
-                heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
-                ..GAOptions::default()
-            }),
-            ..AppOptions::default()
+        let opts = GAOptions {
+            heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+            ..GAOptions::default()
         };
 
         let solution = solve(&cities, &distances, &opts, None, None);

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -37,7 +37,7 @@ pub fn solve(
         ));
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(best_candidate.genotype(), cities, distances)
+    Solution::from_parts(best_candidate.genotype(), cities, distances)
 }
 
 fn solve_ga(

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -17,13 +17,14 @@ pub fn solve(
     problem: &TspProblem,
     opts: &GAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
     let evaluator = build_evaluator(distances);
 
     let population_size = cities.len();
-    let population = match problem.initial_tour.as_deref() {
+    let population = match init_tour {
         Some(t) => TspPopulation::from_cities_seeded(cities, population_size, &evaluator, t),
         None => TspPopulation::from_cities(cities, population_size, &evaluator),
     };
@@ -374,7 +375,7 @@ mod tests {
         };
 
         let problem = TspProblem::new(cities, distances.clone());
-        let solution = solve(&problem, &opts, None);
+        let solution = solve(&problem, &opts, None, None);
 
         assert!(
             solution.total >= 3.9,

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -575,12 +575,13 @@ pub fn find_solver(name: &str) -> Result<Solvers, String> {
 
 pub(crate) fn solve_with_context(
     solver: Solvers,
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &AppOptions,
     progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Result<Solution, String> {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
@@ -615,6 +616,24 @@ pub(crate) fn solve_with_context(
 }
 
 // ---------------------------------------------------------------------------
+// TspProblem
+// ---------------------------------------------------------------------------
+
+/// The TSP problem instance: city layout + precomputed distance matrix.
+/// Always created together from a TSPLIB file and passed as a unit.
+#[derive(Clone)]
+pub struct TspProblem {
+    pub cities: Vec<KDPoint>,
+    pub distances: DistanceMatrix,
+}
+
+impl TspProblem {
+    pub fn new(cities: Vec<KDPoint>, distances: DistanceMatrix) -> Self {
+        TspProblem { cities, distances }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Solution
 // ---------------------------------------------------------------------------
 
@@ -632,7 +651,26 @@ pub struct Solution {
 }
 
 impl Solution {
-    pub fn new(route: &[usize], cities: &[kdtree::KDPoint], distances: &DistanceMatrix) -> Self {
+    pub fn new(route: &[usize], problem: &TspProblem) -> Self {
+        let cities = &problem.cities;
+        let distances = &problem.distances;
+        let cities_idx = cities
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.id, i))
+            .collect();
+
+        Solution {
+            total: distances.tour_length(route),
+            route: route.to_vec(),
+            cities: cities.to_vec(),
+            cities_idx,
+        }
+    }
+
+    /// Convenience constructor for solver functions that already hold separate `cities`
+    /// and `distances` slices and do not need to construct a full [`TspProblem`].
+    pub(crate) fn from_parts(route: &[usize], cities: &[kdtree::KDPoint], distances: &DistanceMatrix) -> Self {
         let cities_idx = cities
             .iter()
             .enumerate()
@@ -895,7 +933,8 @@ mod tests {
         ];
 
         let dm = distance_matrix::from_cities(&cities);
-        let sol = Solution::new(&route, &cities, &dm);
+        let problem = TspProblem::new(cities, dm);
+        let sol = Solution::new(&route, &problem);
         assert_approx(4.0, sol.total);
     }
 }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -582,20 +582,33 @@ pub(crate) fn solve_with_context(
     initial_tour: Option<&[usize]>,
 ) -> Result<Solution, String> {
     let tx = progress_tx.as_ref();
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
-        Solvers::BellmanKarp               => bellman_karp::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::BranchBound               => branch_bound::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::CuckooSearch              => cuckoo_search::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::FlowerPollination         => flower_pollination::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::NearestNeighbor           => nearest_neighbor::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::GeneticAlgorithm          => genetic_algorithm::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::ParticleSwarmOptimization => particle_swarm::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::RandomShuffle             => random_shuffle::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::SimulatedAnnealing        => simulated_annealing::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::StochasticHill            => stochastic_hill::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::TabuSearch                => tabu_search::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::ThreeOpt                  => three_opt::solve(cities, distances, opts, tx, initial_tour),
-        Solvers::TwoOpt                    => two_opt::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::BellmanKarp               => bellman_karp::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::BranchBound               => branch_bound::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::CuckooSearch              => {
+            let cs = opts.cs.as_ref().cloned().unwrap_or_default();
+            cuckoo_search::solve(cities, distances, &cs, tx, initial_tour)
+        }
+        Solvers::FlowerPollination         => {
+            let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
+            flower_pollination::solve(cities, distances, &fpa, tx, initial_tour)
+        }
+        Solvers::NearestNeighbor           => nearest_neighbor::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::GeneticAlgorithm          => {
+            let ga = opts.ga.as_ref().cloned().unwrap_or_default();
+            genetic_algorithm::solve(cities, distances, &ga, tx, initial_tour)
+        }
+        Solvers::ParticleSwarmOptimization => particle_swarm::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::RandomShuffle             => random_shuffle::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::SimulatedAnnealing        => {
+            let sa = opts.sa.as_ref().cloned().unwrap_or_default();
+            simulated_annealing::solve(cities, distances, &sa, tx, initial_tour)
+        }
+        Solvers::StochasticHill            => stochastic_hill::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::TabuSearch                => tabu_search::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::ThreeOpt                  => three_opt::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::TwoOpt                    => two_opt::solve(cities, distances, &h, tx, initial_tour),
         Solvers::Unspecified               => return Err("solver not specified".to_string()),
     };
     Ok(solution)

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -578,35 +578,24 @@ pub(crate) fn solve_with_context(
     problem: &TspProblem,
     opts: &AppOptions,
     progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Result<Solution, String> {
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
-        Solvers::BellmanKarp               => bellman_karp::solve(problem, &h, tx),
-        Solvers::BranchBound               => branch_bound::solve(problem, &h, tx),
-        Solvers::CuckooSearch              => {
-            let cs = opts.cs.as_ref().cloned().unwrap_or_default();
-            cuckoo_search::solve(problem, &cs, tx)
-        }
-        Solvers::FlowerPollination         => {
-            let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
-            flower_pollination::solve(problem, &fpa, tx)
-        }
-        Solvers::NearestNeighbor           => nearest_neighbor::solve(problem, &h, tx),
-        Solvers::GeneticAlgorithm          => {
-            let ga = opts.ga.as_ref().cloned().unwrap_or_default();
-            genetic_algorithm::solve(problem, &ga, tx)
-        }
-        Solvers::ParticleSwarmOptimization => particle_swarm::solve(problem, &h, tx),
-        Solvers::RandomShuffle             => random_shuffle::solve(problem, &h, tx),
-        Solvers::SimulatedAnnealing        => {
-            let sa = opts.sa.as_ref().cloned().unwrap_or_default();
-            simulated_annealing::solve(problem, &sa, tx)
-        }
-        Solvers::StochasticHill            => stochastic_hill::solve(problem, &h, tx),
-        Solvers::TabuSearch                => tabu_search::solve(problem, &h, tx),
-        Solvers::ThreeOpt                  => three_opt::solve(problem, &h, tx),
-        Solvers::TwoOpt                    => two_opt::solve(problem, &h, tx),
+        Solvers::BellmanKarp               => bellman_karp::solve(problem, &h, tx, init_tour),
+        Solvers::BranchBound               => branch_bound::solve(problem, &h, tx, init_tour),
+        Solvers::CuckooSearch              => { let cs = opts.cs.as_ref().cloned().unwrap_or_default(); cuckoo_search::solve(problem, &cs, tx, init_tour) }
+        Solvers::FlowerPollination         => { let fpa = opts.fpa.as_ref().cloned().unwrap_or_default(); flower_pollination::solve(problem, &fpa, tx, init_tour) }
+        Solvers::NearestNeighbor           => nearest_neighbor::solve(problem, &h, tx, init_tour),
+        Solvers::GeneticAlgorithm          => { let ga = opts.ga.as_ref().cloned().unwrap_or_default(); genetic_algorithm::solve(problem, &ga, tx, init_tour) }
+        Solvers::ParticleSwarmOptimization => particle_swarm::solve(problem, &h, tx, init_tour),
+        Solvers::RandomShuffle             => random_shuffle::solve(problem, &h, tx, init_tour),
+        Solvers::SimulatedAnnealing        => { let sa = opts.sa.as_ref().cloned().unwrap_or_default(); simulated_annealing::solve(problem, &sa, tx, init_tour) }
+        Solvers::StochasticHill            => stochastic_hill::solve(problem, &h, tx, init_tour),
+        Solvers::TabuSearch                => tabu_search::solve(problem, &h, tx, init_tour),
+        Solvers::ThreeOpt                  => three_opt::solve(problem, &h, tx, init_tour),
+        Solvers::TwoOpt                    => two_opt::solve(problem, &h, tx, init_tour),
         Solvers::Unspecified               => return Err("solver not specified".to_string()),
     };
     Ok(solution)
@@ -622,12 +611,11 @@ pub(crate) fn solve_with_context(
 pub struct TspProblem {
     pub cities: Vec<KDPoint>,
     pub distances: DistanceMatrix,
-    pub initial_tour: Option<Vec<usize>>,
 }
 
 impl TspProblem {
     pub fn new(cities: Vec<KDPoint>, distances: DistanceMatrix) -> Self {
-        TspProblem { cities, distances, initial_tour: None }
+        TspProblem { cities, distances }
     }
 }
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -578,38 +578,35 @@ pub(crate) fn solve_with_context(
     problem: &TspProblem,
     opts: &AppOptions,
     progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Result<Solution, String> {
-    let cities = &problem.cities;
-    let distances = &problem.distances;
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
-        Solvers::BellmanKarp               => bellman_karp::solve(cities, distances, &h, tx, initial_tour),
-        Solvers::BranchBound               => branch_bound::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::BellmanKarp               => bellman_karp::solve(problem, &h, tx),
+        Solvers::BranchBound               => branch_bound::solve(problem, &h, tx),
         Solvers::CuckooSearch              => {
             let cs = opts.cs.as_ref().cloned().unwrap_or_default();
-            cuckoo_search::solve(cities, distances, &cs, tx, initial_tour)
+            cuckoo_search::solve(problem, &cs, tx)
         }
         Solvers::FlowerPollination         => {
             let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
-            flower_pollination::solve(cities, distances, &fpa, tx, initial_tour)
+            flower_pollination::solve(problem, &fpa, tx)
         }
-        Solvers::NearestNeighbor           => nearest_neighbor::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::NearestNeighbor           => nearest_neighbor::solve(problem, &h, tx),
         Solvers::GeneticAlgorithm          => {
             let ga = opts.ga.as_ref().cloned().unwrap_or_default();
-            genetic_algorithm::solve(cities, distances, &ga, tx, initial_tour)
+            genetic_algorithm::solve(problem, &ga, tx)
         }
-        Solvers::ParticleSwarmOptimization => particle_swarm::solve(cities, distances, &h, tx, initial_tour),
-        Solvers::RandomShuffle             => random_shuffle::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::ParticleSwarmOptimization => particle_swarm::solve(problem, &h, tx),
+        Solvers::RandomShuffle             => random_shuffle::solve(problem, &h, tx),
         Solvers::SimulatedAnnealing        => {
             let sa = opts.sa.as_ref().cloned().unwrap_or_default();
-            simulated_annealing::solve(cities, distances, &sa, tx, initial_tour)
+            simulated_annealing::solve(problem, &sa, tx)
         }
-        Solvers::StochasticHill            => stochastic_hill::solve(cities, distances, &h, tx, initial_tour),
-        Solvers::TabuSearch                => tabu_search::solve(cities, distances, &h, tx, initial_tour),
-        Solvers::ThreeOpt                  => three_opt::solve(cities, distances, &h, tx, initial_tour),
-        Solvers::TwoOpt                    => two_opt::solve(cities, distances, &h, tx, initial_tour),
+        Solvers::StochasticHill            => stochastic_hill::solve(problem, &h, tx),
+        Solvers::TabuSearch                => tabu_search::solve(problem, &h, tx),
+        Solvers::ThreeOpt                  => three_opt::solve(problem, &h, tx),
+        Solvers::TwoOpt                    => two_opt::solve(problem, &h, tx),
         Solvers::Unspecified               => return Err("solver not specified".to_string()),
     };
     Ok(solution)
@@ -625,11 +622,12 @@ pub(crate) fn solve_with_context(
 pub struct TspProblem {
     pub cities: Vec<KDPoint>,
     pub distances: DistanceMatrix,
+    pub initial_tour: Option<Vec<usize>>,
 }
 
 impl TspProblem {
     pub fn new(cities: Vec<KDPoint>, distances: DistanceMatrix) -> Self {
-        TspProblem { cities, distances }
+        TspProblem { cities, distances, initial_tour: None }
     }
 }
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -573,6 +573,16 @@ pub fn find_solver(name: &str) -> Result<Solvers, String> {
 // Internal dispatcher — used by pipeline and tests
 // ---------------------------------------------------------------------------
 
+/// Public entry point for external crates (e.g. WASM). Runs `solver` against
+/// `problem` with `opts`, no progress channel, no warm-start tour.
+pub fn solve_problem(
+    solver: Solvers,
+    problem: &TspProblem,
+    opts: &AppOptions,
+) -> Result<Solution, String> {
+    solve_with_context(solver, problem, opts, None, None)
+}
+
 pub(crate) fn solve_with_context(
     solver: Solvers,
     problem: &TspProblem,

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -130,73 +130,426 @@ impl FromStr for Solvers {
     }
 }
 
-// -- SolverOptions
+// ---------------------------------------------------------------------------
+// Heuristic options shared across all solver-specific option structs
+// ---------------------------------------------------------------------------
 
-#[derive(Clone)]
-pub struct SolverOptions {
+#[derive(Clone, Debug, PartialEq)]
+pub struct HeuristicOptions {
     pub epochs: usize,
     pub platoo_epochs: usize,
-    pub verbose: bool,
     pub n_nearest: usize,
-    pub mutation_probability: f32,
-    pub n_elite: usize,
-    pub cooling_rate: f32,
-    pub max_temperature: f32,
-    pub min_temperature: f32,
-    pub progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
-    pub initial_tour: Option<Vec<usize>>,
+    pub verbose: bool,
 }
 
-impl std::fmt::Debug for SolverOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SolverOptions")
-            .field("epochs", &self.epochs)
-            .field("platoo_epochs", &self.platoo_epochs)
-            .field("verbose", &self.verbose)
-            .field("n_nearest", &self.n_nearest)
-            .field("mutation_probability", &self.mutation_probability)
-            .field("n_elite", &self.n_elite)
-            .field("cooling_rate", &self.cooling_rate)
-            .field("max_temperature", &self.max_temperature)
-            .field("min_temperature", &self.min_temperature)
-            .field("progress_tx", &self.progress_tx.is_some())
-            .field("initial_tour", &self.initial_tour.is_some())
-            .finish()
+impl Default for HeuristicOptions {
+    fn default() -> Self {
+        HeuristicOptions { epochs: 10_000, platoo_epochs: 500, n_nearest: 3, verbose: false }
     }
 }
 
-impl Default for SolverOptions {
+impl HeuristicOptions {
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut h = HeuristicOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    h.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                }
+                "platoo_epochs" => {
+                    h.platoo_epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                }
+                "n_nearest" => {
+                    h.n_nearest = v.as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                }
+                "verbose" => {
+                    h.verbose = v.as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                other => return Err(format!(
+                    "config: unknown field `{other}` in [heuristic] — valid: epochs, platoo_epochs, n_nearest, verbose"
+                )),
+            }
+        }
+        Ok(h)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Self {
+        let mut h = HeuristicOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            h.epochs = v.parse().unwrap_or(h.epochs);
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            h.platoo_epochs = v.parse().unwrap_or(h.platoo_epochs);
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            h.n_nearest = v.parse().unwrap_or(h.n_nearest);
+        }
+        if args.get_flag("verbose") {
+            h.verbose = true;
+        }
+        h
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Solver-specific option structs
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SAOptions {
+    pub heuristic: HeuristicOptions,
+    pub cooling_rate: f32,
+    pub min_temperature: f32,
+    pub max_temperature: f32,
+}
+
+impl Default for SAOptions {
     fn default() -> Self {
-        SolverOptions {
-            epochs: 10_000,
-            platoo_epochs: 500,
-            verbose: false,
-            n_nearest: 3,
-            mutation_probability: 0.001,
-            n_elite: 3,
+        SAOptions {
+            heuristic: HeuristicOptions::default(),
             cooling_rate: 0.0001,
             min_temperature: 0.001,
             max_temperature: 1_000.0,
-            progress_tx: None,
-            initial_tour: None,
         }
     }
 }
 
-impl SolverOptions {
-    pub fn send_progress(&self, msg: progress::ProgressMessage) {
-        if let Some(ref tx) = self.progress_tx {
-            let _ = tx.send(msg);
+impl SAOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.cooling_rate <= 0.0 {
+            return Err(format!("cooling_rate must be > 0 (got {})", self.cooling_rate));
         }
+        if self.cooling_rate >= 1.0 {
+            return Err(format!("cooling_rate must be < 1 (got {})", self.cooling_rate));
+        }
+        if self.max_temperature <= 0.0 {
+            return Err(format!("max_temperature must be > 0 (got {})", self.max_temperature));
+        }
+        if self.min_temperature < 0.0 {
+            return Err(format!("min_temperature must be >= 0 (got {})", self.min_temperature));
+        }
+        if self.min_temperature >= self.max_temperature {
+            return Err(format!(
+                "min_temperature ({}) must be < max_temperature ({})",
+                self.min_temperature, self.max_temperature
+            ));
+        }
+        Ok(())
     }
 
-    pub fn for_internal_seed(&self) -> SolverOptions {
-        SolverOptions {
-            progress_tx: None,
-            initial_tour: None,
-            ..self.clone()
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut sa = SAOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    sa.heuristic.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                }
+                "platoo_epochs" => {
+                    sa.heuristic.platoo_epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                }
+                "n_nearest" => {
+                    sa.heuristic.n_nearest = v.as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                }
+                "verbose" => {
+                    sa.heuristic.verbose = v.as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                "cooling_rate" => { sa.cooling_rate = parse_f32(v, "sa.cooling_rate")?; }
+                "max_temperature" => { sa.max_temperature = parse_f32(v, "sa.max_temperature")?; }
+                "min_temperature" => { sa.min_temperature = parse_f32(v, "sa.min_temperature")?; }
+                other => return Err(format!(
+                    "config: unknown field `{other}` in [sa] — valid: epochs, platoo_epochs, n_nearest, verbose, cooling_rate, max_temperature, min_temperature"
+                )),
+            }
+        }
+        sa.validate()?;
+        Ok(sa)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Self {
+        let mut sa = SAOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            sa.heuristic.epochs = v.parse().unwrap_or(sa.heuristic.epochs);
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            sa.heuristic.platoo_epochs = v.parse().unwrap_or(sa.heuristic.platoo_epochs);
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            sa.heuristic.n_nearest = v.parse().unwrap_or(sa.heuristic.n_nearest);
+        }
+        if args.get_flag("verbose") { sa.heuristic.verbose = true; }
+        if let Some(v) = args.get_one::<String>("cooling_rate") {
+            sa.cooling_rate = v.parse().unwrap_or(sa.cooling_rate);
+        }
+        if let Some(v) = args.get_one::<String>("min_temperature") {
+            sa.min_temperature = v.parse().unwrap_or(sa.min_temperature);
+        }
+        if let Some(v) = args.get_one::<String>("max_temperature") {
+            sa.max_temperature = v.parse().unwrap_or(sa.max_temperature);
+        }
+        sa
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GAOptions {
+    pub heuristic: HeuristicOptions,
+    pub mutation_probability: f32,
+    pub n_elite: usize,
+}
+
+impl Default for GAOptions {
+    fn default() -> Self {
+        GAOptions {
+            heuristic: HeuristicOptions::default(),
+            mutation_probability: 0.001,
+            n_elite: 3,
         }
     }
+}
+
+impl GAOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+            return Err(format!(
+                "mutation_probability must be in [0, 1] (got {})",
+                self.mutation_probability
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut ga = GAOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    ga.heuristic.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                }
+                "platoo_epochs" => {
+                    ga.heuristic.platoo_epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                }
+                "n_nearest" => {
+                    ga.heuristic.n_nearest = v.as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                }
+                "verbose" => {
+                    ga.heuristic.verbose = v.as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                "mutation_probability" => { ga.mutation_probability = parse_f32(v, "ga.mutation_probability")?; }
+                "n_elite" => {
+                    ga.n_elite = v.as_integer()
+                        .ok_or_else(|| format!("config: `ga.n_elite` must be an integer, got {v}"))? as usize;
+                }
+                other => return Err(format!(
+                    "config: unknown field `{other}` in [ga] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability, n_elite"
+                )),
+            }
+        }
+        ga.validate()?;
+        Ok(ga)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Self {
+        let mut ga = GAOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            ga.heuristic.epochs = v.parse().unwrap_or(ga.heuristic.epochs);
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            ga.heuristic.platoo_epochs = v.parse().unwrap_or(ga.heuristic.platoo_epochs);
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            ga.heuristic.n_nearest = v.parse().unwrap_or(ga.heuristic.n_nearest);
+        }
+        if args.get_flag("verbose") { ga.heuristic.verbose = true; }
+        if let Some(v) = args.get_one::<String>("mutation_probability") {
+            ga.mutation_probability = v.parse().unwrap_or(ga.mutation_probability);
+        }
+        if let Some(v) = args.get_one::<String>("n_elite") {
+            ga.n_elite = v.parse().unwrap_or(ga.n_elite);
+        }
+        ga
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CSOptions {
+    pub heuristic: HeuristicOptions,
+    pub mutation_probability: f32,
+}
+
+impl Default for CSOptions {
+    fn default() -> Self {
+        CSOptions { heuristic: HeuristicOptions::default(), mutation_probability: 0.001 }
+    }
+}
+
+impl CSOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+            return Err(format!(
+                "mutation_probability must be in [0, 1] (got {})",
+                self.mutation_probability
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut cs = CSOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    cs.heuristic.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                }
+                "platoo_epochs" => {
+                    cs.heuristic.platoo_epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                }
+                "n_nearest" => {
+                    cs.heuristic.n_nearest = v.as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                }
+                "verbose" => {
+                    cs.heuristic.verbose = v.as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                "mutation_probability" => { cs.mutation_probability = parse_f32(v, "cs.mutation_probability")?; }
+                other => return Err(format!(
+                    "config: unknown field `{other}` in [cs] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
+                )),
+            }
+        }
+        cs.validate()?;
+        Ok(cs)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Self {
+        let mut cs = CSOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            cs.heuristic.epochs = v.parse().unwrap_or(cs.heuristic.epochs);
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            cs.heuristic.platoo_epochs = v.parse().unwrap_or(cs.heuristic.platoo_epochs);
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            cs.heuristic.n_nearest = v.parse().unwrap_or(cs.heuristic.n_nearest);
+        }
+        if args.get_flag("verbose") { cs.heuristic.verbose = true; }
+        if let Some(v) = args.get_one::<String>("mutation_probability") {
+            cs.mutation_probability = v.parse().unwrap_or(cs.mutation_probability);
+        }
+        cs
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FPAOptions {
+    pub heuristic: HeuristicOptions,
+    pub mutation_probability: f32,
+}
+
+impl Default for FPAOptions {
+    fn default() -> Self {
+        FPAOptions { heuristic: HeuristicOptions::default(), mutation_probability: 0.001 }
+    }
+}
+
+impl FPAOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+            return Err(format!(
+                "mutation_probability must be in [0, 1] (got {})",
+                self.mutation_probability
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut fpa = FPAOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    fpa.heuristic.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                }
+                "platoo_epochs" => {
+                    fpa.heuristic.platoo_epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                }
+                "n_nearest" => {
+                    fpa.heuristic.n_nearest = v.as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                }
+                "verbose" => {
+                    fpa.heuristic.verbose = v.as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                "mutation_probability" => { fpa.mutation_probability = parse_f32(v, "fpa.mutation_probability")?; }
+                other => return Err(format!(
+                    "config: unknown field `{other}` in [fpa] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
+                )),
+            }
+        }
+        fpa.validate()?;
+        Ok(fpa)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Self {
+        let mut fpa = FPAOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            fpa.heuristic.epochs = v.parse().unwrap_or(fpa.heuristic.epochs);
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            fpa.heuristic.platoo_epochs = v.parse().unwrap_or(fpa.heuristic.platoo_epochs);
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            fpa.heuristic.n_nearest = v.parse().unwrap_or(fpa.heuristic.n_nearest);
+        }
+        if args.get_flag("verbose") { fpa.heuristic.verbose = true; }
+        if let Some(v) = args.get_one::<String>("mutation_probability") {
+            fpa.mutation_probability = v.parse().unwrap_or(fpa.mutation_probability);
+        }
+        fpa
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AppOptions — pure config shell; no runtime state
+// ---------------------------------------------------------------------------
+
+/// Pure config container. No progress channel, no initial tour — those are runtime concerns.
+/// Each field is populated only for the solver that uses it.
+#[derive(Clone, Debug, Default)]
+pub struct AppOptions {
+    pub sa:        Option<SAOptions>,
+    pub ga:        Option<GAOptions>,
+    pub cs:        Option<CSOptions>,
+    pub fpa:       Option<FPAOptions>,
+    pub heuristic: Option<HeuristicOptions>,
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+fn parse_f32(v: &toml::Value, name: &str) -> Result<f32, String> {
+    v.as_float()
+        .or_else(|| v.as_integer().map(|i| i as f64))
+        .ok_or_else(|| format!("config: `{name}` must be a float, got {v}"))
+        .map(|f| f as f32)
 }
 
 pub fn validate_tour(tour: &[usize], cities: &[KDPoint]) -> Result<(), String> {
@@ -216,32 +569,42 @@ pub fn find_solver(name: &str) -> Result<Solvers, String> {
         .map_err(|_| format!("unknown solver: {name}"))
 }
 
-pub fn solve(
+// ---------------------------------------------------------------------------
+// Internal dispatcher — used by pipeline and tests
+// ---------------------------------------------------------------------------
+
+pub(crate) fn solve_with_context(
     solver: Solvers,
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &SolverOptions,
+    opts: &AppOptions,
+    progress_tx: Option<mpsc::Sender<progress::ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
 ) -> Result<Solution, String> {
+    let tx = progress_tx.as_ref();
     let solution = match solver {
-        Solvers::BellmanKarp => bellman_karp::solve(cities, distances, opts),
-        Solvers::BranchBound => branch_bound::solve(cities, distances, opts),
-        Solvers::CuckooSearch => cuckoo_search::solve(cities, distances, opts),
-        Solvers::FlowerPollination => flower_pollination::solve(cities, distances, opts),
-        Solvers::NearestNeighbor => nearest_neighbor::solve(cities, distances, opts),
-        Solvers::GeneticAlgorithm => genetic_algorithm::solve(cities, distances, opts),
-        Solvers::ParticleSwarmOptimization => particle_swarm::solve(cities, distances, opts),
-        Solvers::RandomShuffle => random_shuffle::solve(cities, distances, opts),
-        Solvers::SimulatedAnnealing => simulated_annealing::solve(cities, distances, opts),
-        Solvers::StochasticHill => stochastic_hill::solve(cities, distances, opts),
-        Solvers::TabuSearch => tabu_search::solve(cities, distances, opts),
-        Solvers::ThreeOpt => three_opt::solve(cities, distances, opts),
-        Solvers::TwoOpt => two_opt::solve(cities, distances, opts),
-        Solvers::Unspecified => return Err("solver not specified".to_string()),
+        Solvers::BellmanKarp               => bellman_karp::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::BranchBound               => branch_bound::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::CuckooSearch              => cuckoo_search::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::FlowerPollination         => flower_pollination::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::NearestNeighbor           => nearest_neighbor::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::GeneticAlgorithm          => genetic_algorithm::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::ParticleSwarmOptimization => particle_swarm::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::RandomShuffle             => random_shuffle::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::SimulatedAnnealing        => simulated_annealing::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::StochasticHill            => stochastic_hill::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::TabuSearch                => tabu_search::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::ThreeOpt                  => three_opt::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::TwoOpt                    => two_opt::solve(cities, distances, opts, tx, initial_tour),
+        Solvers::Unspecified               => return Err("solver not specified".to_string()),
     };
     Ok(solution)
 }
 
-// -- solution implementation
+// ---------------------------------------------------------------------------
+// Solution
+// ---------------------------------------------------------------------------
+
 pub type CityTable = HashMap<usize, KDPoint>;
 
 pub fn city_table_from_vec(cities: &[kdtree::KDPoint]) -> CityTable {
@@ -382,27 +745,60 @@ mod tests {
     use crate::test::helpers::assert_approx;
 
     #[test]
-    fn test_send_progress_with_none_is_noop() {
-        let options = SolverOptions::default();
-        options.send_progress(progress::ProgressMessage::Done);
+    fn test_heuristic_options_has_expected_fields() {
+        let h = HeuristicOptions { epochs: 100, platoo_epochs: 10, n_nearest: 3, verbose: false };
+        assert_eq!(h.epochs, 100);
+        assert_eq!(h.platoo_epochs, 10);
     }
 
     #[test]
-    fn test_send_progress_with_channel_delivers_message() {
-        use std::sync::mpsc;
-        let (tx, rx) = mpsc::channel();
-        let mut options = SolverOptions::default();
-        options.progress_tx = Some(tx);
-        options.send_progress(progress::ProgressMessage::EpochUpdate(99));
-        match rx.recv().unwrap() {
-            progress::ProgressMessage::EpochUpdate(n) => assert_eq!(n, 99),
-            other => panic!("unexpected message: {:?}", other),
-        }
+    fn test_sa_options_embeds_heuristic() {
+        let sa = SAOptions::default();
+        assert!(sa.heuristic.epochs > 0);
+        assert!(sa.cooling_rate > 0.0);
     }
 
     #[test]
-    fn test_solver_options_initial_tour_defaults_to_none() {
-        assert!(SolverOptions::default().initial_tour.is_none());
+    fn test_app_options_has_no_flat_epoch_fields() {
+        let a = AppOptions { sa: None, ga: None, cs: None, fpa: None, heuristic: None };
+        drop(a);
+    }
+
+    #[test]
+    fn test_heuristic_options_from_toml() {
+        let t: toml::Table = toml::from_str(
+            "epochs=5000\nplatoo_epochs=200\nn_nearest=5\nverbose=true"
+        ).unwrap();
+        let h = HeuristicOptions::from_toml(&t).unwrap();
+        assert_eq!(h.epochs, 5000);
+        assert_eq!(h.n_nearest, 5);
+        assert!(h.verbose);
+    }
+
+    #[test]
+    fn test_sa_options_from_toml_parses_all_fields() {
+        let t: toml::Table = toml::from_str(
+            "epochs=5000\ncooling_rate=0.0005\nmax_temperature=200.0\nmin_temperature=0.001"
+        ).unwrap();
+        let sa = SAOptions::from_toml(&t).unwrap();
+        assert_eq!(sa.heuristic.epochs, 5000);
+        assert!((sa.cooling_rate - 0.0005).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_sa_options_from_toml_unknown_key_errors() {
+        let t: toml::Table = toml::from_str("bogus=1.0").unwrap();
+        assert!(SAOptions::from_toml(&t).unwrap_err().contains("bogus"));
+    }
+
+    #[test]
+    fn test_ga_options_from_toml_parses_fields() {
+        let t: toml::Table = toml::from_str(
+            "mutation_probability=0.05\nn_elite=5\nepochs=2000"
+        ).unwrap();
+        let ga = GAOptions::from_toml(&t).unwrap();
+        assert!((ga.mutation_probability - 0.05).abs() < 1e-7);
+        assert_eq!(ga.heuristic.epochs, 2000);
     }
 
     #[test]
@@ -435,14 +831,12 @@ mod tests {
 
     #[test]
     fn test_auto_expand_nn_false_for_stochastic_and_constructors() {
-        // Stochastic solvers use shuffle expansion, not NN
         assert!(!Solvers::SimulatedAnnealing.auto_expand_with_nn());
         assert!(!Solvers::StochasticHill.auto_expand_with_nn());
         assert!(!Solvers::GeneticAlgorithm.auto_expand_with_nn());
         assert!(!Solvers::ParticleSwarmOptimization.auto_expand_with_nn());
         assert!(!Solvers::CuckooSearch.auto_expand_with_nn());
         assert!(!Solvers::FlowerPollination.auto_expand_with_nn());
-        // Constructors: no expansion
         assert!(!Solvers::NearestNeighbor.auto_expand_with_nn());
         assert!(!Solvers::BellmanKarp.auto_expand_with_nn());
         assert!(!Solvers::BranchBound.auto_expand_with_nn());
@@ -467,19 +861,6 @@ mod tests {
         assert!(!Solvers::NearestNeighbor.auto_expand_with_shuffle());
         assert!(!Solvers::BellmanKarp.auto_expand_with_shuffle());
         assert!(!Solvers::RandomShuffle.auto_expand_with_shuffle());
-    }
-
-    #[test]
-    fn test_for_internal_seed_clears_initial_tour_and_progress() {
-        use std::sync::mpsc;
-        let (tx, _rx) = mpsc::channel();
-        let mut opts = SolverOptions::default();
-        opts.initial_tour = Some(vec![1, 2, 3]);
-        opts.progress_tx = Some(tx);
-        let inner = opts.for_internal_seed();
-        assert!(inner.initial_tour.is_none());
-        assert!(inner.progress_tx.is_none());
-        assert_eq!(inner.epochs, opts.epochs); // other fields preserved
     }
 
     #[test]

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -5,19 +5,18 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     _initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
-    tracing::info!(n_nearest = h.n_nearest, cities = cities.len(), "NN starting");
+    tracing::info!(n_nearest = opts.n_nearest, cities = cities.len(), "NN starting");
 
-    let n_nearest = h.n_nearest;
+    let n_nearest = opts.n_nearest;
     let cities_table: HashMap<usize, KDPoint> = cities.iter().map(|c| (c.id, c.clone())).collect();
 
     let mut unvisited: HashSet<usize> = cities.iter().map(|c| c.id).collect();
@@ -72,7 +71,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -88,7 +87,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -99,7 +98,7 @@ mod tests {
     fn test_solve_tour_length_is_positive_and_finite() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         assert!(tour.total > 0.0, "tour length should be positive, got {}", tour.total);
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -114,7 +113,7 @@ mod tests {
             vec![3.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -131,7 +130,7 @@ mod tests {
             vec![1.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         let route = tour.route().to_vec();
         assert_ne!(route, vec![0, 1, 2, 3, 4], "NN produced sorted output (regression)");

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -1,36 +1,44 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
-    tracing::info!(n_nearest = options.n_nearest, cities = cities.len(), "NN starting");
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _initial_tour: Option<&[usize]>,
+) -> Solution {
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
+    tracing::info!(n_nearest = h.n_nearest, cities = cities.len(), "NN starting");
 
-    let n_nearest = options.n_nearest;
+    let n_nearest = h.n_nearest;
     let cities_table: HashMap<usize, KDPoint> = cities.iter().map(|c| (c.id, c.clone())).collect();
 
     let mut unvisited: HashSet<usize> = cities.iter().map(|c| c.id).collect();
     let mut path: Vec<usize> = Vec::with_capacity(cities.len());
 
-    // Start from the first city in the input order.
     let start_id = cities[0].id;
     path.push(start_id);
     unvisited.remove(&start_id);
 
-    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    }
 
     while !unvisited.is_empty() {
         let current_id = *path.last().unwrap();
         let current_city = &cities_table[&current_id];
 
-        options.send_progress(ProgressMessage::CityChange(current_id));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::CityChange(current_id));
+        }
 
-        // Find the nearest unvisited city.  Check the n_nearest frontier first (fast path);
-        // fall back to a linear scan over `unvisited` when all frontier cities are already
-        // visited (common late in the tour when n_nearest is small).
         let frontier = distances.nearest(current_city, n_nearest);
         let next_id = frontier
             .nearest()
@@ -50,17 +58,21 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
 
         path.push(next_id);
         unvisited.remove(&next_id);
-        options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+        }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&path, cities, distances)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -76,8 +88,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let options = SolverOptions::default();
-        let tour = solve(&cities, &dm, &options);
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -88,8 +99,7 @@ mod tests {
     fn test_solve_tour_length_is_positive_and_finite() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let options = SolverOptions::default();
-        let tour = solve(&cities, &dm, &options);
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         assert!(tour.total > 0.0, "tour length should be positive, got {}", tour.total);
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -104,38 +114,27 @@ mod tests {
             vec![3.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let options = SolverOptions::default();
-        let tour = solve(&cities, &dm, &options);
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
         assert_eq!(visited, vec![0, 1, 2, 3]);
     }
 
-    // Regression: the old algorithm never tracked visited cities, so it could
-    // revisit already-traversed nodes and degrade into a near-sorted walk.
-    // With 1-indexed city IDs (as in TSPLIB files), the first city's "nearest"
-    // was always city_id+1 due to a position/id mismatch in distance_matrix::nearest,
-    // making every swap a no-op.  This test catches both regressions.
     #[test]
     fn test_solve_does_not_produce_sorted_output_on_shuffled_input() {
-        // Cities placed so the greedy NN order is NOT 0→1→2→3→4.
-        // Optimal greedy path from 0: 0 → 4 → 3 → 2 → 1 (or similar clustering).
         let cities = kdtree::build_points(&[
-            vec![0.0, 0.0],   // 0 – far from 1
-            vec![100.0, 0.0], // 1 – far from 0
-            vec![99.0, 0.0],  // 2 – near 1
-            vec![98.0, 0.0],  // 3 – near 1 and 2
-            vec![1.0, 0.0],   // 4 – near 0
+            vec![0.0, 0.0],
+            vec![100.0, 0.0],
+            vec![99.0, 0.0],
+            vec![98.0, 0.0],
+            vec![1.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let options = SolverOptions::default();
-        let tour = solve(&cities, &dm, &options);
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         let route = tour.route().to_vec();
-        // The greedy tour must NOT be [0,1,2,3,4] (sorted) — city 4 is much closer to 0.
         assert_ne!(route, vec![0, 1, 2, 3, 4], "NN produced sorted output (regression)");
-        // All cities must still be visited exactly once.
         let mut sorted = route.clone();
         sorted.sort();
         assert_eq!(sorted, vec![0, 1, 2, 3, 4]);

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -65,7 +65,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&path, cities, distances)
+    Solution::from_parts(&path, cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -9,6 +9,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -86,7 +87,7 @@ mod tests {
     #[test]
     fn test_solve_visits_all_cities() {
         let problem = tsp5_problem();
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -96,7 +97,7 @@ mod tests {
     #[test]
     fn test_solve_tour_length_is_positive_and_finite() {
         let problem = tsp5_problem();
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(tour.total > 0.0, "tour length should be positive, got {}", tour.total);
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -112,7 +113,7 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -130,7 +131,7 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let route = tour.route().to_vec();
         assert_ne!(route, vec![0, 1, 2, 3, 4], "NN produced sorted output (regression)");

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -1,23 +1,21 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    _initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     tracing::info!(n_nearest = opts.n_nearest, cities = cities.len(), "NN starting");
 
     let n_nearest = opts.n_nearest;
-    let cities_table: HashMap<usize, KDPoint> = cities.iter().map(|c| (c.id, c.clone())).collect();
+    let cities_table: HashMap<usize, _> = cities.iter().map(|c| (c.id, c.clone())).collect();
 
     let mut unvisited: HashSet<usize> = cities.iter().map(|c| c.id).collect();
     let mut path: Vec<usize> = Vec::with_capacity(cities.len());
@@ -71,23 +69,24 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
-    fn tsp5_cities() -> Vec<KDPoint> {
-        kdtree::build_points(&[
+    fn tsp5_problem() -> TspProblem {
+        let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![0.0, 0.5],
             vec![0.0, 1.0],
             vec![1.0, 1.0],
             vec![1.0, 0.0],
-        ])
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        TspProblem::new(cities, dm)
     }
 
     #[test]
     fn test_solve_visits_all_cities() {
-        let cities = tsp5_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp5_problem();
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -96,9 +95,8 @@ mod tests {
 
     #[test]
     fn test_solve_tour_length_is_positive_and_finite() {
-        let cities = tsp5_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = tsp5_problem();
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         assert!(tour.total > 0.0, "tour length should be positive, got {}", tour.total);
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -113,7 +111,8 @@ mod tests {
             vec![3.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = TspProblem::new(cities, dm);
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -130,7 +129,8 @@ mod tests {
             vec![1.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = TspProblem::new(cities, dm);
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
 
         let route = tour.route().to_vec();
         assert_ne!(route, vec![0, 1, 2, 3, 4], "NN produced sorted output (regression)");

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -5,7 +5,7 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 type Swap = (usize, usize);
 type Velocity = Vec<Swap>;
@@ -25,13 +25,12 @@ fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let n_cities = cities.len();
-    let n_particles = h.n_nearest.max(DEFAULT_N_PARTICLES);
+    let n_particles = opts.n_nearest.max(DEFAULT_N_PARTICLES);
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
     let v_max = ((n_cities as f64 * V_MAX_FACTOR).ceil() as usize).max(1);
 
@@ -76,7 +75,7 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
     }
 
-    let epochs = h.epochs;
+    let epochs = opts.epochs;
     for epoch in 0..epochs {
         #[allow(clippy::cast_precision_loss)]
         let w = W_MAX - (W_MAX - W_MIN) * (epoch as f64 / epochs.max(1) as f64);
@@ -134,7 +133,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     #[test]
     fn test_pso_respects_initial_tour() {
@@ -148,10 +147,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 0, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
@@ -178,10 +174,7 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
         let sol = solve(&cities, &distances, &opts, None, None);
         assert_eq!(sol.route().len(), cities.len());
         assert!(sol.total > 0.0);

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -24,6 +24,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -38,7 +39,7 @@ pub fn solve(
     let mut positions: Vec<Vec<usize>> = (0..n_particles)
         .map(|idx| {
             if idx == 0 {
-                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
+                init_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut p = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -146,8 +147,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
-        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -175,7 +176,7 @@ mod tests {
         let distances = distance_matrix::from_cities(&cities);
         let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
         let problem = TspProblem::new(cities.clone(), distances);
-        let sol = solve(&problem, &opts, None);
+        let sol = solve(&problem, &opts, None, None);
         assert_eq!(sol.route().len(), cities.len());
         assert!(sol.total > 0.0);
     }

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -127,7 +127,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&gbest, cities, distances)
+    Solution::from_parts(&gbest, cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -1,11 +1,9 @@
 use rand::Rng;
 use std::sync::mpsc;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 type Swap = (usize, usize);
 type Velocity = Vec<Swap>;
@@ -23,12 +21,12 @@ fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
 }
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let n_cities = cities.len();
     let n_particles = opts.n_nearest.max(DEFAULT_N_PARTICLES);
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
@@ -40,7 +38,7 @@ pub fn solve(
     let mut positions: Vec<Vec<usize>> = (0..n_particles)
         .map(|idx| {
             if idx == 0 {
-                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
+                problem.initial_tour.as_deref().map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut p = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -133,7 +131,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
     #[test]
     fn test_pso_respects_initial_tour() {
@@ -148,7 +146,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities: cities.clone(), distances: dm, initial_tour: Some(optimal) };
+        let result = solve(&problem, &opts, None);
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -175,7 +174,8 @@ mod tests {
         ]);
         let distances = distance_matrix::from_cities(&cities);
         let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
-        let sol = solve(&cities, &distances, &opts, None, None);
+        let problem = TspProblem::new(cities.clone(), distances);
+        let sol = solve(&problem, &opts, None);
         assert_eq!(sol.route().len(), cities.len());
         assert!(sol.total > 0.0);
     }

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -1,34 +1,37 @@
 use rand::Rng;
+use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::{apply_swaps, swap_sequence, Route};
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
 type Swap = (usize, usize);
 type Velocity = Vec<Swap>;
 
-// PSO hyper-parameters
-const W_MAX: f64 = 0.9; // inertia at epoch 0 (exploration)
-const W_MIN: f64 = 0.4; // inertia at final epoch (exploitation)
-const C1: f64 = 1.5;    // cognitive coefficient
-const C2: f64 = 1.5;    // social coefficient
+const W_MAX: f64 = 0.9;
+const W_MIN: f64 = 0.4;
+const C1: f64 = 1.5;
+const C2: f64 = 1.5;
 const DEFAULT_N_PARTICLES: usize = 30;
-// Without a velocity cap, steady-state swap-list length ≈ (C1+C2)*0.5*(n−1)/(1−W) ≈ 5n,
-// which scrambles the tour completely.  Capping at ~n/3 gives directional movement.
 const V_MAX_FACTOR: f64 = 0.35;
 
 
-/// Scalar-multiply a velocity: keep the first `keep` swaps (clamped to length).
 fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
     v.iter().take(keep).copied().collect()
 }
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let n_cities = cities.len();
-    // n_nearest is repurposed as n_particles; floor at DEFAULT_N_PARTICLES
-    let n_particles = options.n_nearest.max(DEFAULT_N_PARTICLES);
+    let n_particles = h.n_nearest.max(DEFAULT_N_PARTICLES);
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
     let v_max = ((n_cities as f64 * V_MAX_FACTOR).ceil() as usize).max(1);
 
@@ -38,7 +41,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut positions: Vec<Vec<usize>> = (0..n_particles)
         .map(|idx| {
             if idx == 0 {
-                options.initial_tour.clone().unwrap_or_else(|| {
+                initial_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
                     let mut p = city_ids.clone();
                     for i in (1..n_cities).rev() {
                         let j = rng.random_range(0..=i);
@@ -61,7 +64,6 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut pbest: Vec<Vec<usize>> = positions.clone();
     let mut pbest_cost: Vec<f32> = pbest.iter().map(|p| distances.tour_length(p)).collect();
 
-    // Global best
     let (best_idx, _) = pbest_cost
         .iter()
         .enumerate()
@@ -70,13 +72,12 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
     let mut gbest: Vec<usize> = pbest[best_idx].clone();
     let mut gbest_cost: f32 = pbest_cost[best_idx];
 
-    options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    }
 
-    let epochs = options.epochs;
+    let epochs = h.epochs;
     for epoch in 0..epochs {
-        // Linearly decay inertia weight from W_MAX (exploration) to W_MIN (exploitation).
-        // Mirrors simulated annealing's cooling schedule: high randomness early,
-        // fine-tuning near convergence.
         #[allow(clippy::cast_precision_loss)]
         let w = W_MAX - (W_MAX - W_MIN) * (epoch as f64 / epochs.max(1) as f64);
 
@@ -84,34 +85,26 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             let r1: f64 = rng.random();
             let r2: f64 = rng.random();
 
-            // Inertia: keep first round(w * |v|) swaps of current velocity
             #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
             let inertia_keep = (w * velocities[i].len() as f64).round() as usize;
 
-            // Cognitive: toward personal best
             let cog_diff = swap_sequence(&positions[i], &pbest[i]);
             #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
             let cog_keep = (C1 * r1 * cog_diff.len() as f64).round() as usize;
 
-            // Social: toward global best
             let soc_diff = swap_sequence(&positions[i], &gbest);
             #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
             let soc_keep = (C2 * r2 * soc_diff.len() as f64).round() as usize;
 
-            // New velocity = inertia + cognitive + social, capped at v_max.
-            // The cap is the discrete analogue of v_max in continuous PSO:
-            // without it the swap list grows to ~5n and scrambles the tour.
             let mut new_vel = trim_velocity(&velocities[i], inertia_keep);
             new_vel.extend(trim_velocity(&cog_diff, cog_keep));
             new_vel.extend(trim_velocity(&soc_diff, soc_keep));
             new_vel.truncate(v_max);
 
-            // Update position and velocity
             let new_pos = apply_swaps(&positions[i], &new_vel);
             positions[i] = new_pos;
             velocities[i] = new_vel;
 
-            // Evaluate and update bests
             let cost = distances.tour_length(&positions[i]);
 
             if cost < pbest_cost[i] {
@@ -121,21 +114,27 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             if cost < gbest_cost {
                 gbest = positions[i].clone();
                 gbest_cost = cost;
-                options.send_progress(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                if let Some(tx) = progress_tx {
+                    let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                }
             }
         }
 
-        options.send_progress(ProgressMessage::EpochUpdate(epoch));
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::EpochUpdate(epoch));
+        }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&gbest, cities, distances)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
 
     #[test]
     fn test_pso_respects_initial_tour() {
@@ -149,13 +148,11 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = SolverOptions {
-            epochs: 0,
-            initial_tour: Some(optimal.clone()),
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 0, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
         };
-        let result = solve(&cities, &dm, &opts);
-        // With epochs=0 and initial_tour seeded as particle 0, gbest must equal optimal.
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
         visited.sort();
@@ -181,12 +178,11 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let options = SolverOptions {
-            epochs: 20,
-            n_nearest: 5,
-            ..SolverOptions::default()
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
         };
-        let sol = solve(&cities, &distances, &options);
+        let sol = solve(&cities, &distances, &opts, None, None);
         assert_eq!(sol.route().len(), cities.len());
         assert!(sol.total > 0.0);
     }

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -1,15 +1,12 @@
 use std::sync::mpsc;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
-use super::{validate_tour, AppOptions, Solution, Solvers};
+use super::{validate_tour, AppOptions, Solution, Solvers, TspProblem};
 
 pub struct PipelineStage {
     pub solver: Solvers,
     pub options: AppOptions,
-    pub cities: Vec<KDPoint>,
-    pub distances: DistanceMatrix,
+    pub problem: TspProblem,
     pub progress_tx: Option<mpsc::Sender<ProgressMessage>>,
 }
 
@@ -17,18 +14,16 @@ impl PipelineStage {
     pub fn new(
         solver: Solvers,
         options: AppOptions,
-        cities: Vec<KDPoint>,
-        distances: DistanceMatrix,
+        problem: TspProblem,
         progress_tx: Option<mpsc::Sender<ProgressMessage>>,
     ) -> Self {
-        PipelineStage { solver, options, cities, distances, progress_tx }
+        PipelineStage { solver, options, problem, progress_tx }
     }
 
     pub fn solve(&self, initial_tour: Option<&[usize]>) -> Result<Solution, String> {
         super::solve_with_context(
             self.solver,
-            &self.cities,
-            &self.distances,
+            &self.problem,
             &self.options,
             self.progress_tx.clone(),
             initial_tour,
@@ -43,7 +38,7 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
     let mut seed: Option<Vec<usize>> = None;
     for stage in stages {
         if let Some(ref t) = seed {
-            if let Err(e) = validate_tour(t, &stage.cities) {
+            if let Err(e) = validate_tour(t, &stage.problem.cities) {
                 tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
                 seed = None;
             }
@@ -52,7 +47,7 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
         tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
 
         let solution = stage.solve(seed.as_deref())?;
-        validate_tour(solution.route(), &stage.cities)
+        validate_tour(solution.route(), &stage.problem.cities)
             .map_err(|e| format!("stage {:?} invalid tour: {e}", stage.solver))?;
 
         tracing::info!(cost = solution.total, "pipeline: stage complete");
@@ -62,15 +57,15 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
 
     let last = stages.last().unwrap();
     let route = seed.unwrap();
-    Ok(Solution::new(&route, &last.cities, &last.distances))
+    Ok(Solution::new(&route, &last.problem))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, Solvers};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, Solvers, TspProblem};
 
-    fn small_cities() -> Vec<KDPoint> {
+    fn small_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![1.0, 0.0],
@@ -80,15 +75,16 @@ mod tests {
         ])
     }
 
-    fn make_stage(solver: Solvers, cities: Vec<KDPoint>, distances: DistanceMatrix) -> PipelineStage {
-        PipelineStage::new(solver, AppOptions::default(), cities, distances, None)
+    fn make_stage(solver: Solvers, problem: TspProblem) -> PipelineStage {
+        PipelineStage::new(solver, AppOptions::default(), problem, None)
     }
 
     #[test]
     fn test_pipeline_single_step_nn_produces_valid_tour() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let stages = [make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone())];
+        let problem = TspProblem::new(cities.clone(), dm);
+        let stages = [make_stage(Solvers::NearestNeighbor, problem)];
 
         let result = run_pipeline(&stages).unwrap();
 
@@ -104,14 +100,15 @@ mod tests {
     fn test_pipeline_two_steps_nn_then_2opt_no_worse_than_nn() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
 
-        let nn_result = make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone())
+        let nn_result = make_stage(Solvers::NearestNeighbor, problem.clone())
             .solve(None)
             .unwrap();
 
         let stages = [
-            make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone()),
-            make_stage(Solvers::TwoOpt, cities.clone(), dm.clone()),
+            make_stage(Solvers::NearestNeighbor, problem.clone()),
+            make_stage(Solvers::TwoOpt, problem.clone()),
         ];
         let pipeline_result = run_pipeline(&stages).unwrap();
 
@@ -127,7 +124,8 @@ mod tests {
     fn test_pipeline_stage_twoopt_produces_valid_tour() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let stages = [make_stage(Solvers::TwoOpt, cities.clone(), dm.clone())];
+        let problem = TspProblem::new(cities, dm);
+        let stages = [make_stage(Solvers::TwoOpt, problem)];
 
         let result = run_pipeline(&stages);
         assert!(result.is_ok());

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -37,11 +37,10 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
     }
     let mut seed: Option<Vec<usize>> = None;
     for stage in stages {
-        if let Some(ref t) = seed {
-            if let Err(e) = validate_tour(t, &stage.problem.cities) {
-                tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
-                seed = None;
-            }
+        if let Some(ref t) = seed
+            && let Err(e) = validate_tour(t, &stage.problem.cities) {
+            tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
+            seed = None;
         }
         tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
         let solution = stage.solve(seed.as_deref())?;

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -20,33 +20,33 @@ impl PipelineStage {
         PipelineStage { solver, options, problem, progress_tx }
     }
 
-    pub fn solve(&self, initial_tour: Option<&[usize]>) -> Result<Solution, String> {
+    pub fn solve(&self) -> Result<Solution, String> {
         super::solve_with_context(
             self.solver,
             &self.problem,
             &self.options,
             self.progress_tx.clone(),
-            initial_tour,
         )
     }
 }
 
-pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
+pub fn run_pipeline(stages: &mut [PipelineStage]) -> Result<Solution, String> {
     if stages.is_empty() {
         return Err("pipeline has no stages".into());
     }
     let mut seed: Option<Vec<usize>> = None;
-    for stage in stages {
+    for stage in stages.iter_mut() {
         if let Some(ref t) = seed {
             if let Err(e) = validate_tour(t, &stage.problem.cities) {
                 tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
                 seed = None;
             }
         }
+        stage.problem.initial_tour = seed.clone();
 
         tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
 
-        let solution = stage.solve(seed.as_deref())?;
+        let solution = stage.solve()?;
         validate_tour(solution.route(), &stage.problem.cities)
             .map_err(|e| format!("stage {:?} invalid tour: {e}", stage.solver))?;
 
@@ -84,9 +84,9 @@ mod tests {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
-        let stages = [make_stage(Solvers::NearestNeighbor, problem)];
+        let mut stages = [make_stage(Solvers::NearestNeighbor, problem)];
 
-        let result = run_pipeline(&stages).unwrap();
+        let result = run_pipeline(&mut stages).unwrap();
 
         assert_eq!(result.len(), cities.len());
         let mut seen = result.route().to_vec();
@@ -103,21 +103,21 @@ mod tests {
         let problem = TspProblem::new(cities.clone(), dm);
 
         let nn_result = make_stage(Solvers::NearestNeighbor, problem.clone())
-            .solve(None)
+            .solve()
             .unwrap();
 
-        let stages = [
+        let mut stages = [
             make_stage(Solvers::NearestNeighbor, problem.clone()),
             make_stage(Solvers::TwoOpt, problem.clone()),
         ];
-        let pipeline_result = run_pipeline(&stages).unwrap();
+        let pipeline_result = run_pipeline(&mut stages).unwrap();
 
         assert!(pipeline_result.total <= nn_result.total * 1.001);
     }
 
     #[test]
     fn test_pipeline_empty_stages_errors() {
-        assert!(run_pipeline(&[]).is_err());
+        assert!(run_pipeline(&mut []).is_err());
     }
 
     #[test]
@@ -125,9 +125,9 @@ mod tests {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let stages = [make_stage(Solvers::TwoOpt, problem)];
+        let mut stages = [make_stage(Solvers::TwoOpt, problem)];
 
-        let result = run_pipeline(&stages);
+        let result = run_pipeline(&mut stages);
         assert!(result.is_ok());
     }
 }

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -3,57 +3,72 @@ use std::sync::mpsc;
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
-use super::{validate_tour, Solution, SolverOptions, Solvers};
+use super::{validate_tour, AppOptions, Solution, Solvers};
 
-#[derive(Clone, Debug)]
 pub struct PipelineStage {
     pub solver: Solvers,
-    pub options: SolverOptions, // fully resolved at config-load time
+    pub options: AppOptions,
+    pub cities: Vec<KDPoint>,
+    pub distances: DistanceMatrix,
+    pub progress_tx: Option<mpsc::Sender<ProgressMessage>>,
 }
 
-/// Run a pipeline of stages. `progress_tx` and `initial_tour` are injected at
-/// runtime per stage and cannot be set via config.
-pub fn solve(
-    stages: &[PipelineStage],
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
-    progress_tx: Option<mpsc::Sender<ProgressMessage>>,
-) -> Result<Solution, String> {
-    assert!(!stages.is_empty(), "pipeline: stages must not be empty — validate at call site");
-
-    let mut seed: Option<Vec<usize>> = None;
-    let mut last_solution: Option<Solution> = None;
-
-    for (i, stage) in stages.iter().enumerate() {
-        if let Some(ref t) = seed
-            && let Err(e) = validate_tour(t, cities)
-        {
-            tracing::warn!("pipeline stage {i}: invalid seed ({e}); using default seeding");
-            seed = None;
-        }
-
-        let mut stage_opts = stage.options.clone();
-        stage_opts.progress_tx = progress_tx.clone();
-        stage_opts.initial_tour = seed.take();
-
-        tracing::info!(stage = i, solver = ?stage.solver, "pipeline: stage starting");
-
-        let solution = super::solve(stage.solver, cities, distances, &stage_opts)
-            .map_err(|e| format!("pipeline stage {i} ({:?}): {e}", stage.solver))?;
-
-        tracing::info!(stage = i, cost = solution.total, "pipeline: stage complete");
-
-        seed = Some(solution.route().to_vec());
-        last_solution = Some(solution);
+impl PipelineStage {
+    pub fn new(
+        solver: Solvers,
+        options: AppOptions,
+        cities: Vec<KDPoint>,
+        distances: DistanceMatrix,
+        progress_tx: Option<mpsc::Sender<ProgressMessage>>,
+    ) -> Self {
+        PipelineStage { solver, options, cities, distances, progress_tx }
     }
 
-    Ok(last_solution.expect("loop executed — asserted non-empty above"))
+    pub fn solve(&self, initial_tour: Option<&[usize]>) -> Result<Solution, String> {
+        super::solve_with_context(
+            self.solver,
+            &self.cities,
+            &self.distances,
+            &self.options,
+            self.progress_tx.clone(),
+            initial_tour,
+        )
+    }
+}
+
+pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
+    if stages.is_empty() {
+        return Err("pipeline has no stages".into());
+    }
+    let mut seed: Option<Vec<usize>> = None;
+    for stage in stages {
+        if let Some(ref t) = seed {
+            if let Err(e) = validate_tour(t, &stage.cities) {
+                tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
+                seed = None;
+            }
+        }
+
+        tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
+
+        let solution = stage.solve(seed.as_deref())?;
+        validate_tour(solution.route(), &stage.cities)
+            .map_err(|e| format!("stage {:?} invalid tour: {e}", stage.solver))?;
+
+        tracing::info!(cost = solution.total, "pipeline: stage complete");
+
+        seed = Some(solution.route().to_vec());
+    }
+
+    let last = stages.last().unwrap();
+    let route = seed.unwrap();
+    Ok(Solution::new(&route, &last.cities, &last.distances))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, SolverOptions, Solvers};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, Solvers};
 
     fn small_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -65,30 +80,23 @@ mod tests {
         ])
     }
 
-    fn stage(solver: Solvers) -> PipelineStage {
-        PipelineStage { solver, options: SolverOptions::default() }
-    }
-
-    fn stage_with(solver: Solvers, options: SolverOptions) -> PipelineStage {
-        PipelineStage { solver, options }
+    fn make_stage(solver: Solvers, cities: Vec<KDPoint>, distances: DistanceMatrix) -> PipelineStage {
+        PipelineStage::new(solver, AppOptions::default(), cities, distances, None)
     }
 
     #[test]
     fn test_pipeline_single_step_nn_produces_valid_tour() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let stages = [stage(Solvers::NearestNeighbor)];
+        let stages = [make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone())];
 
-        let result = solve(&stages, &cities, &dm, None).unwrap();
+        let result = run_pipeline(&stages).unwrap();
 
         assert_eq!(result.len(), cities.len());
         let mut seen = result.route().to_vec();
         seen.sort();
-        let expected: Vec<usize> = {
-            let mut ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
-            ids.sort();
-            ids
-        };
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
         assert_eq!(seen, expected);
     }
 
@@ -96,26 +104,32 @@ mod tests {
     fn test_pipeline_two_steps_nn_then_2opt_no_worse_than_nn() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let opts = SolverOptions { epochs: 100, ..SolverOptions::default() };
 
-        let nn_result = super::super::solve(
-            Solvers::NearestNeighbor, &cities, &dm, &opts,
-        ).unwrap();
+        let nn_result = make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone())
+            .solve(None)
+            .unwrap();
 
-        let stages = [stage(Solvers::NearestNeighbor), stage_with(Solvers::TwoOpt, opts)];
-        let pipeline_result = solve(&stages, &cities, &dm, None).unwrap();
+        let stages = [
+            make_stage(Solvers::NearestNeighbor, cities.clone(), dm.clone()),
+            make_stage(Solvers::TwoOpt, cities.clone(), dm.clone()),
+        ];
+        let pipeline_result = run_pipeline(&stages).unwrap();
 
-        // 2-opt cannot worsen a tour
         assert!(pipeline_result.total <= nn_result.total * 1.001);
     }
 
     #[test]
-    fn test_pipeline_stage_opts_prevent_recursion() {
+    fn test_pipeline_empty_stages_errors() {
+        assert!(run_pipeline(&[]).is_err());
+    }
+
+    #[test]
+    fn test_pipeline_stage_twoopt_produces_valid_tour() {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let stages = [stage(Solvers::TwoOpt)];
+        let stages = [make_stage(Solvers::TwoOpt, cities.clone(), dm.clone())];
 
-        let result = solve(&stages, &cities, &dm, None);
+        let result = run_pipeline(&stages);
         assert!(result.is_ok());
     }
 }

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -20,38 +20,34 @@ impl PipelineStage {
         PipelineStage { solver, options, problem, progress_tx }
     }
 
-    pub fn solve(&self) -> Result<Solution, String> {
+    pub fn solve(&self, init_tour: Option<&[usize]>) -> Result<Solution, String> {
         super::solve_with_context(
             self.solver,
             &self.problem,
             &self.options,
             self.progress_tx.clone(),
+            init_tour,
         )
     }
 }
 
-pub fn run_pipeline(stages: &mut [PipelineStage]) -> Result<Solution, String> {
+pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
     if stages.is_empty() {
         return Err("pipeline has no stages".into());
     }
     let mut seed: Option<Vec<usize>> = None;
-    for stage in stages.iter_mut() {
+    for stage in stages {
         if let Some(ref t) = seed {
             if let Err(e) = validate_tour(t, &stage.problem.cities) {
                 tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
                 seed = None;
             }
         }
-        stage.problem.initial_tour = seed.clone();
-
         tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
-
-        let solution = stage.solve()?;
+        let solution = stage.solve(seed.as_deref())?;
         validate_tour(solution.route(), &stage.problem.cities)
             .map_err(|e| format!("stage {:?} invalid tour: {e}", stage.solver))?;
-
         tracing::info!(cost = solution.total, "pipeline: stage complete");
-
         seed = Some(solution.route().to_vec());
     }
 
@@ -84,9 +80,9 @@ mod tests {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
-        let mut stages = [make_stage(Solvers::NearestNeighbor, problem)];
+        let stages = [make_stage(Solvers::NearestNeighbor, problem)];
 
-        let result = run_pipeline(&mut stages).unwrap();
+        let result = run_pipeline(&stages).unwrap();
 
         assert_eq!(result.len(), cities.len());
         let mut seen = result.route().to_vec();
@@ -103,21 +99,21 @@ mod tests {
         let problem = TspProblem::new(cities.clone(), dm);
 
         let nn_result = make_stage(Solvers::NearestNeighbor, problem.clone())
-            .solve()
+            .solve(None)
             .unwrap();
 
-        let mut stages = [
+        let stages = [
             make_stage(Solvers::NearestNeighbor, problem.clone()),
             make_stage(Solvers::TwoOpt, problem.clone()),
         ];
-        let pipeline_result = run_pipeline(&mut stages).unwrap();
+        let pipeline_result = run_pipeline(&stages).unwrap();
 
         assert!(pipeline_result.total <= nn_result.total * 1.001);
     }
 
     #[test]
     fn test_pipeline_empty_stages_errors() {
-        assert!(run_pipeline(&mut []).is_err());
+        assert!(run_pipeline(&[]).is_err());
     }
 
     #[test]
@@ -125,9 +121,9 @@ mod tests {
         let cities = small_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let mut stages = [make_stage(Solvers::TwoOpt, problem)];
+        let stages = [make_stage(Solvers::TwoOpt, problem)];
 
-        let result = run_pipeline(&mut stages);
+        let result = run_pipeline(&stages);
         assert!(result.is_ok());
     }
 }

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -24,7 +24,7 @@ pub fn solve(
         let j = rng.random_range(0..=i);
         path.swap(i, j);
     }
-    Solution::new(&path, cities, distances)
+    Solution::from_parts(&path, cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 /// Returns a uniformly random permutation of the city IDs.
 /// Used as a lightweight first pipeline stage for stochastic solvers that rely on
@@ -14,7 +14,7 @@ use super::{AppOptions, Solution};
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    _opts: &AppOptions,
+    _opts: &HeuristicOptions,
     _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     _initial_tour: Option<&[usize]>,
 ) -> Solution {
@@ -30,7 +30,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     fn five_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -46,7 +46,7 @@ mod tests {
     fn test_random_shuffle_produces_valid_tour() {
         let cities = five_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let result = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
         assert_eq!(result.len(), cities.len());
         let mut visited = result.route().to_vec();
@@ -60,7 +60,7 @@ mod tests {
     fn test_random_shuffle_tour_length_is_positive() {
         let cities = five_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let result = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
         assert!(result.total > 0.0);
     }
 }

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -2,22 +2,20 @@ use std::sync::mpsc;
 
 use rand::Rng;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 /// Returns a uniformly random permutation of the city IDs.
 /// Used as a lightweight first pipeline stage for stochastic solvers that rely on
 /// broad high-temperature exploration — a random start outperforms a greedy NN start
 /// for those algorithms because the temperature schedule is calibrated for cold starts.
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     _opts: &HeuristicOptions,
     _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    _initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let mut rng = rand::rng();
     let mut path: Vec<usize> = cities.iter().map(|c| c.id).collect();
     for i in (1..path.len()).rev() {
@@ -30,37 +28,38 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
-    fn five_cities() -> Vec<KDPoint> {
-        kdtree::build_points(&[
+    fn five_city_problem() -> TspProblem {
+        let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![1.0, 0.0],
             vec![1.0, 1.0],
             vec![0.0, 1.0],
             vec![0.5, 0.5],
-        ])
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        TspProblem::new(cities, dm)
     }
 
     #[test]
     fn test_random_shuffle_produces_valid_tour() {
-        let cities = five_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = five_city_problem();
+        let n = problem.cities.len();
+        let result = solve(&problem, &HeuristicOptions::default(), None);
 
-        assert_eq!(result.len(), cities.len());
+        assert_eq!(result.len(), n);
         let mut visited = result.route().to_vec();
         visited.sort();
-        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let mut expected: Vec<usize> = problem.cities.iter().map(|c| c.id).collect();
         expected.sort();
         assert_eq!(visited, expected);
     }
 
     #[test]
     fn test_random_shuffle_tour_length_is_positive() {
-        let cities = five_cities();
-        let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+        let problem = five_city_problem();
+        let result = solve(&problem, &HeuristicOptions::default(), None);
         assert!(result.total > 0.0);
     }
 }

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -13,6 +13,7 @@ pub fn solve(
     problem: &TspProblem,
     _opts: &HeuristicOptions,
     _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -46,7 +47,7 @@ mod tests {
     fn test_random_shuffle_produces_valid_tour() {
         let problem = five_city_problem();
         let n = problem.cities.len();
-        let result = solve(&problem, &HeuristicOptions::default(), None);
+        let result = solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert_eq!(result.len(), n);
         let mut visited = result.route().to_vec();
@@ -59,7 +60,7 @@ mod tests {
     #[test]
     fn test_random_shuffle_tour_length_is_positive() {
         let problem = five_city_problem();
-        let result = solve(&problem, &HeuristicOptions::default(), None);
+        let result = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(result.total > 0.0);
     }
 }

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -1,13 +1,23 @@
+use std::sync::mpsc;
+
+use rand::Rng;
+
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
-use super::{Solution, SolverOptions};
-use rand::Rng;
+use super::progress::ProgressMessage;
+use super::{AppOptions, Solution};
 
 /// Returns a uniformly random permutation of the city IDs.
 /// Used as a lightweight first pipeline stage for stochastic solvers that rely on
 /// broad high-temperature exploration — a random start outperforms a greedy NN start
 /// for those algorithms because the temperature schedule is calibrated for cold starts.
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, _options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    _opts: &AppOptions,
+    _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _initial_tour: Option<&[usize]>,
+) -> Solution {
     let mut rng = rand::rng();
     let mut path: Vec<usize> = cities.iter().map(|c| c.id).collect();
     for i in (1..path.len()).rev() {
@@ -20,7 +30,7 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, _options: &SolverOp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions};
 
     fn five_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -36,7 +46,7 @@ mod tests {
     fn test_random_shuffle_produces_valid_tour() {
         let cities = five_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &SolverOptions::default());
+        let result = solve(&cities, &dm, &AppOptions::default(), None, None);
 
         assert_eq!(result.len(), cities.len());
         let mut visited = result.route().to_vec();
@@ -50,7 +60,7 @@ mod tests {
     fn test_random_shuffle_tour_length_is_positive() {
         let cities = five_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let result = solve(&cities, &dm, &SolverOptions::default());
+        let result = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert!(result.total > 0.0);
     }
 }

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -2,20 +2,18 @@ use std::sync::mpsc;
 
 use rand::Rng;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::probability::{cooling, metropolis};
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{SAOptions, Solution};
+use super::{SAOptions, Solution, TspProblem};
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &SAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let cooling_rate = opts.cooling_rate;
     let mut epoch = 0;
 
@@ -26,7 +24,7 @@ pub fn solve(
         "SA starting"
     );
 
-    let mut best_route = initial_tour
+    let mut best_route = problem.initial_tour.as_deref()
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     let mut best_distance = distances.tour_length(best_route.route());
@@ -80,7 +78,7 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, SAOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, SAOptions, TspProblem};
 
     #[test]
     fn test_sa_respects_initial_tour() {
@@ -96,7 +94,8 @@ mod tests {
             max_temperature: 0.0,
             ..SAOptions::default()
         };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
+        let result = solve(&problem, &opts, None);
         assert_eq!(result.route(), optimal.as_slice());
     }
 

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -11,6 +11,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &SAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -24,7 +25,7 @@ pub fn solve(
         "SA starting"
     );
 
-    let mut best_route = problem.initial_tour.as_deref()
+    let mut best_route = init_tour
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     let mut best_distance = distances.tour_length(best_route.route());
@@ -94,8 +95,8 @@ mod tests {
             max_temperature: 0.0,
             ..SAOptions::default()
         };
-        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities, dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use rand::Rng;
 
 use super::distance_matrix::DistanceMatrix;
@@ -5,31 +7,37 @@ use super::kdtree::KDPoint;
 use super::probability::{cooling, metropolis};
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
-    let cooling_rate = options.cooling_rate;
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let sa = opts.sa.as_ref().cloned().unwrap_or_default();
+    let cooling_rate = sa.cooling_rate;
     let mut epoch = 0;
 
     tracing::info!(
-        epochs = options.epochs,
-        max_temp = options.max_temperature,
-        cooling_rate = options.cooling_rate,
+        epochs = sa.heuristic.epochs,
+        max_temp = sa.max_temperature,
+        cooling_rate = sa.cooling_rate,
         "SA starting"
     );
 
-    let mut best_route = options.initial_tour.as_deref()
+    let mut best_route = initial_tour
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     let mut best_distance = distances.tour_length(best_route.route());
 
-    options.send_progress(ProgressMessage::PathUpdate(
-        best_route.clone(),
-        best_distance,
-    ));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+    }
 
-    let mut temperature = options.max_temperature;
-    while epoch < options.epochs || temperature > options.min_temperature {
+    let mut temperature = sa.max_temperature;
+    while epoch < sa.heuristic.epochs || temperature > sa.min_temperature {
         let candidate = best_route.random_successor();
         let candidate_distance = distances.tour_length(candidate.route());
 
@@ -37,10 +45,9 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             best_route = candidate;
             best_distance = candidate_distance;
 
-            options.send_progress(ProgressMessage::PathUpdate(
-                best_route.clone(),
-                best_distance,
-            ));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+            }
             tracing::info!(epoch, tour_length = best_distance, "SA: new best");
         }
 
@@ -49,7 +56,9 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         epoch += 1;
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(best_route.route(), cities, distances)
 }
 
@@ -58,7 +67,6 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
         return true;
     }
 
-    // if they are basically same - then false
     if (new_distance - old_distance).abs() < f32::EPSILON {
         return false;
     }
@@ -73,47 +81,42 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions, SAOptions};
 
     #[test]
     fn test_sa_respects_initial_tour() {
-        use crate::tsp::{distance_matrix, kdtree};
         let cities = kdtree::build_points(&[
             vec![0.0, 0.0], vec![0.0, 0.5], vec![0.0, 1.0],
             vec![1.0, 1.0], vec![1.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
-        // Provide optimal tour; run 0 epochs so SA can't change it
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let mut opts = SolverOptions {
-            epochs: 0,
-            min_temperature: 1_000_000.0, // ensures loop exits immediately
+        let sa = SAOptions {
+            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            min_temperature: 1_000_000.0,
             max_temperature: 0.0,
-            ..SolverOptions::default()
+            ..SAOptions::default()
         };
-        opts.initial_tour = Some(optimal.clone());
-        let result = solve(&cities, &dm, &opts);
+        let opts = AppOptions { sa: Some(sa), ..AppOptions::default() };
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
     #[test]
     fn test_is_acceptable_always_accepts_improvement() {
-        // lower distance = better, so new_distance < old_distance must always be accepted
-        let temperature = 0.001; // near-zero — almost no random acceptance
+        let temperature = 0.001;
         assert!(is_acceptable(temperature, 100.0, 50.0));
         assert!(is_acceptable(temperature, 100.0, 99.999));
     }
 
     #[test]
     fn test_is_acceptable_never_accepts_equal_distance() {
-        // Equal energies: the function returns false (not an improvement, no chance roll)
-        let temperature = 1_000_000.0; // very high — would normally accept anything
+        let temperature = 1_000_000.0;
         assert!(!is_acceptable(temperature, 10.0, 10.0));
     }
 
     #[test]
     fn test_is_acceptable_probabilistic_for_worsening_at_high_temperature() {
-        // At very high temperature the acceptance probability approaches 1.
-        // Run many trials; almost all should be accepted.
         let temperature = 1_000_000.0;
         let accepted = (0..1000)
             .filter(|_| is_acceptable(temperature, 10.0, 10.001))
@@ -123,7 +126,6 @@ mod tests {
 
     #[test]
     fn test_is_acceptable_rarely_accepts_worsening_at_low_temperature() {
-        // At near-zero temperature, worsening moves should almost never be accepted.
         let temperature = 0.0001;
         let accepted = (0..1000)
             .filter(|_| is_acceptable(temperature, 10.0, 20.0))

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -58,7 +58,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(best_route.route(), cities, distances)
+    Solution::from_parts(best_route.route(), cities, distances)
 }
 
 fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool {

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -7,23 +7,22 @@ use super::kdtree::KDPoint;
 use super::probability::{cooling, metropolis};
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{SAOptions, Solution};
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &SAOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let sa = opts.sa.as_ref().cloned().unwrap_or_default();
-    let cooling_rate = sa.cooling_rate;
+    let cooling_rate = opts.cooling_rate;
     let mut epoch = 0;
 
     tracing::info!(
-        epochs = sa.heuristic.epochs,
-        max_temp = sa.max_temperature,
-        cooling_rate = sa.cooling_rate,
+        epochs = opts.heuristic.epochs,
+        max_temp = opts.max_temperature,
+        cooling_rate = opts.cooling_rate,
         "SA starting"
     );
 
@@ -36,8 +35,8 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
     }
 
-    let mut temperature = sa.max_temperature;
-    while epoch < sa.heuristic.epochs || temperature > sa.min_temperature {
+    let mut temperature = opts.max_temperature;
+    while epoch < opts.heuristic.epochs || temperature > opts.min_temperature {
         let candidate = best_route.random_successor();
         let candidate_distance = distances.tour_length(candidate.route());
 
@@ -81,7 +80,7 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions, SAOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, SAOptions};
 
     #[test]
     fn test_sa_respects_initial_tour() {
@@ -91,13 +90,12 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let sa = SAOptions {
+        let opts = SAOptions {
             heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
             min_temperature: 1_000_000.0,
             max_temperature: 0.0,
             ..SAOptions::default()
         };
-        let opts = AppOptions { sa: Some(sa), ..AppOptions::default() };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -1,25 +1,23 @@
 use std::sync::mpsc;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     tracing::info!(
         epochs = opts.epochs,
         platoo_epochs = opts.platoo_epochs,
         "hill climbing starting"
     );
 
-    let mut current_route = match initial_tour {
+    let mut current_route = match problem.initial_tour.as_deref() {
         Some(t) => Route::new(t),
         None => {
             let mut r = Route::from_cities(cities);
@@ -89,7 +87,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, kdtree::KDPoint, HeuristicOptions, TspProblem};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -112,7 +110,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal) };
+        let result = solve(&problem, &opts, None);
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -120,7 +119,8 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &fast_opts(), None, None);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let tour = solve(&problem, &fast_opts(), None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -131,7 +131,8 @@ mod tests {
     fn test_solve_tour_length_is_positive_and_finite() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &fast_opts(), None, None);
+        let problem = TspProblem::new(cities, dm);
+        let tour = solve(&problem, &fast_opts(), None);
 
         assert!(tour.total > 0.0, "tour length should be positive");
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -141,8 +142,9 @@ mod tests {
     fn test_solve_terminates_within_epoch_limit() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
         let opts = HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() };
-        let tour = solve(&cities, &dm, &opts, None, None);
+        let tour = solve(&problem, &opts, None);
         assert_eq!(tour.route().len(), cities.len());
     }
 }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -4,20 +4,18 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
-
     tracing::info!(
-        epochs = h.epochs,
-        platoo_epochs = h.platoo_epochs,
+        epochs = opts.epochs,
+        platoo_epochs = opts.platoo_epochs,
         "hill climbing starting"
     );
 
@@ -62,8 +60,8 @@ pub fn solve(
 
         epoch += 1;
 
-        if n_stale > h.platoo_epochs && h.platoo_epochs > 0 {
-            tracing::warn!(epoch, plateau_epochs = h.platoo_epochs, "hill: plateau, restarting");
+        if n_stale > opts.platoo_epochs && opts.platoo_epochs > 0 {
+            tracing::warn!(epoch, plateau_epochs = opts.platoo_epochs, "hill: plateau, restarting");
 
             current_route.shuffle();
             n_stale = 0;
@@ -73,13 +71,13 @@ pub fn solve(
             }
         }
 
-        if h.epochs > 0 && epoch > h.epochs {
+        if opts.epochs > 0 && epoch > opts.epochs {
             break;
         }
     }
 
     if !found_improvement {
-        tracing::warn!(epochs = h.epochs, tour_length = best_distance, "hill: no improvement found");
+        tracing::warn!(epochs = opts.epochs, tour_length = best_distance, "hill: no improvement found");
     }
 
     if let Some(tx) = progress_tx {
@@ -91,7 +89,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -103,11 +101,8 @@ mod tests {
         ])
     }
 
-    fn fast_opts() -> AppOptions {
-        AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 500, platoo_epochs: 100, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        }
+    fn fast_opts() -> HeuristicOptions {
+        HeuristicOptions { epochs: 500, platoo_epochs: 100, ..HeuristicOptions::default() }
     }
 
     #[test]
@@ -116,10 +111,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
@@ -149,10 +141,7 @@ mod tests {
     fn test_solve_terminates_within_epoch_limit() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() };
         let tour = solve(&cities, &dm, &opts, None, None);
         assert_eq!(tour.route().len(), cities.len());
     }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -1,17 +1,27 @@
+use std::sync::mpsc;
+
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
+
     tracing::info!(
-        epochs = options.epochs,
-        platoo_epochs = options.platoo_epochs,
+        epochs = h.epochs,
+        platoo_epochs = h.platoo_epochs,
         "hill climbing starting"
     );
 
-    let mut current_route = match options.initial_tour.as_deref() {
+    let mut current_route = match initial_tour {
         Some(t) => Route::new(t),
         None => {
             let mut r = Route::from_cities(cities);
@@ -19,10 +29,10 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             r
         }
     };
-    options.send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+    }
 
-    // Baseline from the shuffled state — sequential ordering would be
-    // an artificially low bar that random successors can never beat.
     let mut best_route = current_route.clone();
     let mut best_distance = distances.tour_length(best_route.route());
 
@@ -34,53 +44,54 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         let candidate_distance = distances.tour_length(candidate.route());
 
         if candidate_distance < best_distance {
-            current_route = candidate.clone(); // follow the gradient
+            current_route = candidate.clone();
             best_route = candidate;
             best_distance = candidate_distance;
             found_improvement = true;
 
             n_stale = 0;
 
-            options.send_progress(ProgressMessage::PathUpdate(
-                best_route.clone(),
-                best_distance,
-            ));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+            }
 
             tracing::info!(epoch, tour_length = best_distance, "hill: new best");
         } else {
-            n_stale += 1; // to measure how long we have been walking around on the platoo
+            n_stale += 1;
         }
 
         epoch += 1;
 
-        // restart search if been wandering too long on the platoo
-        if n_stale > options.platoo_epochs && options.platoo_epochs > 0 {
-            tracing::warn!(epoch, plateau_epochs = options.platoo_epochs, "hill: plateau, restarting");
+        if n_stale > h.platoo_epochs && h.platoo_epochs > 0 {
+            tracing::warn!(epoch, plateau_epochs = h.platoo_epochs, "hill: plateau, restarting");
 
             current_route.shuffle();
             n_stale = 0;
 
-            options.send_progress(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::PathUpdate(current_route.clone(), 0.0));
+            }
         }
 
-        // check if we should finish the search
-        if options.epochs > 0 && epoch > options.epochs {
+        if h.epochs > 0 && epoch > h.epochs {
             break;
         }
     }
 
     if !found_improvement {
-        tracing::warn!(epochs = options.epochs, tour_length = best_distance, "hill: no improvement found");
+        tracing::warn!(epochs = h.epochs, tour_length = best_distance, "hill: no improvement found");
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(best_route.route(), cities, distances)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -92,29 +103,24 @@ mod tests {
         ])
     }
 
-    fn fast_options() -> SolverOptions {
-        let mut opts = SolverOptions::default();
-        opts.epochs = 500;
-        opts.platoo_epochs = 100;
-        opts
+    fn fast_opts() -> AppOptions {
+        AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 500, platoo_epochs: 100, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        }
     }
 
     #[test]
     fn test_hill_respects_initial_tour_skips_shuffle() {
-        // When seeded, hill climbing should NOT shuffle the tour.
-        // Verify by providing the known-optimal tour and checking
-        // the solver doesn't produce something worse than sequential
-        // (if it shuffled, average quality would degrade).
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let mut opts = SolverOptions::default();
-        opts.epochs = 1;
-        opts.platoo_epochs = 1;
-        opts.initial_tour = Some(optimal.clone());
-        let result = solve(&cities, &dm, &opts);
-        // Seeded from optimal: result should equal optimal (1 epoch can't improve on optimal)
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        };
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -122,7 +128,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &fast_options());
+        let tour = solve(&cities, &dm, &fast_opts(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -133,7 +139,7 @@ mod tests {
     fn test_solve_tour_length_is_positive_and_finite() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &fast_options());
+        let tour = solve(&cities, &dm, &fast_opts(), None, None);
 
         assert!(tour.total > 0.0, "tour length should be positive");
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -143,10 +149,11 @@ mod tests {
     fn test_solve_terminates_within_epoch_limit() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let mut opts = SolverOptions::default();
-        opts.epochs = 100;
-        opts.platoo_epochs = 50;
-        let tour = solve(&cities, &dm, &opts);
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        };
+        let tour = solve(&cities, &dm, &opts, None, None);
         assert_eq!(tour.route().len(), cities.len());
     }
 }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -83,7 +83,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(best_route.route(), cities, distances)
+    Solution::from_parts(best_route.route(), cities, distances)
 }
 
 #[cfg(test)]

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -8,6 +8,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -17,7 +18,7 @@ pub fn solve(
         "hill climbing starting"
     );
 
-    let mut current_route = match problem.initial_tour.as_deref() {
+    let mut current_route = match init_tour {
         Some(t) => Route::new(t),
         None => {
             let mut r = Route::from_cities(cities);
@@ -110,8 +111,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() };
-        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities, dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -120,7 +121,7 @@ mod tests {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
-        let tour = solve(&problem, &fast_opts(), None);
+        let tour = solve(&problem, &fast_opts(), None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -132,7 +133,7 @@ mod tests {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let tour = solve(&problem, &fast_opts(), None);
+        let tour = solve(&problem, &fast_opts(), None, None);
 
         assert!(tour.total > 0.0, "tour length should be positive");
         assert!(tour.total.is_finite(), "tour length should be finite");
@@ -144,7 +145,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
         let opts = HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() };
-        let tour = solve(&problem, &opts, None);
+        let tour = solve(&problem, &opts, None, None);
         assert_eq!(tour.route().len(), cities.len());
     }
 }

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -5,19 +5,18 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    opts: &AppOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
-    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let tabu_capacity = cities.len();
 
-    tracing::info!(epochs = h.epochs, tabu_capacity, "tabu search starting");
+    tracing::info!(epochs = opts.epochs, tabu_capacity, "tabu search starting");
 
     let mut tabu_list = TabuList::new(tabu_capacity);
 
@@ -51,7 +50,7 @@ pub fn solve(
         u = local_best;
 
         epoch += 1;
-        done = update_terminate(epoch, h.epochs);
+        done = update_terminate(epoch, opts.epochs);
     }
 
     if let Some(tx) = progress_tx {
@@ -110,7 +109,7 @@ impl TabuList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
     use crate::tsp::route::Route;
 
     fn tsp5_cities() -> Vec<KDPoint> {
@@ -163,10 +162,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 1, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 1, ..HeuristicOptions::default() };
         let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
@@ -175,10 +171,7 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 200, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
         let tour = solve(&cities, &dm, &opts, None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
@@ -190,10 +183,7 @@ mod tests {
     fn test_solve_tour_length_is_positive() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let opts = AppOptions {
-            heuristic: Some(HeuristicOptions { epochs: 200, ..HeuristicOptions::default() }),
-            ..AppOptions::default()
-        };
+        let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
         let tour = solve(&cities, &dm, &opts, None, None);
 
         assert!(tour.total > 0.0, "tour length must be positive");

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -2,25 +2,24 @@ use std::collections::VecDeque;
 use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let tabu_capacity = cities.len();
 
     tracing::info!(epochs = opts.epochs, tabu_capacity, "tabu search starting");
 
     let mut tabu_list = TabuList::new(tabu_capacity);
 
-    let mut best_route = initial_tour
+    let mut best_route = problem.initial_tour.as_deref()
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     tabu_list.add(best_route.clone());
@@ -109,7 +108,7 @@ impl TabuList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, kdtree::KDPoint, HeuristicOptions, TspProblem};
     use crate::tsp::route::Route;
 
     fn tsp5_cities() -> Vec<KDPoint> {
@@ -163,7 +162,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 1, ..HeuristicOptions::default() };
-        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
+        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal) };
+        let result = solve(&problem, &opts, None);
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -171,8 +171,9 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
         let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
-        let tour = solve(&cities, &dm, &opts, None, None);
+        let tour = solve(&problem, &opts, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -183,8 +184,9 @@ mod tests {
     fn test_solve_tour_length_is_positive() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
         let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
-        let tour = solve(&cities, &dm, &opts, None, None);
+        let tour = solve(&problem, &opts, None);
 
         assert!(tour.total > 0.0, "tour length must be positive");
     }

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -1,24 +1,34 @@
 use std::collections::VecDeque;
+use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
+    let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let tabu_capacity = cities.len();
 
-    tracing::info!(epochs = options.epochs, tabu_capacity, "tabu search starting");
+    tracing::info!(epochs = h.epochs, tabu_capacity, "tabu search starting");
 
     let mut tabu_list = TabuList::new(tabu_capacity);
 
-    let mut best_route = options.initial_tour.as_deref()
+    let mut best_route = initial_tour
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     tabu_list.add(best_route.clone());
 
-    options.send_progress(ProgressMessage::PathUpdate(best_route.clone(), 0.0));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), 0.0));
+    }
 
     let mut u = best_route.clone();
     let mut best_distance = distances.tour_length(u.route());
@@ -30,10 +40,9 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
             best_route = local_best.clone();
             best_distance = local_distance;
 
-            options.send_progress(ProgressMessage::PathUpdate(
-                best_route.clone(),
-                best_distance,
-            ));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+            }
 
             tracing::info!(epoch, tour_length = local_distance, "tabu: new best");
         }
@@ -42,10 +51,12 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         u = local_best;
 
         epoch += 1;
-        done = update_terminate(epoch, options.epochs);
+        done = update_terminate(epoch, h.epochs);
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(best_route.route(), cities, distances)
 }
 
@@ -72,7 +83,7 @@ fn update_terminate(epoch: usize, max_epochs: usize) -> bool {
 }
 
 struct TabuList {
-    pub capacity: usize, // number of max items we are going to block
+    pub capacity: usize,
     items: VecDeque<Route>,
 }
 
@@ -85,12 +96,9 @@ impl TabuList {
     }
 
     pub fn add(&mut self, route: Route) {
-        // if queue is full drop the oldest item
         if self.items.len() >= self.capacity {
             self.items.pop_back();
         }
-
-        // add new item at the beginning
         self.items.push_front(route);
     }
 
@@ -102,7 +110,7 @@ impl TabuList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions, HeuristicOptions};
     use crate::tsp::route::Route;
 
     fn tsp5_cities() -> Vec<KDPoint> {
@@ -153,15 +161,13 @@ mod tests {
     fn test_tabu_respects_initial_tour() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        // Provide the known-optimal tour as initial_tour.
-        // With a tiny epoch budget (1 iteration), tabu can't find anything better than optimal,
-        // so best_route must remain equal to the seeded tour.
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let mut opts = SolverOptions::default();
-        opts.epochs = 1;
-        opts.initial_tour = Some(optimal.clone());
-        let result = solve(&cities, &dm, &opts);
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 1, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        };
+        let result = solve(&cities, &dm, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -169,9 +175,11 @@ mod tests {
     fn test_solve_visits_all_cities() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let mut options = SolverOptions::default();
-        options.epochs = 200;
-        let tour = solve(&cities, &dm, &options);
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 200, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        };
+        let tour = solve(&cities, &dm, &opts, None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -182,9 +190,11 @@ mod tests {
     fn test_solve_tour_length_is_positive() {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
-        let mut options = SolverOptions::default();
-        options.epochs = 200;
-        let tour = solve(&cities, &dm, &options);
+        let opts = AppOptions {
+            heuristic: Some(HeuristicOptions { epochs: 200, ..HeuristicOptions::default() }),
+            ..AppOptions::default()
+        };
+        let tour = solve(&cities, &dm, &opts, None, None);
 
         assert!(tour.total > 0.0, "tour length must be positive");
     }

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -10,6 +10,7 @@ pub fn solve(
     problem: &TspProblem,
     opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -19,7 +20,7 @@ pub fn solve(
 
     let mut tabu_list = TabuList::new(tabu_capacity);
 
-    let mut best_route = problem.initial_tour.as_deref()
+    let mut best_route = init_tour
         .map(Route::new)
         .unwrap_or_else(|| Route::from_cities(cities));
     tabu_list.add(best_route.clone());
@@ -162,8 +163,8 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = HeuristicOptions { epochs: 1, ..HeuristicOptions::default() };
-        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal) };
-        let result = solve(&problem, &opts, None);
+        let problem = TspProblem::new(cities, dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
     }
 
@@ -173,7 +174,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
         let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
-        let tour = solve(&problem, &opts, None);
+        let tour = solve(&problem, &opts, None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
         visited.sort();
@@ -186,7 +187,7 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
         let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
-        let tour = solve(&problem, &opts, None);
+        let tour = solve(&problem, &opts, None, None);
 
         assert!(tour.total > 0.0, "tour length must be positive");
     }

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -56,7 +56,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(best_route.route(), cities, distances)
+    Solution::from_parts(best_route.route(), cities, distances)
 }
 
 fn select(distances: &DistanceMatrix, route: &Route, tabu_list: &TabuList) -> (Route, f32) {

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -17,6 +17,7 @@ pub fn solve(
     problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
@@ -26,7 +27,7 @@ pub fn solve(
         return Solution::from_parts(&path, cities, distances);
     }
 
-    let mut path: Vec<usize> = problem.initial_tour.as_deref()
+    let mut path: Vec<usize> = init_tour
         .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
@@ -215,8 +216,8 @@ mod tests {
         ]);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let dm = build_dm(&cities);
-        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
-        let result = solve(&problem, &HeuristicOptions::default(), None);
+        let problem = TspProblem::new(cities, dm);
+        let result = solve(&problem, &HeuristicOptions::default(), None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -357,7 +358,7 @@ mod tests {
     fn solve_square_finds_optimal() {
         let cities = square_cities();
         let problem = make_problem(cities.clone());
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }
@@ -366,7 +367,7 @@ mod tests {
     fn solve_degenerate_triangle_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0), (0.5, 1.0)]);
         let problem = make_problem(cities.clone());
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!(tour.total > 0.0);
     }
@@ -375,7 +376,7 @@ mod tests {
     fn solve_two_cities_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0)]);
         let problem = make_problem(cities.clone());
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
     }
 
@@ -389,7 +390,7 @@ mod tests {
             (1.0, 0.0),
         ]);
         let problem = make_problem(cities.clone());
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -50,6 +50,11 @@ pub fn solve(
     Solution::from_parts(&path, cities, distances)
 }
 
+/// Scans all C(n,3) triples and returns the coordinates of the globally best
+/// improving 3-opt move `(i, j, k, case)`, or `None` if the tour is already
+/// locally optimal.
+///
+/// Pure: no side effects, no progress messages.
 fn find_best_move(
     path: &[usize],
     distances: &DistanceMatrix,
@@ -61,17 +66,21 @@ fn find_best_move(
     for i in 0..n - 2 {
         let a = path[i];
         let b = path[i + 1];
+        // Hoist edge (A,B) — invariant for all j, k given i.
         let d_ab = d(distances, a, b);
 
         for j in i + 1..n - 1 {
             let c = path[j];
             let dt = path[j + 1];
+            // Hoist (i,j)-invariant distances: 4 lookups saved per k iteration.
             let d_c_dt = d(distances, c, dt);
             let d_ac   = d(distances, a, c);
             let d_b_dt = d(distances, b, dt);
             let d_a_dt = d(distances, a, dt);
 
             for k in j + 1..n {
+                // Skip the degenerate triple where i==0, k==n-1: the wrap-around
+                // edge makes F==A, causing the formula to measure A→A.
                 if i == 0 && k == n - 1 {
                     continue;
                 }
@@ -114,24 +123,50 @@ fn find_best_move(
     best_move
 }
 
+/// Pre-computed distances for one (i, j, k) triple, grouped by the loop level
+/// at which they are computed and hoisted.
 struct TripleEdges {
+    // i-level
     d_ab: f32,
+    // j-level
     d_c_dt: f32, d_ac: f32, d_b_dt: f32, d_a_dt: f32,
+    // k-level
     d_ef: f32, d_ce: f32, d_dt_f: f32, d_be: f32, d_cf: f32, d_bf: f32, d_ae: f32,
 }
 
+/// Returns the 7 non-identity reconnection costs for a triple.
+///
+/// Index 0 = case 1, …, index 6 = case 7. The original three-edge cost
+/// (`d_ab + d_c_dt + d_ef`) is not included; the caller compares against it.
+///
+/// New edge sets (A=path[i], B=path[i+1], C=path[j], D=path[j+1],
+///               E=path[k], F=path[(k+1)%n]):
+///
+/// | idx | case | middle          | new edges             |
+/// |-----|------|-----------------|-----------------------|
+/// |  0  |  1   | rev(s1)+s2      | (A,C)+(B,D)+(E,F)     |
+/// |  1  |  2   | s1+rev(s2)      | (A,B)+(C,E)+(D,F)     |
+/// |  2  |  3   | rev(s1)+rev(s2) | (A,C)+(B,E)+(D,F)     |
+/// |  3  |  4   | s2+s1           | (A,D)+(E,B)+(C,F)     |
+/// |  4  |  5   | s2+rev(s1)      | (A,D)+(E,C)+(B,F)     |
+/// |  5  |  6   | rev(s2)+s1      | (A,E)+(D,B)+(C,F)     |
+/// |  6  |  7   | rev(s2)+rev(s1) | (A,E)+(D,C)+(B,F)     |
 fn reconnection_costs(e: &TripleEdges) -> [f32; 7] {
     [
-        e.d_ac  + e.d_b_dt + e.d_ef,
-        e.d_ab  + e.d_ce   + e.d_dt_f,
-        e.d_ac  + e.d_be   + e.d_dt_f,
-        e.d_a_dt + e.d_be  + e.d_cf,
-        e.d_a_dt + e.d_ce  + e.d_bf,
-        e.d_ae  + e.d_b_dt + e.d_cf,
-        e.d_ae  + e.d_c_dt + e.d_bf,
+        e.d_ac  + e.d_b_dt + e.d_ef,   // 1
+        e.d_ab  + e.d_ce   + e.d_dt_f, // 2
+        e.d_ac  + e.d_be   + e.d_dt_f, // 3
+        e.d_a_dt + e.d_be  + e.d_cf,   // 4
+        e.d_a_dt + e.d_ce  + e.d_bf,   // 5
+        e.d_ae  + e.d_b_dt + e.d_cf,   // 6
+        e.d_ae  + e.d_c_dt + e.d_bf,   // 7
     ]
 }
 
+/// Applies case `case` (1–7) to `path` in place.
+///
+/// Cases 1–3 use segment reversals only (no allocation).
+/// Cases 4–7 swap the two segments (one small Vec allocation per move).
 fn apply_3opt(path: &mut [usize], i: usize, j: usize, k: usize, case: u8) {
     match case {
         1 => path[i + 1..=j].reverse(),

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -1,8 +1,10 @@
+use std::sync::mpsc;
+
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
 /// 3-opt local search.
 ///
@@ -12,17 +14,24 @@ use super::{Solution, SolverOptions};
 ///
 /// Complexity: O(n³) per pass. The number of passes is bounded by the number
 /// of distinct improving moves, which is small on a NN-seeded tour.
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    _opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
     let n = cities.len();
     if n < 4 {
         let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
         return Solution::new(&path, cities, distances);
     }
 
-    let mut path: Vec<usize> = options.initial_tour.clone()
+    let mut path: Vec<usize> = initial_tour
+        .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
-    send_path(options, &path);
+    send_path(progress_tx, &path);
 
     let mut improved = true;
     while improved {
@@ -30,20 +39,17 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
         if let Some((i, j, k, case)) = find_best_move(&path, distances) {
             tracing::debug!(i, j, k, case, "3-opt: best improvement");
             apply_3opt(&mut path, i, j, k, case);
-            send_path(options, &path);
+            send_path(progress_tx, &path);
             improved = true;
         }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&path, cities, distances)
 }
 
-/// Scans all C(n,3) triples and returns the coordinates of the globally best
-/// improving 3-opt move `(i, j, k, case)`, or `None` if the tour is already
-/// locally optimal.
-///
-/// Pure: no side effects, no progress messages.
 fn find_best_move(
     path: &[usize],
     distances: &DistanceMatrix,
@@ -55,21 +61,17 @@ fn find_best_move(
     for i in 0..n - 2 {
         let a = path[i];
         let b = path[i + 1];
-        // Hoist edge (A,B) — invariant for all j, k given i.
         let d_ab = d(distances, a, b);
 
         for j in i + 1..n - 1 {
             let c = path[j];
             let dt = path[j + 1];
-            // Hoist (i,j)-invariant distances: 4 lookups saved per k iteration.
             let d_c_dt = d(distances, c, dt);
             let d_ac   = d(distances, a, c);
             let d_b_dt = d(distances, b, dt);
             let d_a_dt = d(distances, a, dt);
 
             for k in j + 1..n {
-                // Skip the degenerate triple where i==0, k==n-1: the wrap-around
-                // edge makes F==A, causing the formula to measure A→A.
                 if i == 0 && k == n - 1 {
                     continue;
                 }
@@ -77,7 +79,6 @@ fn find_best_move(
                 let e = path[k];
                 let f = path[(k + 1) % n];
 
-                // Per-k distances, each shared by multiple cases below.
                 let d_ef   = d(distances, e, f);
                 let d_ce   = d(distances, c, e);
                 let d_dt_f = d(distances, dt, f);
@@ -113,50 +114,24 @@ fn find_best_move(
     best_move
 }
 
-/// Pre-computed distances for one (i, j, k) triple, grouped by the loop level
-/// at which they are computed and hoisted.
 struct TripleEdges {
-    // i-level
     d_ab: f32,
-    // j-level
     d_c_dt: f32, d_ac: f32, d_b_dt: f32, d_a_dt: f32,
-    // k-level
     d_ef: f32, d_ce: f32, d_dt_f: f32, d_be: f32, d_cf: f32, d_bf: f32, d_ae: f32,
 }
 
-/// Returns the 7 non-identity reconnection costs for a triple.
-///
-/// Index 0 = case 1, …, index 6 = case 7. The original three-edge cost
-/// (`d_ab + d_c_dt + d_ef`) is not included; the caller compares against it.
-///
-/// New edge sets (A=path[i], B=path[i+1], C=path[j], D=path[j+1],
-///               E=path[k], F=path[(k+1)%n]):
-///
-/// | idx | case | middle          | new edges             |
-/// |-----|------|-----------------|-----------------------|
-/// |  0  |  1   | rev(s1)+s2      | (A,C)+(B,D)+(E,F)     |
-/// |  1  |  2   | s1+rev(s2)      | (A,B)+(C,E)+(D,F)     |
-/// |  2  |  3   | rev(s1)+rev(s2) | (A,C)+(B,E)+(D,F)     |
-/// |  3  |  4   | s2+s1           | (A,D)+(E,B)+(C,F)     |
-/// |  4  |  5   | s2+rev(s1)      | (A,D)+(E,C)+(B,F)     |
-/// |  5  |  6   | rev(s2)+s1      | (A,E)+(D,B)+(C,F)     |
-/// |  6  |  7   | rev(s2)+rev(s1) | (A,E)+(D,C)+(B,F)     |
 fn reconnection_costs(e: &TripleEdges) -> [f32; 7] {
     [
-        e.d_ac  + e.d_b_dt + e.d_ef,   // 1
-        e.d_ab  + e.d_ce   + e.d_dt_f, // 2
-        e.d_ac  + e.d_be   + e.d_dt_f, // 3
-        e.d_a_dt + e.d_be  + e.d_cf,   // 4
-        e.d_a_dt + e.d_ce  + e.d_bf,   // 5
-        e.d_ae  + e.d_b_dt + e.d_cf,   // 6
-        e.d_ae  + e.d_c_dt + e.d_bf,   // 7
+        e.d_ac  + e.d_b_dt + e.d_ef,
+        e.d_ab  + e.d_ce   + e.d_dt_f,
+        e.d_ac  + e.d_be   + e.d_dt_f,
+        e.d_a_dt + e.d_be  + e.d_cf,
+        e.d_a_dt + e.d_ce  + e.d_bf,
+        e.d_ae  + e.d_b_dt + e.d_cf,
+        e.d_ae  + e.d_c_dt + e.d_bf,
     ]
 }
 
-/// Applies case `case` (1–7) to `path` in place.
-///
-/// Cases 1–3 use segment reversals only (no allocation).
-/// Cases 4–7 swap the two segments (one small Vec allocation per move).
 fn apply_3opt(path: &mut [usize], i: usize, j: usize, k: usize, case: u8) {
     match case {
         1 => path[i + 1..=j].reverse(),
@@ -196,24 +171,21 @@ fn d(dm: &DistanceMatrix, a: usize, b: usize) -> f32 {
     dm.distance_between(a, b).expect("three_opt: invalid city pair")
 }
 
-fn send_path(options: &SolverOptions, path: &[usize]) {
-    if options.progress_tx.is_some() {
-        options.send_progress(ProgressMessage::PathUpdate(Route::new(path), 0.0));
+fn send_path(tx: Option<&mpsc::Sender<ProgressMessage>>, path: &[usize]) {
+    if let Some(t) = tx {
+        let _ = t.send(ProgressMessage::PathUpdate(Route::new(path), 0.0));
     }
 }
-
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions};
 
     fn build_dm(cities: &[kdtree::KDPoint]) -> DistanceMatrix {
         distance_matrix::from_cities(cities)
     }
 
-    /// Square: 0-1-2-3 with side 1, optimal tour = 4.0
     fn square_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[
             vec![0.0, 0.0],
@@ -223,7 +195,6 @@ mod tests {
         ])
     }
 
-    /// Build a city vec from (x,y) pairs.
     fn pts(coords: &[(f32, f32)]) -> Vec<kdtree::KDPoint> {
         let vecs: Vec<Vec<f32>> = coords.iter().map(|&(x, y)| vec![x, y]).collect();
         kdtree::build_points(&vecs)
@@ -231,8 +202,6 @@ mod tests {
 
     #[test]
     fn test_three_opt_respects_initial_tour() {
-        // TSP5: optimal tour [0,1,2,3,4] with cost 4.0
-        // Provide optimal as initial_tour → 3-opt can't improve → result == initial_tour
         let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![0.0, 0.5],
@@ -242,9 +211,7 @@ mod tests {
         ]);
         let dm = build_dm(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let mut opts = SolverOptions::default();
-        opts.initial_tour = Some(optimal.clone());
-        let result = solve(&cities, &dm, &opts);
+        let result = solve(&cities, &dm, &AppOptions::default(), None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -256,12 +223,6 @@ mod tests {
         ids == got
     }
 
-    // --- apply_3opt unit tests — one per case ---
-
-    /// Case 1: reverse seg1.
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// seg1 = [1,2], seg2 = [3,4]
-    /// case 1: rev(seg1)+seg2 → [0,2,1,3,4,5]
     #[test]
     fn apply_case1_reverses_seg1() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -269,10 +230,6 @@ mod tests {
         assert_eq!(path, vec![0, 2, 1, 3, 4, 5]);
     }
 
-    /// Case 2: reverse seg2.
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// seg1 = [1,2], seg2 = [3,4]
-    /// case 2: seg1+rev(seg2) → [0,1,2,4,3,5]
     #[test]
     fn apply_case2_reverses_seg2() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -280,9 +237,6 @@ mod tests {
         assert_eq!(path, vec![0, 1, 2, 4, 3, 5]);
     }
 
-    /// Case 3: reverse both segments separately.
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// case 3: rev(seg1)+rev(seg2) → [0,2,1,4,3,5]
     #[test]
     fn apply_case3_reverses_both_segs() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -290,9 +244,6 @@ mod tests {
         assert_eq!(path, vec![0, 2, 1, 4, 3, 5]);
     }
 
-    /// Case 4: swap seg1 and seg2 (no reversal).
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// case 4: seg2+seg1 → [0,3,4,1,2,5]
     #[test]
     fn apply_case4_swaps_segments() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -300,9 +251,6 @@ mod tests {
         assert_eq!(path, vec![0, 3, 4, 1, 2, 5]);
     }
 
-    /// Case 5: seg2 + rev(seg1).
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// case 5: seg2+rev(seg1) → [0,3,4,2,1,5]
     #[test]
     fn apply_case5_swaps_and_reverses_seg1() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -310,9 +258,6 @@ mod tests {
         assert_eq!(path, vec![0, 3, 4, 2, 1, 5]);
     }
 
-    /// Case 6: rev(seg2) + seg1.
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// case 6: rev(seg2)+seg1 → [0,4,3,1,2,5]
     #[test]
     fn apply_case6_swaps_and_reverses_seg2() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -320,9 +265,6 @@ mod tests {
         assert_eq!(path, vec![0, 4, 3, 1, 2, 5]);
     }
 
-    /// Case 7: rev(seg2) + rev(seg1).
-    /// path = [0,1,2,3,4,5], i=0 j=2 k=4
-    /// case 7: rev(seg2)+rev(seg1) → [0,4,3,2,1,5]
     #[test]
     fn apply_case7_reverses_both_and_swaps() {
         let mut path = vec![0usize, 1, 2, 3, 4, 5];
@@ -330,20 +272,14 @@ mod tests {
         assert_eq!(path, vec![0, 4, 3, 2, 1, 5]);
     }
 
-    // --- find_best_move unit tests ---
-
-    /// Optimal 4-city square tour should have no improving 3-opt move.
     #[test]
     fn find_best_move_returns_none_on_optimal() {
         let cities = square_cities();
         let dm = build_dm(&cities);
-        // NN produces the optimal tour for the square.
         let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
         assert_eq!(find_best_move(&path, &dm), None);
     }
 
-    /// A deliberately bad 5-city tour (with crossings) must have an improving move,
-    /// and applying it must strictly lower the tour cost.
     #[test]
     fn find_best_move_finds_improvement() {
         let cities = pts(&[
@@ -354,7 +290,6 @@ mod tests {
             (1.0, 0.0),
         ]);
         let dm = build_dm(&cities);
-        // Crossed tour: 0→2→4→1→3 (cost ≈ 6.06, well above optimal 4.0).
         let bad_path = vec![0usize, 2, 4, 1, 3];
         let orig_cost: f32 = dm.tour_length(&bad_path);
 
@@ -371,12 +306,6 @@ mod tests {
         );
     }
 
-    // --- reconnection_costs unit tests — one per case ---
-    //
-    // Fixed distances: d_ab=1, d_c_dt=2, d_ac=3, d_b_dt=4, d_a_dt=5,
-    //                  d_ef=6, d_ce=7, d_dt_f=8, d_be=9, d_cf=10, d_bf=11, d_ae=12
-    // orig = d_ab + d_c_dt + d_ef = 1 + 2 + 6 = 9  (all cases exceed it here)
-
     fn sample_edges() -> TripleEdges {
         TripleEdges {
             d_ab: 1.0, d_c_dt: 2.0, d_ac: 3.0, d_b_dt: 4.0, d_a_dt: 5.0,
@@ -386,53 +315,44 @@ mod tests {
 
     #[test]
     fn reconnection_costs_case1() {
-        // (A,C)+(B,D)+(E,F) = d_ac + d_b_dt + d_ef = 3+4+6 = 13
         assert_eq!(reconnection_costs(&sample_edges())[0], 13.0);
     }
 
     #[test]
     fn reconnection_costs_case2() {
-        // (A,B)+(C,E)+(D,F) = d_ab + d_ce + d_dt_f = 1+7+8 = 16
         assert_eq!(reconnection_costs(&sample_edges())[1], 16.0);
     }
 
     #[test]
     fn reconnection_costs_case3() {
-        // (A,C)+(B,E)+(D,F) = d_ac + d_be + d_dt_f = 3+9+8 = 20
         assert_eq!(reconnection_costs(&sample_edges())[2], 20.0);
     }
 
     #[test]
     fn reconnection_costs_case4() {
-        // (A,D)+(E,B)+(C,F) = d_a_dt + d_be + d_cf = 5+9+10 = 24
         assert_eq!(reconnection_costs(&sample_edges())[3], 24.0);
     }
 
     #[test]
     fn reconnection_costs_case5() {
-        // (A,D)+(E,C)+(B,F) = d_a_dt + d_ce + d_bf = 5+7+11 = 23
         assert_eq!(reconnection_costs(&sample_edges())[4], 23.0);
     }
 
     #[test]
     fn reconnection_costs_case6() {
-        // (A,E)+(D,B)+(C,F) = d_ae + d_b_dt + d_cf = 12+4+10 = 26
         assert_eq!(reconnection_costs(&sample_edges())[5], 26.0);
     }
 
     #[test]
     fn reconnection_costs_case7() {
-        // (A,E)+(D,C)+(B,F) = d_ae + d_c_dt + d_bf = 12+2+11 = 25
         assert_eq!(reconnection_costs(&sample_edges())[6], 25.0);
     }
-
-    // --- solver-level tests ---
 
     #[test]
     fn solve_square_finds_optimal() {
         let cities = square_cities();
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }
@@ -441,7 +361,7 @@ mod tests {
     fn solve_degenerate_triangle_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0), (0.5, 1.0)]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!(tour.total > 0.0);
     }
@@ -450,11 +370,10 @@ mod tests {
     fn solve_two_cities_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0)]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
     }
 
-    /// 3-opt on a deliberately suboptimal 5-city tour should match or beat 2-opt.
     #[test]
     fn solve_five_cities_unit_square() {
         let cities = pts(&[
@@ -465,7 +384,7 @@ mod tests {
             (1.0, 0.0),
         ]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &SolverOptions::default());
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -1,10 +1,9 @@
 use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 /// 3-opt local search.
 ///
@@ -15,19 +14,19 @@ use super::{HeuristicOptions, Solution};
 /// Complexity: O(n³) per pass. The number of passes is bounded by the number
 /// of distinct improving moves, which is small on a NN-seeded tour.
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     let n = cities.len();
     if n < 4 {
         let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
         return Solution::from_parts(&path, cities, distances);
     }
 
-    let mut path: Vec<usize> = initial_tour
+    let mut path: Vec<usize> = problem.initial_tour.as_deref()
         .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
@@ -180,10 +179,15 @@ fn send_path(tx: Option<&mpsc::Sender<ProgressMessage>>, path: &[usize]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
     fn build_dm(cities: &[kdtree::KDPoint]) -> DistanceMatrix {
         distance_matrix::from_cities(cities)
+    }
+
+    fn make_problem(cities: Vec<kdtree::KDPoint>) -> TspProblem {
+        let dm = build_dm(&cities);
+        TspProblem::new(cities, dm)
     }
 
     fn square_cities() -> Vec<kdtree::KDPoint> {
@@ -209,9 +213,10 @@ mod tests {
             vec![1.0, 1.0],
             vec![1.0, 0.0],
         ]);
-        let dm = build_dm(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let result = solve(&cities, &dm, &HeuristicOptions::default(), None,Some(&optimal));
+        let dm = build_dm(&cities);
+        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
+        let result = solve(&problem, &HeuristicOptions::default(), None);
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -351,8 +356,8 @@ mod tests {
     #[test]
     fn solve_square_finds_optimal() {
         let cities = square_cities();
-        let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
+        let problem = make_problem(cities.clone());
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }
@@ -360,8 +365,8 @@ mod tests {
     #[test]
     fn solve_degenerate_triangle_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0), (0.5, 1.0)]);
-        let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
+        let problem = make_problem(cities.clone());
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!(tour.total > 0.0);
     }
@@ -369,8 +374,8 @@ mod tests {
     #[test]
     fn solve_two_cities_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0)]);
-        let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
+        let problem = make_problem(cities.clone());
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
         assert!(is_valid_tour(tour.route(), &cities));
     }
 
@@ -383,8 +388,8 @@ mod tests {
             (1.0, 1.0),
             (1.0, 0.0),
         ]);
-        let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
+        let problem = make_problem(cities.clone());
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -24,7 +24,7 @@ pub fn solve(
     let n = cities.len();
     if n < 4 {
         let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        return Solution::new(&path, cities, distances);
+        return Solution::from_parts(&path, cities, distances);
     }
 
     let mut path: Vec<usize> = initial_tour
@@ -47,7 +47,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&path, cities, distances)
+    Solution::from_parts(&path, cities, distances)
 }
 
 fn find_best_move(

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -4,7 +4,7 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 /// 3-opt local search.
 ///
@@ -17,7 +17,7 @@ use super::{AppOptions, Solution};
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    _opts: &AppOptions,
+    _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
@@ -180,7 +180,7 @@ fn send_path(tx: Option<&mpsc::Sender<ProgressMessage>>, path: &[usize]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     fn build_dm(cities: &[kdtree::KDPoint]) -> DistanceMatrix {
         distance_matrix::from_cities(cities)
@@ -211,7 +211,7 @@ mod tests {
         ]);
         let dm = build_dm(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let result = solve(&cities, &dm, &AppOptions::default(), None, Some(&optimal));
+        let result = solve(&cities, &dm, &HeuristicOptions::default(), None,Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -352,7 +352,7 @@ mod tests {
     fn solve_square_finds_optimal() {
         let cities = square_cities();
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }
@@ -361,7 +361,7 @@ mod tests {
     fn solve_degenerate_triangle_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0), (0.5, 1.0)]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!(tour.total > 0.0);
     }
@@ -370,7 +370,7 @@ mod tests {
     fn solve_two_cities_is_valid() {
         let cities = pts(&[(0.0, 0.0), (1.0, 0.0)]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
         assert!(is_valid_tour(tour.route(), &cities));
     }
 
@@ -384,7 +384,7 @@ mod tests {
             (1.0, 0.0),
         ]);
         let dm = build_dm(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
         assert!(is_valid_tour(tour.route(), &cities));
         assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
     }

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -1,22 +1,20 @@
 use std::sync::mpsc;
 
-use super::distance_matrix::DistanceMatrix;
-use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{HeuristicOptions, Solution};
+use super::{HeuristicOptions, Solution, TspProblem};
 
 pub fn solve(
-    cities: &[KDPoint],
-    distances: &DistanceMatrix,
+    problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
-    initial_tour: Option<&[usize]>,
 ) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
     tracing::info!(cities = cities.len(), "2-opt starting");
 
     let n_indices = cities.len() - 1;
-    let mut path: Vec<usize> = initial_tour
+    let mut path: Vec<usize> = problem.initial_tour.as_deref()
         .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
@@ -75,7 +73,7 @@ fn swap_2opt(path: &mut [usize], from: usize, to: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
 
     #[test]
     fn test_swap_2opt_2middle_elems_in_even_size_list() {
@@ -102,7 +100,8 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let result = solve(&cities, &dm, &HeuristicOptions::default(), None,Some(&optimal));
+        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
+        let result = solve(&problem, &HeuristicOptions::default(), None);
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -117,7 +116,8 @@ mod tests {
         ]);
 
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
+        let problem = TspProblem::new(cities, dm);
+        let tour = solve(&problem, &HeuristicOptions::default(), None);
         assert_eq!(4.0, tour.total);
         assert_eq!(&[0, 1, 2, 3, 4], tour.route());
     }

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -8,13 +8,14 @@ pub fn solve(
     problem: &TspProblem,
     _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
     tracing::info!(cities = cities.len(), "2-opt starting");
 
     let n_indices = cities.len() - 1;
-    let mut path: Vec<usize> = problem.initial_tour.as_deref()
+    let mut path: Vec<usize> = init_tour
         .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
@@ -100,8 +101,8 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let problem = TspProblem { cities, distances: dm, initial_tour: Some(optimal.clone()) };
-        let result = solve(&problem, &HeuristicOptions::default(), None);
+        let problem = TspProblem::new(cities, dm);
+        let result = solve(&problem, &HeuristicOptions::default(), None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -117,7 +118,7 @@ mod tests {
 
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let tour = solve(&problem, &HeuristicOptions::default(), None);
+        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert_eq!(4.0, tour.total);
         assert_eq!(&[0, 1, 2, 3, 4], tour.route());
     }

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -4,12 +4,12 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{AppOptions, Solution};
+use super::{HeuristicOptions, Solution};
 
 pub fn solve(
     cities: &[KDPoint],
     distances: &DistanceMatrix,
-    _opts: &AppOptions,
+    _opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     initial_tour: Option<&[usize]>,
 ) -> Solution {
@@ -75,7 +75,7 @@ fn swap_2opt(path: &mut [usize], from: usize, to: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions};
+    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions};
 
     #[test]
     fn test_swap_2opt_2middle_elems_in_even_size_list() {
@@ -102,7 +102,7 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let result = solve(&cities, &dm, &AppOptions::default(), None, Some(&optimal));
+        let result = solve(&cities, &dm, &HeuristicOptions::default(), None,Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -117,7 +117,7 @@ mod tests {
         ]);
 
         let dm = distance_matrix::from_cities(&cities);
-        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
+        let tour = solve(&cities, &dm, &HeuristicOptions::default(), None,None);
         assert_eq!(4.0, tour.total);
         assert_eq!(&[0, 1, 2, 3, 4], tour.route());
     }

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -1,23 +1,36 @@
+use std::sync::mpsc;
+
 use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::progress::ProgressMessage;
 use super::route::Route;
-use super::{Solution, SolverOptions};
+use super::{AppOptions, Solution};
 
-pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution {
+pub fn solve(
+    cities: &[KDPoint],
+    distances: &DistanceMatrix,
+    _opts: &AppOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    initial_tour: Option<&[usize]>,
+) -> Solution {
     tracing::info!(cities = cities.len(), "2-opt starting");
 
     let n_indices = cities.len() - 1;
-    let mut path: Vec<usize> = options.initial_tour.clone()
+    let mut path: Vec<usize> = initial_tour
+        .map(|t| t.to_vec())
         .unwrap_or_else(|| cities.iter().map(|c| c.id).collect());
 
-    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), 0.0));
+    }
 
     let mut improved = true;
     while improved {
         improved = false;
         for i in 0..(n_indices - 2) {
-            options.send_progress(ProgressMessage::CityChange(path[i]));
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressMessage::CityChange(path[i]));
+            }
 
             for j in (i + 2)..n_indices {
                 let current_distance =
@@ -32,14 +45,18 @@ pub fn solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOpt
                     swap_2opt(&mut path, i + 1, j);
                     improved = true;
 
-                    options.send_progress(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
+                    if let Some(tx) = progress_tx {
+                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
+                    }
                     tracing::debug!(i, j, tour_length = new_distance, "2-opt: improvement");
                 }
             }
         }
     }
 
-    options.send_progress(ProgressMessage::Done);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
     Solution::new(&path, cities, distances)
 }
 
@@ -58,30 +75,24 @@ fn swap_2opt(path: &mut [usize], from: usize, to: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree};
+    use crate::tsp::{distance_matrix, kdtree, AppOptions};
 
     #[test]
     fn test_swap_2opt_2middle_elems_in_even_size_list() {
         let mut path = vec![1, 2, 3, 4];
-
         swap_2opt(&mut path, 1, 2);
-
         assert_eq!(vec![1, 3, 2, 4], path);
     }
 
     #[test]
     fn test_swap_2opt_single_middle_elem_does_nothing() {
         let mut path = vec![1, 2, 3, 4];
-
         swap_2opt(&mut path, 1, 1);
-
         assert_eq!(vec![1, 2, 3, 4], path);
     }
 
     #[test]
     fn test_two_opt_respects_initial_tour() {
-        // TSP5: optimal tour [0,1,2,3,4] with cost 4.0
-        // Provide optimal as initial_tour → 2-opt can't improve → result == initial_tour
         let cities = kdtree::build_points(&[
             vec![0.0, 0.0],
             vec![0.0, 0.5],
@@ -91,9 +102,7 @@ mod tests {
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
-        let mut opts = SolverOptions::default();
-        opts.initial_tour = Some(optimal.clone());
-        let result = solve(&cities, &dm, &opts);
+        let result = solve(&cities, &dm, &AppOptions::default(), None, Some(&optimal));
         assert_eq!(result.route(), optimal.as_slice());
     }
 
@@ -108,8 +117,7 @@ mod tests {
         ]);
 
         let dm = distance_matrix::from_cities(&cities);
-        let default_opts = SolverOptions::default();
-        let tour = solve(&cities, &dm, &default_opts);
+        let tour = solve(&cities, &dm, &AppOptions::default(), None, None);
         assert_eq!(4.0, tour.total);
         assert_eq!(&[0, 1, 2, 3, 4], tour.route());
     }

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -57,7 +57,7 @@ pub fn solve(
     if let Some(tx) = progress_tx {
         let _ = tx.send(ProgressMessage::Done);
     }
-    Solution::new(&path, cities, distances)
+    Solution::from_parts(&path, cities, distances)
 }
 
 fn swap_2opt(path: &mut [usize], from: usize, to: usize) {

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -3,9 +3,49 @@ mod bindings;
 
 use bindings::teeline::solver::types::{City, Solution, SolveOptions};
 use bindings::Guest;
-use teeline::tsp::{distance_matrix::DistanceMatrix, kdtree::KDPoint, SolverOptions};
+use teeline::tsp::{
+    distance_matrix::DistanceMatrix, kdtree::KDPoint, AppOptions, CSOptions, FPAOptions,
+    GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
+};
 
 struct Component;
+
+fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
+    let heuristic = HeuristicOptions {
+        epochs: o.epochs as usize,
+        platoo_epochs: o.platoo_epochs as usize,
+        n_nearest: o.n_nearest as usize,
+        verbose: false,
+    };
+    match solver {
+        Solvers::SimulatedAnnealing => AppOptions {
+            sa: Some(SAOptions {
+                heuristic,
+                cooling_rate: o.cooling_rate,
+                max_temperature: o.max_temperature,
+                min_temperature: o.min_temperature,
+            }),
+            ..AppOptions::default()
+        },
+        Solvers::GeneticAlgorithm => AppOptions {
+            ga: Some(GAOptions {
+                heuristic,
+                mutation_probability: o.mutation_probability,
+                n_elite: o.n_elite as usize,
+            }),
+            ..AppOptions::default()
+        },
+        Solvers::CuckooSearch => AppOptions {
+            cs: Some(CSOptions { heuristic, mutation_probability: o.mutation_probability }),
+            ..AppOptions::default()
+        },
+        Solvers::FlowerPollination => AppOptions {
+            fpa: Some(FPAOptions { heuristic, mutation_probability: o.mutation_probability }),
+            ..AppOptions::default()
+        },
+        _ => AppOptions { heuristic: Some(heuristic), ..AppOptions::default() },
+    }
+}
 
 impl Guest for Component {
     fn solve(
@@ -23,21 +63,11 @@ impl Guest for Component {
         let distances = DistanceMatrix::from_cities(&kd_cities)
             .map_err(|e| format!("distance matrix: {e}"))?;
 
-        let opts = SolverOptions {
-            epochs: options.epochs as usize,
-            platoo_epochs: options.platoo_epochs as usize,
-            cooling_rate: options.cooling_rate,
-            max_temperature: options.max_temperature,
-            min_temperature: options.min_temperature,
-            mutation_probability: options.mutation_probability,
-            n_elite: options.n_elite as usize,
-            n_nearest: options.n_nearest as usize,
-            progress_tx: None,
-            ..Default::default()
-        };
+        let problem = TspProblem::new(kd_cities, distances);
+        let opts = build_opts(solver_id, &options);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            teeline::tsp::solve(solver_id, &kd_cities, &distances, &opts)
+            teeline::tsp::solve_problem(solver_id, &problem, &opts)
         }))
         .map_err(|_| format!("solver '{solver}' panicked"))?
         .map(|s| Solution {

--- a/tests/fixtures/pipeline_bad_cooling_rate.toml
+++ b/tests/fixtures/pipeline_bad_cooling_rate.toml
@@ -1,3 +1,7 @@
 [[stage]]
 solver = "sa"
-cooling_rate = 0.0
+
+[stage.sa]
+cooling_rate    = 0.0
+max_temperature = 1000.0
+min_temperature = 0.001

--- a/tests/fixtures/pipeline_global_nn_sa.toml
+++ b/tests/fixtures/pipeline_global_nn_sa.toml
@@ -1,11 +1,11 @@
-[global]
-epochs = 50
-
 [[stage]]
 solver = "nn"
 
 [[stage]]
 solver = "sa"
-max_temperature = 200.0
-cooling_rate    = 0.001
+
+[stage.sa]
 epochs          = 50
+cooling_rate    = 0.001
+max_temperature = 200.0
+min_temperature = 0.001

--- a/tests/fixtures/pipeline_nn_2opt.toml
+++ b/tests/fixtures/pipeline_nn_2opt.toml
@@ -3,4 +3,3 @@ solver = "nn"
 
 [[stage]]
 solver = "2opt"
-epochs = 100

--- a/tests/no_gui_build.rs
+++ b/tests/no_gui_build.rs
@@ -1,7 +1,8 @@
-use teeline::tsp::SolverOptions;
+use teeline::tsp::{AppOptions, HeuristicOptions};
 
 #[test]
-fn solver_options_default_no_gui() {
-    let opts = SolverOptions::default();
-    assert_eq!(opts.epochs, 10_000);
+fn heuristic_options_default_no_gui() {
+    let defaults = HeuristicOptions::default();
+    assert_eq!(defaults.epochs, 10_000);
+    let _ = AppOptions::default();
 }

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -31,8 +31,8 @@ fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> V
 fn test_pipeline_config_runs_and_produces_valid_output() {
     let p = fixture("pipeline_nn_2opt.toml");
     let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
-    let mut stages = berlin52_stages(stage_configs);
-    let solution = run_pipeline(&mut stages).unwrap();
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
     assert!(solution.total > 0.0);
     assert_eq!(solution.route().len(), 52);
 }
@@ -47,8 +47,8 @@ fn test_pipeline_config_sa_stage_epochs_applied() {
     let (_, opts) = sa_stage.unwrap();
     assert_eq!(opts.sa.as_ref().unwrap().heuristic.epochs, 50);
     // Also verify it runs to completion
-    let mut stages = berlin52_stages(stage_configs);
-    let solution = run_pipeline(&mut stages).unwrap();
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
     assert_eq!(solution.route().len(), 52);
 }
 

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -1,12 +1,27 @@
 use std::path::{Path, PathBuf};
 
 use teeline::config::{resolve_config_file, select_pipeline_source, IdentityProvider};
-use teeline::tsp::{pipeline, tsplib};
+use teeline::tsp::{
+    pipeline::{run_pipeline, PipelineStage},
+    tsplib, Solvers,
+};
 
 const BERLIN52: &str = "tests/fixtures/berlin52.tsp";
 
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(format!("tests/fixtures/{name}"))
+}
+
+fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> Vec<PipelineStage> {
+    let tsp = tsplib::read_from_file(Path::new(BERLIN52)).unwrap();
+    let cities = tsp.cities().to_vec();
+    let distances = tsp.distance_matrix().unwrap();
+    stage_configs
+        .into_iter()
+        .map(|(solver, options)| {
+            PipelineStage::new(solver, options, cities.clone(), distances.clone(), None)
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -16,26 +31,25 @@ fn fixture(name: &str) -> PathBuf {
 #[test]
 fn test_pipeline_config_runs_and_produces_valid_output() {
     let p = fixture("pipeline_nn_2opt.toml");
-    let (stages, _) = resolve_config_file(&p, &IdentityProvider).unwrap();
-    let tsp = tsplib::read_from_file(Path::new(BERLIN52)).unwrap();
-    let cities = tsp.cities().to_vec();
-    let distances = tsp.distance_matrix().unwrap();
-    let solution = pipeline::solve(&stages, &cities, &distances, None).unwrap();
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
     assert!(solution.total > 0.0);
     assert_eq!(solution.route().len(), 52);
 }
 
 #[test]
-fn test_pipeline_config_global_epochs_applied() {
+fn test_pipeline_config_sa_stage_epochs_applied() {
     let p = fixture("pipeline_global_nn_sa.toml");
-    let (stages, _) = resolve_config_file(&p, &IdentityProvider).unwrap();
-    // [global] epochs = 50 should propagate to all stages
-    assert!(stages.iter().all(|s| s.options.epochs == 50));
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    // SA stage should have epochs=50 in its [stage.sa] options
+    let sa_stage = stage_configs.iter().find(|(s, _)| *s == Solvers::SimulatedAnnealing);
+    assert!(sa_stage.is_some(), "expected SA stage in fixture");
+    let (_, opts) = sa_stage.unwrap();
+    assert_eq!(opts.sa.as_ref().unwrap().heuristic.epochs, 50);
     // Also verify it runs to completion
-    let tsp = tsplib::read_from_file(Path::new(BERLIN52)).unwrap();
-    let cities = tsp.cities().to_vec();
-    let distances = tsp.distance_matrix().unwrap();
-    let solution = pipeline::solve(&stages, &cities, &distances, None).unwrap();
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
     assert_eq!(solution.route().len(), 52);
 }
 
@@ -93,4 +107,3 @@ fn test_pipeline_cooling_rate_zero_errors() {
     let err = resolve_config_file(&p, &IdentityProvider).unwrap_err();
     assert!(err.contains("cooling_rate"), "got: {err}");
 }
-

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -14,9 +14,7 @@ fn fixture(name: &str) -> PathBuf {
 
 fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> Vec<PipelineStage> {
     let tsp = tsplib::read_from_file(Path::new(BERLIN52)).unwrap();
-    let cities = tsp.cities().to_vec();
-    let distances = tsp.distance_matrix().unwrap();
-    let problem = TspProblem::new(cities, distances);
+    let problem = TspProblem::new(tsp.cities().to_vec(), tsp.distance_matrix().unwrap());
     stage_configs
         .into_iter()
         .map(|(solver, options)| {
@@ -33,8 +31,8 @@ fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> V
 fn test_pipeline_config_runs_and_produces_valid_output() {
     let p = fixture("pipeline_nn_2opt.toml");
     let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
-    let stages = berlin52_stages(stage_configs);
-    let solution = run_pipeline(&stages).unwrap();
+    let mut stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&mut stages).unwrap();
     assert!(solution.total > 0.0);
     assert_eq!(solution.route().len(), 52);
 }
@@ -49,8 +47,8 @@ fn test_pipeline_config_sa_stage_epochs_applied() {
     let (_, opts) = sa_stage.unwrap();
     assert_eq!(opts.sa.as_ref().unwrap().heuristic.epochs, 50);
     // Also verify it runs to completion
-    let stages = berlin52_stages(stage_configs);
-    let solution = run_pipeline(&stages).unwrap();
+    let mut stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&mut stages).unwrap();
     assert_eq!(solution.route().len(), 52);
 }
 

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use teeline::config::{resolve_config_file, select_pipeline_source, IdentityProvider};
 use teeline::tsp::{
     pipeline::{run_pipeline, PipelineStage},
-    tsplib, Solvers,
+    tsplib, Solvers, TspProblem,
 };
 
 const BERLIN52: &str = "tests/fixtures/berlin52.tsp";
@@ -16,10 +16,11 @@ fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> V
     let tsp = tsplib::read_from_file(Path::new(BERLIN52)).unwrap();
     let cities = tsp.cities().to_vec();
     let distances = tsp.distance_matrix().unwrap();
+    let problem = TspProblem::new(cities, distances);
     stage_configs
         .into_iter()
         .map(|(solver, options)| {
-            PipelineStage::new(solver, options, cities.clone(), distances.clone(), None)
+            PipelineStage::new(solver, options, problem.clone(), None)
         })
         .collect()
 }

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -15,7 +15,7 @@ use teeline::tsp::{
     bellman_karp, branch_bound, cuckoo_search, distance_matrix, flower_pollination,
     genetic_algorithm, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
     stochastic_hill, tabu_search, two_opt, tsplib,
-    CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions,
+    CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, TspProblem,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -32,6 +32,10 @@ fn load_berlin52() -> Vec<kdtree::KDPoint> {
 
 fn build_dm(cities: &[kdtree::KDPoint]) -> distance_matrix::DistanceMatrix {
     distance_matrix::from_cities(cities)
+}
+
+fn make_problem(cities: &[kdtree::KDPoint]) -> TspProblem {
+    TspProblem::new(cities.to_vec(), build_dm(cities))
 }
 
 fn tsp5_cities() -> Vec<kdtree::KDPoint> {
@@ -70,8 +74,7 @@ fn stochastic_options(epochs: usize) -> HeuristicOptions {
 #[test]
 fn nearest_neighbor_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour =
-        nearest_neighbor::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on berlin52");
 }
@@ -79,8 +82,7 @@ fn nearest_neighbor_valid_tour_berlin52() {
 #[test]
 fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
     let cities = load_berlin52();
-    let tour =
-        nearest_neighbor::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(tour.total > 0.0, "NN tour length should be positive");
     assert!(tour.total.is_finite(), "NN tour length should be finite");
@@ -91,7 +93,7 @@ fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
 #[test]
 fn two_opt_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on berlin52");
 }
@@ -99,7 +101,7 @@ fn two_opt_valid_tour_berlin52() {
 #[test]
 fn two_opt_tour_within_50pct_of_optimal_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(
         tour.total < 7542.0 * 1.5,
@@ -113,8 +115,7 @@ fn two_opt_tour_within_50pct_of_optimal_berlin52() {
 #[test]
 fn tabu_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour =
-        tabu_search::solve(&cities, &build_dm(&cities), &stochastic_options(500), None, None);
+    let tour = tabu_search::solve(&make_problem(&cities), &stochastic_options(500), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "tabu tour is not valid on berlin52");
 }
@@ -124,8 +125,7 @@ fn tabu_search_valid_tour_berlin52() {
 #[test]
 fn stochastic_hill_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour =
-        stochastic_hill::solve(&cities, &build_dm(&cities), &stochastic_options(500), None, None);
+    let tour = stochastic_hill::solve(&make_problem(&cities), &stochastic_options(500), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "hill tour is not valid on berlin52");
 }
@@ -139,7 +139,7 @@ fn simulated_annealing_valid_tour_berlin52() {
         heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
         ..SAOptions::default()
     };
-    let tour = simulated_annealing::solve(&cities, &build_dm(&cities), &opts, None, None);
+    let tour = simulated_annealing::solve(&make_problem(&cities), &opts, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "SA tour is not valid on berlin52");
 }
@@ -153,7 +153,7 @@ fn genetic_algorithm_valid_tour_berlin52() {
         heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
         ..GAOptions::default()
     };
-    let tour = genetic_algorithm::solve(&cities, &build_dm(&cities), &opts, None, None);
+    let tour = genetic_algorithm::solve(&make_problem(&cities), &opts, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "GA tour is not valid on berlin52");
 }
@@ -163,8 +163,7 @@ fn genetic_algorithm_valid_tour_berlin52() {
 #[test]
 fn particle_swarm_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour =
-        particle_swarm::solve(&cities, &build_dm(&cities), &stochastic_options(200), None, None);
+    let tour = particle_swarm::solve(&make_problem(&cities), &stochastic_options(200), None);
 
     assert!(
         is_valid_tour(tour.route(), &cities),
@@ -182,7 +181,7 @@ fn cuckoo_search_valid_tour_berlin52() {
         mutation_probability: 0.25,
         ..CSOptions::default()
     };
-    let tour = cuckoo_search::solve(&cities, &build_dm(&cities), &opts, None, None);
+    let tour = cuckoo_search::solve(&make_problem(&cities), &opts, None);
     assert!(
         is_valid_tour(tour.route(), &cities),
         "Cuckoo Search tour is not valid on berlin52"
@@ -194,7 +193,7 @@ fn cuckoo_search_valid_tour_berlin52() {
 #[test]
 fn bellman_karp_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = bellman_karp::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = bellman_karp::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid");
     // known optimal: 0→1→2→3→4→0 = 4.0
@@ -208,7 +207,7 @@ fn bellman_karp_optimal_tour_tsp5() {
 #[test]
 fn branch_bound_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = branch_bound::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
+    let tour = branch_bound::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "B&B tour is not valid");
     assert!(
@@ -246,7 +245,8 @@ fn nn_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let problem = TspProblem::new(cities.clone(), dm);
+    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on gr17");
     assert!(tour.total > 0.0);
@@ -257,7 +257,8 @@ fn nn_valid_tour_bays29() {
     let data = load_tsp("bays29.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("bays29 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let problem = TspProblem::new(cities.clone(), dm);
+    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on bays29");
     assert!(tour.total > 0.0);
@@ -268,7 +269,8 @@ fn two_opt_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = two_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let problem = TspProblem::new(cities.clone(), dm);
+    let tour = two_opt::solve(&problem, &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on gr17");
     // optimal is 2085; allow 1.5×
@@ -286,7 +288,8 @@ fn bellman_karp_optimal_ring6_explicit() {
     let data = load_tsp("ring6_explicit.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("ring6 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let problem = TspProblem::new(cities.clone(), dm);
+    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on ring6");
     assert!(
@@ -301,7 +304,8 @@ fn bellman_karp_optimal_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let problem = TspProblem::new(cities.clone(), dm);
+    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on gr17");
     assert!(
@@ -321,7 +325,7 @@ fn flower_pollination_valid_tour_berlin52() {
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };
-    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
+    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None);
     assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
 }
 
@@ -333,7 +337,7 @@ fn flower_pollination_tour_is_finite_and_positive() {
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };
-    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
+    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None);
     assert!(tour.total > 0.0);
     assert!(tour.total.is_finite());
 }

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -15,7 +15,7 @@ use teeline::tsp::{
     bellman_karp, branch_bound, cuckoo_search, distance_matrix, flower_pollination,
     genetic_algorithm, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
     stochastic_hill, tabu_search, two_opt, tsplib,
-    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions,
+    CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -57,14 +57,11 @@ fn is_valid_tour(tour_route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
     visited == expected_ids(cities)
 }
 
-fn stochastic_options(epochs: usize) -> AppOptions {
-    AppOptions {
-        heuristic: Some(HeuristicOptions {
-            epochs,
-            platoo_epochs: epochs / 5,
-            ..HeuristicOptions::default()
-        }),
-        ..AppOptions::default()
+fn stochastic_options(epochs: usize) -> HeuristicOptions {
+    HeuristicOptions {
+        epochs,
+        platoo_epochs: epochs / 5,
+        ..HeuristicOptions::default()
     }
 }
 
@@ -74,7 +71,7 @@ fn stochastic_options(epochs: usize) -> AppOptions {
 fn nearest_neighbor_valid_tour_berlin52() {
     let cities = load_berlin52();
     let tour =
-        nearest_neighbor::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+        nearest_neighbor::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on berlin52");
 }
@@ -83,7 +80,7 @@ fn nearest_neighbor_valid_tour_berlin52() {
 fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
     let cities = load_berlin52();
     let tour =
-        nearest_neighbor::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+        nearest_neighbor::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(tour.total > 0.0, "NN tour length should be positive");
     assert!(tour.total.is_finite(), "NN tour length should be finite");
@@ -94,7 +91,7 @@ fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
 #[test]
 fn two_opt_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+    let tour = two_opt::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on berlin52");
 }
@@ -102,7 +99,7 @@ fn two_opt_valid_tour_berlin52() {
 #[test]
 fn two_opt_tour_within_50pct_of_optimal_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+    let tour = two_opt::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(
         tour.total < 7542.0 * 1.5,
@@ -138,12 +135,9 @@ fn stochastic_hill_valid_tour_berlin52() {
 #[test]
 fn simulated_annealing_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let opts = AppOptions {
-        sa: Some(SAOptions {
-            heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
-            ..SAOptions::default()
-        }),
-        ..AppOptions::default()
+    let opts = SAOptions {
+        heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
+        ..SAOptions::default()
     };
     let tour = simulated_annealing::solve(&cities, &build_dm(&cities), &opts, None, None);
 
@@ -155,12 +149,9 @@ fn simulated_annealing_valid_tour_berlin52() {
 #[test]
 fn genetic_algorithm_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let opts = AppOptions {
-        ga: Some(GAOptions {
-            heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
-            ..GAOptions::default()
-        }),
-        ..AppOptions::default()
+    let opts = GAOptions {
+        heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+        ..GAOptions::default()
     };
     let tour = genetic_algorithm::solve(&cities, &build_dm(&cities), &opts, None, None);
 
@@ -186,13 +177,10 @@ fn particle_swarm_valid_tour_berlin52() {
 #[test]
 fn cuckoo_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let opts = AppOptions {
-        cs: Some(CSOptions {
-            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
-            mutation_probability: 0.25,
-            ..CSOptions::default()
-        }),
-        ..AppOptions::default()
+    let opts = CSOptions {
+        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        mutation_probability: 0.25,
+        ..CSOptions::default()
     };
     let tour = cuckoo_search::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(
@@ -206,7 +194,7 @@ fn cuckoo_search_valid_tour_berlin52() {
 #[test]
 fn bellman_karp_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = bellman_karp::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+    let tour = bellman_karp::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid");
     // known optimal: 0→1→2→3→4→0 = 4.0
@@ -220,7 +208,7 @@ fn bellman_karp_optimal_tour_tsp5() {
 #[test]
 fn branch_bound_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = branch_bound::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
+    let tour = branch_bound::solve(&cities, &build_dm(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "B&B tour is not valid");
     assert!(
@@ -258,7 +246,7 @@ fn nn_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on gr17");
     assert!(tour.total > 0.0);
@@ -269,7 +257,7 @@ fn nn_valid_tour_bays29() {
     let data = load_tsp("bays29.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("bays29 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on bays29");
     assert!(tour.total > 0.0);
@@ -280,7 +268,7 @@ fn two_opt_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = two_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = two_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on gr17");
     // optimal is 2085; allow 1.5×
@@ -298,7 +286,7 @@ fn bellman_karp_optimal_ring6_explicit() {
     let data = load_tsp("ring6_explicit.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("ring6 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on ring6");
     assert!(
@@ -313,7 +301,7 @@ fn bellman_karp_optimal_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = bellman_karp::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on gr17");
     assert!(
@@ -328,13 +316,10 @@ fn bellman_karp_optimal_gr17() {
 #[test]
 fn flower_pollination_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let opts = AppOptions {
-        fpa: Some(FPAOptions {
-            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
-            mutation_probability: 0.8,
-            ..FPAOptions::default()
-        }),
-        ..AppOptions::default()
+    let opts = FPAOptions {
+        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        mutation_probability: 0.8,
+        ..FPAOptions::default()
     };
     let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
@@ -343,13 +328,10 @@ fn flower_pollination_valid_tour_berlin52() {
 #[test]
 fn flower_pollination_tour_is_finite_and_positive() {
     let cities = load_berlin52();
-    let opts = AppOptions {
-        fpa: Some(FPAOptions {
-            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
-            mutation_probability: 0.8,
-            ..FPAOptions::default()
-        }),
-        ..AppOptions::default()
+    let opts = FPAOptions {
+        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        mutation_probability: 0.8,
+        ..FPAOptions::default()
     };
     let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(tour.total > 0.0);

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -74,7 +74,7 @@ fn stochastic_options(epochs: usize) -> HeuristicOptions {
 #[test]
 fn nearest_neighbor_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on berlin52");
 }
@@ -82,7 +82,7 @@ fn nearest_neighbor_valid_tour_berlin52() {
 #[test]
 fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(tour.total > 0.0, "NN tour length should be positive");
     assert!(tour.total.is_finite(), "NN tour length should be finite");
@@ -93,7 +93,7 @@ fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
 #[test]
 fn two_opt_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on berlin52");
 }
@@ -101,7 +101,7 @@ fn two_opt_valid_tour_berlin52() {
 #[test]
 fn two_opt_tour_within_50pct_of_optimal_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(
         tour.total < 7542.0 * 1.5,
@@ -115,7 +115,7 @@ fn two_opt_tour_within_50pct_of_optimal_berlin52() {
 #[test]
 fn tabu_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = tabu_search::solve(&make_problem(&cities), &stochastic_options(500), None);
+    let tour = tabu_search::solve(&make_problem(&cities), &stochastic_options(500), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "tabu tour is not valid on berlin52");
 }
@@ -125,7 +125,7 @@ fn tabu_search_valid_tour_berlin52() {
 #[test]
 fn stochastic_hill_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = stochastic_hill::solve(&make_problem(&cities), &stochastic_options(500), None);
+    let tour = stochastic_hill::solve(&make_problem(&cities), &stochastic_options(500), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "hill tour is not valid on berlin52");
 }
@@ -139,7 +139,7 @@ fn simulated_annealing_valid_tour_berlin52() {
         heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
         ..SAOptions::default()
     };
-    let tour = simulated_annealing::solve(&make_problem(&cities), &opts, None);
+    let tour = simulated_annealing::solve(&make_problem(&cities), &opts, None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "SA tour is not valid on berlin52");
 }
@@ -153,7 +153,7 @@ fn genetic_algorithm_valid_tour_berlin52() {
         heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
         ..GAOptions::default()
     };
-    let tour = genetic_algorithm::solve(&make_problem(&cities), &opts, None);
+    let tour = genetic_algorithm::solve(&make_problem(&cities), &opts, None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "GA tour is not valid on berlin52");
 }
@@ -163,7 +163,7 @@ fn genetic_algorithm_valid_tour_berlin52() {
 #[test]
 fn particle_swarm_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = particle_swarm::solve(&make_problem(&cities), &stochastic_options(200), None);
+    let tour = particle_swarm::solve(&make_problem(&cities), &stochastic_options(200), None, None);
 
     assert!(
         is_valid_tour(tour.route(), &cities),
@@ -181,7 +181,7 @@ fn cuckoo_search_valid_tour_berlin52() {
         mutation_probability: 0.25,
         ..CSOptions::default()
     };
-    let tour = cuckoo_search::solve(&make_problem(&cities), &opts, None);
+    let tour = cuckoo_search::solve(&make_problem(&cities), &opts, None, None);
     assert!(
         is_valid_tour(tour.route(), &cities),
         "Cuckoo Search tour is not valid on berlin52"
@@ -193,7 +193,7 @@ fn cuckoo_search_valid_tour_berlin52() {
 #[test]
 fn bellman_karp_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = bellman_karp::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = bellman_karp::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid");
     // known optimal: 0→1→2→3→4→0 = 4.0
@@ -207,7 +207,7 @@ fn bellman_karp_optimal_tour_tsp5() {
 #[test]
 fn branch_bound_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = branch_bound::solve(&make_problem(&cities), &HeuristicOptions::default(), None);
+    let tour = branch_bound::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "B&B tour is not valid");
     assert!(
@@ -246,7 +246,7 @@ fn nn_valid_tour_gr17() {
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
     let problem = TspProblem::new(cities.clone(), dm);
-    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None);
+    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on gr17");
     assert!(tour.total > 0.0);
@@ -258,7 +258,7 @@ fn nn_valid_tour_bays29() {
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("bays29 distance matrix");
     let problem = TspProblem::new(cities.clone(), dm);
-    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None);
+    let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on bays29");
     assert!(tour.total > 0.0);
@@ -270,7 +270,7 @@ fn two_opt_valid_tour_gr17() {
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
     let problem = TspProblem::new(cities.clone(), dm);
-    let tour = two_opt::solve(&problem, &HeuristicOptions::default(), None);
+    let tour = two_opt::solve(&problem, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on gr17");
     // optimal is 2085; allow 1.5×
@@ -289,7 +289,7 @@ fn bellman_karp_optimal_ring6_explicit() {
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("ring6 distance matrix");
     let problem = TspProblem::new(cities.clone(), dm);
-    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
+    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on ring6");
     assert!(
@@ -305,7 +305,7 @@ fn bellman_karp_optimal_gr17() {
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
     let problem = TspProblem::new(cities.clone(), dm);
-    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None);
+    let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on gr17");
     assert!(
@@ -325,7 +325,7 @@ fn flower_pollination_valid_tour_berlin52() {
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };
-    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None);
+    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None, None);
     assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
 }
 
@@ -337,7 +337,7 @@ fn flower_pollination_tour_is_finite_and_positive() {
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };
-    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None);
+    let tour = flower_pollination::solve(&make_problem(&cities), &opts, None, None);
     assert!(tour.total > 0.0);
     assert!(tour.total.is_finite());
 }

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -14,7 +14,8 @@ use std::path::Path;
 use teeline::tsp::{
     bellman_karp, branch_bound, cuckoo_search, distance_matrix, flower_pollination,
     genetic_algorithm, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
-    stochastic_hill, tabu_search, two_opt, tsplib, SolverOptions,
+    stochastic_hill, tabu_search, two_opt, tsplib,
+    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -56,11 +57,15 @@ fn is_valid_tour(tour_route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
     visited == expected_ids(cities)
 }
 
-fn stochastic_options(epochs: usize) -> SolverOptions {
-    let mut opts = SolverOptions::default();
-    opts.epochs = epochs;
-    opts.platoo_epochs = epochs / 5;
-    opts
+fn stochastic_options(epochs: usize) -> AppOptions {
+    AppOptions {
+        heuristic: Some(HeuristicOptions {
+            epochs,
+            platoo_epochs: epochs / 5,
+            ..HeuristicOptions::default()
+        }),
+        ..AppOptions::default()
+    }
 }
 
 // ─── nearest neighbor ────────────────────────────────────────────────────────
@@ -68,7 +73,8 @@ fn stochastic_options(epochs: usize) -> SolverOptions {
 #[test]
 fn nearest_neighbor_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour =
+        nearest_neighbor::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on berlin52");
 }
@@ -76,7 +82,8 @@ fn nearest_neighbor_valid_tour_berlin52() {
 #[test]
 fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour =
+        nearest_neighbor::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(tour.total > 0.0, "NN tour length should be positive");
     assert!(tour.total.is_finite(), "NN tour length should be finite");
@@ -87,7 +94,7 @@ fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
 #[test]
 fn two_opt_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour = two_opt::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on berlin52");
 }
@@ -95,7 +102,7 @@ fn two_opt_valid_tour_berlin52() {
 #[test]
 fn two_opt_tour_within_50pct_of_optimal_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour = two_opt::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(
         tour.total < 7542.0 * 1.5,
@@ -109,7 +116,8 @@ fn two_opt_tour_within_50pct_of_optimal_berlin52() {
 #[test]
 fn tabu_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = tabu_search::solve(&cities, &build_dm(&cities), &stochastic_options(500));
+    let tour =
+        tabu_search::solve(&cities, &build_dm(&cities), &stochastic_options(500), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "tabu tour is not valid on berlin52");
 }
@@ -119,7 +127,8 @@ fn tabu_search_valid_tour_berlin52() {
 #[test]
 fn stochastic_hill_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = stochastic_hill::solve(&cities, &build_dm(&cities), &stochastic_options(500));
+    let tour =
+        stochastic_hill::solve(&cities, &build_dm(&cities), &stochastic_options(500), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "hill tour is not valid on berlin52");
 }
@@ -129,9 +138,14 @@ fn stochastic_hill_valid_tour_berlin52() {
 #[test]
 fn simulated_annealing_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let mut opts = SolverOptions::default();
-    opts.epochs = 2000;
-    let tour = simulated_annealing::solve(&cities, &build_dm(&cities), &opts);
+    let opts = AppOptions {
+        sa: Some(SAOptions {
+            heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
+            ..SAOptions::default()
+        }),
+        ..AppOptions::default()
+    };
+    let tour = simulated_annealing::solve(&cities, &build_dm(&cities), &opts, None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "SA tour is not valid on berlin52");
 }
@@ -141,9 +155,14 @@ fn simulated_annealing_valid_tour_berlin52() {
 #[test]
 fn genetic_algorithm_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let mut opts = SolverOptions::default();
-    opts.epochs = 100;
-    let tour = genetic_algorithm::solve(&cities, &build_dm(&cities), &opts);
+    let opts = AppOptions {
+        ga: Some(GAOptions {
+            heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+            ..GAOptions::default()
+        }),
+        ..AppOptions::default()
+    };
+    let tour = genetic_algorithm::solve(&cities, &build_dm(&cities), &opts, None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "GA tour is not valid on berlin52");
 }
@@ -153,7 +172,8 @@ fn genetic_algorithm_valid_tour_berlin52() {
 #[test]
 fn particle_swarm_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = particle_swarm::solve(&cities, &build_dm(&cities), &stochastic_options(200));
+    let tour =
+        particle_swarm::solve(&cities, &build_dm(&cities), &stochastic_options(200), None, None);
 
     assert!(
         is_valid_tour(tour.route(), &cities),
@@ -166,9 +186,15 @@ fn particle_swarm_valid_tour_berlin52() {
 #[test]
 fn cuckoo_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let mut opts = stochastic_options(200);
-    opts.mutation_probability = 0.25;
-    let tour = cuckoo_search::solve(&cities, &build_dm(&cities), &opts);
+    let opts = AppOptions {
+        cs: Some(CSOptions {
+            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+            mutation_probability: 0.25,
+            ..CSOptions::default()
+        }),
+        ..AppOptions::default()
+    };
+    let tour = cuckoo_search::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(
         is_valid_tour(tour.route(), &cities),
         "Cuckoo Search tour is not valid on berlin52"
@@ -180,7 +206,7 @@ fn cuckoo_search_valid_tour_berlin52() {
 #[test]
 fn bellman_karp_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = bellman_karp::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour = bellman_karp::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid");
     // known optimal: 0→1→2→3→4→0 = 4.0
@@ -194,7 +220,7 @@ fn bellman_karp_optimal_tour_tsp5() {
 #[test]
 fn branch_bound_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = branch_bound::solve(&cities, &build_dm(&cities), &SolverOptions::default());
+    let tour = branch_bound::solve(&cities, &build_dm(&cities), &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "B&B tour is not valid");
     assert!(
@@ -232,7 +258,7 @@ fn nn_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &SolverOptions::default());
+    let tour = nearest_neighbor::solve(&cities, &dm, &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on gr17");
     assert!(tour.total > 0.0);
@@ -243,7 +269,7 @@ fn nn_valid_tour_bays29() {
     let data = load_tsp("bays29.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("bays29 distance matrix");
-    let tour = nearest_neighbor::solve(&cities, &dm, &SolverOptions::default());
+    let tour = nearest_neighbor::solve(&cities, &dm, &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on bays29");
     assert!(tour.total > 0.0);
@@ -254,7 +280,7 @@ fn two_opt_valid_tour_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = two_opt::solve(&cities, &dm, &SolverOptions::default());
+    let tour = two_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on gr17");
     // optimal is 2085; allow 1.5×
@@ -272,7 +298,7 @@ fn bellman_karp_optimal_ring6_explicit() {
     let data = load_tsp("ring6_explicit.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("ring6 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &SolverOptions::default());
+    let tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on ring6");
     assert!(
@@ -287,7 +313,7 @@ fn bellman_karp_optimal_gr17() {
     let data = load_tsp("gr17.tsp");
     let cities = data.cities().to_vec();
     let dm = data.distance_matrix().expect("gr17 distance matrix");
-    let tour = bellman_karp::solve(&cities, &dm, &SolverOptions::default());
+    let tour = bellman_karp::solve(&cities, &dm, &AppOptions::default(), None, None);
 
     assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on gr17");
     assert!(
@@ -302,18 +328,30 @@ fn bellman_karp_optimal_gr17() {
 #[test]
 fn flower_pollination_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let mut opts = stochastic_options(200);
-    opts.mutation_probability = 0.8;
-    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts);
+    let opts = AppOptions {
+        fpa: Some(FPAOptions {
+            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+            mutation_probability: 0.8,
+            ..FPAOptions::default()
+        }),
+        ..AppOptions::default()
+    };
+    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
 }
 
 #[test]
 fn flower_pollination_tour_is_finite_and_positive() {
     let cities = load_berlin52();
-    let mut opts = stochastic_options(200);
-    opts.mutation_probability = 0.8;
-    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts);
+    let opts = AppOptions {
+        fpa: Some(FPAOptions {
+            heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+            mutation_probability: 0.8,
+            ..FPAOptions::default()
+        }),
+        ..AppOptions::default()
+    };
+    let tour = flower_pollination::solve(&cities, &build_dm(&cities), &opts, None, None);
     assert!(tour.total > 0.0);
     assert!(tour.total.is_finite());
 }

--- a/tests/three_opt_test.rs
+++ b/tests/three_opt_test.rs
@@ -4,7 +4,7 @@
 /// Slow tests on berlin52 and att48 are marked #[ignore] and can be run with:
 ///   cargo test --test three_opt_test -- --include-ignored
 use std::path::Path;
-use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, HeuristicOptions};
+use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, HeuristicOptions, TspProblem};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -18,6 +18,11 @@ fn build_dm(cities: &[kdtree::KDPoint]) -> distance_matrix::DistanceMatrix {
     distance_matrix::from_cities(cities)
 }
 
+fn make_problem(cities: Vec<kdtree::KDPoint>) -> TspProblem {
+    let dm = build_dm(&cities);
+    TspProblem::new(cities, dm)
+}
+
 fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
     let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
     expected.sort_unstable();
@@ -27,8 +32,7 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 }
 
 fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
-    let dm = build_dm(cities);
-    nearest_neighbor::solve(cities, &dm, &HeuristicOptions::default(), None, None).total
+    nearest_neighbor::solve(&make_problem(cities.to_vec()), &HeuristicOptions::default(), None).total
 }
 
 // ─── fast integration tests (gr17, 17 cities) ────────────────────────────────
@@ -36,16 +40,14 @@ fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
 #[test]
 fn three_opt_valid_tour_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
     assert!(is_valid_tour(tour.route(), &cities), "gr17 tour is invalid");
 }
 
 #[test]
 fn three_opt_improves_on_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -60,8 +62,7 @@ fn three_opt_improves_on_gr17() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
     assert!(is_valid_tour(tour.route(), &cities), "berlin52 tour is invalid");
 }
 
@@ -69,8 +70,7 @@ fn three_opt_valid_tour_berlin52() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -82,8 +82,7 @@ fn three_opt_improves_on_berlin52() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
     assert!(is_valid_tour(tour.route(), &cities), "att48 tour is invalid");
 }
 
@@ -91,8 +90,7 @@ fn three_opt_valid_tour_att48() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,

--- a/tests/three_opt_test.rs
+++ b/tests/three_opt_test.rs
@@ -32,7 +32,7 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 }
 
 fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
-    nearest_neighbor::solve(&make_problem(cities.to_vec()), &HeuristicOptions::default(), None).total
+    nearest_neighbor::solve(&make_problem(cities.to_vec()), &HeuristicOptions::default(), None, None).total
 }
 
 // ─── fast integration tests (gr17, 17 cities) ────────────────────────────────
@@ -40,14 +40,14 @@ fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
 #[test]
 fn three_opt_valid_tour_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "gr17 tour is invalid");
 }
 
 #[test]
 fn three_opt_improves_on_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -62,7 +62,7 @@ fn three_opt_improves_on_gr17() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "berlin52 tour is invalid");
 }
 
@@ -70,7 +70,7 @@ fn three_opt_valid_tour_berlin52() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -82,7 +82,7 @@ fn three_opt_improves_on_berlin52() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None);
+    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "att48 tour is invalid");
 }
 
@@ -90,7 +90,7 @@ fn three_opt_valid_tour_att48() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None).total;
+    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,

--- a/tests/three_opt_test.rs
+++ b/tests/three_opt_test.rs
@@ -4,7 +4,7 @@
 /// Slow tests on berlin52 and att48 are marked #[ignore] and can be run with:
 ///   cargo test --test three_opt_test -- --include-ignored
 use std::path::Path;
-use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, SolverOptions};
+use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, AppOptions};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -28,7 +28,7 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 
 fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
     let dm = build_dm(cities);
-    nearest_neighbor::solve(cities, &dm, &SolverOptions::default()).total
+    nearest_neighbor::solve(cities, &dm, &AppOptions::default(), None, None).total
 }
 
 // ─── fast integration tests (gr17, 17 cities) ────────────────────────────────
@@ -37,7 +37,7 @@ fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
 fn three_opt_valid_tour_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &SolverOptions::default());
+    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "gr17 tour is invalid");
 }
 
@@ -45,7 +45,7 @@ fn three_opt_valid_tour_gr17() {
 fn three_opt_improves_on_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &SolverOptions::default()).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -61,7 +61,7 @@ fn three_opt_improves_on_gr17() {
 fn three_opt_valid_tour_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &SolverOptions::default());
+    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "berlin52 tour is invalid");
 }
 
@@ -70,7 +70,7 @@ fn three_opt_valid_tour_berlin52() {
 fn three_opt_improves_on_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &SolverOptions::default()).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -83,7 +83,7 @@ fn three_opt_improves_on_berlin52() {
 fn three_opt_valid_tour_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &SolverOptions::default());
+    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "att48 tour is invalid");
 }
 
@@ -92,7 +92,7 @@ fn three_opt_valid_tour_att48() {
 fn three_opt_improves_on_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &SolverOptions::default()).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,

--- a/tests/three_opt_test.rs
+++ b/tests/three_opt_test.rs
@@ -4,7 +4,7 @@
 /// Slow tests on berlin52 and att48 are marked #[ignore] and can be run with:
 ///   cargo test --test three_opt_test -- --include-ignored
 use std::path::Path;
-use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, AppOptions};
+use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, HeuristicOptions};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -28,7 +28,7 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 
 fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
     let dm = build_dm(cities);
-    nearest_neighbor::solve(cities, &dm, &AppOptions::default(), None, None).total
+    nearest_neighbor::solve(cities, &dm, &HeuristicOptions::default(), None, None).total
 }
 
 // ─── fast integration tests (gr17, 17 cities) ────────────────────────────────
@@ -37,7 +37,7 @@ fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
 fn three_opt_valid_tour_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "gr17 tour is invalid");
 }
 
@@ -45,7 +45,7 @@ fn three_opt_valid_tour_gr17() {
 fn three_opt_improves_on_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -61,7 +61,7 @@ fn three_opt_improves_on_gr17() {
 fn three_opt_valid_tour_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "berlin52 tour is invalid");
 }
 
@@ -70,7 +70,7 @@ fn three_opt_valid_tour_berlin52() {
 fn three_opt_improves_on_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -83,7 +83,7 @@ fn three_opt_improves_on_berlin52() {
 fn three_opt_valid_tour_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let tour = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None);
+    let tour = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None);
     assert!(is_valid_tour(tour.route(), &cities), "att48 tour is invalid");
 }
 
@@ -92,7 +92,7 @@ fn three_opt_valid_tour_att48() {
 fn three_opt_improves_on_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
     let dm = build_dm(&cities);
-    let three_opt_total = three_opt::solve(&cities, &dm, &AppOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(&cities, &dm, &HeuristicOptions::default(), None, None).total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,


### PR DESCRIPTION
## Summary

- **`HeuristicOptions`** (`epochs`, `platoo_epochs`, `n_nearest`, `verbose`) is now embedded in every solver-specific options struct (`SAOptions`, `GAOptions`, `CSOptions`, `FPAOptions`), making each solver self-contained
- **`SolverOptions` → `AppOptions`**: pure config shell with `Option<SAOptions>`, `Option<GAOptions>`, `Option<CSOptions>`, `Option<FPAOptions>`, `Option<HeuristicOptions>` — no runtime state (no `progress_tx`, `initial_tour`)
- **All 13 solver `solve()` functions** use a new 5-arg signature: `(cities, distances, opts: &AppOptions, progress_tx: Option<&Sender<...>>, initial_tour: Option<&[usize]>)` — runtime context is explicit, not embedded in options
- **`PipelineStage`** is now a runtime execution object: owns `cities`, `distances`, `progress_tx`, and has a `solve(initial_tour)` method
- **`load_pipeline_config`** returns `Vec<(Solvers, AppOptions)>` — it can't build stages (no city data yet); `main.rs` constructs `PipelineStage` objects after loading TSP data
- **`CliArgsProvider`** is solver-aware: routes CLI flags to the correct `XOptions::from_cli()` slot based on the active solver
- **`[global]` TOML section removed**: solver-specific fields go under `[stage.sa]` / `[stage.ga]` etc.; generic solver fields go under `[stage.heuristic]`. Unknown keys and wrong sub-tables are hard errors (no more warnings)

## Test plan

- [x] `cargo test` — 270 tests, 0 failures
- [x] `./target/debug/bin pipeline --config=configs/classic-tuned.toml -i data/tsplib/berlin52.tsp` — valid tour
- [x] `./target/debug/bin pipeline --config=configs/thorough-tuned.toml -i data/tsplib/berlin52.tsp` — valid tour
- [x] `./target/debug/bin solve sa -i data/tsplib/berlin52.tsp --cooling_rate 0.0005 --epochs 5000` — CLI flags still routed correctly
- [x] Unknown top-level key in stage (`epochs = 5000` outside sub-table) → hard error
- [x] Wrong sub-table for solver (`[stage.sa]` on `solver = "nn"`) → hard error

Closes #87