### PR TITLE
feat: extract eframe GUI into teeline-gui workspace member (issue #91)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,19 +25,19 @@ jobs:
     - name: Add wasm32-wasip2 target
       run: rustup target add wasm32-wasip2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -p teeline -p teeline-gui --verbose
     - name: Build WASM component
       run: cargo component build --manifest-path teeline-wasm/Cargo.toml
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -p teeline -p teeline-gui --verbose
     - name: Run e2e tests (BATS)
       run: ./tests/bats/bin/bats tests/e2e/
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy -p teeline -p teeline-gui -- -D warnings
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Coverage
-      run: cargo llvm-cov --lcov --output-path lcov.info
+      run: cargo llvm-cov -p teeline -p teeline-gui --lcov --output-path lcov.info
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,7 +3776,6 @@ name = "teeline"
 version = "0.3.0"
 dependencies = [
  "clap",
- "eframe",
  "rand 0.9.4",
  "regex",
  "serde",
@@ -3785,6 +3784,17 @@ dependencies = [
  "tracing-subscriber",
  "wasmtime",
  "wasmtime-wasi",
+]
+
+[[package]]
+name = "teeline-gui"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "eframe",
+ "teeline",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "teeline-wasm"]
+members = [".", "teeline-wasm", "teeline-gui"]
 default-members = ["."]
 resolver = "2"
 
@@ -13,22 +13,12 @@ edition = "2024"
 name = "teeline"
 path = "src/lib.rs"
 
-[[bin]]
-name = "bin"
-path = "src/main.rs"
-required-features = ["gui"]
-
-[features]
-default = ["gui"]
-gui = ["dep:eframe"]
-
 [dependencies]
 clap = "4.6.1"
 rand = "0.9"
 regex = "1.12.3"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-eframe = { version = "0.33", features = ["x11", "wayland"], optional = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,31 @@ After finishing the book I took the [Discrete Optimization](https://coursera.org
 
 ### Build
 
-```bash
-# debug build (faster compile, slower runtime)
-cargo build
+The workspace has two crates: `teeline` (pure solver library) and `teeline-gui` (CLI binary + egui visualisation). To get the runnable binary, build `teeline-gui`:
 
-# optimised release build (recommended for real use)
-cargo build --release
+```bash
+# debug build — fast compile, slower runtime
+cargo build -p teeline-gui
+
+# optimised release build — recommended for real use
+cargo build -p teeline-gui --release
+
+# solver library only (no GUI, no eframe dependency — useful for embedding)
+cargo build -p teeline
+```
+
+With [go-task](https://taskfile.dev/) installed you can use the shorter aliases:
+
+```bash
+task build          # debug binary (teeline-gui)
+task build:release  # release binary
 ```
 
 ### Quick test
 
 ```bash
 # run the unit and integration test suite
-cargo test
+cargo test -p teeline -p teeline-gui
 
 # run end-to-end CLI tests (requires the debug binary to be built first)
 ./tests/bats/bin/bats tests/e2e/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,14 +2,14 @@ version: '3'
 
 tasks:
   build:
-    desc: Compile debug binary
+    desc: Compile debug binary (teeline-gui)
     cmds:
-      - cargo build
+      - cargo build -p teeline-gui
 
   build:release:
-    desc: Compile optimised binary
+    desc: Compile optimised binary (teeline-gui)
     cmds:
-      - cargo build --release
+      - cargo build -p teeline-gui --release
 
   build:wasm:
     desc: Build WASM component (requires cargo-component and wasm32-wasip2 target)

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -12,8 +12,6 @@ pub mod particle_swarm;
 pub mod pipeline;
 pub mod probability;
 pub mod progress;
-#[cfg(feature = "gui")]
-pub mod progress_eframe;
 pub mod random_shuffle;
 pub mod route;
 pub mod simulated_annealing;

--- a/teeline-gui/Cargo.toml
+++ b/teeline-gui/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "teeline-gui"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "teeline_gui"
+
+[[bin]]
+name = "bin"
+path = "src/main.rs"
+
+[dependencies]
+teeline = { path = ".." }
+eframe = { version = "0.33", features = ["x11", "wayland"] }
+clap = "4.6.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/teeline-gui/src/lib.rs
+++ b/teeline-gui/src/lib.rs
@@ -1,0 +1,2 @@
+mod plot;
+pub use plot::ProgressPlot;

--- a/teeline-gui/src/main.rs
+++ b/teeline-gui/src/main.rs
@@ -10,8 +10,9 @@ use teeline::config::{
 use teeline::tsp::{
     self, AppOptions, Solution, Solvers, TspProblem, distance_matrix,
     pipeline::{PipelineStage, run_pipeline},
-    progress, progress_eframe, tsplib,
+    progress, tsplib,
 };
+use teeline_gui::ProgressPlot;
 use tracing_subscriber::EnvFilter;
 
 // ---------------------------------------------------------------------------
@@ -329,11 +330,10 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         }
     };
 
-    let maybe_display: Option<progress_eframe::ProgressPlot>;
+    let maybe_display: Option<ProgressPlot>;
     let progress_tx;
     if args.get_flag("gui") {
-        let (display, tx) =
-            progress_eframe::ProgressPlot::new_with_channel(&cities, 1024.0, 1024.0, 50.0);
+        let (display, tx) = ProgressPlot::new_with_channel(&cities, 1024.0, 1024.0, 50.0);
         progress_tx = Some(tx);
         maybe_display = Some(display);
     } else {

--- a/teeline-gui/src/plot.rs
+++ b/teeline-gui/src/plot.rs
@@ -1,12 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc;
 
-use eframe;
 use eframe::egui::{self, Align2, Color32, FontId, Pos2, Rect, Stroke};
 
-use super::kdtree::KDPoint;
-use super::progress::ProgressMessage;
-use super::route::Route;
+use teeline::tsp::kdtree::KDPoint;
+use teeline::tsp::progress::ProgressMessage;
+use teeline::tsp::route::Route;
 
 type RectCoords = [f64; 4];
 type Point2D = (f64, f64);
@@ -429,8 +428,8 @@ fn point_to_viewport(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tsp::kdtree::build_points;
-    use crate::tsp::route::Route;
+    use teeline::tsp::kdtree::build_points;
+    use teeline::tsp::route::Route;
 
     #[test]
     fn test_route_edge_keys_triangle() {

--- a/tests/no_gui_build.rs
+++ b/tests/no_gui_build.rs
@@ -1,8 +1,0 @@
-use teeline::tsp::{AppOptions, HeuristicOptions};
-
-#[test]
-fn heuristic_options_default_no_gui() {
-    let defaults = HeuristicOptions::default();
-    assert_eq!(defaults.epochs, 10_000);
-    let _ = AppOptions::default();
-}


### PR DESCRIPTION
## Summary

Moves all GUI code out of the `teeline` library into a new `teeline-gui` workspace member, making `teeline` a pure solver library with no feature flags and no eframe dependency.

- **New crate** `teeline-gui/` with `[lib]` (exposes `ProgressPlot`) + `[[bin]] name = "bin"` (the CLI)
- `teeline-gui/src/plot.rs` — moved from `src/tsp/progress_eframe.rs`; updated `super::` imports to `teeline::tsp::`
- `teeline-gui/src/main.rs` — moved from `src/main.rs`; removed `#[cfg(feature = "gui")]` guards; uses `teeline_gui::ProgressPlot` directly
- `Cargo.toml` — removed `[features]`, `eframe` optional dep, and `[[bin]]` section
- `src/tsp/mod.rs` — removed `#[cfg(feature = "gui")] pub mod progress_eframe`
- Deleted `src/main.rs`, `src/tsp/progress_eframe.rs`, `tests/no_gui_build.rs`
- CI updated to use `-p teeline -p teeline-gui` (excludes `teeline-wasm` which requires `cargo-component`)
- ADR-006 committed to KB at `decisions/adr-006-teeline-gui-extraction`

`ProgressMessage` stays in `teeline` — it is the typed `mpsc` channel contract every solver sends to; moving it would create a circular dependency.

## Test plan

- [x] `cargo build -p teeline` — pure library, no eframe
- [x] `cargo build -p teeline-gui` — GUI crate compiles
- [x] `cargo test -p teeline -p teeline-gui` — all tests pass
- [x] `cargo clippy -p teeline -p teeline-gui -- -D warnings` — clean
- [x] `cargo component build --manifest-path teeline-wasm/Cargo.toml` — WASM still works
- [x] `./target/debug/bin solve nn -i tests/fixtures/berlin52.tsp` — binary runs headlessly
- [x] `./tests/bats/bin/bats tests/e2e/` — 24/24 BATS tests pass
