### PR TITLE
feat: add 'solvers' subcommand to list supported solvers (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cargo test -p teeline -p teeline-gui
 ./target/release/bin --help
 ./target/release/bin solve --help
 ./target/release/bin convert --help
+./target/release/bin solvers --help
 ```
 
 ### Install locally (optional)
@@ -135,6 +136,53 @@ Output format:
 ```
 
 First line: `<tour_cost> <optimised_flag>`. Second line: space-separated city IDs in visit order.
+
+---
+
+## Listing available solvers
+
+The `solvers` subcommand prints the solver catalogue so you never have to look up alias names manually.
+
+```bash
+# human-readable table: full name, short alias, type
+teeline solvers
+
+# one alias per line — suitable for shell scripting
+teeline solvers --short
+
+# heuristic solvers only (excludes exact algorithms)
+teeline solvers --heuristic --short
+
+# exact solvers only
+teeline solvers --exact
+```
+
+Example output:
+
+```
+NAME                   ALIAS    TYPE
+bellman_karp           bhk      exact
+branch_bound           —        exact
+nearest_neighbor       nn       heuristic
+two_opt                2opt     heuristic
+three_opt              3opt     heuristic
+simulated_annealing    sa       heuristic
+genetic_algorithm      ga       heuristic
+tabu_search            tabu     heuristic
+particle_swarm         pso      heuristic
+cuckoo_search          cs       heuristic
+flower_pollination     fpa      heuristic
+stochastic_hill        —        heuristic
+random_shuffle         shuffle  utility
+```
+
+The `--short` form is useful for driving scripts or benchmarks:
+
+```bash
+for solver in $(teeline solvers --heuristic --short); do
+    teeline solve $solver -i data/tsplib/berlin52.tsp 2>/dev/null | head -1
+done
+```
 
 ---
 
@@ -579,7 +627,7 @@ In short:
 3. Add tests — unit tests go inline with the source file; library integration tests go in `tests/`; CLI end-to-end tests go in `tests/e2e/` as BATS scripts.
 4. Open a pull request and wait for a code review.
 
-When adding a new solver, follow the pattern of the existing ones: a `solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution` function in its own file under `src/tsp/`, then register it in three places in `src/tsp/mod.rs`: the `Solvers` enum, the `FromStr` impl, and the `tsp::solve` dispatch match arm. The WASM surface picks it up automatically.
+When adding a new solver, follow the pattern of the existing ones: a `solve(cities: &[KDPoint], distances: &DistanceMatrix, options: &SolverOptions) -> Solution` function in its own file under `src/tsp/`, then register it in four places in `src/tsp/mod.rs`: the `Solvers` enum, the `FromStr` impl, the `tsp::solve` dispatch match arm, and `Solvers::all_meta()` (the catalogue used by the `solvers` subcommand). The WASM surface picks it up automatically.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,7 @@ tasks:
     deps: [build:release]
     cmds:
       - echo "=== berlin52 (optimal 7542) ==="
-      - for solver in nn 2opt 3opt sa ga tabu pso cs fpa; do printf "%-12s " $solver; ./target/release/bin solve $solver -i tests/fixtures/berlin52.tsp 2>/dev/null | head -1; done
+      - for solver in $(./target/release/bin solvers --heuristic --short); do printf "%-12s " $solver; ./target/release/bin solve $solver -i tests/fixtures/berlin52.tsp 2>/dev/null | head -1; done
 
   clean:
     desc: Remove build artifacts

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -107,6 +107,79 @@ impl Solvers {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Solver catalogue — single source of truth for the `solvers` subcommand
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SolverKind {
+    Exact,
+    Heuristic,
+    Utility,
+}
+
+impl SolverKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SolverKind::Exact => "exact",
+            SolverKind::Heuristic => "heuristic",
+            SolverKind::Utility => "utility",
+        }
+    }
+}
+
+pub struct SolverMeta {
+    pub name: &'static str,
+    pub alias: Option<&'static str>,
+    pub kind: SolverKind,
+}
+
+impl SolverMeta {
+    pub fn short(&self) -> &'static str {
+        self.alias.unwrap_or(self.name)
+    }
+}
+
+impl Solvers {
+    pub fn all_meta() -> &'static [SolverMeta] {
+        &[
+            SolverMeta { name: "bellman_karp", alias: Some("bhk"), kind: SolverKind::Exact },
+            SolverMeta { name: "branch_bound", alias: None, kind: SolverKind::Exact },
+            SolverMeta { name: "nearest_neighbor", alias: Some("nn"), kind: SolverKind::Heuristic },
+            SolverMeta { name: "two_opt", alias: Some("2opt"), kind: SolverKind::Heuristic },
+            SolverMeta { name: "three_opt", alias: Some("3opt"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "simulated_annealing",
+                alias: Some("sa"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "genetic_algorithm",
+                alias: Some("ga"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta { name: "tabu_search", alias: Some("tabu"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "particle_swarm",
+                alias: Some("pso"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta { name: "cuckoo_search", alias: Some("cs"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "flower_pollination",
+                alias: Some("fpa"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta { name: "stochastic_hill", alias: None, kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "random_shuffle",
+                alias: Some("shuffle"),
+                kind: SolverKind::Utility,
+            },
+        ]
+    }
+}
+
 impl FromStr for Solvers {
     type Err = &'static str;
 

--- a/teeline-gui/src/main.rs
+++ b/teeline-gui/src/main.rs
@@ -8,7 +8,7 @@ use teeline::config::{
     select_pipeline_source,
 };
 use teeline::tsp::{
-    self, AppOptions, Solution, Solvers, TspProblem, distance_matrix,
+    self, AppOptions, Solution, SolverKind, Solvers, TspProblem, distance_matrix,
     pipeline::{PipelineStage, run_pipeline},
     progress, tsplib,
 };
@@ -137,6 +137,29 @@ fn main() {
                 .required(false),
         );
 
+    let solvers_cmd = Command::new("solvers")
+        .about("List supported solvers")
+        .arg(
+            Arg::new("short")
+                .long("short")
+                .action(ArgAction::SetTrue)
+                .help("machine-readable: one alias per line (suitable for shell scripting)"),
+        )
+        .arg(
+            Arg::new("heuristic")
+                .long("heuristic")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("exact")
+                .help("show only heuristic solvers"),
+        )
+        .arg(
+            Arg::new("exact")
+                .long("exact")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("heuristic")
+                .help("show only exact solvers"),
+        );
+
     let cli = Command::new("Teeline")
         .version(tsp::VERSION)
         .author(tsp::AUTHOR)
@@ -145,12 +168,14 @@ fn main() {
         .subcommand(solve_cmd)
         .subcommand(pipeline_cmd)
         .subcommand(convert_cmd)
+        .subcommand(solvers_cmd)
         .get_matches();
 
     match cli.subcommand() {
         Some(("solve", args)) => run_solve(args),
         Some(("pipeline", args)) => run_pipeline_cmd(args),
         Some(("convert", args)) => run_convert(args),
+        Some(("solvers", args)) => run_solvers(args),
         _ => unreachable!("clap ensures a subcommand is always present"),
     }
 }
@@ -425,6 +450,34 @@ fn run_convert(args: &ArgMatches) {
         if let Err(e) = tsp::convert::convert_file(&input, &out_path) {
             eprintln!("error: {e}");
             std::process::exit(1);
+        }
+    }
+}
+
+fn run_solvers(args: &ArgMatches) {
+    let only_heuristic = args.get_flag("heuristic");
+    let only_exact = args.get_flag("exact");
+    let short = args.get_flag("short");
+
+    let all = Solvers::all_meta();
+    let filtered = all.iter().filter(|m| {
+        if only_heuristic {
+            m.kind == SolverKind::Heuristic
+        } else if only_exact {
+            m.kind == SolverKind::Exact
+        } else {
+            true
+        }
+    });
+
+    if short {
+        for m in filtered {
+            println!("{}", m.short());
+        }
+    } else {
+        println!("{:<22} {:<8} TYPE", "NAME", "ALIAS");
+        for m in filtered {
+            println!("{:<22} {:<8} {}", m.name, m.alias.unwrap_or("—"), m.kind.as_str());
         }
     }
 }

--- a/tests/e2e/solvers.bats
+++ b/tests/e2e/solvers.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# End-to-end CLI tests for the `solvers` subcommand.
+# Run: ./tests/bats/bin/bats tests/e2e/solvers.bats
+# Requires the debug binary to be built first: cargo build -p teeline-gui
+
+setup() {
+    REPO_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
+    BIN="$REPO_ROOT/target/debug/bin"
+}
+
+# ---------------------------------------------------------------------------
+# Default (table) output
+# ---------------------------------------------------------------------------
+
+@test "solvers exits 0" {
+    run "$BIN" solvers
+    [ "$status" -eq 0 ]
+}
+
+@test "solvers prints header row" {
+    run "$BIN" solvers
+    echo "$output" | grep -E '^NAME'
+}
+
+@test "solvers table includes nn as heuristic" {
+    run "$BIN" solvers
+    echo "$output" | grep -E 'nearest_neighbor\s+nn\s+heuristic'
+}
+
+@test "solvers table includes bhk as exact" {
+    run "$BIN" solvers
+    echo "$output" | grep -E 'bellman_karp\s+bhk\s+exact'
+}
+
+@test "solvers table includes random_shuffle as utility" {
+    run "$BIN" solvers
+    echo "$output" | grep -E 'random_shuffle\s+shuffle\s+utility'
+}
+
+# ---------------------------------------------------------------------------
+# --short output
+# ---------------------------------------------------------------------------
+
+@test "solvers --short prints one token per line without header" {
+    run "$BIN" solvers --short
+    [ "$status" -eq 0 ]
+    # No header line
+    echo "$output" | grep -v '^NAME'
+    # Each line is a single word (no spaces)
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[a-z0-9_-]+$ ]]
+    done <<< "$output"
+}
+
+@test "solvers --short output is usable in a for loop" {
+    run bash -c "\"$BIN\" solvers --short | wc -l"
+    [ "$status" -eq 0 ]
+    # At least 10 solvers
+    [ "$output" -ge 10 ]
+}
+
+# ---------------------------------------------------------------------------
+# --heuristic filter
+# ---------------------------------------------------------------------------
+
+@test "solvers --heuristic --short excludes bhk" {
+    run "$BIN" solvers --heuristic --short
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -v '^bhk$'
+    ! echo "$output" | grep -qx 'bhk'
+}
+
+@test "solvers --heuristic --short excludes branch_bound" {
+    run "$BIN" solvers --heuristic --short
+    ! echo "$output" | grep -qx 'branch_bound'
+}
+
+@test "solvers --heuristic --short includes nn" {
+    run "$BIN" solvers --heuristic --short
+    echo "$output" | grep -qx 'nn'
+}
+
+# ---------------------------------------------------------------------------
+# --exact filter
+# ---------------------------------------------------------------------------
+
+@test "solvers --exact --short returns only bhk and branch_bound" {
+    run "$BIN" solvers --exact --short
+    [ "$status" -eq 0 ]
+    # Must contain bhk
+    echo "$output" | grep -qx 'bhk'
+    # Must contain branch_bound
+    echo "$output" | grep -qx 'branch_bound'
+    # Must contain exactly 2 lines
+    [ "$(echo "$output" | wc -l)" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Conflicting flags
+# ---------------------------------------------------------------------------
+
+@test "solvers --heuristic --exact exits non-zero" {
+    run "$BIN" solvers --heuristic --exact
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `SolverKind` + `SolverMeta` types and `Solvers::all_meta()` to `teeline` — the single source of truth for the solver catalogue (name, alias, kind)
- New `solvers` subcommand in `teeline-gui` with `--short`, `--heuristic`, `--exact` flags
- `Taskfile.yml` `bench:berlin52` now derives solver list dynamically via `$(bin solvers --heuristic --short)` — no more hardcoded alias list
- 12 BATS e2e tests in `tests/e2e/solvers.bats`

Closes #93

## Test plan

- [x] `cargo clippy -p teeline -p teeline-gui -- -D warnings` clean
- [x] `cargo test -p teeline -p teeline-gui` — 274 tests pass
- [x] `./tests/bats/bin/bats tests/e2e/solvers.bats` — 12/12 pass
- [x] `bin solvers` prints table with NAME / ALIAS / TYPE columns
- [x] `bin solvers --short` prints one alias per line, no header
- [x] `bin solvers --heuristic --short` excludes bhk and branch_bound
- [x] `bin solvers --exact --short` returns only bhk and branch_bound (2 lines)
- [x] `bin solvers --heuristic --exact` exits non-zero (conflicting flags)