### PR TITLE
feat: add Taskfile.yml for development workflows (issue #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,39 @@ Quick summary (pipeline presets first, then standalone `--no-seed` baselines):
 
 ---
 
+## Development
+
+Common development tasks are standardised in [`Taskfile.yml`](Taskfile.yml). Install [go-task](https://taskfile.dev/installation/):
+
+```bash
+brew install go-task                        # macOS
+go install github.com/go-task/task/v3/cmd/task@latest  # any platform with Go
+```
+
+See all available tasks:
+
+```bash
+task --list
+```
+
+Key workflows:
+
+```bash
+task build               # compile debug binary
+task test                # run unit and integration tests
+task test:e2e            # run BATS end-to-end CLI tests
+task test:all            # unit + e2e
+task lint                # clippy (warnings are errors)
+task fmt                 # auto-format with rustfmt
+task check               # build + test + lint + fmt:check (mirrors CI)
+
+task run -- solve nn -i tests/fixtures/berlin52.tsp   # run solver via cargo run
+task bench:berlin52      # compare all approximate solvers on berlin52 (release build)
+task build:wasm          # build the WebAssembly component
+```
+
+---
+
 ## Contributing
 
 Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,78 @@
+version: '3'
+
+tasks:
+  build:
+    desc: Compile debug binary
+    cmds:
+      - cargo build
+
+  build:release:
+    desc: Compile optimised binary
+    cmds:
+      - cargo build --release
+
+  build:wasm:
+    desc: Build WASM component (requires cargo-component and wasm32-wasip2 target)
+    cmds:
+      - cargo component build --manifest-path teeline-wasm/Cargo.toml
+
+  test:
+    desc: Run all unit and integration tests
+    cmds:
+      - cargo test
+
+  test:verbose:
+    desc: Run tests with captured output
+    cmds:
+      - cargo test -- --nocapture
+
+  test:e2e:
+    desc: Run BATS end-to-end tests (requires debug binary)
+    deps: [build]
+    cmds:
+      - ./tests/bats/bin/bats tests/e2e/
+
+  test:all:
+    desc: Run unit tests and e2e tests
+    deps: [test, test:e2e]
+
+  lint:
+    desc: Run Clippy (warnings are errors)
+    cmds:
+      - cargo clippy -- -D warnings
+
+  lint:fix:
+    desc: Apply automatic Clippy fixes
+    cmds:
+      - cargo clippy --fix -- -D warnings
+
+  fmt:
+    desc: Format code with rustfmt
+    cmds:
+      - cargo fmt
+
+  fmt:check:
+    desc: Check formatting without modifying files (used in CI)
+    cmds:
+      - cargo fmt -- --check
+
+  check:
+    desc: Run build + test + lint + fmt:check (mirrors CI)
+    deps: [build, test, lint, fmt:check]
+
+  run:
+    desc: Run solver (e.g. task run -- solve nn -i tests/fixtures/berlin52.tsp)
+    cmds:
+      - cargo run -- {{.CLI_ARGS}}
+
+  bench:berlin52:
+    desc: Run approximate solvers on berlin52 and compare tour lengths (optimal 7542)
+    deps: [build:release]
+    cmds:
+      - echo "=== berlin52 (optimal 7542) ==="
+      - for solver in nn 2opt 3opt sa ga tabu pso cs fpa; do printf "%-12s " $solver; ./target/release/bin solve $solver -i tests/fixtures/berlin52.tsp 2>/dev/null | head -1; done
+
+  clean:
+    desc: Remove build artifacts
+    cmds:
+      - cargo clean

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::tsp::{AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers};
+use crate::tsp::{
+    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers,
+};
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
 /// Each provider takes a base and returns an overridden copy.
@@ -36,7 +38,9 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                     base.fpa = Some(FPAOptions::from_toml(t)?);
                 }
                 "heuristic" => {
-                    let t = value.as_table().ok_or("config: `heuristic` must be a table")?;
+                    let t = value
+                        .as_table()
+                        .ok_or("config: `heuristic` must be a table")?;
                     base.heuristic = Some(HeuristicOptions::from_toml(t)?);
                 }
                 other => {
@@ -59,8 +63,8 @@ pub fn load_pipeline_config(
     source: &str,
     base: AppOptions,
 ) -> Result<Vec<(Solvers, AppOptions)>, String> {
-    let root: toml::Table = toml::from_str(source)
-        .map_err(|e| format!("config: TOML parse error: {e}"))?;
+    let root: toml::Table =
+        toml::from_str(source).map_err(|e| format!("config: TOML parse error: {e}"))?;
 
     let stage_array = root
         .get("stage")
@@ -83,25 +87,29 @@ pub fn load_pipeline_config(
             .get("solver")
             .ok_or_else(|| format!("config: [[stage]] entry {i} missing required `solver` field"))?
             .as_str()
-            .ok_or_else(|| {
-                format!("config: [[stage]] entry {i}: `solver` must be a string")
-            })?;
+            .ok_or_else(|| format!("config: [[stage]] entry {i}: `solver` must be a string"))?;
 
-        let solver = Solvers::from_str(solver_name).map_err(|_| {
-            format!("config: [[stage]] entry {i}: unknown solver `{solver_name}`")
-        })?;
+        let solver = Solvers::from_str(solver_name)
+            .map_err(|_| format!("config: [[stage]] entry {i}: unknown solver `{solver_name}`"))?;
 
         let stage_options = TomlTableProvider(table).provide(base.clone())?;
 
         // Hard error if a solver-specific sub-table is present for the wrong solver.
         for (sub, belongs) in [
-            ("sa",        matches!(solver, Solvers::SimulatedAnnealing)),
-            ("ga",        matches!(solver, Solvers::GeneticAlgorithm)),
-            ("cs",        matches!(solver, Solvers::CuckooSearch)),
-            ("fpa",       matches!(solver, Solvers::FlowerPollination)),
-            ("heuristic", !matches!(solver,
-                Solvers::SimulatedAnnealing | Solvers::GeneticAlgorithm |
-                Solvers::CuckooSearch | Solvers::FlowerPollination)),
+            ("sa", matches!(solver, Solvers::SimulatedAnnealing)),
+            ("ga", matches!(solver, Solvers::GeneticAlgorithm)),
+            ("cs", matches!(solver, Solvers::CuckooSearch)),
+            ("fpa", matches!(solver, Solvers::FlowerPollination)),
+            (
+                "heuristic",
+                !matches!(
+                    solver,
+                    Solvers::SimulatedAnnealing
+                        | Solvers::GeneticAlgorithm
+                        | Solvers::CuckooSearch
+                        | Solvers::FlowerPollination
+                ),
+            ),
         ] {
             if table.contains_key(sub) && !belongs {
                 return Err(format!(
@@ -133,9 +141,9 @@ pub fn select_pipeline_source(
     steps: Option<&[String]>,
 ) -> Result<PipelineSource, String> {
     match (config, steps) {
-        (Some(_), Some(s)) if !s.is_empty() => Err(
-            "--config and --steps are mutually exclusive — provide one or the other".into(),
-        ),
+        (Some(_), Some(s)) if !s.is_empty() => {
+            Err("--config and --steps are mutually exclusive — provide one or the other".into())
+        }
         (Some(path), _) => Ok(PipelineSource::Config(path.to_path_buf())),
         (None, Some(names)) if !names.is_empty() => {
             let solvers = names
@@ -189,7 +197,9 @@ mod tests {
     #[test]
     fn test_toml_provider_skips_solver_key() {
         let table: toml::Table = toml::from_str("solver = \"nn\"").unwrap();
-        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
         assert!(opts.sa.is_none());
         assert!(opts.heuristic.is_none());
     }
@@ -199,7 +209,9 @@ mod tests {
         let table: toml::Table = toml::from_str(
             "solver = \"sa\"\n[sa]\nepochs = 5000\ncooling_rate = 0.0005\nmax_temperature = 200.0\nmin_temperature = 0.001"
         ).unwrap();
-        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
         let sa = opts.sa.unwrap();
         assert_eq!(sa.heuristic.epochs, 5000);
         assert!((sa.cooling_rate - 0.0005).abs() < 1e-6);
@@ -209,14 +221,18 @@ mod tests {
     fn test_toml_provider_heuristic_sub_table_works() {
         let table: toml::Table =
             toml::from_str("solver = \"2opt\"\n[heuristic]\nepochs = 500").unwrap();
-        let opts = TomlTableProvider(&table).provide(AppOptions::default()).unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
         assert_eq!(opts.heuristic.unwrap().epochs, 500);
     }
 
     #[test]
     fn test_toml_provider_unknown_key_errors() {
         let table: toml::Table = toml::from_str("epoch = 9999").unwrap();
-        let err = TomlTableProvider(&table).provide(AppOptions::default()).unwrap_err();
+        let err = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap_err();
         assert!(err.contains("unknown field"), "got: {err}");
         assert!(err.contains("epoch"), "got: {err}");
     }
@@ -224,7 +240,9 @@ mod tests {
     #[test]
     fn test_toml_provider_flat_epochs_errors_as_unknown_key() {
         let table: toml::Table = toml::from_str("solver = \"sa\"\nepochs = 9999").unwrap();
-        let err = TomlTableProvider(&table).provide(AppOptions::default()).unwrap_err();
+        let err = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap_err();
         assert!(err.contains("unknown field"), "got: {err}");
     }
 
@@ -234,7 +252,10 @@ mod tests {
     fn test_load_pipeline_config_empty_stages_errors() {
         let toml = "[global]\nepochs = 100\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
-        assert!(err.contains("[[stage]]") || err.contains("stage"), "got: {err}");
+        assert!(
+            err.contains("[[stage]]") || err.contains("stage"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -253,56 +274,49 @@ mod tests {
 
     #[test]
     fn test_load_pipeline_config_cooling_rate_zero_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("cooling_rate"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_cooling_rate_ge_one_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 1.5\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 1.5\nmax_temperature = 1000.0\nmin_temperature = 0.001\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("cooling_rate"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_negative_max_temperature_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = -1.0\nmin_temperature = 0.001\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = -1.0\nmin_temperature = 0.001\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("max_temperature"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_min_ge_max_temperature_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmin_temperature = 500.0\nmax_temperature = 100.0\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmin_temperature = 500.0\nmax_temperature = 100.0\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("min_temperature"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_mutation_probability_out_of_range_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"ga\"\n\n[stage.ga]\nmutation_probability = 1.5\n";
+        let toml = "[[stage]]\nsolver = \"ga\"\n\n[stage.ga]\nmutation_probability = 1.5\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("mutation_probability"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_sa_sub_table_on_nn_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"nn\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n";
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("sa"), "got: {err}");
     }
 
     #[test]
     fn test_load_pipeline_config_heuristic_sub_table_on_sa_errors() {
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n\n[stage.heuristic]\nepochs = 5000\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n\n[stage.heuristic]\nepochs = 5000\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("heuristic"), "got: {err}");
     }
@@ -353,8 +367,7 @@ mod tests {
     #[test]
     fn test_load_pipeline_config_sa_uses_from_toml_validation() {
         // validate() is called inside SAOptions::from_toml()
-        let toml =
-            "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0005\nmax_temperature = 200.0\nmin_temperature = 0.001\n";
+        let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.0005\nmax_temperature = 200.0\nmin_temperature = 0.001\n";
         let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
         let sa = stages[0].1.sa.as_ref().unwrap();
         assert!((sa.max_temperature - 200.0).abs() < 0.01);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod config;
 #[cfg(test)]
 mod test;
-pub mod config;
 pub mod tsp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,13 @@ use std::str::FromStr;
 use std::thread;
 
 use teeline::config::{
-    resolve_config_file, select_pipeline_source, IdentityProvider, AppOptionsProvider, PipelineSource,
+    AppOptionsProvider, IdentityProvider, PipelineSource, resolve_config_file,
+    select_pipeline_source,
 };
 use teeline::tsp::{
-    self, distance_matrix,
-    pipeline::{run_pipeline, PipelineStage},
-    progress, progress_eframe, tsplib, AppOptions, Solution, Solvers, TspProblem,
+    self, AppOptions, Solution, Solvers, TspProblem, distance_matrix,
+    pipeline::{PipelineStage, run_pipeline},
+    progress, progress_eframe, tsplib,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -71,9 +72,11 @@ fn main() {
     let tuning = tuning_args();
 
     let solve_cmd = Command::new("solve")
-        .about("Solve a TSP instance. Deterministic solvers (2opt, 3opt, tabu) auto-expand to \
+        .about(
+            "Solve a TSP instance. Deterministic solvers (2opt, 3opt, tabu) auto-expand to \
                 pipeline(nn, solver); stochastic solvers (sa, ga, pso, cs, fpa, stochastic_hill) \
-                auto-expand to pipeline(shuffle, solver).")
+                auto-expand to pipeline(shuffle, solver).",
+        )
         .arg(
             Arg::new("solver")
                 .index(1)
@@ -93,8 +96,10 @@ fn main() {
         .args(tuning.clone());
 
     let pipeline_cmd = Command::new("pipeline")
-        .about("Chain multiple solvers; each stage warm-starts from the previous result. \
-                Provide either --steps or --config (mutually exclusive).")
+        .about(
+            "Chain multiple solvers; each stage warm-starts from the previous result. \
+                Provide either --steps or --config (mutually exclusive).",
+        )
         .arg(
             Arg::new("steps")
                 .long("steps")
@@ -282,8 +287,10 @@ fn run_pipeline_cmd(args: &ArgMatches) {
 }
 
 fn run_as_pipeline(steps: &[Solvers], args: &ArgMatches) {
-    let stage_configs: Vec<(Solvers, AppOptions)> =
-        steps.iter().map(|&s| (s, solver_options_from_args(args, s))).collect();
+    let stage_configs: Vec<(Solvers, AppOptions)> = steps
+        .iter()
+        .map(|&s| (s, solver_options_from_args(args, s)))
+        .collect();
     run_as_pipeline_stages(stage_configs, args);
 }
 
@@ -334,15 +341,15 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         maybe_display = None;
     }
 
-    let opt_tour = args
-        .get_one::<String>("optimal_tour")
-        .and_then(|p| match teeline::tsp::opt_tour::read_from_file(Path::new(p.as_str())) {
+    let opt_tour = args.get_one::<String>("optimal_tour").and_then(|p| {
+        match teeline::tsp::opt_tour::read_from_file(Path::new(p.as_str())) {
             Ok(t) => Some(t),
             Err(e) => {
                 eprintln!("--optimal-tour: {e}");
                 None
             }
-        });
+        }
+    });
 
     if let Some(ref ot) = opt_tour
         && let Some(ref tx) = progress_tx
@@ -361,7 +368,12 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
     let stages: Vec<PipelineStage> = stage_configs
         .into_iter()
         .map(|(solver, options)| {
-            PipelineStage::new(solver, options, TspProblem::new(cities.clone(), distances.clone()), progress_tx.clone())
+            PipelineStage::new(
+                solver,
+                options,
+                TspProblem::new(cities.clone(), distances.clone()),
+                progress_tx.clone(),
+            )
         })
         .collect();
 
@@ -500,7 +512,11 @@ mod tests {
     fn options_cmd() -> Command {
         Command::new("test")
             .arg(Arg::new("solver").index(1).required(true))
-            .arg(Arg::new("no_seed").long("no-seed").action(ArgAction::SetTrue))
+            .arg(
+                Arg::new("no_seed")
+                    .long("no-seed")
+                    .action(ArgAction::SetTrue),
+            )
             .args(tuning_args())
     }
 
@@ -532,8 +548,8 @@ mod tests {
     fn test_solver_options_invalid_epochs_errors() {
         // Invalid parse must now return Err (strict CLI validation).
         let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "bad"]);
-        let result = CliArgsProvider::new(&args, Solvers::NearestNeighbor)
-            .provide(AppOptions::default());
+        let result =
+            CliArgsProvider::new(&args, Solvers::NearestNeighbor).provide(AppOptions::default());
         assert!(result.is_err(), "expected Err for --epochs bad");
     }
 
@@ -568,8 +584,7 @@ mod tests {
 
     #[test]
     fn test_solver_options_mutation_probability_parsed() {
-        let args = options_cmd()
-            .get_matches_from(["test", "ga", "--mutation_probability", "0.05"]);
+        let args = options_cmd().get_matches_from(["test", "ga", "--mutation_probability", "0.05"]);
         let opts = solver_options_from_args(&args, Solvers::GeneticAlgorithm);
         assert!((opts.ga.unwrap_or_default().mutation_probability - 0.05).abs() < 1e-5);
     }
@@ -577,11 +592,13 @@ mod tests {
     #[test]
     fn test_solver_options_invalid_mutation_probability_errors() {
         // Invalid parse must return Err (strict CLI validation).
-        let args = options_cmd()
-            .get_matches_from(["test", "ga", "--mutation_probability", "nope"]);
-        let result = CliArgsProvider::new(&args, Solvers::GeneticAlgorithm)
-            .provide(AppOptions::default());
-        assert!(result.is_err(), "expected Err for --mutation_probability nope");
+        let args = options_cmd().get_matches_from(["test", "ga", "--mutation_probability", "nope"]);
+        let result =
+            CliArgsProvider::new(&args, Solvers::GeneticAlgorithm).provide(AppOptions::default());
+        assert!(
+            result.is_err(),
+            "expected Err for --mutation_probability nope"
+        );
     }
 
     #[test]
@@ -611,7 +628,9 @@ mod tests {
     fn test_cli_args_provider_overrides_base() {
         let args = options_cmd().get_matches_from(["test", "nn", "--epochs", "777"]);
         let base = AppOptions::default();
-        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor).provide(base).unwrap();
+        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor)
+            .provide(base)
+            .unwrap();
         assert_eq!(opts.heuristic.unwrap_or_default().epochs, 777);
     }
 
@@ -619,7 +638,9 @@ mod tests {
     fn test_cli_args_provider_no_args_uses_defaults() {
         let args = options_cmd().get_matches_from(["test", "nn"]);
         let base = AppOptions::default();
-        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor).provide(base).unwrap();
+        let opts = CliArgsProvider::new(&args, Solvers::NearestNeighbor)
+            .provide(base)
+            .unwrap();
         assert_eq!(
             opts.heuristic.unwrap_or_default().epochs,
             HeuristicOptions::default().epochs
@@ -631,7 +652,11 @@ mod tests {
         let steps = resolve_preset("classic").unwrap();
         assert_eq!(
             steps,
-            vec![Solvers::NearestNeighbor, Solvers::TwoOpt, Solvers::SimulatedAnnealing]
+            vec![
+                Solvers::NearestNeighbor,
+                Solvers::TwoOpt,
+                Solvers::SimulatedAnnealing
+            ]
         );
     }
 
@@ -646,7 +671,11 @@ mod tests {
         let steps = resolve_preset("thorough").unwrap();
         assert_eq!(
             steps,
-            vec![Solvers::NearestNeighbor, Solvers::ThreeOpt, Solvers::SimulatedAnnealing]
+            vec![
+                Solvers::NearestNeighbor,
+                Solvers::ThreeOpt,
+                Solvers::SimulatedAnnealing
+            ]
         );
     }
 

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -46,7 +46,8 @@ pub fn solve(
             .unwrap_or(UNKNOWN_DISTANCE);
 
         if let Some(city_id) = dists.pos2city_id(&i)
-            && let Some(tx) = progress_tx {
+            && let Some(tx) = progress_tx
+        {
             let _ = tx.send(ProgressMessage::CityChange(city_id));
         }
     }
@@ -182,7 +183,7 @@ fn show_table(opt: &DPTable) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     fn tsp_5_1_problem() -> TspProblem {
         let cities = kdtree::build_points(&[
@@ -224,11 +225,7 @@ mod tests {
 
     #[test]
     fn test_solve_with_3_cities() {
-        let cities = kdtree::build_points(&[
-            vec![0.0, 0.0],
-            vec![3.0, 0.0],
-            vec![0.0, 4.0],
-        ]);
+        let cities = kdtree::build_points(&[vec![0.0, 0.0], vec![3.0, 0.0], vec![0.0, 4.0]]);
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
         let solution = solve(&problem, &HeuristicOptions::default(), None, None);
@@ -237,6 +234,10 @@ mod tests {
         visited.sort();
         assert_eq!(visited, vec![0, 1, 2]);
 
-        assert!((solution.total - 12.0).abs() < 1e-3, "got {}", solution.total);
+        assert!(
+            (solution.total - 12.0).abs() < 1e-3,
+            "got {}",
+            solution.total
+        );
     }
 }

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -184,7 +184,7 @@ fn undo_move(path: &mut Path, k: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{bellman_karp, distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, bellman_karp, distance_matrix, kdtree};
 
     fn tsp5_problem() -> TspProblem {
         let cities = kdtree::build_points(&[

--- a/src/tsp/convert.rs
+++ b/src/tsp/convert.rs
@@ -123,21 +123,30 @@ mod tests {
     fn test_parse_discopt_empty_after_skip_errors() {
         let input = "0\n";
         let result = parse_discopt(input);
-        assert!(result.is_err(), "expected error for file with only a header line");
+        assert!(
+            result.is_err(),
+            "expected error for file with only a header line"
+        );
     }
 
     #[test]
     fn test_parse_discopt_bad_float_errors() {
         let input = "2\n0.0 abc\n1.0 2.0\n";
         let result = parse_discopt(input);
-        assert!(result.is_err(), "expected parse error for non-numeric coordinate");
+        assert!(
+            result.is_err(),
+            "expected parse error for non-numeric coordinate"
+        );
     }
 
     #[test]
     fn test_parse_discopt_missing_y_errors() {
         let input = "1\n1.5\n";
         let result = parse_discopt(input);
-        assert!(result.is_err(), "expected error when y coordinate is absent");
+        assert!(
+            result.is_err(),
+            "expected error when y coordinate is absent"
+        );
     }
 
     // ── write_tsplib ─────────────────────────────────────────────────────────
@@ -233,7 +242,10 @@ mod tests {
         fs::write(&input, "1\n").unwrap(); // header only, no coords
 
         let result = convert_file(&input, &output);
-        assert!(result.is_err(), "must return Err when content has no coordinates");
+        assert!(
+            result.is_err(),
+            "must return Err when content has no coordinates"
+        );
     }
 
     // ── convert_dir ──────────────────────────────────────────────────────────
@@ -262,7 +274,10 @@ mod tests {
             Path::new("/tmp/teeline_cd_err_out"),
         );
         assert_eq!(ok, 0);
-        assert!(!errors.is_empty(), "must report an error for missing directory");
+        assert!(
+            !errors.is_empty(),
+            "must report an error for missing directory"
+        );
     }
 
     #[test]

--- a/src/tsp/cuckoo_search.rs
+++ b/src/tsp/cuckoo_search.rs
@@ -9,7 +9,6 @@ use super::{CSOptions, Solution, TspProblem};
 
 const DEFAULT_N_NESTS: usize = 25;
 
-
 fn apply_k_random_2opt(tour: &[usize], k: usize, rng: &mut impl Rng) -> Vec<usize> {
     let n = tour.len();
     let mut result = tour.to_vec();
@@ -78,7 +77,11 @@ pub fn solve(
     for epoch in 0..opts.heuristic.epochs {
         for cuckoo_idx in 0..n_nests {
             let levy = levy_step(&mut rng).abs();
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
             let k = ((levy * (n_cities as f64 * 0.1)).ceil() as usize).clamp(1, n_cities / 2);
 
             let new_tour = apply_k_random_2opt(&nests[cuckoo_idx], k, &mut rng);
@@ -135,7 +138,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, CSOptions, HeuristicOptions, TspProblem};
+    use crate::tsp::{CSOptions, HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     #[test]
     fn test_cs_respects_initial_tour() {
@@ -150,7 +153,10 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = CSOptions {
-            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 0,
+                ..HeuristicOptions::default()
+            },
             ..CSOptions::default()
         };
         let problem = TspProblem::new(cities.clone(), dm);
@@ -191,7 +197,11 @@ mod tests {
         ]);
         let distances = distance_matrix::from_cities(&cities);
         let opts = CSOptions {
-            heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 30,
+                n_nearest: 5,
+                ..HeuristicOptions::default()
+            },
             mutation_probability: 0.25,
         };
         let problem = TspProblem::new(cities.clone(), distances);
@@ -200,7 +210,10 @@ mod tests {
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
         expected.sort();
-        assert_eq!(visited, expected, "CS tour does not visit all cities exactly once");
+        assert_eq!(
+            visited, expected,
+            "CS tour does not visit all cities exactly once"
+        );
         assert!(sol.total > 0.0);
     }
 }

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -72,8 +72,7 @@ pub struct DistanceMatrix {
 
 impl DistanceMatrix {
     pub fn new(n: usize, distances: Vec<f32>, cities: CityTable) -> Self {
-        let city_idx: HashMap<usize, usize> =
-            cities.iter().map(|(k, c)| (c.id, *k)).collect();
+        let city_idx: HashMap<usize, usize> = cities.iter().map(|(k, c)| (c.id, *k)).collect();
 
         assert!(n == city_idx.len(), "city_idx size differs from n cities");
         DistanceMatrix {
@@ -167,10 +166,7 @@ impl DistanceMatrix {
 
     /// returns list of distances from city N, where 0 distance from the city;
     pub fn distances_from(&self, city_id: usize) -> Vec<f32> {
-        let pos: usize = *self
-            .city_idx
-            .get(&city_id)
-            .expect("Unknown city id");
+        let pos: usize = *self.city_idx.get(&city_id).expect("Unknown city id");
 
         self.distances_from_index(pos)
     }

--- a/src/tsp/flower_pollination.rs
+++ b/src/tsp/flower_pollination.rs
@@ -4,11 +4,10 @@ use rand::Rng;
 
 use super::probability::{bernoulli, levy_step, sample_without_replacement};
 use super::progress::ProgressMessage;
-use super::route::{apply_swaps, swap_sequence, Route};
+use super::route::{Route, apply_swaps, swap_sequence};
 use super::{FPAOptions, Solution, TspProblem};
 
 const DEFAULT_N_FLOWERS: usize = 25;
-
 
 fn global_pollination(flower: &[usize], gbest: &[usize], rng: &mut impl Rng) -> Vec<usize> {
     let seq = swap_sequence(flower, gbest);
@@ -16,7 +15,11 @@ fn global_pollination(flower: &[usize], gbest: &[usize], rng: &mut impl Rng) -> 
         return flower.to_vec();
     }
     let levy = levy_step(rng).abs();
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
     let n_swaps = ((levy * seq.len() as f64 * 0.5).ceil() as usize).clamp(1, seq.len());
     apply_swaps(flower, &seq[..n_swaps])
 }
@@ -38,7 +41,11 @@ fn local_pollination(
         return flower.to_vec();
     }
     let epsilon: f64 = rng.random();
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
     let n_swaps = ((epsilon * seq.len() as f64).ceil() as usize).clamp(1, seq.len());
     apply_swaps(flower, &seq[..n_swaps])
 }
@@ -124,7 +131,8 @@ pub fn solve(
                     gbest = flowers[i].clone();
                     gbest_cost = new_cost;
                     if let Some(tx) = progress_tx {
-                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                        let _ =
+                            tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
                     }
                     tracing::info!(epoch, tour_length = gbest_cost, "FPA: new best");
                 }
@@ -145,7 +153,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, FPAOptions, HeuristicOptions, TspProblem};
+    use crate::tsp::{FPAOptions, HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     #[test]
     fn test_fpa_respects_initial_tour() {
@@ -160,7 +168,10 @@ mod tests {
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
         let opts = FPAOptions {
-            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 0,
+                ..HeuristicOptions::default()
+            },
             ..FPAOptions::default()
         };
         let problem = TspProblem::new(cities.clone(), dm);
@@ -189,7 +200,11 @@ mod tests {
         let problem = four_city_setup();
         let cities = problem.cities.clone();
         let opts = FPAOptions {
-            heuristic: HeuristicOptions { epochs: 30, n_nearest: 5, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 30,
+                n_nearest: 5,
+                ..HeuristicOptions::default()
+            },
             mutation_probability: 0.8,
         };
         let sol = solve(&problem, &opts, None, None);
@@ -197,7 +212,10 @@ mod tests {
         visited.sort();
         let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
         expected.sort();
-        assert_eq!(visited, expected, "FPA tour does not visit all cities exactly once");
+        assert_eq!(
+            visited, expected,
+            "FPA tour does not visit all cities exactly once"
+        );
         assert!(sol.total > 0.0);
         assert!(sol.total.is_finite());
     }

--- a/src/tsp/genetic_algorithm.rs
+++ b/src/tsp/genetic_algorithm.rs
@@ -8,7 +8,7 @@ use super::distance_matrix::DistanceMatrix;
 use super::kdtree::KDPoint;
 use super::probability::probability;
 use super::progress::ProgressMessage;
-use super::route::{random_position_pair, Route};
+use super::route::{Route, random_position_pair};
 use super::{GAOptions, Solution, TspProblem};
 
 type FitnessFn = Rc<dyn Fn(&[usize]) -> f32>;
@@ -75,8 +75,12 @@ fn solve_ga(
             let parent2 = current_population.random_selection();
 
             let (mut child1, mut child2) = ordered_crossover(parent1, parent2, &fitness_fn);
-            if probability(mutation_prob) { child1.mutate() };
-            if probability(mutation_prob) { child2.mutate() };
+            if probability(mutation_prob) {
+                child1.mutate()
+            };
+            if probability(mutation_prob) {
+                child2.mutate()
+            };
 
             new_population.add(child1);
             new_population.add(child2);
@@ -93,7 +97,11 @@ fn solve_ga(
             ));
         }
 
-        tracing::debug!(epoch, fitness = current_population.best().fitness(), "GA: generation");
+        tracing::debug!(
+            epoch,
+            fitness = current_population.best().fitness(),
+            "GA: generation"
+        );
 
         epoch += 1;
     }
@@ -330,7 +338,7 @@ impl TspGenotype {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, GAOptions, HeuristicOptions, TspProblem};
+    use crate::tsp::{GAOptions, HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -370,7 +378,10 @@ mod tests {
         ]);
         let distances = distance_matrix::from_cities(&cities);
         let opts = GAOptions {
-            heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 100,
+                ..HeuristicOptions::default()
+            },
             ..GAOptions::default()
         };
 
@@ -402,9 +413,7 @@ mod tests {
     #[test]
     fn test_seeded_population_n5_fraction() {
         let n = 20usize;
-        let cities = kdtree::build_points(
-            &(0..n).map(|i| vec![i as f32, 0.0]).collect::<Vec<_>>(),
-        );
+        let cities = kdtree::build_points(&(0..n).map(|i| vec![i as f32, 0.0]).collect::<Vec<_>>());
         let dm = distance_matrix::from_cities(&cities);
         let seed: Vec<usize> = (0..n).rev().collect();
         let evaluator = make_evaluator(dm);
@@ -430,9 +439,7 @@ mod tests {
     #[test]
     fn test_from_cities_produces_diverse_population() {
         let n = 20usize;
-        let cities = kdtree::build_points(
-            &(0..n).map(|i| vec![i as f32, 0.0]).collect::<Vec<_>>(),
-        );
+        let cities = kdtree::build_points(&(0..n).map(|i| vec![i as f32, 0.0]).collect::<Vec<_>>());
         let dm = distance_matrix::from_cities(&cities);
         let evaluator = make_evaluator(dm);
 

--- a/src/tsp/kdtree.rs
+++ b/src/tsp/kdtree.rs
@@ -310,7 +310,6 @@ impl KDPoint {
         self.coords.get(dimension).copied()
     }
 
-
     pub fn distance(&self, other: &KDPoint) -> f32 {
         let distance: f32 = self
             .coords

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1,26 +1,26 @@
 pub mod bellman_karp;
-pub mod pipeline;
 pub mod branch_bound;
-pub mod random_shuffle;
 pub mod convert;
 pub mod cuckoo_search;
-pub mod flower_pollination;
 pub mod distance_matrix;
+pub mod flower_pollination;
 pub mod genetic_algorithm;
 pub mod kdtree;
 pub mod nearest_neighbor;
+pub mod opt_tour;
+pub mod particle_swarm;
+pub mod pipeline;
+pub mod probability;
 pub mod progress;
 #[cfg(feature = "gui")]
 pub mod progress_eframe;
+pub mod random_shuffle;
 pub mod route;
 pub mod simulated_annealing;
 pub mod stochastic_hill;
 pub mod tabu_search;
-pub mod opt_tour;
-pub mod particle_swarm;
-pub mod probability;
-pub mod tsplib;
 pub mod three_opt;
+pub mod tsplib;
 pub mod two_opt;
 
 use crate::tsp::distance_matrix::DistanceMatrix;
@@ -87,7 +87,10 @@ impl Solvers {
     /// Deterministic local-search solvers: monotone hill-climbers that can only reach
     /// solutions reachable from their starting tour. A better start always means a better end.
     pub fn auto_expand_with_nn(&self) -> bool {
-        matches!(self, Solvers::TwoOpt | Solvers::ThreeOpt | Solvers::TabuSearch)
+        matches!(
+            self,
+            Solvers::TwoOpt | Solvers::ThreeOpt | Solvers::TabuSearch
+        )
     }
 
     /// Stochastic solvers whose temperature / diversity schedule is calibrated for cold starts.
@@ -144,7 +147,12 @@ pub struct HeuristicOptions {
 
 impl Default for HeuristicOptions {
     fn default() -> Self {
-        HeuristicOptions { epochs: 10_000, platoo_epochs: 500, n_nearest: 3, verbose: false }
+        HeuristicOptions {
+            epochs: 10_000,
+            platoo_epochs: 500,
+            n_nearest: 3,
+            verbose: false,
+        }
     }
 }
 
@@ -154,24 +162,32 @@ impl HeuristicOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    h.epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                    h.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "platoo_epochs" => {
-                    h.platoo_epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                    h.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
                 }
                 "n_nearest" => {
-                    h.n_nearest = v.as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                    h.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "verbose" => {
-                    h.verbose = v.as_bool()
+                    h.verbose = v
+                        .as_bool()
                         .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
                 }
-                other => return Err(format!(
-                    "config: unknown field `{other}` in [heuristic] — valid: epochs, platoo_epochs, n_nearest, verbose"
-                )),
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [heuristic] — valid: epochs, platoo_epochs, n_nearest, verbose"
+                    ));
+                }
             }
         }
         h.validate()?;
@@ -181,15 +197,18 @@ impl HeuristicOptions {
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
         let mut h = HeuristicOptions::default();
         if let Some(v) = args.get_one::<String>("epochs") {
-            h.epochs = v.parse()
+            h.epochs = v
+                .parse()
                 .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("platoo_epochs") {
-            h.platoo_epochs = v.parse()
+            h.platoo_epochs = v
+                .parse()
                 .map_err(|_| format!("--platoo-epochs: invalid integer `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("n_nearest") {
-            h.n_nearest = v.parse()
+            h.n_nearest = v
+                .parse()
                 .map_err(|_| format!("--n-nearest: invalid integer `{v}`"))?;
         }
         if args.get_flag("verbose") {
@@ -234,16 +253,28 @@ impl SAOptions {
     pub fn validate(&self) -> Result<(), String> {
         self.heuristic.validate()?;
         if self.cooling_rate <= 0.0 {
-            return Err(format!("cooling_rate must be > 0 (got {})", self.cooling_rate));
+            return Err(format!(
+                "cooling_rate must be > 0 (got {})",
+                self.cooling_rate
+            ));
         }
         if self.cooling_rate >= 1.0 {
-            return Err(format!("cooling_rate must be < 1 (got {})", self.cooling_rate));
+            return Err(format!(
+                "cooling_rate must be < 1 (got {})",
+                self.cooling_rate
+            ));
         }
         if self.max_temperature <= 0.0 {
-            return Err(format!("max_temperature must be > 0 (got {})", self.max_temperature));
+            return Err(format!(
+                "max_temperature must be > 0 (got {})",
+                self.max_temperature
+            ));
         }
         if self.min_temperature < 0.0 {
-            return Err(format!("min_temperature must be >= 0 (got {})", self.min_temperature));
+            return Err(format!(
+                "min_temperature must be >= 0 (got {})",
+                self.min_temperature
+            ));
         }
         if self.min_temperature >= self.max_temperature {
             return Err(format!(
@@ -259,27 +290,41 @@ impl SAOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    sa.heuristic.epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                    sa.heuristic.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "platoo_epochs" => {
-                    sa.heuristic.platoo_epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                    sa.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
                 }
                 "n_nearest" => {
-                    sa.heuristic.n_nearest = v.as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                    sa.heuristic.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "verbose" => {
-                    sa.heuristic.verbose = v.as_bool()
+                    sa.heuristic.verbose = v
+                        .as_bool()
                         .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
                 }
-                "cooling_rate" => { sa.cooling_rate = parse_f32(v, "sa.cooling_rate")?; }
-                "max_temperature" => { sa.max_temperature = parse_f32(v, "sa.max_temperature")?; }
-                "min_temperature" => { sa.min_temperature = parse_f32(v, "sa.min_temperature")?; }
-                other => return Err(format!(
-                    "config: unknown field `{other}` in [sa] — valid: epochs, platoo_epochs, n_nearest, verbose, cooling_rate, max_temperature, min_temperature"
-                )),
+                "cooling_rate" => {
+                    sa.cooling_rate = parse_f32(v, "sa.cooling_rate")?;
+                }
+                "max_temperature" => {
+                    sa.max_temperature = parse_f32(v, "sa.max_temperature")?;
+                }
+                "min_temperature" => {
+                    sa.min_temperature = parse_f32(v, "sa.min_temperature")?;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [sa] — valid: epochs, platoo_epochs, n_nearest, verbose, cooling_rate, max_temperature, min_temperature"
+                    ));
+                }
             }
         }
         sa.validate()?;
@@ -287,17 +332,23 @@ impl SAOptions {
     }
 
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
-        let mut sa = SAOptions { heuristic: HeuristicOptions::from_cli(args)?, ..SAOptions::default() };
+        let mut sa = SAOptions {
+            heuristic: HeuristicOptions::from_cli(args)?,
+            ..SAOptions::default()
+        };
         if let Some(v) = args.get_one::<String>("cooling_rate") {
-            sa.cooling_rate = v.parse()
+            sa.cooling_rate = v
+                .parse()
                 .map_err(|_| format!("--cooling-rate: invalid float `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("min_temperature") {
-            sa.min_temperature = v.parse()
+            sa.min_temperature = v
+                .parse()
                 .map_err(|_| format!("--min-temperature: invalid float `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("max_temperature") {
-            sa.max_temperature = v.parse()
+            sa.max_temperature = v
+                .parse()
                 .map_err(|_| format!("--max-temperature: invalid float `{v}`"))?;
         }
         sa.validate()?;
@@ -339,29 +390,40 @@ impl GAOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    ga.heuristic.epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                    ga.heuristic.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "platoo_epochs" => {
-                    ga.heuristic.platoo_epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                    ga.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
                 }
                 "n_nearest" => {
-                    ga.heuristic.n_nearest = v.as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                    ga.heuristic.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "verbose" => {
-                    ga.heuristic.verbose = v.as_bool()
+                    ga.heuristic.verbose = v
+                        .as_bool()
                         .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
                 }
-                "mutation_probability" => { ga.mutation_probability = parse_f32(v, "ga.mutation_probability")?; }
-                "n_elite" => {
-                    ga.n_elite = v.as_integer()
-                        .ok_or_else(|| format!("config: `ga.n_elite` must be an integer, got {v}"))? as usize;
+                "mutation_probability" => {
+                    ga.mutation_probability = parse_f32(v, "ga.mutation_probability")?;
                 }
-                other => return Err(format!(
-                    "config: unknown field `{other}` in [ga] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability, n_elite"
-                )),
+                "n_elite" => {
+                    ga.n_elite = v.as_integer().ok_or_else(|| {
+                        format!("config: `ga.n_elite` must be an integer, got {v}")
+                    })? as usize;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [ga] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability, n_elite"
+                    ));
+                }
             }
         }
         ga.validate()?;
@@ -369,13 +431,18 @@ impl GAOptions {
     }
 
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
-        let mut ga = GAOptions { heuristic: HeuristicOptions::from_cli(args)?, ..GAOptions::default() };
+        let mut ga = GAOptions {
+            heuristic: HeuristicOptions::from_cli(args)?,
+            ..GAOptions::default()
+        };
         if let Some(v) = args.get_one::<String>("mutation_probability") {
-            ga.mutation_probability = v.parse()
+            ga.mutation_probability = v
+                .parse()
                 .map_err(|_| format!("--mutation-probability: invalid float `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("n_elite") {
-            ga.n_elite = v.parse()
+            ga.n_elite = v
+                .parse()
                 .map_err(|_| format!("--n-elite: invalid integer `{v}`"))?;
         }
         ga.validate()?;
@@ -391,7 +458,10 @@ pub struct CSOptions {
 
 impl Default for CSOptions {
     fn default() -> Self {
-        CSOptions { heuristic: HeuristicOptions::default(), mutation_probability: 0.001 }
+        CSOptions {
+            heuristic: HeuristicOptions::default(),
+            mutation_probability: 0.001,
+        }
     }
 }
 
@@ -412,25 +482,35 @@ impl CSOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    cs.heuristic.epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                    cs.heuristic.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "platoo_epochs" => {
-                    cs.heuristic.platoo_epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                    cs.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
                 }
                 "n_nearest" => {
-                    cs.heuristic.n_nearest = v.as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                    cs.heuristic.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "verbose" => {
-                    cs.heuristic.verbose = v.as_bool()
+                    cs.heuristic.verbose = v
+                        .as_bool()
                         .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
                 }
-                "mutation_probability" => { cs.mutation_probability = parse_f32(v, "cs.mutation_probability")?; }
-                other => return Err(format!(
-                    "config: unknown field `{other}` in [cs] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
-                )),
+                "mutation_probability" => {
+                    cs.mutation_probability = parse_f32(v, "cs.mutation_probability")?;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [cs] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
+                    ));
+                }
             }
         }
         cs.validate()?;
@@ -438,9 +518,13 @@ impl CSOptions {
     }
 
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
-        let mut cs = CSOptions { heuristic: HeuristicOptions::from_cli(args)?, ..CSOptions::default() };
+        let mut cs = CSOptions {
+            heuristic: HeuristicOptions::from_cli(args)?,
+            ..CSOptions::default()
+        };
         if let Some(v) = args.get_one::<String>("mutation_probability") {
-            cs.mutation_probability = v.parse()
+            cs.mutation_probability = v
+                .parse()
                 .map_err(|_| format!("--mutation-probability: invalid float `{v}`"))?;
         }
         cs.validate()?;
@@ -456,7 +540,10 @@ pub struct FPAOptions {
 
 impl Default for FPAOptions {
     fn default() -> Self {
-        FPAOptions { heuristic: HeuristicOptions::default(), mutation_probability: 0.001 }
+        FPAOptions {
+            heuristic: HeuristicOptions::default(),
+            mutation_probability: 0.001,
+        }
     }
 }
 
@@ -477,25 +564,35 @@ impl FPAOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    fpa.heuristic.epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))? as usize;
+                    fpa.heuristic.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "platoo_epochs" => {
-                    fpa.heuristic.platoo_epochs = v.as_integer()
-                        .ok_or_else(|| format!("config: `platoo_epochs` must be an integer, got {v}"))? as usize;
+                    fpa.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
                 }
                 "n_nearest" => {
-                    fpa.heuristic.n_nearest = v.as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))? as usize;
+                    fpa.heuristic.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
                 }
                 "verbose" => {
-                    fpa.heuristic.verbose = v.as_bool()
+                    fpa.heuristic.verbose = v
+                        .as_bool()
                         .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
                 }
-                "mutation_probability" => { fpa.mutation_probability = parse_f32(v, "fpa.mutation_probability")?; }
-                other => return Err(format!(
-                    "config: unknown field `{other}` in [fpa] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
-                )),
+                "mutation_probability" => {
+                    fpa.mutation_probability = parse_f32(v, "fpa.mutation_probability")?;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [fpa] — valid: epochs, platoo_epochs, n_nearest, verbose, mutation_probability"
+                    ));
+                }
             }
         }
         fpa.validate()?;
@@ -503,9 +600,13 @@ impl FPAOptions {
     }
 
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
-        let mut fpa = FPAOptions { heuristic: HeuristicOptions::from_cli(args)?, ..FPAOptions::default() };
+        let mut fpa = FPAOptions {
+            heuristic: HeuristicOptions::from_cli(args)?,
+            ..FPAOptions::default()
+        };
         if let Some(v) = args.get_one::<String>("mutation_probability") {
-            fpa.mutation_probability = v.parse()
+            fpa.mutation_probability = v
+                .parse()
                 .map_err(|_| format!("--mutation-probability: invalid float `{v}`"))?;
         }
         fpa.validate()?;
@@ -521,10 +622,10 @@ impl FPAOptions {
 /// Each field is populated only for the solver that uses it.
 #[derive(Clone, Debug, Default)]
 pub struct AppOptions {
-    pub sa:        Option<SAOptions>,
-    pub ga:        Option<GAOptions>,
-    pub cs:        Option<CSOptions>,
-    pub fpa:       Option<FPAOptions>,
+    pub sa: Option<SAOptions>,
+    pub ga: Option<GAOptions>,
+    pub cs: Option<CSOptions>,
+    pub fpa: Option<FPAOptions>,
     pub heuristic: Option<HeuristicOptions>,
 }
 
@@ -541,7 +642,11 @@ fn parse_f32(v: &toml::Value, name: &str) -> Result<f32, String> {
 
 pub fn validate_tour(tour: &[usize], cities: &[KDPoint]) -> Result<(), String> {
     if tour.len() != cities.len() {
-        return Err(format!("tour length {} != cities length {}", tour.len(), cities.len()));
+        return Err(format!(
+            "tour length {} != cities length {}",
+            tour.len(),
+            cities.len()
+        ));
     }
     let city_ids: std::collections::HashSet<usize> = cities.iter().map(|c| c.id).collect();
     let tour_ids: std::collections::HashSet<usize> = tour.iter().copied().collect();
@@ -580,20 +685,32 @@ pub(crate) fn solve_with_context(
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
-        Solvers::BellmanKarp               => bellman_karp::solve(problem, &h, tx, init_tour),
-        Solvers::BranchBound               => branch_bound::solve(problem, &h, tx, init_tour),
-        Solvers::CuckooSearch              => { let cs = opts.cs.as_ref().cloned().unwrap_or_default(); cuckoo_search::solve(problem, &cs, tx, init_tour) }
-        Solvers::FlowerPollination         => { let fpa = opts.fpa.as_ref().cloned().unwrap_or_default(); flower_pollination::solve(problem, &fpa, tx, init_tour) }
-        Solvers::NearestNeighbor           => nearest_neighbor::solve(problem, &h, tx, init_tour),
-        Solvers::GeneticAlgorithm          => { let ga = opts.ga.as_ref().cloned().unwrap_or_default(); genetic_algorithm::solve(problem, &ga, tx, init_tour) }
+        Solvers::BellmanKarp => bellman_karp::solve(problem, &h, tx, init_tour),
+        Solvers::BranchBound => branch_bound::solve(problem, &h, tx, init_tour),
+        Solvers::CuckooSearch => {
+            let cs = opts.cs.as_ref().cloned().unwrap_or_default();
+            cuckoo_search::solve(problem, &cs, tx, init_tour)
+        }
+        Solvers::FlowerPollination => {
+            let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
+            flower_pollination::solve(problem, &fpa, tx, init_tour)
+        }
+        Solvers::NearestNeighbor => nearest_neighbor::solve(problem, &h, tx, init_tour),
+        Solvers::GeneticAlgorithm => {
+            let ga = opts.ga.as_ref().cloned().unwrap_or_default();
+            genetic_algorithm::solve(problem, &ga, tx, init_tour)
+        }
         Solvers::ParticleSwarmOptimization => particle_swarm::solve(problem, &h, tx, init_tour),
-        Solvers::RandomShuffle             => random_shuffle::solve(problem, &h, tx, init_tour),
-        Solvers::SimulatedAnnealing        => { let sa = opts.sa.as_ref().cloned().unwrap_or_default(); simulated_annealing::solve(problem, &sa, tx, init_tour) }
-        Solvers::StochasticHill            => stochastic_hill::solve(problem, &h, tx, init_tour),
-        Solvers::TabuSearch                => tabu_search::solve(problem, &h, tx, init_tour),
-        Solvers::ThreeOpt                  => three_opt::solve(problem, &h, tx, init_tour),
-        Solvers::TwoOpt                    => two_opt::solve(problem, &h, tx, init_tour),
-        Solvers::Unspecified               => return Err("solver not specified".to_string()),
+        Solvers::RandomShuffle => random_shuffle::solve(problem, &h, tx, init_tour),
+        Solvers::SimulatedAnnealing => {
+            let sa = opts.sa.as_ref().cloned().unwrap_or_default();
+            simulated_annealing::solve(problem, &sa, tx, init_tour)
+        }
+        Solvers::StochasticHill => stochastic_hill::solve(problem, &h, tx, init_tour),
+        Solvers::TabuSearch => tabu_search::solve(problem, &h, tx, init_tour),
+        Solvers::ThreeOpt => three_opt::solve(problem, &h, tx, init_tour),
+        Solvers::TwoOpt => two_opt::solve(problem, &h, tx, init_tour),
+        Solvers::Unspecified => return Err("solver not specified".to_string()),
     };
     Ok(solution)
 }
@@ -637,11 +754,7 @@ impl Solution {
     pub fn new(route: &[usize], problem: &TspProblem) -> Self {
         let cities = &problem.cities;
         let distances = &problem.distances;
-        let cities_idx = cities
-            .iter()
-            .enumerate()
-            .map(|(i, c)| (c.id, i))
-            .collect();
+        let cities_idx = cities.iter().enumerate().map(|(i, c)| (c.id, i)).collect();
 
         Solution {
             total: distances.tour_length(route),
@@ -653,12 +766,12 @@ impl Solution {
 
     /// Convenience constructor for solver functions that already hold separate `cities`
     /// and `distances` slices and do not need to construct a full [`TspProblem`].
-    pub(crate) fn from_parts(route: &[usize], cities: &[kdtree::KDPoint], distances: &DistanceMatrix) -> Self {
-        let cities_idx = cities
-            .iter()
-            .enumerate()
-            .map(|(i, c)| (c.id, i))
-            .collect();
+    pub(crate) fn from_parts(
+        route: &[usize],
+        cities: &[kdtree::KDPoint],
+        distances: &DistanceMatrix,
+    ) -> Self {
+        let cities_idx = cities.iter().enumerate().map(|(i, c)| (c.id, i)).collect();
 
         Solution {
             total: distances.tour_length(route),
@@ -780,7 +893,12 @@ mod tests {
 
     #[test]
     fn test_heuristic_options_has_expected_fields() {
-        let h = HeuristicOptions { epochs: 100, platoo_epochs: 10, n_nearest: 3, verbose: false };
+        let h = HeuristicOptions {
+            epochs: 100,
+            platoo_epochs: 10,
+            n_nearest: 3,
+            verbose: false,
+        };
         assert_eq!(h.epochs, 100);
         assert_eq!(h.platoo_epochs, 10);
     }
@@ -794,15 +912,20 @@ mod tests {
 
     #[test]
     fn test_app_options_has_no_flat_epoch_fields() {
-        let a = AppOptions { sa: None, ga: None, cs: None, fpa: None, heuristic: None };
+        let a = AppOptions {
+            sa: None,
+            ga: None,
+            cs: None,
+            fpa: None,
+            heuristic: None,
+        };
         drop(a);
     }
 
     #[test]
     fn test_heuristic_options_from_toml() {
-        let t: toml::Table = toml::from_str(
-            "epochs=5000\nplatoo_epochs=200\nn_nearest=5\nverbose=true"
-        ).unwrap();
+        let t: toml::Table =
+            toml::from_str("epochs=5000\nplatoo_epochs=200\nn_nearest=5\nverbose=true").unwrap();
         let h = HeuristicOptions::from_toml(&t).unwrap();
         assert_eq!(h.epochs, 5000);
         assert_eq!(h.n_nearest, 5);
@@ -811,15 +934,28 @@ mod tests {
 
     #[test]
     fn test_heuristic_validate_rejects_n_nearest_zero() {
-        let h = HeuristicOptions { epochs: 100, platoo_epochs: 50, n_nearest: 0, verbose: false };
+        let h = HeuristicOptions {
+            epochs: 100,
+            platoo_epochs: 50,
+            n_nearest: 0,
+            verbose: false,
+        };
         let err = h.validate().unwrap_err();
-        assert!(err.contains("n_nearest"), "error should name the field: {err}");
+        assert!(
+            err.contains("n_nearest"),
+            "error should name the field: {err}"
+        );
     }
 
     #[test]
     fn test_heuristic_validate_accepts_epochs_zero_and_platoo_zero() {
         // epochs=0 is "run forever"; platoo_epochs=0 disables plateau restarts — both valid.
-        let h = HeuristicOptions { epochs: 0, platoo_epochs: 0, n_nearest: 1, verbose: false };
+        let h = HeuristicOptions {
+            epochs: 0,
+            platoo_epochs: 0,
+            n_nearest: 1,
+            verbose: false,
+        };
         assert!(h.validate().is_ok());
     }
 
@@ -828,9 +964,21 @@ mod tests {
         use clap::{Arg, ArgAction, Command};
         let cmd = Command::new("t")
             .arg(Arg::new("epochs").long("epochs").action(ArgAction::Set))
-            .arg(Arg::new("platoo_epochs").long("platoo_epochs").action(ArgAction::Set))
-            .arg(Arg::new("n_nearest").long("n_nearest").action(ArgAction::Set))
-            .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue));
+            .arg(
+                Arg::new("platoo_epochs")
+                    .long("platoo_epochs")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("n_nearest")
+                    .long("n_nearest")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .action(ArgAction::SetTrue),
+            );
         let args = cmd.get_matches_from(["t", "--epochs", "bad"]);
         let result = HeuristicOptions::from_cli(&args);
         assert!(result.is_err(), "expected Err for --epochs bad");
@@ -840,32 +988,63 @@ mod tests {
         use clap::{Arg, ArgAction, Command};
         Command::new("t")
             .arg(Arg::new("epochs").long("epochs").action(ArgAction::Set))
-            .arg(Arg::new("platoo_epochs").long("platoo_epochs").action(ArgAction::Set))
-            .arg(Arg::new("n_nearest").long("n_nearest").action(ArgAction::Set))
-            .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue))
-            .arg(Arg::new("cooling_rate").long("cooling_rate").action(ArgAction::Set))
-            .arg(Arg::new("min_temperature").long("min_temperature").action(ArgAction::Set))
-            .arg(Arg::new("max_temperature").long("max_temperature").action(ArgAction::Set))
+            .arg(
+                Arg::new("platoo_epochs")
+                    .long("platoo_epochs")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("n_nearest")
+                    .long("n_nearest")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("cooling_rate")
+                    .long("cooling_rate")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("min_temperature")
+                    .long("min_temperature")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("max_temperature")
+                    .long("max_temperature")
+                    .action(ArgAction::Set),
+            )
     }
 
     #[test]
     fn test_sa_from_cli_errors_on_bad_float() {
         let args = sa_test_cmd().get_matches_from(["t", "--cooling_rate", "xyz"]);
-        assert!(SAOptions::from_cli(&args).is_err(), "expected Err for --cooling_rate xyz");
+        assert!(
+            SAOptions::from_cli(&args).is_err(),
+            "expected Err for --cooling_rate xyz"
+        );
     }
 
     #[test]
     fn test_sa_from_cli_errors_on_out_of_range_cooling_rate() {
         let args = sa_test_cmd().get_matches_from(["t", "--cooling_rate", "5.0"]);
         let result = SAOptions::from_cli(&args);
-        assert!(result.is_err(), "expected Err for cooling_rate=5.0 (out of (0,1))");
+        assert!(
+            result.is_err(),
+            "expected Err for cooling_rate=5.0 (out of (0,1))"
+        );
     }
 
     #[test]
     fn test_sa_options_from_toml_parses_all_fields() {
         let t: toml::Table = toml::from_str(
-            "epochs=5000\ncooling_rate=0.0005\nmax_temperature=200.0\nmin_temperature=0.001"
-        ).unwrap();
+            "epochs=5000\ncooling_rate=0.0005\nmax_temperature=200.0\nmin_temperature=0.001",
+        )
+        .unwrap();
         let sa = SAOptions::from_toml(&t).unwrap();
         assert_eq!(sa.heuristic.epochs, 5000);
         assert!((sa.cooling_rate - 0.0005).abs() < 1e-6);
@@ -879,9 +1058,8 @@ mod tests {
 
     #[test]
     fn test_ga_options_from_toml_parses_fields() {
-        let t: toml::Table = toml::from_str(
-            "mutation_probability=0.05\nn_elite=5\nepochs=2000"
-        ).unwrap();
+        let t: toml::Table =
+            toml::from_str("mutation_probability=0.05\nn_elite=5\nepochs=2000").unwrap();
         let ga = GAOptions::from_toml(&t).unwrap();
         assert!((ga.mutation_probability - 0.05).abs() < 1e-7);
         assert_eq!(ga.heuristic.epochs, 2000);

--- a/src/tsp/nearest_neighbor.rs
+++ b/src/tsp/nearest_neighbor.rs
@@ -13,7 +13,11 @@ pub fn solve(
 ) -> Solution {
     let cities = &problem.cities;
     let distances = &problem.distances;
-    tracing::info!(n_nearest = opts.n_nearest, cities = cities.len(), "NN starting");
+    tracing::info!(
+        n_nearest = opts.n_nearest,
+        cities = cities.len(),
+        "NN starting"
+    );
 
     let n_nearest = opts.n_nearest;
     let cities_table: HashMap<usize, _> = cities.iter().map(|c| (c.id, c.clone())).collect();
@@ -47,8 +51,12 @@ pub fn solve(
                 *unvisited
                     .iter()
                     .min_by(|&&a, &&b| {
-                        let da = distances.distance_between(current_id, a).unwrap_or(f32::MAX);
-                        let db = distances.distance_between(current_id, b).unwrap_or(f32::MAX);
+                        let da = distances
+                            .distance_between(current_id, a)
+                            .unwrap_or(f32::MAX);
+                        let db = distances
+                            .distance_between(current_id, b)
+                            .unwrap_or(f32::MAX);
                         da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
                     })
                     .expect("unvisited is non-empty")
@@ -70,7 +78,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     fn tsp5_problem() -> TspProblem {
         let cities = kdtree::build_points(&[
@@ -99,7 +107,11 @@ mod tests {
         let problem = tsp5_problem();
         let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
-        assert!(tour.total > 0.0, "tour length should be positive, got {}", tour.total);
+        assert!(
+            tour.total > 0.0,
+            "tour length should be positive, got {}",
+            tour.total
+        );
         assert!(tour.total.is_finite(), "tour length should be finite");
     }
 
@@ -134,7 +146,11 @@ mod tests {
         let tour = solve(&problem, &HeuristicOptions::default(), None, None);
 
         let route = tour.route().to_vec();
-        assert_ne!(route, vec![0, 1, 2, 3, 4], "NN produced sorted output (regression)");
+        assert_ne!(
+            route,
+            vec![0, 1, 2, 3, 4],
+            "NN produced sorted output (regression)"
+        );
         let mut sorted = route.clone();
         sorted.sort();
         assert_eq!(sorted, vec![0, 1, 2, 3, 4]);

--- a/src/tsp/opt_tour.rs
+++ b/src/tsp/opt_tour.rs
@@ -168,7 +168,10 @@ EOF";
         let result = parse_from_str(WRONG_TYPE_TOUR);
         assert!(result.is_err());
         let msg = result.unwrap_err();
-        assert!(msg.contains("TYPE"), "error should mention TYPE, got: {msg}");
+        assert!(
+            msg.contains("TYPE"),
+            "error should mention TYPE, got: {msg}"
+        );
     }
 
     #[test]

--- a/src/tsp/particle_swarm.rs
+++ b/src/tsp/particle_swarm.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 use std::sync::mpsc;
 
 use super::progress::ProgressMessage;
-use super::route::{apply_swaps, swap_sequence, Route};
+use super::route::{Route, apply_swaps, swap_sequence};
 use super::{HeuristicOptions, Solution, TspProblem};
 
 type Swap = (usize, usize);
@@ -14,7 +14,6 @@ const C1: f64 = 1.5;
 const C2: f64 = 1.5;
 const DEFAULT_N_PARTICLES: usize = 30;
 const V_MAX_FACTOR: f64 = 0.35;
-
 
 fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
     v.iter().take(keep).copied().collect()
@@ -132,7 +131,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     #[test]
     fn test_pso_respects_initial_tour() {
@@ -146,7 +145,10 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 0,
+            ..HeuristicOptions::default()
+        };
         let problem = TspProblem::new(cities.clone(), dm);
         let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
@@ -174,7 +176,11 @@ mod tests {
             vec![0.0, 1.0],
         ]);
         let distances = distance_matrix::from_cities(&cities);
-        let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 20,
+            n_nearest: 5,
+            ..HeuristicOptions::default()
+        };
         let problem = TspProblem::new(cities.clone(), distances);
         let sol = solve(&problem, &opts, None, None);
         assert_eq!(sol.route().len(), cities.len());

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc;
 
 use super::progress::ProgressMessage;
-use super::{validate_tour, AppOptions, Solution, Solvers, TspProblem};
+use super::{AppOptions, Solution, Solvers, TspProblem, validate_tour};
 
 pub struct PipelineStage {
     pub solver: Solvers,
@@ -17,7 +17,12 @@ impl PipelineStage {
         problem: TspProblem,
         progress_tx: Option<mpsc::Sender<ProgressMessage>>,
     ) -> Self {
-        PipelineStage { solver, options, problem, progress_tx }
+        PipelineStage {
+            solver,
+            options,
+            problem,
+            progress_tx,
+        }
     }
 
     pub fn solve(&self, init_tour: Option<&[usize]>) -> Result<Solution, String> {
@@ -38,7 +43,8 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
     let mut seed: Option<Vec<usize>> = None;
     for stage in stages {
         if let Some(ref t) = seed
-            && let Err(e) = validate_tour(t, &stage.problem.cities) {
+            && let Err(e) = validate_tour(t, &stage.problem.cities)
+        {
             tracing::warn!("pipeline: invalid seed ({e}); using default seeding");
             seed = None;
         }
@@ -58,7 +64,7 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, AppOptions, Solvers, TspProblem};
+    use crate::tsp::{AppOptions, Solvers, TspProblem, distance_matrix, kdtree};
 
     fn small_cities() -> Vec<kdtree::KDPoint> {
         kdtree::build_points(&[

--- a/src/tsp/progress_eframe.rs
+++ b/src/tsp/progress_eframe.rs
@@ -12,15 +12,15 @@ type RectCoords = [f64; 4];
 type Point2D = (f64, f64);
 type EdgeData = (Pos2, Pos2);
 
-const WHITE:              Color32 = Color32::from_rgb(255, 255, 255);
-const CITY_COLOR:         Color32 = Color32::from_rgb(30,  30,  30);
-const CURRENT_CITY_COLOR: Color32 = Color32::from_rgb(220, 30,  30);
-const BEST_EDGE_COLOR:    Color32 = Color32::from_rgb(34,  139, 34);
-const SHARED_EDGE_COLOR:  Color32 = Color32::from_rgb(0,   100, 0);
-const UNIQUE_OPT_COLOR:   Color32 = Color32::from_rgb(180, 180, 180);
-const CURRENT_EDGE_COLOR: Color32 = Color32::from_rgb(30,  100, 220);
-const ACTIVE_EDGE_COLOR:  Color32 = Color32::from_rgb(255, 140, 0);
-const STATUS_COLOR:       Color32 = Color32::from_rgb(220, 30,  30);
+const WHITE: Color32 = Color32::from_rgb(255, 255, 255);
+const CITY_COLOR: Color32 = Color32::from_rgb(30, 30, 30);
+const CURRENT_CITY_COLOR: Color32 = Color32::from_rgb(220, 30, 30);
+const BEST_EDGE_COLOR: Color32 = Color32::from_rgb(34, 139, 34);
+const SHARED_EDGE_COLOR: Color32 = Color32::from_rgb(0, 100, 0);
+const UNIQUE_OPT_COLOR: Color32 = Color32::from_rgb(180, 180, 180);
+const CURRENT_EDGE_COLOR: Color32 = Color32::from_rgb(30, 100, 220);
+const ACTIVE_EDGE_COLOR: Color32 = Color32::from_rgb(255, 140, 0);
+const STATUS_COLOR: Color32 = Color32::from_rgb(220, 30, 30);
 const FONT_SIZE: f32 = 16.0;
 
 struct NodeData {
@@ -46,9 +46,12 @@ pub struct ProgressPlot {
 }
 
 impl ProgressPlot {
-    pub fn new_with_channel(cities: &[KDPoint], width: f64, height: f64, margin: f64)
-        -> (Self, mpsc::Sender<ProgressMessage>)
-    {
+    pub fn new_with_channel(
+        cities: &[KDPoint],
+        width: f64,
+        height: f64,
+        margin: f64,
+    ) -> (Self, mpsc::Sender<ProgressMessage>) {
         let (tx, rx) = mpsc::channel();
         let mut plot = ProgressPlot {
             rx,
@@ -169,7 +172,12 @@ impl ProgressPlot {
                 self.city_table.get(&a).cloned(),
                 self.city_table.get(&b).cloned(),
             ) {
-                let edge = build_edge(&from, &to, &self.cities_bounding_box, &self.viewport_dimensions);
+                let edge = build_edge(
+                    &from,
+                    &to,
+                    &self.cities_bounding_box,
+                    &self.viewport_dimensions,
+                );
                 data.push(((a.min(b), a.max(b)), edge));
             }
         }
@@ -186,7 +194,12 @@ impl ProgressPlot {
                 self.city_table.get(&from_id).cloned(),
                 self.city_table.get(to_id).cloned(),
             ) {
-                edges.push(build_edge(&from, &to, &self.cities_bounding_box, &self.viewport_dimensions));
+                edges.push(build_edge(
+                    &from,
+                    &to,
+                    &self.cities_bounding_box,
+                    &self.viewport_dimensions,
+                ));
                 from_id = *to_id;
             }
         }
@@ -195,7 +208,12 @@ impl ProgressPlot {
             self.city_table.get(&from_id).cloned(),
             self.city_table.get(&path[0]).cloned(),
         ) {
-            edges.push(build_edge(&from, &to, &self.cities_bounding_box, &self.viewport_dimensions));
+            edges.push(build_edge(
+                &from,
+                &to,
+                &self.cities_bounding_box,
+                &self.viewport_dimensions,
+            ));
         }
 
         edges
@@ -235,8 +253,16 @@ impl eframe::App for ProgressPlot {
                 }
 
                 if let (Some(prev_id), Some(curr_id)) = (self.prev_city_id, self.current_city_id) {
-                    let prev_pos = self.nodes.iter().find(|n| n.city_id == prev_id).map(|n| n.pos);
-                    let curr_pos = self.nodes.iter().find(|n| n.city_id == curr_id).map(|n| n.pos);
+                    let prev_pos = self
+                        .nodes
+                        .iter()
+                        .find(|n| n.city_id == prev_id)
+                        .map(|n| n.pos);
+                    let curr_pos = self
+                        .nodes
+                        .iter()
+                        .find(|n| n.city_id == curr_id)
+                        .map(|n| n.pos);
                     if let (Some(p), Some(c)) = (prev_pos, curr_pos) {
                         painter.line_segment([p, c], Stroke::new(3.0, ACTIVE_EDGE_COLOR));
                     }
@@ -271,7 +297,11 @@ impl eframe::App for ProgressPlot {
                     STATUS_COLOR,
                 );
 
-                draw_legend(painter, &self.viewport_dimensions, !self.optimal_edge_data.is_empty());
+                draw_legend(
+                    painter,
+                    &self.viewport_dimensions,
+                    !self.optimal_edge_data.is_empty(),
+                );
             });
 
         ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -287,15 +317,27 @@ struct ViewportDimensions {
 
 impl ViewportDimensions {
     fn new(width: f64, height: f64, margin: f64) -> Self {
-        ViewportDimensions { height, width, margin }
+        ViewportDimensions {
+            height,
+            width,
+            margin,
+        }
     }
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn build_edge(from: &KDPoint, to: &KDPoint, bbox: &RectCoords, vp: &ViewportDimensions) -> EdgeData {
+fn build_edge(
+    from: &KDPoint,
+    to: &KDPoint,
+    bbox: &RectCoords,
+    vp: &ViewportDimensions,
+) -> EdgeData {
     let (fx, fy) = scaled_point(from, bbox, vp);
     let (tx, ty) = scaled_point(to, bbox, vp);
-    (Pos2::new(fx as f32, fy as f32), Pos2::new(tx as f32, ty as f32))
+    (
+        Pos2::new(fx as f32, fy as f32),
+        Pos2::new(tx as f32, ty as f32),
+    )
 }
 
 fn scaled_point(point: &KDPoint, window: &RectCoords, viewport: &ViewportDimensions) -> Point2D {
@@ -310,12 +352,20 @@ fn cities_bounding_box(cities: &[KDPoint]) -> RectCoords {
 
     for city in cities.iter() {
         if let Some(x) = city.get(0) {
-            if x < x_min { x_min = x; }
-            if x > x_max { x_max = x; }
+            if x < x_min {
+                x_min = x;
+            }
+            if x > x_max {
+                x_max = x;
+            }
         }
         if let Some(y) = city.get(1) {
-            if y < y_min { y_min = y; }
-            if y > y_max { y_max = y; }
+            if y < y_min {
+                y_min = y;
+            }
+            if y > y_max {
+                y_max = y;
+            }
         }
     }
 
@@ -358,7 +408,12 @@ fn draw_legend(painter: &egui::Painter, vp: &ViewportDimensions, show_optimal: b
 }
 
 // converts EUC2D space into GUI coords [0..self.height, 0..self.width]
-fn point_to_viewport(x: f64, y: f64, window: &RectCoords, viewport: &ViewportDimensions) -> Point2D {
+fn point_to_viewport(
+    x: f64,
+    y: f64,
+    window: &RectCoords,
+    viewport: &ViewportDimensions,
+) -> Point2D {
     let x_min = window[0];
     let y_min = window[1];
     let x_max = window[2];
@@ -397,11 +452,7 @@ mod tests {
 
     #[test]
     fn test_cities_bounding_box_basic() {
-        let cities = build_points(&[
-            vec![0.0, 5.0],
-            vec![10.0, 0.0],
-            vec![3.0, 8.0],
-        ]);
+        let cities = build_points(&[vec![0.0, 5.0], vec![10.0, 0.0], vec![3.0, 8.0]]);
         let bbox = cities_bounding_box(&cities);
         assert!((bbox[0] - 0.0).abs() < 0.01);
         assert!((bbox[1] - 0.0).abs() < 0.01);

--- a/src/tsp/random_shuffle.rs
+++ b/src/tsp/random_shuffle.rs
@@ -29,7 +29,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     fn five_city_problem() -> TspProblem {
         let cities = kdtree::build_points(&[

--- a/src/tsp/route.rs
+++ b/src/tsp/route.rs
@@ -1,7 +1,7 @@
+use rand::Rng;
 /// Route is ordered list of city ids that our traveling salesperson
 /// is going to visit
 use rand::seq::SliceRandom;
-use rand::Rng;
 
 use super::kdtree::KDPoint;
 

--- a/src/tsp/simulated_annealing.rs
+++ b/src/tsp/simulated_annealing.rs
@@ -31,7 +31,10 @@ pub fn solve(
     let mut best_distance = distances.tour_length(best_route.route());
 
     if let Some(tx) = progress_tx {
-        let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+        let _ = tx.send(ProgressMessage::PathUpdate(
+            best_route.clone(),
+            best_distance,
+        ));
     }
 
     let mut temperature = opts.max_temperature;
@@ -44,7 +47,10 @@ pub fn solve(
             best_distance = candidate_distance;
 
             if let Some(tx) = progress_tx {
-                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+                let _ = tx.send(ProgressMessage::PathUpdate(
+                    best_route.clone(),
+                    best_distance,
+                ));
             }
             tracing::info!(epoch, tour_length = best_distance, "SA: new best");
         }
@@ -79,18 +85,24 @@ fn is_acceptable(temperature: f32, old_distance: f32, new_distance: f32) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, SAOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, SAOptions, TspProblem, distance_matrix, kdtree};
 
     #[test]
     fn test_sa_respects_initial_tour() {
         let cities = kdtree::build_points(&[
-            vec![0.0, 0.0], vec![0.0, 0.5], vec![0.0, 1.0],
-            vec![1.0, 1.0], vec![1.0, 0.0],
+            vec![0.0, 0.0],
+            vec![0.0, 0.5],
+            vec![0.0, 1.0],
+            vec![1.0, 1.0],
+            vec![1.0, 0.0],
         ]);
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let opts = SAOptions {
-            heuristic: HeuristicOptions { epochs: 0, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                epochs: 0,
+                ..HeuristicOptions::default()
+            },
             min_temperature: 1_000_000.0,
             max_temperature: 0.0,
             ..SAOptions::default()
@@ -119,7 +131,10 @@ mod tests {
         let accepted = (0..1000)
             .filter(|_| is_acceptable(temperature, 10.0, 10.001))
             .count();
-        assert!(accepted > 900, "expected >90% acceptance at high T, got {accepted}/1000");
+        assert!(
+            accepted > 900,
+            "expected >90% acceptance at high T, got {accepted}/1000"
+        );
     }
 
     #[test]
@@ -128,6 +143,9 @@ mod tests {
         let accepted = (0..1000)
             .filter(|_| is_acceptable(temperature, 10.0, 20.0))
             .count();
-        assert!(accepted < 100, "expected <10% acceptance at low T, got {accepted}/1000");
+        assert!(
+            accepted < 100,
+            "expected <10% acceptance at low T, got {accepted}/1000"
+        );
     }
 }

--- a/src/tsp/stochastic_hill.rs
+++ b/src/tsp/stochastic_hill.rs
@@ -49,7 +49,10 @@ pub fn solve(
             n_stale = 0;
 
             if let Some(tx) = progress_tx {
-                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+                let _ = tx.send(ProgressMessage::PathUpdate(
+                    best_route.clone(),
+                    best_distance,
+                ));
             }
 
             tracing::info!(epoch, tour_length = best_distance, "hill: new best");
@@ -60,7 +63,11 @@ pub fn solve(
         epoch += 1;
 
         if n_stale > opts.platoo_epochs && opts.platoo_epochs > 0 {
-            tracing::warn!(epoch, plateau_epochs = opts.platoo_epochs, "hill: plateau, restarting");
+            tracing::warn!(
+                epoch,
+                plateau_epochs = opts.platoo_epochs,
+                "hill: plateau, restarting"
+            );
 
             current_route.shuffle();
             n_stale = 0;
@@ -76,7 +83,11 @@ pub fn solve(
     }
 
     if !found_improvement {
-        tracing::warn!(epochs = opts.epochs, tour_length = best_distance, "hill: no improvement found");
+        tracing::warn!(
+            epochs = opts.epochs,
+            tour_length = best_distance,
+            "hill: no improvement found"
+        );
     }
 
     if let Some(tx) = progress_tx {
@@ -88,7 +99,7 @@ pub fn solve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, kdtree::KDPoint, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree, kdtree::KDPoint};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -101,7 +112,11 @@ mod tests {
     }
 
     fn fast_opts() -> HeuristicOptions {
-        HeuristicOptions { epochs: 500, platoo_epochs: 100, ..HeuristicOptions::default() }
+        HeuristicOptions {
+            epochs: 500,
+            platoo_epochs: 100,
+            ..HeuristicOptions::default()
+        }
     }
 
     #[test]
@@ -110,7 +125,11 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = HeuristicOptions { epochs: 1, platoo_epochs: 1, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 1,
+            platoo_epochs: 1,
+            ..HeuristicOptions::default()
+        };
         let problem = TspProblem::new(cities, dm);
         let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
@@ -144,7 +163,11 @@ mod tests {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
-        let opts = HeuristicOptions { epochs: 100, platoo_epochs: 50, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 100,
+            platoo_epochs: 50,
+            ..HeuristicOptions::default()
+        };
         let tour = solve(&problem, &opts, None, None);
         assert_eq!(tour.route().len(), cities.len());
     }

--- a/src/tsp/tabu_search.rs
+++ b/src/tsp/tabu_search.rs
@@ -40,7 +40,10 @@ pub fn solve(
             best_distance = local_distance;
 
             if let Some(tx) = progress_tx {
-                let _ = tx.send(ProgressMessage::PathUpdate(best_route.clone(), best_distance));
+                let _ = tx.send(ProgressMessage::PathUpdate(
+                    best_route.clone(),
+                    best_distance,
+                ));
             }
 
             tracing::info!(epoch, tour_length = local_distance, "tabu: new best");
@@ -109,8 +112,8 @@ impl TabuList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, kdtree::KDPoint, HeuristicOptions, TspProblem};
     use crate::tsp::route::Route;
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree, kdtree::KDPoint};
 
     fn tsp5_cities() -> Vec<KDPoint> {
         kdtree::build_points(&[
@@ -162,7 +165,10 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = HeuristicOptions { epochs: 1, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 1,
+            ..HeuristicOptions::default()
+        };
         let problem = TspProblem::new(cities, dm);
         let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
@@ -173,7 +179,10 @@ mod tests {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities.clone(), dm);
-        let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 200,
+            ..HeuristicOptions::default()
+        };
         let tour = solve(&problem, &opts, None, None);
 
         let mut visited: Vec<usize> = tour.route().to_vec();
@@ -186,7 +195,10 @@ mod tests {
         let cities = tsp5_cities();
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
-        let opts = HeuristicOptions { epochs: 200, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 200,
+            ..HeuristicOptions::default()
+        };
         let tour = solve(&problem, &opts, None, None);
 
         assert!(tour.total > 0.0, "tour length must be positive");

--- a/src/tsp/three_opt.rs
+++ b/src/tsp/three_opt.rs
@@ -55,10 +55,7 @@ pub fn solve(
 /// locally optimal.
 ///
 /// Pure: no side effects, no progress messages.
-fn find_best_move(
-    path: &[usize],
-    distances: &DistanceMatrix,
-) -> Option<(usize, usize, usize, u8)> {
+fn find_best_move(path: &[usize], distances: &DistanceMatrix) -> Option<(usize, usize, usize, u8)> {
     let n = path.len();
     let mut best_move: Option<(usize, usize, usize, u8)> = None;
     let mut best_savings = 0.0_f32;
@@ -74,7 +71,7 @@ fn find_best_move(
             let dt = path[j + 1];
             // Hoist (i,j)-invariant distances: 4 lookups saved per k iteration.
             let d_c_dt = d(distances, c, dt);
-            let d_ac   = d(distances, a, c);
+            let d_ac = d(distances, a, c);
             let d_b_dt = d(distances, b, dt);
             let d_a_dt = d(distances, a, dt);
 
@@ -88,18 +85,28 @@ fn find_best_move(
                 let e = path[k];
                 let f = path[(k + 1) % n];
 
-                let d_ef   = d(distances, e, f);
-                let d_ce   = d(distances, c, e);
+                let d_ef = d(distances, e, f);
+                let d_ce = d(distances, c, e);
                 let d_dt_f = d(distances, dt, f);
-                let d_be   = d(distances, b, e);
-                let d_cf   = d(distances, c, f);
-                let d_bf   = d(distances, b, f);
-                let d_ae   = d(distances, a, e);
+                let d_be = d(distances, b, e);
+                let d_cf = d(distances, c, f);
+                let d_bf = d(distances, b, f);
+                let d_ae = d(distances, a, e);
 
                 let orig = d_ab + d_c_dt + d_ef;
                 let te = TripleEdges {
-                    d_ab, d_c_dt, d_ac, d_b_dt, d_a_dt,
-                    d_ef, d_ce, d_dt_f, d_be, d_cf, d_bf, d_ae,
+                    d_ab,
+                    d_c_dt,
+                    d_ac,
+                    d_b_dt,
+                    d_a_dt,
+                    d_ef,
+                    d_ce,
+                    d_dt_f,
+                    d_be,
+                    d_cf,
+                    d_bf,
+                    d_ae,
                 };
                 let costs = reconnection_costs(&te);
 
@@ -129,9 +136,18 @@ struct TripleEdges {
     // i-level
     d_ab: f32,
     // j-level
-    d_c_dt: f32, d_ac: f32, d_b_dt: f32, d_a_dt: f32,
+    d_c_dt: f32,
+    d_ac: f32,
+    d_b_dt: f32,
+    d_a_dt: f32,
     // k-level
-    d_ef: f32, d_ce: f32, d_dt_f: f32, d_be: f32, d_cf: f32, d_bf: f32, d_ae: f32,
+    d_ef: f32,
+    d_ce: f32,
+    d_dt_f: f32,
+    d_be: f32,
+    d_cf: f32,
+    d_bf: f32,
+    d_ae: f32,
 }
 
 /// Returns the 7 non-identity reconnection costs for a triple.
@@ -153,13 +169,13 @@ struct TripleEdges {
 /// |  6  |  7   | rev(s2)+rev(s1) | (A,E)+(D,C)+(B,F)     |
 fn reconnection_costs(e: &TripleEdges) -> [f32; 7] {
     [
-        e.d_ac  + e.d_b_dt + e.d_ef,   // 1
-        e.d_ab  + e.d_ce   + e.d_dt_f, // 2
-        e.d_ac  + e.d_be   + e.d_dt_f, // 3
-        e.d_a_dt + e.d_be  + e.d_cf,   // 4
-        e.d_a_dt + e.d_ce  + e.d_bf,   // 5
-        e.d_ae  + e.d_b_dt + e.d_cf,   // 6
-        e.d_ae  + e.d_c_dt + e.d_bf,   // 7
+        e.d_ac + e.d_b_dt + e.d_ef, // 1
+        e.d_ab + e.d_ce + e.d_dt_f, // 2
+        e.d_ac + e.d_be + e.d_dt_f, // 3
+        e.d_a_dt + e.d_be + e.d_cf, // 4
+        e.d_a_dt + e.d_ce + e.d_bf, // 5
+        e.d_ae + e.d_b_dt + e.d_cf, // 6
+        e.d_ae + e.d_c_dt + e.d_bf, // 7
     ]
 }
 
@@ -203,7 +219,8 @@ fn apply_3opt(path: &mut [usize], i: usize, j: usize, k: usize, case: u8) {
 
 #[inline]
 fn d(dm: &DistanceMatrix, a: usize, b: usize) -> f32 {
-    dm.distance_between(a, b).expect("three_opt: invalid city pair")
+    dm.distance_between(a, b)
+        .expect("three_opt: invalid city pair")
 }
 
 fn send_path(tx: Option<&mpsc::Sender<ProgressMessage>>, path: &[usize]) {
@@ -215,7 +232,7 @@ fn send_path(tx: Option<&mpsc::Sender<ProgressMessage>>, path: &[usize]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     fn build_dm(cities: &[kdtree::KDPoint]) -> DistanceMatrix {
         distance_matrix::from_cities(cities)
@@ -323,19 +340,16 @@ mod tests {
 
     #[test]
     fn find_best_move_finds_improvement() {
-        let cities = pts(&[
-            (0.0, 0.0),
-            (0.0, 0.5),
-            (0.0, 1.0),
-            (1.0, 1.0),
-            (1.0, 0.0),
-        ]);
+        let cities = pts(&[(0.0, 0.0), (0.0, 0.5), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)]);
         let dm = build_dm(&cities);
         let bad_path = vec![0usize, 2, 4, 1, 3];
         let orig_cost: f32 = dm.tour_length(&bad_path);
 
         let result = find_best_move(&bad_path, &dm);
-        assert!(result.is_some(), "expected an improving move on the crossed tour");
+        assert!(
+            result.is_some(),
+            "expected an improving move on the crossed tour"
+        );
 
         let (i, j, k, case) = result.unwrap();
         let mut improved_path = bad_path.clone();
@@ -349,8 +363,18 @@ mod tests {
 
     fn sample_edges() -> TripleEdges {
         TripleEdges {
-            d_ab: 1.0, d_c_dt: 2.0, d_ac: 3.0, d_b_dt: 4.0, d_a_dt: 5.0,
-            d_ef: 6.0, d_ce: 7.0, d_dt_f: 8.0, d_be: 9.0, d_cf: 10.0, d_bf: 11.0, d_ae: 12.0,
+            d_ab: 1.0,
+            d_c_dt: 2.0,
+            d_ac: 3.0,
+            d_b_dt: 4.0,
+            d_a_dt: 5.0,
+            d_ef: 6.0,
+            d_ce: 7.0,
+            d_dt_f: 8.0,
+            d_be: 9.0,
+            d_cf: 10.0,
+            d_bf: 11.0,
+            d_ae: 12.0,
         }
     }
 
@@ -395,7 +419,11 @@ mod tests {
         let problem = make_problem(cities.clone());
         let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
-        assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
+        assert!(
+            (tour.total - 4.0).abs() < 1e-4,
+            "expected 4.0, got {}",
+            tour.total
+        );
     }
 
     #[test]
@@ -417,16 +445,14 @@ mod tests {
 
     #[test]
     fn solve_five_cities_unit_square() {
-        let cities = pts(&[
-            (0.0, 0.0),
-            (0.0, 0.5),
-            (0.0, 1.0),
-            (1.0, 1.0),
-            (1.0, 0.0),
-        ]);
+        let cities = pts(&[(0.0, 0.0), (0.0, 0.5), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)]);
         let problem = make_problem(cities.clone());
         let tour = solve(&problem, &HeuristicOptions::default(), None, None);
         assert!(is_valid_tour(tour.route(), &cities));
-        assert!((tour.total - 4.0).abs() < 1e-4, "expected 4.0, got {}", tour.total);
+        assert!(
+            (tour.total - 4.0).abs() < 1e-4,
+            "expected 4.0, got {}",
+            tour.total
+        );
     }
 }

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -8,9 +8,9 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
+use super::CityTable;
 use super::distance_matrix::{self, DistanceMatrix};
 use super::kdtree::KDPoint;
-use super::CityTable;
 
 const COORD_SECTION_KEY: &str = "NODE_COORD_SECTION";
 const DISPLAY_DATA_SECTION_KEY: &str = "DISPLAY_DATA_SECTION";
@@ -140,17 +140,14 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
                 }
             },
             TspReaderStates::Insection(section_id)
-                if (section_id == COORD_SECTION_KEY
-                    || section_id == DISPLAY_DATA_SECTION_KEY) =>
+                if (section_id == COORD_SECTION_KEY || section_id == DISPLAY_DATA_SECTION_KEY) =>
             {
                 match coords_from_text(line_no, &line) {
                     Err(msg) => return Err(msg),
                     Ok(pt) => cities.push(pt),
                 }
             }
-            TspReaderStates::Insection(section_id)
-                if section_id == EDGE_WEIGHT_SECTION_KEY =>
-            {
+            TspReaderStates::Insection(section_id) if section_id == EDGE_WEIGHT_SECTION_KEY => {
                 raw_weight_tokens.extend(
                     line.split_whitespace()
                         .filter_map(|t| f32::from_str(t).ok()),

--- a/src/tsp/two_opt.rs
+++ b/src/tsp/two_opt.rs
@@ -32,20 +32,27 @@ pub fn solve(
             }
 
             for j in (i + 2)..n_indices {
-                let current_distance =
-                    distances.distance_between(path[i], path[i + 1]).expect("two_opt: invalid city pair")
-                    + distances.distance_between(path[j], path[j + 1]).expect("two_opt: invalid city pair");
+                let current_distance = distances
+                    .distance_between(path[i], path[i + 1])
+                    .expect("two_opt: invalid city pair")
+                    + distances
+                        .distance_between(path[j], path[j + 1])
+                        .expect("two_opt: invalid city pair");
 
-                let new_distance =
-                    distances.distance_between(path[i], path[j]).expect("two_opt: invalid city pair")
-                    + distances.distance_between(path[i + 1], path[j + 1]).expect("two_opt: invalid city pair");
+                let new_distance = distances
+                    .distance_between(path[i], path[j])
+                    .expect("two_opt: invalid city pair")
+                    + distances
+                        .distance_between(path[i + 1], path[j + 1])
+                        .expect("two_opt: invalid city pair");
 
                 if new_distance < current_distance {
                     swap_2opt(&mut path, i + 1, j);
                     improved = true;
 
                     if let Some(tx) = progress_tx {
-                        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
+                        let _ =
+                            tx.send(ProgressMessage::PathUpdate(Route::new(&path), new_distance));
                     }
                     tracing::debug!(i, j, tour_length = new_distance, "2-opt: improvement");
                 }
@@ -74,7 +81,7 @@ fn swap_2opt(path: &mut [usize], from: usize, to: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::{distance_matrix, kdtree, HeuristicOptions, TspProblem};
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
 
     #[test]
     fn test_swap_2opt_2middle_elems_in_even_size_list() {

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -1,11 +1,11 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::teeline::solver::types::{City, Solution, SolveOptions};
 use bindings::Guest;
+use bindings::teeline::solver::types::{City, Solution, SolveOptions};
 use teeline::tsp::{
-    distance_matrix::DistanceMatrix, kdtree::KDPoint, AppOptions, CSOptions, FPAOptions,
-    GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
+    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
+    distance_matrix::DistanceMatrix, kdtree::KDPoint,
 };
 
 struct Component;
@@ -36,23 +36,28 @@ fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
             ..AppOptions::default()
         },
         Solvers::CuckooSearch => AppOptions {
-            cs: Some(CSOptions { heuristic, mutation_probability: o.mutation_probability }),
+            cs: Some(CSOptions {
+                heuristic,
+                mutation_probability: o.mutation_probability,
+            }),
             ..AppOptions::default()
         },
         Solvers::FlowerPollination => AppOptions {
-            fpa: Some(FPAOptions { heuristic, mutation_probability: o.mutation_probability }),
+            fpa: Some(FPAOptions {
+                heuristic,
+                mutation_probability: o.mutation_probability,
+            }),
             ..AppOptions::default()
         },
-        _ => AppOptions { heuristic: Some(heuristic), ..AppOptions::default() },
+        _ => AppOptions {
+            heuristic: Some(heuristic),
+            ..AppOptions::default()
+        },
     }
 }
 
 impl Guest for Component {
-    fn solve(
-        solver: String,
-        cities: Vec<City>,
-        options: SolveOptions,
-    ) -> Result<Solution, String> {
+    fn solve(solver: String, cities: Vec<City>, options: SolveOptions) -> Result<Solution, String> {
         let solver_id = teeline::tsp::find_solver(&solver)?;
 
         let kd_cities: Vec<KDPoint> = cities
@@ -60,8 +65,8 @@ impl Guest for Component {
             .map(|c| KDPoint::new_with_id(c.id as usize, &[c.x, c.y]))
             .collect();
 
-        let distances = DistanceMatrix::from_cities(&kd_cities)
-            .map_err(|e| format!("distance matrix: {e}"))?;
+        let distances =
+            DistanceMatrix::from_cities(&kd_cities).map_err(|e| format!("distance matrix: {e}"))?;
 
         let problem = TspProblem::new(kd_cities, distances);
         let opts = build_opts(solver_id, &options);

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use teeline::config::{resolve_config_file, select_pipeline_source, IdentityProvider};
+use teeline::config::{IdentityProvider, resolve_config_file, select_pipeline_source};
 use teeline::tsp::{
-    pipeline::{run_pipeline, PipelineStage},
-    tsplib, Solvers, TspProblem,
+    Solvers, TspProblem,
+    pipeline::{PipelineStage, run_pipeline},
+    tsplib,
 };
 
 const BERLIN52: &str = "tests/fixtures/berlin52.tsp";
@@ -17,9 +18,7 @@ fn berlin52_stages(stage_configs: Vec<(Solvers, teeline::tsp::AppOptions)>) -> V
     let problem = TspProblem::new(tsp.cities().to_vec(), tsp.distance_matrix().unwrap());
     stage_configs
         .into_iter()
-        .map(|(solver, options)| {
-            PipelineStage::new(solver, options, problem.clone(), None)
-        })
+        .map(|(solver, options)| PipelineStage::new(solver, options, problem.clone(), None))
         .collect()
 }
 
@@ -42,7 +41,9 @@ fn test_pipeline_config_sa_stage_epochs_applied() {
     let p = fixture("pipeline_global_nn_sa.toml");
     let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
     // SA stage should have epochs=50 in its [stage.sa] options
-    let sa_stage = stage_configs.iter().find(|(s, _)| *s == Solvers::SimulatedAnnealing);
+    let sa_stage = stage_configs
+        .iter()
+        .find(|(s, _)| *s == Solvers::SimulatedAnnealing);
     assert!(sa_stage.is_some(), "expected SA stage in fixture");
     let (_, opts) = sa_stage.unwrap();
     assert_eq!(opts.sa.as_ref().unwrap().heuristic.epochs, 50);

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -12,18 +12,17 @@
 /// because solution quality depends on runtime epochs.
 use std::path::Path;
 use teeline::tsp::{
-    bellman_karp, branch_bound, cuckoo_search, distance_matrix, flower_pollination,
-    genetic_algorithm, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
-    stochastic_hill, tabu_search, two_opt, tsplib,
-    CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, TspProblem,
+    CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, TspProblem, bellman_karp,
+    branch_bound, cuckoo_search, distance_matrix, flower_pollination, genetic_algorithm, kdtree,
+    nearest_neighbor, particle_swarm, simulated_annealing, stochastic_hill, tabu_search, tsplib,
+    two_opt,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 fn load_tsp(fixture: &str) -> tsplib::TspLibData {
     let path = Path::new("tests/fixtures").join(fixture);
-    tsplib::read_from_file(&path)
-        .unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
+    tsplib::read_from_file(&path).unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
 }
 
 fn load_berlin52() -> Vec<kdtree::KDPoint> {
@@ -74,15 +73,28 @@ fn stochastic_options(epochs: usize) -> HeuristicOptions {
 #[test]
 fn nearest_neighbor_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
-    assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "NN tour is not valid on berlin52"
+    );
 }
 
 #[test]
 fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
     let cities = load_berlin52();
-    let tour = nearest_neighbor::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = nearest_neighbor::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
     assert!(tour.total > 0.0, "NN tour length should be positive");
     assert!(tour.total.is_finite(), "NN tour length should be finite");
@@ -93,15 +105,28 @@ fn nearest_neighbor_tour_is_finite_and_positive_berlin52() {
 #[test]
 fn two_opt_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = two_opt::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
-    assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "2-opt tour is not valid on berlin52"
+    );
 }
 
 #[test]
 fn two_opt_tour_within_50pct_of_optimal_berlin52() {
     let cities = load_berlin52();
-    let tour = two_opt::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = two_opt::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
     assert!(
         tour.total < 7542.0 * 1.5,
@@ -117,7 +142,10 @@ fn tabu_search_valid_tour_berlin52() {
     let cities = load_berlin52();
     let tour = tabu_search::solve(&make_problem(&cities), &stochastic_options(500), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "tabu tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "tabu tour is not valid on berlin52"
+    );
 }
 
 // ─── stochastic hill climbing ─────────────────────────────────────────────────
@@ -127,7 +155,10 @@ fn stochastic_hill_valid_tour_berlin52() {
     let cities = load_berlin52();
     let tour = stochastic_hill::solve(&make_problem(&cities), &stochastic_options(500), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "hill tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "hill tour is not valid on berlin52"
+    );
 }
 
 // ─── simulated annealing ──────────────────────────────────────────────────────
@@ -136,12 +167,18 @@ fn stochastic_hill_valid_tour_berlin52() {
 fn simulated_annealing_valid_tour_berlin52() {
     let cities = load_berlin52();
     let opts = SAOptions {
-        heuristic: HeuristicOptions { epochs: 2000, ..HeuristicOptions::default() },
+        heuristic: HeuristicOptions {
+            epochs: 2000,
+            ..HeuristicOptions::default()
+        },
         ..SAOptions::default()
     };
     let tour = simulated_annealing::solve(&make_problem(&cities), &opts, None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "SA tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "SA tour is not valid on berlin52"
+    );
 }
 
 // ─── genetic algorithm ────────────────────────────────────────────────────────
@@ -150,12 +187,18 @@ fn simulated_annealing_valid_tour_berlin52() {
 fn genetic_algorithm_valid_tour_berlin52() {
     let cities = load_berlin52();
     let opts = GAOptions {
-        heuristic: HeuristicOptions { epochs: 100, ..HeuristicOptions::default() },
+        heuristic: HeuristicOptions {
+            epochs: 100,
+            ..HeuristicOptions::default()
+        },
         ..GAOptions::default()
     };
     let tour = genetic_algorithm::solve(&make_problem(&cities), &opts, None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "GA tour is not valid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "GA tour is not valid on berlin52"
+    );
 }
 
 // ─── particle swarm optimisation ─────────────────────────────────────────────
@@ -177,7 +220,10 @@ fn particle_swarm_valid_tour_berlin52() {
 fn cuckoo_search_valid_tour_berlin52() {
     let cities = load_berlin52();
     let opts = CSOptions {
-        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        heuristic: HeuristicOptions {
+            epochs: 200,
+            ..HeuristicOptions::default()
+        },
         mutation_probability: 0.25,
         ..CSOptions::default()
     };
@@ -193,9 +239,17 @@ fn cuckoo_search_valid_tour_berlin52() {
 #[test]
 fn bellman_karp_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = bellman_karp::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = bellman_karp::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
-    assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "BHK tour is not valid"
+    );
     // known optimal: 0→1→2→3→4→0 = 4.0
     assert!(
         (tour.total - 4.0).abs() < 1e-3,
@@ -207,9 +261,17 @@ fn bellman_karp_optimal_tour_tsp5() {
 #[test]
 fn branch_bound_optimal_tour_tsp5() {
     let cities = tsp5_cities();
-    let tour = branch_bound::solve(&make_problem(&cities), &HeuristicOptions::default(), None, None);
+    let tour = branch_bound::solve(
+        &make_problem(&cities),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
 
-    assert!(is_valid_tour(tour.route(), &cities), "B&B tour is not valid");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "B&B tour is not valid"
+    );
     assert!(
         (tour.total - 4.0).abs() < 1e-3,
         "B&B should find optimal tour ~4.0, got {}",
@@ -222,21 +284,30 @@ fn branch_bound_optimal_tour_tsp5() {
 #[test]
 fn parser_loads_gr17_lower_diag_row() {
     let data = load_tsp("gr17.tsp");
-    assert!(data.has_explicit_weights(), "gr17 should have explicit weights");
+    assert!(
+        data.has_explicit_weights(),
+        "gr17 should have explicit weights"
+    );
     assert_eq!(data.cities().len(), 17, "gr17 has 17 cities");
 }
 
 #[test]
 fn parser_loads_bayg29_upper_row() {
     let data = load_tsp("bayg29.tsp");
-    assert!(data.has_explicit_weights(), "bayg29 should have explicit weights");
+    assert!(
+        data.has_explicit_weights(),
+        "bayg29 should have explicit weights"
+    );
     assert_eq!(data.cities().len(), 29, "bayg29 has 29 cities");
 }
 
 #[test]
 fn parser_loads_bays29_full_matrix() {
     let data = load_tsp("bays29.tsp");
-    assert!(data.has_explicit_weights(), "bays29 should have explicit weights");
+    assert!(
+        data.has_explicit_weights(),
+        "bays29 should have explicit weights"
+    );
     assert_eq!(data.cities().len(), 29, "bays29 has 29 cities");
 }
 
@@ -248,7 +319,10 @@ fn nn_valid_tour_gr17() {
     let problem = TspProblem::new(cities.clone(), dm);
     let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on gr17");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "NN tour is not valid on gr17"
+    );
     assert!(tour.total > 0.0);
 }
 
@@ -260,7 +334,10 @@ fn nn_valid_tour_bays29() {
     let problem = TspProblem::new(cities.clone(), dm);
     let tour = nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "NN tour is not valid on bays29");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "NN tour is not valid on bays29"
+    );
     assert!(tour.total > 0.0);
 }
 
@@ -272,7 +349,10 @@ fn two_opt_valid_tour_gr17() {
     let problem = TspProblem::new(cities.clone(), dm);
     let tour = two_opt::solve(&problem, &HeuristicOptions::default(), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "2-opt tour is not valid on gr17");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "2-opt tour is not valid on gr17"
+    );
     // optimal is 2085; allow 1.5×
     assert!(
         tour.total < 2085.0 * 1.5,
@@ -291,7 +371,10 @@ fn bellman_karp_optimal_ring6_explicit() {
     let problem = TspProblem::new(cities.clone(), dm);
     let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on ring6");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "BHK tour is not valid on ring6"
+    );
     assert!(
         (tour.total - 60.0).abs() < 1.0,
         "BHK should find optimal 60 on ring6, got {}",
@@ -307,7 +390,10 @@ fn bellman_karp_optimal_gr17() {
     let problem = TspProblem::new(cities.clone(), dm);
     let tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
-    assert!(is_valid_tour(tour.route(), &cities), "BHK tour is not valid on gr17");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "BHK tour is not valid on gr17"
+    );
     assert!(
         (tour.total - 2085.0).abs() < 1.0,
         "BHK should find optimal ~2085 on gr17, got {}",
@@ -321,19 +407,28 @@ fn bellman_karp_optimal_gr17() {
 fn flower_pollination_valid_tour_berlin52() {
     let cities = load_berlin52();
     let opts = FPAOptions {
-        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        heuristic: HeuristicOptions {
+            epochs: 200,
+            ..HeuristicOptions::default()
+        },
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };
     let tour = flower_pollination::solve(&make_problem(&cities), &opts, None, None);
-    assert!(is_valid_tour(tour.route(), &cities), "FPA tour invalid on berlin52");
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "FPA tour invalid on berlin52"
+    );
 }
 
 #[test]
 fn flower_pollination_tour_is_finite_and_positive() {
     let cities = load_berlin52();
     let opts = FPAOptions {
-        heuristic: HeuristicOptions { epochs: 200, ..HeuristicOptions::default() },
+        heuristic: HeuristicOptions {
+            epochs: 200,
+            ..HeuristicOptions::default()
+        },
         mutation_probability: 0.8,
         ..FPAOptions::default()
     };

--- a/tests/three_opt_test.rs
+++ b/tests/three_opt_test.rs
@@ -4,14 +4,15 @@
 /// Slow tests on berlin52 and att48 are marked #[ignore] and can be run with:
 ///   cargo test --test three_opt_test -- --include-ignored
 use std::path::Path;
-use teeline::tsp::{distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib, HeuristicOptions, TspProblem};
+use teeline::tsp::{
+    HeuristicOptions, TspProblem, distance_matrix, kdtree, nearest_neighbor, three_opt, tsplib,
+};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn load_tsp(fixture: &str) -> tsplib::TspLibData {
     let path = Path::new("tests/fixtures").join(fixture);
-    tsplib::read_from_file(&path)
-        .unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
+    tsplib::read_from_file(&path).unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
 }
 
 fn build_dm(cities: &[kdtree::KDPoint]) -> distance_matrix::DistanceMatrix {
@@ -32,7 +33,13 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 }
 
 fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
-    nearest_neighbor::solve(&make_problem(cities.to_vec()), &HeuristicOptions::default(), None, None).total
+    nearest_neighbor::solve(
+        &make_problem(cities.to_vec()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    )
+    .total
 }
 
 // ─── fast integration tests (gr17, 17 cities) ────────────────────────────────
@@ -40,14 +47,25 @@ fn nn_tour_length(cities: &[kdtree::KDPoint]) -> f32 {
 #[test]
 fn three_opt_valid_tour_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
+    let tour = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
     assert!(is_valid_tour(tour.route(), &cities), "gr17 tour is invalid");
 }
 
 #[test]
 fn three_opt_improves_on_gr17() {
     let cities = load_tsp("gr17.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    )
+    .total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -62,15 +80,29 @@ fn three_opt_improves_on_gr17() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
-    assert!(is_valid_tour(tour.route(), &cities), "berlin52 tour is invalid");
+    let tour = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "berlin52 tour is invalid"
+    );
 }
 
 #[test]
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_berlin52() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    )
+    .total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,
@@ -82,15 +114,29 @@ fn three_opt_improves_on_berlin52() {
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_valid_tour_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let tour = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None);
-    assert!(is_valid_tour(tour.route(), &cities), "att48 tour is invalid");
+    let tour = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    );
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "att48 tour is invalid"
+    );
 }
 
 #[test]
 #[ignore = "slow in debug mode (~minutes); run with: cargo test --test three_opt_test -- --include-ignored"]
 fn three_opt_improves_on_att48() {
     let cities = load_tsp("att48.tsp").cities().to_vec();
-    let three_opt_total = three_opt::solve(&make_problem(cities.clone()), &HeuristicOptions::default(), None, None).total;
+    let three_opt_total = three_opt::solve(
+        &make_problem(cities.clone()),
+        &HeuristicOptions::default(),
+        None,
+        None,
+    )
+    .total;
     let nn_total = nn_tour_length(&cities);
     assert!(
         three_opt_total < nn_total,

--- a/tests/wasm_component.rs
+++ b/tests/wasm_component.rs
@@ -48,11 +48,31 @@ fn make_store(engine: &Engine) -> Store<HostState> {
 fn five_cities() -> Vec<crate::teeline::solver::types::City> {
     use crate::teeline::solver::types::City;
     vec![
-        City { id: 0, x: 565.0, y: 575.0 },
-        City { id: 1, x: 25.0, y: 185.0 },
-        City { id: 2, x: 345.0, y: 750.0 },
-        City { id: 3, x: 945.0, y: 685.0 },
-        City { id: 4, x: 845.0, y: 655.0 },
+        City {
+            id: 0,
+            x: 565.0,
+            y: 575.0,
+        },
+        City {
+            id: 1,
+            x: 25.0,
+            y: 185.0,
+        },
+        City {
+            id: 2,
+            x: 345.0,
+            y: 750.0,
+        },
+        City {
+            id: 3,
+            x: 945.0,
+            y: 685.0,
+        },
+        City {
+            id: 4,
+            x: 845.0,
+            y: 655.0,
+        },
     ]
 }
 


### PR DESCRIPTION
## Summary

- Adds `Taskfile.yml` at project root with 15 standardised tasks for build, test, lint, format, run, bench, and WASM workflows
- Adds **Development** section to `README.md` with install instructions and key workflows
- Commits ADR-002 to GitKB documenting the Taskfile choice over Makefile/just/cargo-make
- Applies `rustfmt` across all source files (pre-existing formatting drift)

## Changes from original issue proposal

| Original | Updated |
|----------|---------|
| `cmd:` (singular) | `cmds:` (list) — required by Taskfile v3 |
| No WASM task | Added `build:wasm` (`cargo component build`) |
| No e2e task | Added `test:e2e` (BATS suite, added in PR #90) + `test:all` |
| `bench:berlin52` used `--disable_progress` | Removed (flag no longer exists); added `2>/dev/null` for stderr |
| bench solver list: nn 2opt sa ga tabu | Extended: `nn 2opt 3opt sa ga tabu pso cs fpa` |
| input `data/tsplib/berlin52.tsp` | Updated to `tests/fixtures/berlin52.tsp` |
| ADR-002 referenced in issue | ADR-002 committed to KB at `decisions/adr-002-taskfile` |

## Test plan

- [x] `task --list` shows all 15 tasks
- [x] `task build` compiles
- [x] `task lint` passes (clippy clean)
- [x] `task fmt:check` passes
- [x] `task run -- solve nn -i tests/fixtures/berlin52.tsp` produces output