### PR TITLE
feat(teeline-qt): Solver Picker screen (issue #104)

### DIFF
--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -177,31 +177,286 @@ ApplicationWindow {
 
     }
 
-    // ── Inline component: SolverPage (placeholder — issue #104) ────────────
+    // ── Solver metadata (static) ────────────────────────────────────────────
+    readonly property var solverList: [
+        { name: "Bellman-Held-Karp",    alias: "bhk",            category: "Exact",
+          desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
+          complexity: "O(n² · 2ⁿ)", hasOptions: false, exact: true },
+        { name: "Branch & Bound",       alias: "branch_bound",   category: "Exact",
+          desc: "Exact branch-and-bound with lower-bound pruning.",
+          complexity: "O(n!)",        hasOptions: false, exact: true },
+        { name: "Nearest Neighbor",     alias: "nn",             category: "Constructive",
+          desc: "Greedy heuristic: always visit the nearest unvisited city.",
+          complexity: "O(n²)",        hasOptions: false, exact: false },
+        { name: "2-opt",                alias: "2opt",           category: "Local Search",
+          desc: "Iteratively reverses sub-tours to remove crossing edges.",
+          complexity: "O(n²) / pass", hasOptions: false, exact: false },
+        { name: "3-opt",                alias: "3opt",           category: "Local Search",
+          desc: "Extends 2-opt by considering triple-edge reconnections.",
+          complexity: "O(n³) / pass", hasOptions: false, exact: false },
+        { name: "Simulated Annealing",  alias: "sa",             category: "Metaheuristic",
+          desc: "Accepts worse moves with decreasing probability to escape local optima.",
+          complexity: "O(epochs · n)", hasOptions: true,  exact: false },
+        { name: "Genetic Algorithm",    alias: "ga",             category: "Metaheuristic",
+          desc: "Evolves a population of tours via crossover and mutation operators.",
+          complexity: "O(epochs · pop · n)", hasOptions: true, exact: false },
+        { name: "Particle Swarm",       alias: "pso",            category: "Metaheuristic",
+          desc: "Discrete PSO with velocity-capped particles guided by a global best.",
+          complexity: "O(epochs · swarm · n)", hasOptions: true, exact: false },
+        { name: "Cuckoo Search",        alias: "cs",             category: "Metaheuristic",
+          desc: "Lévy-flight search with probabilistic nest abandonment.",
+          complexity: "O(epochs · nests · n)", hasOptions: true, exact: false },
+        { name: "Flower Pollination",   alias: "fpa",            category: "Metaheuristic",
+          desc: "Global Lévy-flight toward best tour; local ε-scaled cross-pollination.",
+          complexity: "O(epochs · pop · n)", hasOptions: true, exact: false },
+        { name: "Stochastic Hill Climb",alias: "stochastic_hill",category: "Metaheuristic",
+          desc: "Random-restart hill climbing to escape local optima.",
+          complexity: "O(epochs · n)", hasOptions: false, exact: false },
+        { name: "Tabu Search",          alias: "tabu",           category: "Metaheuristic",
+          desc: "Local search with a memory structure to avoid revisiting solutions.",
+          complexity: "O(epochs · n)", hasOptions: false, exact: false },
+        { name: "Random Shuffle",       alias: "shuffle",        category: "Utility",
+          desc: "Baseline random tour. Useful as a warm-start seed for pipelines.",
+          complexity: "O(n)",          hasOptions: false, exact: false },
+    ]
+
+    // ── Inline component: SolverPage ────────────────────────────────────────
     component SolverPage: Page {
         signal backRequested()
+        signal solveRequested()
+        signal configureRequested()
+
         background: Rectangle { color: "#1a1a2e" }
 
+        // Track which item is selected by index
+        property int selectedIdx: -1
+        property var selectedSolver: selectedIdx >= 0 ? solverList[selectedIdx] : null
+
+        // Disable exact solvers when problem is too large
+        property bool exactWarning: selectedSolver !== null
+                                    && selectedSolver.exact
+                                    && FileLoader.cityCount > 20
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 0
+            spacing: 0
+
+            // ── Left panel: solver list ──────────────────────────────────────
+            Rectangle {
+                Layout.preferredWidth: 280
+                Layout.fillHeight: true
+                color: "#13132b"
+
+                ListView {
+                    id: solverListView
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    model: solverList
+                    clip: true
+
+                    section.property: "category"
+                    section.delegate: Rectangle {
+                        width: solverListView.width
+                        height: 28
+                        color: "transparent"
+                        required property string section
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.left: parent.left
+                            anchors.leftMargin: 8
+                            text: section
+                            font.pixelSize: 11
+                            font.bold: true
+                            color: "#607d8b"
+                            font.letterSpacing: 1.2
+                        }
+                    }
+
+                    delegate: ItemDelegate {
+                        width: solverListView.width
+                        height: 36
+                        required property var modelData
+                        required property int index
+
+                        property bool isExactWarning: modelData.exact && FileLoader.cityCount > 20
+
+                        highlighted: index === selectedIdx
+                        enabled: !isExactWarning
+
+                        contentItem: Text {
+                            text: modelData.name
+                            color: isExactWarning ? "#555" : (index === selectedIdx ? "#00e676" : "#e0e0e0")
+                            font.pixelSize: 13
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        background: Rectangle {
+                            color: index === selectedIdx ? "#1e3a5f" : "transparent"
+                            radius: 4
+                        }
+
+                        onClicked: {
+                            selectedIdx = index
+                            SolverEngine.selectSolver(modelData.alias)
+                        }
+
+                        ToolTip.visible: isExactWarning && hovered
+                        ToolTip.text: "Disabled: " + FileLoader.cityCount + " cities > 20 (exact solver)"
+                        ToolTip.delay: 400
+                    }
+                }
+            }
+
+            // Divider
+            Rectangle { width: 1; Layout.fillHeight: true; color: "#2a2a4a" }
+
+            // ── Right panel: detail ──────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.margins: 32
+                spacing: 16
+
+                // No selection state
+                ColumnLayout {
+                    visible: selectedSolver === null
+                    Layout.fillWidth: true
+                    spacing: 8
+                    Item { Layout.fillHeight: true }
+                    Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Select a solver"
+                        font.pixelSize: 18
+                        color: "#555"
+                    }
+                    Item { Layout.fillHeight: true }
+                }
+
+                // Detail panel
+                ColumnLayout {
+                    visible: selectedSolver !== null
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    Text {
+                        text: selectedSolver ? selectedSolver.name : ""
+                        font.pixelSize: 22
+                        font.bold: true
+                        color: "#e0e0e0"
+                    }
+
+                    Text {
+                        text: selectedSolver ? selectedSolver.category : ""
+                        font.pixelSize: 12
+                        color: "#607d8b"
+                        font.letterSpacing: 1
+                    }
+
+                    Text {
+                        text: selectedSolver ? selectedSolver.desc : ""
+                        font.pixelSize: 14
+                        color: "#b0b0b0"
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        spacing: 8
+                        Text { text: "Complexity:"; color: "#607d8b"; font.pixelSize: 12 }
+                        Text {
+                            text: selectedSolver ? selectedSolver.complexity : ""
+                            color: "#e0e0e0"
+                            font.pixelSize: 12
+                            font.family: "monospace"
+                        }
+                    }
+
+                    // Exact solver warning
+                    Rectangle {
+                        visible: exactWarning
+                        Layout.fillWidth: true
+                        height: warningText.implicitHeight + 16
+                        color: "#3a1a00"
+                        radius: 6
+                        border.color: "#ff6d00"
+                        border.width: 1
+
+                        Text {
+                            id: warningText
+                            anchors { fill: parent; margins: 8 }
+                            text: "⚠  " + FileLoader.cityCount + " cities — exact solvers are practical only for n ≤ 20"
+                            color: "#ff9800"
+                            font.pixelSize: 12
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+
+                // Bottom action bar
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    Button {
+                        text: "← Back"
+                        onClicked: backRequested()
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    Button {
+                        text: "Configure →"
+                        visible: selectedSolver !== null && selectedSolver.hasOptions
+                        enabled: selectedSolver !== null && !exactWarning
+                        onClicked: configureRequested()
+                    }
+
+                    Button {
+                        text: "Solve ▶"
+                        highlighted: true
+                        visible: selectedSolver !== null && !selectedSolver.hasOptions
+                        enabled: selectedSolver !== null && !exactWarning
+                        onClicked: solveRequested()
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Inline component: ConfigPage (placeholder — issue #106) ─────────────
+    component ConfigPage: Page {
+        signal backRequested()
+        signal solveRequested()
+        background: Rectangle { color: "#1a1a2e" }
         ColumnLayout {
             anchors.centerIn: parent
             spacing: 16
-            Text {
-                text: "Solver Picker"
-                font.pixelSize: 24
-                color: "#e0e0e0"
+            Text { text: "Solver Config"; font.pixelSize: 24; color: "#e0e0e0"; Layout.alignment: Qt.AlignHCenter }
+            Text { text: "Coming in issue #106"; font.pixelSize: 14; color: "#9e9e9e"; Layout.alignment: Qt.AlignHCenter }
+            Text { text: "Solver: " + SolverEngine.selectedSolver; font.pixelSize: 13; color: "#4fc3f7"; Layout.alignment: Qt.AlignHCenter }
+            RowLayout {
                 Layout.alignment: Qt.AlignHCenter
+                spacing: 12
+                Button { text: "← Back"; onClicked: backRequested() }
+                Button { text: "Solve ▶"; highlighted: true; onClicked: solveRequested() }
             }
-            Text {
-                text: "Coming in issue #104"
-                font.pixelSize: 14
-                color: "#9e9e9e"
-                Layout.alignment: Qt.AlignHCenter
-            }
-            Button {
-                text: "← Back"
-                Layout.alignment: Qt.AlignHCenter
-                onClicked: backRequested()
-            }
+        }
+    }
+
+    // ── Inline component: VisualizationPage (placeholder — issue #105) ──────
+    component VisualizationPage: Page {
+        signal backRequested()
+        background: Rectangle { color: "#0f0f23" }
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 16
+            Text { text: "Visualization"; font.pixelSize: 24; color: "#e0e0e0"; Layout.alignment: Qt.AlignHCenter }
+            Text { text: "Coming in issue #105"; font.pixelSize: 14; color: "#9e9e9e"; Layout.alignment: Qt.AlignHCenter }
+            Text { text: "Solver: " + SolverEngine.selectedSolver; font.pixelSize: 13; color: "#00e676"; Layout.alignment: Qt.AlignHCenter }
+            Button { text: "← Back"; Layout.alignment: Qt.AlignHCenter; onClicked: backRequested() }
         }
     }
 
@@ -214,15 +469,28 @@ ApplicationWindow {
 
     Component {
         id: welcomeComp
-        WelcomePage {
-            onNextRequested: stackView.push(solverComp)
-        }
+        WelcomePage { onNextRequested: stackView.push(solverComp) }
     }
 
     Component {
         id: solverComp
         SolverPage {
-            onBackRequested: stackView.pop()
+            onBackRequested:    stackView.pop()
+            onConfigureRequested: stackView.push(configComp)
+            onSolveRequested:   stackView.push(vizComp)
         }
+    }
+
+    Component {
+        id: configComp
+        ConfigPage {
+            onBackRequested:  stackView.pop()
+            onSolveRequested: stackView.push(vizComp)
+        }
+    }
+
+    Component {
+        id: vizComp
+        VisualizationPage { onBackRequested: stackView.pop() }
     }
 }

--- a/teeline-qt/src/main.rs
+++ b/teeline-qt/src/main.rs
@@ -1,6 +1,8 @@
 mod file_loader;
+mod solver_engine;
 
 use file_loader::FileLoader;
+use solver_engine::SolverEngine;
 use qtbridge::{qobject_impl, QApp};
 
 #[derive(Default)]
@@ -13,6 +15,7 @@ fn main() {
     QApp::new()
         .register::<AppBackend>()
         .register::<FileLoader>()
+        .register::<SolverEngine>()
         .load_qml(include_bytes!("Main.qml"))
         .run();
 }

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -1,0 +1,32 @@
+use qtbridge::qobject_impl;
+
+pub struct SolverEngine {
+    selected_solver: String,
+}
+
+impl Default for SolverEngine {
+    fn default() -> Self {
+        Self {
+            selected_solver: String::new(),
+        }
+    }
+}
+
+#[qobject_impl(Singleton)]
+impl SolverEngine {
+    qproperty!("selectedSolver", Member = selected_solver, Write = set_selected_solver, Notify = "selectedSolverChanged");
+
+    fn set_selected_solver(&mut self, v: String) {
+        self.selected_solver = v;
+        self.selected_solver_changed();
+    }
+
+    #[qsignal]
+    fn selected_solver_changed(&self);
+
+    /// Called from QML to select a solver by alias.
+    #[qslot]
+    fn select_solver(&mut self, alias: String) {
+        self.set_selected_solver(alias);
+    }
+}


### PR DESCRIPTION
## Summary

- **`SolverEngine` Rust QObject** (Singleton): holds `selectedSolver` string, exposes `selectSolver(alias)` slot — keeps Rust as the source of truth for which solver is active
- **SolverPage** inline component:
  - Left panel: `ListView` with `section.property = "category"` giving automatic group headers (Exact / Constructive / Local Search / Metaheuristic / Utility) for all 13 solvers
  - Right panel: solver name, category chip, description, complexity note
  - Exact solver warning: orange banner + row disabled when `FileLoader.cityCount > 20`; tooltip on hover
  - "Configure →" for solvers with `HeuristicOptions` (SA/GA/PSO/CS/FPA); "Solve ▶" for the rest
- **ConfigPage** and **VisualizationPage** placeholder components added (issues #106 and #105)
- **StackView** fully wired: Welcome → Solver → Config/Visualization, with "← Back" on every screen

## Test plan

- [x] Builds cleanly, no QML errors at startup
- [ ] Load a file on Welcome screen → Next → all 13 solvers visible in 5 groups
- [ ] Select `bhk` with berlin52 (52 cities) → warning banner appears, "Solve ▶" disabled
- [ ] Select `sa` → "Configure →" appears; select `nn` → "Solve ▶" appears
- [ ] "Solve ▶" on `nn` → Visualization placeholder shows "Solver: nn"
- [ ] "Configure →" on `sa` → Config placeholder shows "Solver: sa"
- [ ] "← Back" works on all screens
- [ ] CI `build-qt` passes

Closes #104