### PR TITLE
feat(teeline-qt): Welcome / File Picker screen (issue #103)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ name = "teeline-qt"
 version = "0.1.0"
 dependencies = [
  "qtbridge",
+ "serde_json",
  "teeline",
 ]
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,26 @@ tasks:
     cmds:
       - cargo build -p teeline-cli --release
 
+  build:qt:
+    desc: Compile teeline-qt (requires Qt 6 at ~/Qt/6.11.1/gcc_64)
+    vars:
+      QT_PREFIX: "{{.HOME}}/Qt/6.11.1/gcc_64"
+    env:
+      PATH: "{{.QT_PREFIX}}/bin:{{.PATH}}"
+      LD_LIBRARY_PATH: "{{.QT_PREFIX}}/lib:{{.LD_LIBRARY_PATH}}"
+    cmds:
+      - cargo build -p teeline-qt
+
+  run:qt:
+    desc: Run teeline-qt (requires Qt 6 at ~/Qt/6.11.1/gcc_64)
+    vars:
+      QT_PREFIX: "{{.HOME}}/Qt/6.11.1/gcc_64"
+    env:
+      PATH: "{{.QT_PREFIX}}/bin:{{.PATH}}"
+      LD_LIBRARY_PATH: "{{.QT_PREFIX}}/lib:{{.LD_LIBRARY_PATH}}"
+    cmds:
+      - ./target/debug/teeline-qt
+
   build:wasm:
     desc: Build WASM component (requires cargo-component and wasm32-wasip2 target)
     cmds:

--- a/teeline-qt/Cargo.toml
+++ b/teeline-qt/Cargo.toml
@@ -16,3 +16,4 @@ dist = false  # requires Qt runtime; not a standalone distributable binary
 [dependencies]
 qtbridge = { git = "https://github.com/qt/qtbridge-rust", branch = "dev" }
 teeline = { path = ".." }
+serde_json = "1"

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -96,11 +96,13 @@ ApplicationWindow {
                     width: 200
                     height: 200
 
-                    Rectangle { anchors.fill: parent; color: "#0f0f23"; radius: 4 }
-
                     onPaint: {
                         var ctx = getContext("2d")
-                        ctx.clearRect(0, 0, width, height)
+                        ctx.fillStyle = "#0f0f23"
+                        ctx.beginPath()
+                        ctx.roundedRect(0, 0, width, height, 4, 4)
+                        ctx.fill()
+
                         var raw = FileLoader.citiesJson
                         if (!raw || raw === "[]") return
                         var cities = JSON.parse(raw)

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -1,16 +1,226 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Dialogs
 import teeline_qt
 
 ApplicationWindow {
+    id: root
     visible: true
-    width: 640
-    height: 480
-    title: "teeline-qt"
+    width: 900
+    height: 640
+    title: "teeline-qt — TSP Solver"
 
-    Text {
-        anchors.centerIn: parent
-        text: "teeline-qt"
-        font.pixelSize: 32
+    // ── Inline component: WelcomePage ───────────────────────────────────────
+    component WelcomePage: Page {
+        signal nextRequested()
+
+        background: Rectangle { color: "#1a1a2e" }
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 32
+            spacing: 24
+
+            Text {
+                text: "teeline-qt"
+                font.pixelSize: 28
+                font.bold: true
+                color: "#e0e0e0"
+            }
+
+            // Drop zone
+            Rectangle {
+                Layout.fillWidth: true
+                height: 160
+                radius: 8
+                color: dropArea.containsDrag ? "#2a3f5f" : "#16213e"
+                border.color: dropArea.containsDrag ? "#4fc3f7" : "#3a4f7a"
+                border.width: 2
+
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    spacing: 12
+                    Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Drop a .tsp file here"
+                        font.pixelSize: 16
+                        color: "#9e9e9e"
+                    }
+                    Button {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Browse…"
+                        onClicked: fileDialog.open()
+                    }
+                }
+
+                DropArea {
+                    id: dropArea
+                    anchors.fill: parent
+                    onDropped: function(drop) {
+                        if (drop.urls.length > 0)
+                            FileLoader.loadFile(drop.urls[0].toString())
+                    }
+                }
+            }
+
+            // Error message
+            Text {
+                visible: FileLoader.errorMessage !== ""
+                text: FileLoader.errorMessage
+                color: "#ef5350"
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            // Metadata + mini-map
+            RowLayout {
+                visible: FileLoader.isLoaded
+                Layout.fillWidth: true
+                spacing: 24
+
+                ColumnLayout {
+                    spacing: 8
+                    Layout.preferredWidth: 240
+                    Text { text: "Problem:";       color: "#9e9e9e"; font.pixelSize: 12 }
+                    Text { text: FileLoader.problemName;    color: "#e0e0e0"; font.pixelSize: 14; font.bold: true }
+                    Text { text: "Cities:";        color: "#9e9e9e"; font.pixelSize: 12 }
+                    Text { text: FileLoader.cityCount;      color: "#e0e0e0"; font.pixelSize: 14 }
+                    Text { text: "Edge weights:";  color: "#9e9e9e"; font.pixelSize: 12 }
+                    Text { text: FileLoader.edgeWeightType; color: "#e0e0e0"; font.pixelSize: 14 }
+                }
+
+                Canvas {
+                    id: miniMap
+                    width: 200
+                    height: 200
+
+                    Rectangle { anchors.fill: parent; color: "#0f0f23"; radius: 4 }
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+                        var raw = FileLoader.citiesJson
+                        if (!raw || raw === "[]") return
+                        var cities = JSON.parse(raw)
+                        var pad = 8, w = width - pad*2, h = height - pad*2
+                        ctx.fillStyle = "#00e676"
+                        for (var i = 0; i < cities.length; i++) {
+                            ctx.beginPath()
+                            ctx.arc(pad + cities[i].x * w, pad + cities[i].y * h, 2.5, 0, Math.PI*2)
+                            ctx.fill()
+                        }
+                    }
+
+                    Connections {
+                        target: FileLoader
+                        function onCitiesJsonChanged() { miniMap.requestPaint() }
+                    }
+                }
+            }
+
+            // Recent files (persisted via Rust/FileLoader)
+            ColumnLayout {
+                id: recentSection
+                property var recentList: FileLoader.recentFilesJson !== "[]"
+                                         ? JSON.parse(FileLoader.recentFilesJson) : []
+                visible: recentList.length > 0
+                spacing: 4
+                Text { text: "Recent files"; color: "#9e9e9e"; font.pixelSize: 12 }
+                Repeater {
+                    model: recentSection.recentList.slice(0, 5)
+                    delegate: Text {
+                        required property string modelData
+                        text: modelData
+                        color: "#4fc3f7"
+                        font.pixelSize: 13
+                        elide: Text.ElideLeft
+                        width: 420
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: FileLoader.loadFile(modelData)
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.fillHeight: true }
+
+            // Bottom bar
+            RowLayout {
+                Layout.fillWidth: true
+                Switch {
+                    text: "Advanced (Pipeline Builder)"
+                    enabled: false
+                    opacity: 0.4
+                }
+                Item { Layout.fillWidth: true }
+                Button {
+                    text: "Next →"
+                    enabled: FileLoader.isLoaded
+                    highlighted: FileLoader.isLoaded
+                    onClicked: nextRequested()
+                }
+            }
+        }
+
+        FileDialog {
+            id: fileDialog
+            title: "Open TSPLIB file"
+            nameFilters: ["TSPLIB files (*.tsp)", "All files (*)"]
+            onAccepted: FileLoader.loadFile(selectedFile.toString())
+        }
+
+    }
+
+    // ── Inline component: SolverPage (placeholder — issue #104) ────────────
+    component SolverPage: Page {
+        signal backRequested()
+        background: Rectangle { color: "#1a1a2e" }
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 16
+            Text {
+                text: "Solver Picker"
+                font.pixelSize: 24
+                color: "#e0e0e0"
+                Layout.alignment: Qt.AlignHCenter
+            }
+            Text {
+                text: "Coming in issue #104"
+                font.pixelSize: 14
+                color: "#9e9e9e"
+                Layout.alignment: Qt.AlignHCenter
+            }
+            Button {
+                text: "← Back"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: backRequested()
+            }
+        }
+    }
+
+    // ── StackView navigation ────────────────────────────────────────────────
+    StackView {
+        id: stackView
+        anchors.fill: parent
+        initialItem: welcomeComp
+    }
+
+    Component {
+        id: welcomeComp
+        WelcomePage {
+            onNextRequested: stackView.push(solverComp)
+        }
+    }
+
+    Component {
+        id: solverComp
+        SolverPage {
+            onBackRequested: stackView.pop()
+        }
     }
 }

--- a/teeline-qt/src/file_loader.rs
+++ b/teeline-qt/src/file_loader.rs
@@ -1,0 +1,139 @@
+use std::path::Path;
+use teeline::tsp::{kdtree::KDPoint, tsplib};
+use qtbridge::qobject_impl;
+
+pub struct FileLoader {
+    city_count: i32,
+    problem_name: String,
+    edge_weight_type: String,
+    is_loaded: bool,
+    error_message: String,
+    cities_json: String,
+    recent_files_json: String,
+}
+
+impl Default for FileLoader {
+    fn default() -> Self {
+        Self {
+            city_count: 0,
+            problem_name: String::new(),
+            edge_weight_type: String::new(),
+            is_loaded: false,
+            error_message: String::new(),
+            cities_json: "[]".to_string(),
+            recent_files_json: load_recent_files(),
+        }
+    }
+}
+
+#[qobject_impl(Singleton)]
+impl FileLoader {
+    qproperty!("cityCount",        Member = city_count,        Write = set_city_count,        Notify = "cityCountChanged");
+    qproperty!("problemName",      Member = problem_name,      Write = set_problem_name,      Notify = "problemNameChanged");
+    qproperty!("edgeWeightType",   Member = edge_weight_type,  Write = set_edge_weight_type,  Notify = "edgeWeightTypeChanged");
+    qproperty!("isLoaded",         Member = is_loaded,         Write = set_is_loaded,         Notify = "isLoadedChanged");
+    qproperty!("errorMessage",     Member = error_message,     Write = set_error_message,     Notify = "errorMessageChanged");
+    qproperty!("citiesJson",       Member = cities_json,       Write = set_cities_json,       Notify = "citiesJsonChanged");
+    qproperty!("recentFilesJson",  Member = recent_files_json, Write = set_recent_files_json, Notify = "recentFilesJsonChanged");
+
+    fn set_city_count(&mut self, v: i32)       { self.city_count = v;        self.city_count_changed(); }
+    fn set_problem_name(&mut self, v: String)   { self.problem_name = v;      self.problem_name_changed(); }
+    fn set_edge_weight_type(&mut self, v: String) { self.edge_weight_type = v; self.edge_weight_type_changed(); }
+    fn set_is_loaded(&mut self, v: bool)        { self.is_loaded = v;         self.is_loaded_changed(); }
+    fn set_error_message(&mut self, v: String)  { self.error_message = v;     self.error_message_changed(); }
+    fn set_cities_json(&mut self, v: String)    { self.cities_json = v;       self.cities_json_changed(); }
+    fn set_recent_files_json(&mut self, v: String) { self.recent_files_json = v; self.recent_files_json_changed(); }
+
+    #[qsignal] fn city_count_changed(&self);
+    #[qsignal] fn problem_name_changed(&self);
+    #[qsignal] fn edge_weight_type_changed(&self);
+    #[qsignal] fn is_loaded_changed(&self);
+    #[qsignal] fn error_message_changed(&self);
+    #[qsignal] fn cities_json_changed(&self);
+    #[qsignal] fn recent_files_json_changed(&self);
+
+    /// Load a TSPLIB file. `path` may be a filesystem path or a file:// URL.
+    #[qslot]
+    fn load_file(&mut self, path: String) {
+        let clean = path
+            .strip_prefix("file:///")
+            .or_else(|| path.strip_prefix("file://"))
+            .unwrap_or(&path)
+            .to_string();
+
+        match tsplib::read_from_file(Path::new(&clean)) {
+            Ok(data) => {
+                let ew_type = if data.has_explicit_weights() { "EXPLICIT" } else { "EUC_2D" };
+                self.set_problem_name(data.name.clone());
+                self.set_city_count(data.len() as i32);
+                self.set_edge_weight_type(ew_type.to_string());
+                self.set_cities_json(cities_to_json(data.cities()));
+                self.set_error_message(String::new());
+                self.set_is_loaded(true);
+
+                let updated = push_recent(clean, &self.recent_files_json);
+                save_recent_files(&updated);
+                self.set_recent_files_json(updated);
+            }
+            Err(e) => {
+                self.set_error_message(e);
+                self.set_is_loaded(false);
+            }
+        }
+    }
+}
+
+// ── Recent files persistence ──────────────────────────────────────────────
+
+fn recent_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".config")
+        .join("teeline-qt")
+        .join("recent.json")
+}
+
+fn load_recent_files() -> String {
+    std::fs::read_to_string(recent_path()).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn save_recent_files(json: &str) {
+    let path = recent_path();
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(&path, json);
+}
+
+/// Push `path` to the front of the JSON recent-files list (max 10 entries).
+fn push_recent(path: String, current_json: &str) -> String {
+    let mut list: Vec<String> = serde_json::from_str(current_json).unwrap_or_default();
+    list.retain(|p| p != &path);
+    list.insert(0, path);
+    list.truncate(10);
+    serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+}
+
+// ── City serialisation ────────────────────────────────────────────────────
+
+fn cities_to_json(cities: &[KDPoint]) -> String {
+    if cities.is_empty() {
+        return "[]".to_string();
+    }
+    let min_x = cities.iter().map(|c| c.x()).fold(f32::INFINITY, f32::min);
+    let max_x = cities.iter().map(|c| c.x()).fold(f32::NEG_INFINITY, f32::max);
+    let min_y = cities.iter().map(|c| c.y()).fold(f32::INFINITY, f32::min);
+    let max_y = cities.iter().map(|c| c.y()).fold(f32::NEG_INFINITY, f32::max);
+    let rx = (max_x - min_x).max(1.0);
+    let ry = (max_y - min_y).max(1.0);
+
+    let pts: Vec<String> = cities
+        .iter()
+        .map(|c| {
+            let nx = (c.x() - min_x) / rx;
+            let ny = (c.y() - min_y) / ry;
+            format!("{{\"x\":{:.4},\"y\":{:.4}}}", nx, ny)
+        })
+        .collect();
+    format!("[{}]", pts.join(","))
+}

--- a/teeline-qt/src/file_loader.rs
+++ b/teeline-qt/src/file_loader.rs
@@ -56,11 +56,11 @@ impl FileLoader {
     #[qslot]
     fn load_file(&mut self, path: String) {
         let clean = path
-            .strip_prefix("file:///")
-            .or_else(|| path.strip_prefix("file://"))
+            .strip_prefix("file://")
             .unwrap_or(&path)
             .to_string();
 
+        eprintln!("[FileLoader] loading: {clean}");
         match tsplib::read_from_file(Path::new(&clean)) {
             Ok(data) => {
                 let ew_type = if data.has_explicit_weights() { "EXPLICIT" } else { "EUC_2D" };

--- a/teeline-qt/src/main.rs
+++ b/teeline-qt/src/main.rs
@@ -1,3 +1,6 @@
+mod file_loader;
+
+use file_loader::FileLoader;
 use qtbridge::{qobject_impl, QApp};
 
 #[derive(Default)]
@@ -9,6 +12,7 @@ impl AppBackend {}
 fn main() {
     QApp::new()
         .register::<AppBackend>()
+        .register::<FileLoader>()
         .load_qml(include_bytes!("Main.qml"))
         .run();
 }


### PR DESCRIPTION
## Summary

- **`FileLoader` Rust QObject** (Singleton): wraps `teeline::tsplib::read_from_file`, exposes 7 QML properties (`cityCount`, `problemName`, `edgeWeightType`, `isLoaded`, `errorMessage`, `citiesJson`, `recentFilesJson`) and a `loadFile(path)` slot
- **Recent files**: persisted as JSON in `~/.config/teeline-qt/recent.json` (Rust-side, avoids deprecated `Qt.labs.settings`)
- **City mini-map**: coordinates normalised to [0,1] in Rust, drawn via QML Canvas `arc` calls
- **`Main.qml`**: `StackView` with `WelcomePage` + `SolverPage` (placeholder) as Qt 6 inline `component` definitions — necessary because `include_bytes!` only loads one QML file
- **WelcomePage**: `DropArea` drop zone, `FileDialog` browse button, metadata panel, 200×200 canvas dot-map, recent files list, disabled Advanced toggle, "Next →" enabled only when `FileLoader.isLoaded`

## Test plan

- [x] Builds cleanly (`cargo build -p teeline-qt`)
- [x] Runs without QML errors (no warnings in stderr)
- [x] Drop `berlin52.tsp` → metadata shows 52 cities, dot-map renders
- [x] "Browse…" opens native file dialog
- [x] Invalid file → inline error message shown
- [x] "Next →" disabled until file loaded, then navigates to placeholder SolverPage
- [x] Recent files list appears after loading a file, persists across restarts
- [x] CI `build-qt` job passes

Closes #103