### PR TITLE
feat: visualization screen with live solver progress (#105)

### DIFF
--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -746,7 +746,7 @@ pub fn solve_problem(
     solve_with_context(solver, problem, opts, None, None)
 }
 
-pub(crate) fn solve_with_context(
+pub fn solve_with_context(
     solver: Solvers,
     problem: &TspProblem,
     opts: &AppOptions,

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -212,7 +212,7 @@ ApplicationWindow {
         { name: "Stochastic Hill Climb",alias: "stochastic_hill",category: "Metaheuristic",
           desc: "Random-restart hill climbing to escape local optima.",
           complexity: "O(epochs · n)", hasOptions: false, exact: false },
-        { name: "Tabu Search",          alias: "tabu",           category: "Metaheuristic",
+        { name: "Tabu Search",          alias: "tabu_search",    category: "Metaheuristic",
           desc: "Local search with a memory structure to avoid revisiting solutions.",
           complexity: "O(epochs · n)", hasOptions: false, exact: false },
         { name: "Random Shuffle",       alias: "shuffle",        category: "Utility",
@@ -446,17 +446,197 @@ ApplicationWindow {
         }
     }
 
-    // ── Inline component: VisualizationPage (placeholder — issue #105) ──────
+    // ── Inline component: VisualizationPage (issue #105) ────────────────────
     component VisualizationPage: Page {
         signal backRequested()
+
         background: Rectangle { color: "#0f0f23" }
-        ColumnLayout {
-            anchors.centerIn: parent
-            spacing: 16
-            Text { text: "Visualization"; font.pixelSize: 24; color: "#e0e0e0"; Layout.alignment: Qt.AlignHCenter }
-            Text { text: "Coming in issue #105"; font.pixelSize: 14; color: "#9e9e9e"; Layout.alignment: Qt.AlignHCenter }
-            Text { text: "Solver: " + SolverEngine.selectedSolver; font.pixelSize: 13; color: "#00e676"; Layout.alignment: Qt.AlignHCenter }
-            Button { text: "← Back"; Layout.alignment: Qt.AlignHCenter; onClicked: backRequested() }
+
+        // ── Tour canvas ────────────────────────────────────────────────────
+        Canvas {
+            id: tourCanvas
+            anchors.fill: parent
+
+            property var cityPos: ({})   // id → {x,y} in canvas coords
+
+            function rebuild() {
+                var raw = FileLoader.citiesJson
+                if (!raw || raw === "[]") { cityPos = {}; return }
+                var cities = JSON.parse(raw)
+                var pad = 48, w = width - pad*2, h = height - pad*2 - 56
+                var m = {}
+                for (var i = 0; i < cities.length; i++) {
+                    m[cities[i].id] = {
+                        x: pad + cities[i].x * w,
+                        y: pad + cities[i].y * h
+                    }
+                }
+                cityPos = m
+            }
+
+            onWidthChanged:  { rebuild(); requestPaint() }
+            onHeightChanged: { rebuild(); requestPaint() }
+            Component.onCompleted: { rebuild(); requestPaint() }
+
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.fillStyle = "#0f0f23"
+                ctx.fillRect(0, 0, width, height)
+
+                var pos = cityPos
+                var ids = Object.keys(pos)
+                if (!ids.length) return
+
+                // Tour edges
+                var tourRaw = SolverEngine.tourJson
+                if (tourRaw && tourRaw !== "[]") {
+                    var tour = JSON.parse(tourRaw)
+                    if (tour.length > 1) {
+                        ctx.strokeStyle = "#00e676"
+                        ctx.lineWidth = 1.2
+                        ctx.globalAlpha = 0.65
+                        ctx.beginPath()
+                        var p0 = pos[tour[0]]
+                        if (p0) { ctx.moveTo(p0.x, p0.y) }
+                        for (var j = 1; j < tour.length; j++) {
+                            var p = pos[tour[j]]
+                            if (p) ctx.lineTo(p.x, p.y)
+                        }
+                        if (p0) ctx.lineTo(p0.x, p0.y)
+                        ctx.stroke()
+                        ctx.globalAlpha = 1.0
+                    }
+                }
+
+                // City dots
+                ctx.fillStyle = "#4fc3f7"
+                for (var i = 0; i < ids.length; i++) {
+                    var c = pos[ids[i]]
+                    ctx.beginPath()
+                    ctx.arc(c.x, c.y, 3.5, 0, Math.PI*2)
+                    ctx.fill()
+                }
+            }
+
+            Connections {
+                target: SolverEngine
+                function onTourJsonChanged() { tourCanvas.requestPaint() }
+            }
+            Connections {
+                target: FileLoader
+                function onCitiesJsonChanged() { tourCanvas.rebuild(); tourCanvas.requestPaint() }
+            }
+        }
+
+        // ── KPI overlay (top-right) ────────────────────────────────────────
+        Rectangle {
+            anchors.top: parent.top
+            anchors.right: parent.right
+            anchors.margins: 12
+            width: kpiCol.implicitWidth + 24
+            height: kpiCol.implicitHeight + 20
+            color: "#cc0a0a1e"
+            radius: 8
+            border.color: "#2a2a5a"
+            border.width: 1
+            z: 10
+
+            ColumnLayout {
+                id: kpiCol
+                anchors.centerIn: parent
+                spacing: 6
+
+                RowLayout {
+                    spacing: 12
+                    Text { text: "Solver"; color: "#607d8b"; font.pixelSize: 11 }
+                    Text { text: SolverEngine.selectedSolver; color: "#4fc3f7"; font.pixelSize: 13; font.bold: true }
+                }
+                RowLayout {
+                    spacing: 12
+                    Text { text: "Best cost"; color: "#607d8b"; font.pixelSize: 11 }
+                    Text {
+                        text: SolverEngine.bestCost > 0 ? SolverEngine.bestCost.toFixed(2) : "—"
+                        color: "#00e676"; font.pixelSize: 15; font.bold: true
+                    }
+                }
+                RowLayout {
+                    spacing: 12
+                    Text { text: "Iteration"; color: "#607d8b"; font.pixelSize: 11 }
+                    Text { text: SolverEngine.iteration.toString(); color: "#e0e0e0"; font.pixelSize: 13 }
+                }
+                RowLayout {
+                    spacing: 12
+                    Text { text: "Elapsed"; color: "#607d8b"; font.pixelSize: 11 }
+                    Text {
+                        text: {
+                            var ms = SolverEngine.elapsedMs
+                            if (ms < 1000) return ms + " ms"
+                            return (ms / 1000).toFixed(1) + " s"
+                        }
+                        color: "#e0e0e0"; font.pixelSize: 13
+                    }
+                }
+
+                // Running indicator
+                RowLayout {
+                    visible: SolverEngine.running
+                    spacing: 6
+                    Rectangle {
+                        width: 8; height: 8; radius: 4; color: "#00e676"
+                        SequentialAnimation on opacity {
+                            loops: Animation.Infinite
+                            NumberAnimation { to: 0.2; duration: 600 }
+                            NumberAnimation { to: 1.0; duration: 600 }
+                        }
+                    }
+                    Text { text: "Solving…"; color: "#00e676"; font.pixelSize: 11 }
+                }
+            }
+        }
+
+        // ── Bottom bar ─────────────────────────────────────────────────────
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 56
+            color: "#0d0d1e"
+            z: 10
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 20
+                anchors.rightMargin: 20
+                spacing: 12
+
+                Button {
+                    text: "← Back"
+                    visible: !SolverEngine.running
+                    onClicked: backRequested()
+                }
+
+                Button {
+                    text: "Stop"
+                    visible: SolverEngine.running
+                    onClicked: SolverEngine.cancel()
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                    visible: !SolverEngine.running && SolverEngine.bestCost > 0
+                    text: "Tour length: " + SolverEngine.bestCost.toFixed(2)
+                    color: "#00e676"
+                    font.pixelSize: 15
+                    font.bold: true
+                }
+
+                Button {
+                    text: "← New problem"
+                    visible: !SolverEngine.running && SolverEngine.bestCost > 0
+                    onClicked: backRequested()
+                }
+            }
         }
     }
 
@@ -477,7 +657,10 @@ ApplicationWindow {
         SolverPage {
             onBackRequested:    stackView.pop()
             onConfigureRequested: stackView.push(configComp)
-            onSolveRequested:   stackView.push(vizComp)
+            onSolveRequested: {
+                SolverEngine.startSolve(FileLoader.filePath)
+                stackView.push(vizComp)
+            }
         }
     }
 
@@ -485,7 +668,10 @@ ApplicationWindow {
         id: configComp
         ConfigPage {
             onBackRequested:  stackView.pop()
-            onSolveRequested: stackView.push(vizComp)
+            onSolveRequested: {
+                SolverEngine.startSolve(FileLoader.filePath)
+                stackView.push(vizComp)
+            }
         }
     }
 

--- a/teeline-qt/src/file_loader.rs
+++ b/teeline-qt/src/file_loader.rs
@@ -10,6 +10,7 @@ pub struct FileLoader {
     error_message: String,
     cities_json: String,
     recent_files_json: String,
+    file_path: String,
 }
 
 impl Default for FileLoader {
@@ -22,6 +23,7 @@ impl Default for FileLoader {
             error_message: String::new(),
             cities_json: "[]".to_string(),
             recent_files_json: load_recent_files(),
+            file_path: String::new(),
         }
     }
 }
@@ -35,6 +37,7 @@ impl FileLoader {
     qproperty!("errorMessage",     Member = error_message,     Write = set_error_message,     Notify = "errorMessageChanged");
     qproperty!("citiesJson",       Member = cities_json,       Write = set_cities_json,       Notify = "citiesJsonChanged");
     qproperty!("recentFilesJson",  Member = recent_files_json, Write = set_recent_files_json, Notify = "recentFilesJsonChanged");
+    qproperty!("filePath",         Member = file_path,         Write = set_file_path,         Notify = "filePathChanged");
 
     fn set_city_count(&mut self, v: i32)       { self.city_count = v;        self.city_count_changed(); }
     fn set_problem_name(&mut self, v: String)   { self.problem_name = v;      self.problem_name_changed(); }
@@ -43,6 +46,7 @@ impl FileLoader {
     fn set_error_message(&mut self, v: String)  { self.error_message = v;     self.error_message_changed(); }
     fn set_cities_json(&mut self, v: String)    { self.cities_json = v;       self.cities_json_changed(); }
     fn set_recent_files_json(&mut self, v: String) { self.recent_files_json = v; self.recent_files_json_changed(); }
+    fn set_file_path(&mut self, v: String)      { self.file_path = v;         self.file_path_changed(); }
 
     #[qsignal] fn city_count_changed(&self);
     #[qsignal] fn problem_name_changed(&self);
@@ -51,6 +55,7 @@ impl FileLoader {
     #[qsignal] fn error_message_changed(&self);
     #[qsignal] fn cities_json_changed(&self);
     #[qsignal] fn recent_files_json_changed(&self);
+    #[qsignal] fn file_path_changed(&self);
 
     /// Load a TSPLIB file. `path` may be a filesystem path or a file:// URL.
     #[qslot]
@@ -70,6 +75,7 @@ impl FileLoader {
                 self.set_cities_json(cities_to_json(data.cities()));
                 self.set_error_message(String::new());
                 self.set_is_loaded(true);
+                self.set_file_path(clean.clone());
 
                 let updated = push_recent(clean, &self.recent_files_json);
                 save_recent_files(&updated);
@@ -132,7 +138,7 @@ fn cities_to_json(cities: &[KDPoint]) -> String {
         .map(|c| {
             let nx = (c.x() - min_x) / rx;
             let ny = (c.y() - min_y) / ry;
-            format!("{{\"x\":{:.4},\"y\":{:.4}}}", nx, ny)
+            format!("{{\"id\":{},\"x\":{:.4},\"y\":{:.4}}}", c.id, nx, ny)
         })
         .collect();
     format!("[{}]", pts.join(","))

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -1,13 +1,33 @@
-use qtbridge::qobject_impl;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::mpsc;
+use std::time::Instant;
+
+use qtbridge::{QObjectHolder, invoke_method, qobject_impl};
+use teeline::tsp::{
+    self, AppOptions, Solvers, TspProblem,
+    progress::ProgressMessage,
+    tsplib,
+};
 
 pub struct SolverEngine {
     selected_solver: String,
+    running: bool,
+    best_cost: f32,
+    iteration: i32,
+    elapsed_ms: i32,
+    tour_json: String,
 }
 
 impl Default for SolverEngine {
     fn default() -> Self {
         Self {
             selected_solver: String::new(),
+            running: false,
+            best_cost: 0.0,
+            iteration: 0,
+            elapsed_ms: 0,
+            tour_json: "[]".to_string(),
         }
     }
 }
@@ -15,18 +35,135 @@ impl Default for SolverEngine {
 #[qobject_impl(Singleton)]
 impl SolverEngine {
     qproperty!("selectedSolver", Member = selected_solver, Write = set_selected_solver, Notify = "selectedSolverChanged");
+    qproperty!("running",        Member = running,         Write = set_running,         Notify = "runningChanged");
+    qproperty!("bestCost",       Member = best_cost,       Write = set_best_cost,       Notify = "bestCostChanged");
+    qproperty!("iteration",      Member = iteration,       Write = set_iteration,       Notify = "iterationChanged");
+    qproperty!("elapsedMs",      Member = elapsed_ms,      Write = set_elapsed_ms,      Notify = "elapsedMsChanged");
+    qproperty!("tourJson",       Member = tour_json,       Write = set_tour_json,       Notify = "tourJsonChanged");
 
-    fn set_selected_solver(&mut self, v: String) {
-        self.selected_solver = v;
-        self.selected_solver_changed();
-    }
+    fn set_selected_solver(&mut self, v: String)  { self.selected_solver = v;  self.selected_solver_changed(); }
+    fn set_running(&mut self, v: bool)             { self.running = v;           self.running_changed(); }
+    fn set_best_cost(&mut self, v: f32)            { self.best_cost = v;         self.best_cost_changed(); }
+    fn set_iteration(&mut self, v: i32)            { self.iteration = v;         self.iteration_changed(); }
+    fn set_elapsed_ms(&mut self, v: i32)           { self.elapsed_ms = v;        self.elapsed_ms_changed(); }
+    fn set_tour_json(&mut self, v: String)         { self.tour_json = v;         self.tour_json_changed(); }
 
-    #[qsignal]
-    fn selected_solver_changed(&self);
+    #[qsignal] fn selected_solver_changed(&self);
+    #[qsignal] fn running_changed(&self);
+    #[qsignal] fn best_cost_changed(&self);
+    #[qsignal] fn iteration_changed(&self);
+    #[qsignal] fn elapsed_ms_changed(&self);
+    #[qsignal] fn tour_json_changed(&self);
 
-    /// Called from QML to select a solver by alias.
     #[qslot]
     fn select_solver(&mut self, alias: String) {
         self.set_selected_solver(alias);
     }
+
+    /// Reset state and launch the solver on a background thread.
+    #[qslot]
+    fn start_solve(&mut self, file_path: String) {
+        self.set_running(true);
+        self.set_best_cost(0.0);
+        self.set_iteration(0);
+        self.set_elapsed_ms(0);
+        self.set_tour_json("[]".to_string());
+
+        // Two invokers: progress updates and the final done notification.
+        let inv_progress = self.get_qml_method_invoker();
+        let inv_done = self.get_qml_method_invoker();
+        let alias = self.selected_solver.clone();
+
+        std::thread::spawn(move || {
+            let solver = match Solvers::from_str(&alias) {
+                Ok(s) => s,
+                Err(_) => {
+                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, format!("Unknown solver: {alias}"));
+                    return;
+                }
+            };
+
+            let data = match tsplib::read_from_file(Path::new(&file_path)) {
+                Ok(d) => d,
+                Err(e) => {
+                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, e);
+                    return;
+                }
+            };
+
+            let cities = data.cities().to_vec();
+            let distances = match data.distance_matrix() {
+                Ok(d) => d,
+                Err(e) => {
+                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, e.to_string());
+                    return;
+                }
+            };
+            let problem = TspProblem::new(cities, distances);
+            let opts = AppOptions::default();
+
+            let (tx, rx) = mpsc::channel::<ProgressMessage>();
+            let start = Instant::now();
+
+            // Progress-forwarding thread: receives solver updates, fires Qt slots.
+            std::thread::spawn(move || {
+                let mut epoch = 0i32;
+                while let Ok(msg) = rx.recv() {
+                    match msg {
+                        ProgressMessage::PathUpdate(route, cost) => {
+                            epoch += 1;
+                            let tour = route_to_json(route.route());
+                            let ms = start.elapsed().as_millis() as i32;
+                            invoke_method!(inv_progress, "onProgressUpdate", tour, cost, epoch, ms);
+                        }
+                        ProgressMessage::EpochUpdate(n) => {
+                            epoch = n as i32;
+                        }
+                        ProgressMessage::Done | ProgressMessage::OptimalTour(_) => break,
+                        _ => {}
+                    }
+                }
+            });
+
+            match tsp::solve_with_context(solver, &problem, &opts, Some(tx), None) {
+                Ok(solution) => {
+                    let tour = route_to_json(solution.route());
+                    let ms = start.elapsed().as_millis() as i32;
+                    invoke_method!(inv_done, "onSolveDone", tour, solution.total, ms, String::new());
+                }
+                Err(e) => {
+                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, e);
+                }
+            }
+        });
+    }
+
+    /// Called on the Qt main thread by the progress-forwarding thread.
+    #[qslot]
+    fn on_progress_update(&mut self, tour_json: String, cost: f32, iteration: i32, elapsed_ms: i32) {
+        self.set_tour_json(tour_json);
+        self.set_best_cost(cost);
+        self.set_iteration(iteration);
+        self.set_elapsed_ms(elapsed_ms);
+    }
+
+    /// Called on the Qt main thread when the solver finishes (or errors).
+    #[qslot]
+    fn on_solve_done(&mut self, tour_json: String, cost: f32, elapsed_ms: i32, _error: String) {
+        self.set_tour_json(tour_json);
+        self.set_best_cost(cost);
+        self.set_elapsed_ms(elapsed_ms);
+        self.set_running(false);
+    }
+
+    /// Stop displaying updates (solver continues in background, harmlessly).
+    #[qslot]
+    fn cancel(&mut self) {
+        self.set_running(false);
+    }
+}
+
+fn route_to_json(route: &[usize]) -> String {
+    let nums: Vec<String> = route.iter().map(|id| id.to_string()).collect();
+    format!("[{}]", nums.join(","))
 }


### PR DESCRIPTION
## Summary

- **VisualizationPage**: full-screen Canvas renders city dots and live tour edges as the solver iterates; KPI overlay shows solver name, best cost, iteration count, and elapsed time with an animated pulsing indicator while running
- **SolverEngine**: new properties `running`, `bestCost`, `iteration`, `elapsedMs`, `tourJson`; `startSolve(filePath)` spawns a background `std::thread` that runs `solve_with_context()` with a `mpsc` progress channel; two `QmlMethodInvoker`s relay `onProgressUpdate` / `onSolveDone` back to the Qt main thread
- **FileLoader**: adds `filePath` property (stored on successful load); city JSON now includes `id` field so the canvas can map tour city-IDs to canvas coordinates
- **lib**: `solve_with_context` promoted from `pub(crate)` to `pub`
- Fix `tabu_search` alias (QML had `"tabu"`, solver registry requires `"tabu_search"`)

## Test plan

- [ ] Load a `.tsp` file (e.g. `data/tsplib/berlin52.tsp`)
- [ ] Select a fast solver (e.g. `2opt`, `nn`, `sa`)
- [ ] Press "Solve ▶" — VisualizationPage opens, canvas draws cities, tour edges update live
- [ ] KPI strip shows incrementing iteration count, decreasing cost, and elapsed time
- [ ] Pulsing green dot visible while running
- [ ] "Stop" button appears while running; pressing it stops updates and shows "← Back"
- [ ] When solver completes, "← Back" / "← New problem" and final tour length shown
- [ ] `cargo build -p teeline-qt` passes without warnings