### PR TITLE
fix: DistanceMatrix correctness and panic safety (issue #97)

### DIFF
--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -45,7 +45,7 @@ pub fn solve(
             .distance_by_pos(i, last_pos)
             .unwrap_or(UNKNOWN_DISTANCE);
 
-        if let Some(city_id) = dists.pos2city_id(&i)
+        if let Some(city_id) = dists.pos2city_id(i)
             && let Some(tx) = progress_tx
         {
             let _ = tx.send(ProgressMessage::CityChange(city_id));
@@ -149,7 +149,7 @@ fn read_optimal_route(opt: &DPTable, dm: &DistanceMatrix, n: usize, best_val: f3
 
     let route: Vec<usize> = route_ids
         .iter()
-        .map(|pos| dm.pos2city_id(pos).unwrap_or(0))
+        .map(|&pos| dm.pos2city_id(pos).unwrap_or(0))
         .collect();
 
     route

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -75,6 +75,14 @@ impl DistanceMatrix {
         let city_idx: HashMap<usize, usize> = cities.iter().map(|(k, c)| (c.id, *k)).collect();
 
         assert!(n == city_idx.len(), "city_idx size differs from n cities");
+        assert_eq!(
+            distances.len(),
+            n * (n - 1) / 2,
+            "distances length {} != n*(n-1)/2={} for n={}",
+            distances.len(),
+            n * (n - 1) / 2,
+            n
+        );
         DistanceMatrix {
             n,
             size: distances.len(),
@@ -117,6 +125,14 @@ impl DistanceMatrix {
         self.items.is_empty()
     }
 
+    pub fn num_cities(&self) -> usize {
+        self.n
+    }
+
+    pub fn num_distances(&self) -> usize {
+        self.size
+    }
+
     pub fn distances(&self) -> &[f32] {
         &self.items
     }
@@ -127,18 +143,13 @@ impl DistanceMatrix {
         if pos1 == pos2 {
             return Ok(0.0);
         }
-
-        let from_city = std::cmp::max(pos1, pos2);
-        let to_city = std::cmp::min(pos1, pos2);
-
-        let n_items_before = (from_city - 1) * from_city / 2;
-        if n_items_before > self.size {
-            return Err("city with biggest id is not in distance matrix");
+        if pos1 >= self.n || pos2 >= self.n {
+            return Err("position out of range");
         }
-
-        let distance_idx = n_items_before + to_city;
-
-        Ok(self.items[distance_idx])
+        let from = pos1.max(pos2);
+        let to = pos1.min(pos2);
+        let idx = from * (from - 1) / 2 + to;
+        self.items.get(idx).copied().ok_or("distance index out of range")
     }
 
     /// returns distance between city n and m
@@ -147,21 +158,11 @@ impl DistanceMatrix {
     /// here bigger cityId works like padding, then smaller id acts as index from padding
     pub fn distance_between(&self, city_id1: usize, city_id2: usize) -> Result<f32, &'static str> {
         if city_id1 == city_id2 {
-            return Ok(0.0); // elements on the diagonal
+            return Ok(0.0);
         }
-
-        // translate city ids to matrix id
-        let pos1 = self
-            .city_idx
-            .get(&city_id1)
-            .expect("city_id1 doesnt exists in index");
-
-        let pos2 = self
-            .city_idx
-            .get(&city_id2)
-            .expect("city_id2 doesnt exists in index");
-
-        self.distance_by_pos(*pos1, *pos2)
+        let pos1 = self.city_idx.get(&city_id1).copied().ok_or("city_id1 not in index")?;
+        let pos2 = self.city_idx.get(&city_id2).copied().ok_or("city_id2 not in index")?;
+        self.distance_by_pos(pos1, pos2)
     }
 
     /// returns list of distances from city N, where 0 distance from the city;
@@ -172,18 +173,28 @@ impl DistanceMatrix {
     }
 
     pub fn tour_length(&self, path: &[usize]) -> f32 {
-        let tour_length = path.len();
-        if tour_length < 2 {
+        if path.len() < 2 {
             return 0.0;
         }
-
-        let last_city_id = *path.last().unwrap();
-        let mut total = self.distance_between(last_city_id, path[0]).unwrap();
-
-        for i in 1..tour_length {
-            total += self.distance_between(path[i], path[i - 1]).unwrap();
+        // Translate city IDs to positions upfront; unknown city ID → return 0.0.
+        let positions: Option<Vec<usize>> = path.iter().map(|&id| self.city_id2pos(id)).collect();
+        match positions {
+            None => 0.0,
+            Some(pos_path) => self.tour_length_by_pos(&pos_path),
         }
+    }
 
+    /// Position-based tour length — no HashMap lookups per edge.
+    /// All positions must be in 0..num_cities().
+    pub fn tour_length_by_pos(&self, path: &[usize]) -> f32 {
+        if path.len() < 2 {
+            return 0.0;
+        }
+        let last = *path.last().unwrap();
+        let mut total = self.distance_by_pos(last, path[0]).unwrap_or(0.0);
+        for w in path.windows(2) {
+            total += self.distance_by_pos(w[0], w[1]).unwrap_or(0.0);
+        }
         total
     }
 
@@ -191,45 +202,45 @@ impl DistanceMatrix {
         &self.city_idx
     }
 
-    pub fn pos2city_id(&self, pos: &usize) -> Option<usize> {
-        self.cities.get(pos).map(|c| c.id)
+    pub fn pos2city_id(&self, pos: usize) -> Option<usize> {
+        self.cities.get(&pos).map(|c| c.id)
     }
 
-    pub fn city_id2pos(&self, city_id: &usize) -> Option<usize> {
-        self.city_idx.get(city_id).copied()
+    pub fn city_id2pos(&self, city_id: usize) -> Option<usize> {
+        self.city_idx.get(&city_id).copied()
     }
 
     pub fn nearest(&self, target: &KDPoint, n: usize) -> NearestResult {
         let mut search_result = NearestResult::new(*target, f32::INFINITY, n);
 
-        if let Some(city_pos) = self.city_id2pos(&target.id) {
-            let distances_from_target = self.distances_from_index(city_pos);
-            for (pos, distance) in distances_from_target.iter().enumerate() {
-                // Look up by matrix position, not city_id.  city_id != pos when city IDs
-                // are not 0-based (e.g. 1-indexed TSPLIB files like berlin52.tsp).
-                if let Some(pt) = self.cities.get(&pos) {
-                    search_result.add(*pt, *distance);
-                }
+        let city_pos = match self.city_id2pos(target.id) {
+            Some(pos) => pos,
+            None => return search_result, // unknown target → empty result, no panic
+        };
+
+        let distances_from_target = self.distances_from_index(city_pos);
+        for (pos, distance) in distances_from_target.iter().enumerate() {
+            if pos == city_pos {
+                continue; // skip self (belt-and-suspenders; add() already gates on pt.id)
             }
-        } else {
-            panic!("DistanceMatrix.nearest with unknow_id");
+            // Look up by matrix position, not city_id.  city_id != pos when city IDs
+            // are not 0-based (e.g. 1-indexed TSPLIB files like berlin52.tsp).
+            if let Some(pt) = self.cities.get(&pos) {
+                search_result.add(*pt, *distance);
+            }
         }
 
         search_result
     }
 
     fn distances_from_index(&self, pos: usize) -> Vec<f32> {
-        let mut distances: Vec<f32> = vec![];
-
+        let mut distances = Vec::with_capacity(self.n);
         for i in 0..pos {
-            distances.push(self.distance_by_pos(pos, i).unwrap_or(-1.0));
+            distances.push(self.distance_by_pos(pos, i).expect("valid position in distances_from_index"));
         }
-
-        let n_cities = self.n;
-        for i in pos..n_cities {
-            distances.push(self.distance_by_pos(i, pos).unwrap_or(-1.0));
+        for i in pos..self.n {
+            distances.push(self.distance_by_pos(i, pos).expect("valid position in distances_from_index"));
         }
-
         distances
     }
 }

--- a/tests/test_kdtree_and_distance_matrix.rs
+++ b/tests/test_kdtree_and_distance_matrix.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use teeline::tsp::distance_matrix::DistanceMatrix;
 use teeline::tsp::kdtree::KDPoint;
 use teeline::tsp::{distance_matrix, kdtree};
 
@@ -45,6 +46,94 @@ fn test_knn_n_gt_1_matches_oracle() {
             "n={n}: kdtree={kd_ids:?}  oracle={dm_ids:?}"
         );
     }
+}
+
+// ── Issue #97 regression tests ───────────────────────────────────────────────
+
+/// nearest() must not include the query city itself (self-distance 0.0).
+/// Guaranteed by NearestResult::add() since #95 — test documents the contract.
+#[test]
+fn test_nearest_excludes_self() {
+    let cities = kdtree::build_points(&[
+        vec![0.0, 0.0], // id=0 <- target
+        vec![1.0, 0.0], // id=1
+        vec![2.0, 0.0], // id=2
+    ]);
+    let dm = distance_matrix::from_cities(&cities);
+    let result = dm.nearest(&cities[0], 2);
+    let ids: Vec<usize> = result.nearest().iter().map(|r| r.point.id).collect();
+    assert!(!ids.contains(&0), "self must not appear in nearest results: {ids:?}");
+}
+
+/// distance_by_pos must return Err (not panic) for an out-of-range position.
+/// Bug: old guard `n_items_before > size` passes for pos == n, then panics on
+/// direct index access.
+#[test]
+fn test_distance_by_pos_out_of_range_returns_err() {
+    let cities = kdtree::build_points(&[
+        vec![0.0, 0.0],
+        vec![1.0, 0.0],
+        vec![2.0, 0.0], // n=3
+    ]);
+    let dm = DistanceMatrix::from_cities(&cities).unwrap();
+    assert!(dm.distance_by_pos(3, 0).is_err(), "pos >= n must be Err");
+    assert!(dm.distance_by_pos(0, 3).is_err(), "pos >= n must be Err");
+}
+
+/// distance_between must return Err for an unknown city ID, not panic.
+#[test]
+fn test_distance_between_unknown_city_returns_err() {
+    let cities = kdtree::build_points(&[vec![0.0, 0.0], vec![1.0, 0.0]]);
+    let dm = DistanceMatrix::from_cities(&cities).unwrap();
+    assert!(dm.distance_between(99, 0).is_err());
+    assert!(dm.distance_between(0, 99).is_err());
+}
+
+/// nearest() must return an empty result (not panic) for an unknown target city ID.
+#[test]
+fn test_nearest_unknown_target_returns_empty() {
+    let cities = kdtree::build_points(&[
+        vec![0.0, 0.0],
+        vec![1.0, 0.0],
+        vec![2.0, 0.0],
+    ]);
+    let dm = distance_matrix::from_cities(&cities);
+    let unknown = KDPoint::new_with_id(99, &[0.0, 0.0]);
+    let result = dm.nearest(&unknown, 2);
+    assert_eq!(0, result.nearest().len(), "unknown target → empty result");
+}
+
+/// tour_length must not panic for a path that contains an unknown city ID.
+#[test]
+fn test_tour_length_with_unknown_city_does_not_panic() {
+    let cities = kdtree::build_points(&[
+        vec![0.0, 0.0],
+        vec![0.0, 0.5],
+        vec![0.0, 1.0],
+        vec![1.0, 1.0],
+        vec![1.0, 0.0],
+    ]);
+    let dm = DistanceMatrix::from_cities(&cities).unwrap();
+    let _ = dm.tour_length(&[0, 99, 1]); // must not panic
+}
+
+/// tour_length_by_pos must return the same result as tour_length for a valid path.
+#[test]
+fn test_tour_length_by_pos_matches_tour_length() {
+    let cities = kdtree::build_points(&[
+        vec![0.0, 0.0],
+        vec![0.0, 0.5],
+        vec![0.0, 1.0],
+        vec![1.0, 1.0],
+        vec![1.0, 0.0],
+    ]);
+    let dm = DistanceMatrix::from_cities(&cities).unwrap();
+    let city_id_path = vec![0usize, 1, 2, 3, 4];
+    let pos_path = vec![0usize, 1, 2, 3, 4]; // positions == ids for 0-indexed cities
+    assert_eq!(
+        dm.tour_length(&city_id_path),
+        dm.tour_length_by_pos(&pos_path)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **`distance_by_pos`**: fix off-by-one bounds guard (`pos >= n` instead of `n_items_before > size`); use `.get()` instead of direct index — returns `Err` instead of panicking for `pos == n`
- **`distance_between`**: replace `.expect()` with `?` — returns `Err` for unknown city IDs instead of panicking
- **`nearest()`**: return empty `NearestResult` for unknown target city (was `panic!()`); add explicit self-skip in the enumeration loop
- **`tour_length`**: no more `unwrap()` — translates city IDs to positions upfront, returns `0.0` for any unknown city ID; delegates to `tour_length_by_pos` internally
- **`tour_length_by_pos`**: new position-space hot-loop variant — 2 fewer HashMap lookups per edge
- **`distances_from_index`**: remove `-1.0` sentinel (silently ranked failed lookups as closest neighbour); use `expect` since the `Err` path is unreachable after the bounds fix
- **`new()`**: assert distance-vec length matches `n*(n-1)/2` at construction
- **`num_cities()`** / **`num_distances()`**: unambiguous accessors (`len()` returned triangle size, not city count)
- **`pos2city_id`** / **`city_id2pos`**: take `usize` by value (were `&usize`); update `bellman_karp.rs` call sites

No solver changes needed — `tour_length() -> f32` API is unchanged.

Note: the "self in results" bug from the issue was already fixed by the `NearestResult::add()` guard added in #95. A regression test documents the contract.

## Test plan

- [x] 6 new regression tests — all pass
- [x] `cargo test` — 209 tests pass (was 203)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Solver smoke tests: `bhk tiny5=4.0` ✓, `bhk gr17=2085` ✓, `branch_bound tiny5=4.0` ✓, `nn tiny5=4.0` ✓