### PR TITLE
feat: solver config screen with parameter forms (#106)

### DIFF
--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -532,40 +532,26 @@ ApplicationWindow {
                     Layout.margins: 32
                     spacing: 28
 
-                    // Shared TextField style: light background + dark text
-                    component Cfg_Label: Text {
-                        color: "#c8c8e0"; font.pixelSize: 13; font.bold: true
-                    }
-                    component Cfg_Hint: Text {
-                        color: "#7890a8"; font.pixelSize: 11
-                    }
-                    component Cfg_Field: TextField {
-                        font.pixelSize: 14
-                        color: acceptableInput ? "#111122" : "#c0302a"
-                        placeholderTextColor: "#8888aa"
-                        background: Rectangle {
-                            color: "#dde0f5"; radius: 4
-                            border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"
-                            border.width: 1
-                        }
-                    }
-
                     // ── Common: epochs ────────────────────────────────────
                     ColumnLayout {
                         spacing: 6; Layout.fillWidth: true
-                        Cfg_Label { text: "Epochs" }
-                        Cfg_Field {
+                        Text { text: "Epochs"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                        TextField {
                             id: epochsField
                             Layout.preferredWidth: 220
+                            font.pixelSize: 14
                             text: isSA ? saDefaults.epochs.toString()
                                        : isGA ? gaDefaults.epochs.toString()
                                        : isPSO ? psoDefaults.epochs.toString()
                                        : isCS ? csDefaults.epochs.toString()
                                        : fpaDefaults.epochs.toString()
                             placeholderText: "10000"
+                            color: acceptableInput ? "#111122" : "#c0302a"
+                            placeholderTextColor: "#8888aa"
                             validator: IntValidator { bottom: 1; top: 10000000 }
+                            background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                         }
-                        Cfg_Hint { text: "Number of iterations the solver will run" }
+                        Text { text: "Number of iterations the solver will run"; color: "#7890a8"; font.pixelSize: 11 }
                     }
 
                     // ── SA fields ─────────────────────────────────────────
@@ -575,48 +561,52 @@ ApplicationWindow {
 
                         ColumnLayout {
                             spacing: 6; Layout.fillWidth: true
-                            Cfg_Label { text: "Cooling rate" }
-                            Cfg_Field {
+                            Text { text: "Cooling rate"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                            TextField {
                                 id: crField
                                 Layout.preferredWidth: 220
+                                font.pixelSize: 14
                                 text: saDefaults.cooling_rate.toString()
                                 placeholderText: "0.0001"
+                                color: acceptableInput ? "#111122" : "#c0302a"
+                                placeholderTextColor: "#8888aa"
                                 validator: DoubleValidator { bottom: 0.000001; top: 0.999999; notation: DoubleValidator.StandardNotation }
+                                background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                             }
-                            Cfg_Hint { text: "Must be > 0 and < 1" }
+                            Text { text: "Must be > 0 and < 1"; color: "#7890a8"; font.pixelSize: 11 }
                         }
 
                         RowLayout {
                             spacing: 32; Layout.fillWidth: true
                             ColumnLayout {
                                 spacing: 6
-                                Cfg_Label { text: "Min temperature" }
-                                Cfg_Field {
+                                Text { text: "Min temperature"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                                TextField {
                                     id: minTField
-                                    width: 180
+                                    width: 180; font.pixelSize: 14
                                     text: saDefaults.min_temperature.toString()
                                     placeholderText: "0.001"
+                                    color: "#111122"; placeholderTextColor: "#8888aa"
                                     validator: DoubleValidator { bottom: 0; notation: DoubleValidator.StandardNotation }
+                                    background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                                 }
                             }
                             ColumnLayout {
                                 spacing: 6
-                                Cfg_Label { text: "Max temperature" }
-                                Cfg_Field {
+                                Text { text: "Max temperature"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                                TextField {
                                     id: maxTField
-                                    width: 180
+                                    width: 180; font.pixelSize: 14
                                     text: saDefaults.max_temperature.toString()
                                     placeholderText: "1000.0"
+                                    color: "#111122"; placeholderTextColor: "#8888aa"
                                     validator: DoubleValidator { bottom: 0.000001; notation: DoubleValidator.StandardNotation }
+                                    background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                                 }
                             }
                         }
                         Text {
-                            visible: {
-                                var mn = parseFloat(minTField.text)
-                                var mx = parseFloat(maxTField.text)
-                                return !isNaN(mn) && !isNaN(mx) && mn >= mx
-                            }
+                            visible: { var mn = parseFloat(minTField.text); var mx = parseFloat(maxTField.text); return !isNaN(mn) && !isNaN(mx) && mn >= mx }
                             text: "⚠  Min temperature must be less than max temperature"
                             color: "#ef5350"; font.pixelSize: 12
                         }
@@ -629,28 +619,32 @@ ApplicationWindow {
 
                         ColumnLayout {
                             spacing: 6; Layout.fillWidth: true
-                            Cfg_Label { text: "Mutation probability" }
-                            Cfg_Field {
+                            Text { text: "Mutation probability"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                            TextField {
                                 id: mpField
-                                Layout.preferredWidth: 220
+                                Layout.preferredWidth: 220; font.pixelSize: 14
                                 text: gaDefaults.mutation_probability.toString()
                                 placeholderText: "0.001"
+                                color: acceptableInput ? "#111122" : "#c0302a"; placeholderTextColor: "#8888aa"
                                 validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
+                                background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                             }
-                            Cfg_Hint { text: "Range [0, 1]" }
+                            Text { text: "Range [0, 1]"; color: "#7890a8"; font.pixelSize: 11 }
                         }
 
                         ColumnLayout {
                             spacing: 6
-                            Cfg_Label { text: "Elite count" }
-                            Cfg_Field {
+                            Text { text: "Elite count"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                            TextField {
                                 id: eliteField
-                                width: 140
+                                width: 140; font.pixelSize: 14
                                 text: gaDefaults.n_elite.toString()
                                 placeholderText: "3"
+                                color: acceptableInput ? "#111122" : "#c0302a"; placeholderTextColor: "#8888aa"
                                 validator: IntValidator { bottom: 1; top: 1000 }
+                                background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                             }
-                            Cfg_Hint { text: "Elite solutions preserved each generation" }
+                            Text { text: "Elite solutions preserved each generation"; color: "#7890a8"; font.pixelSize: 11 }
                         }
                     }
 
@@ -658,31 +652,35 @@ ApplicationWindow {
                     ColumnLayout {
                         visible: isCS || isFPA
                         spacing: 6; Layout.fillWidth: true
-                        Cfg_Label { text: "Mutation probability" }
-                        Cfg_Field {
+                        Text { text: "Mutation probability"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                        TextField {
                             id: mpField2
-                            Layout.preferredWidth: 220
+                            Layout.preferredWidth: 220; font.pixelSize: 14
                             text: isCS ? csDefaults.mutation_probability.toString()
                                        : fpaDefaults.mutation_probability.toString()
                             placeholderText: "0.001"
+                            color: acceptableInput ? "#111122" : "#c0302a"; placeholderTextColor: "#8888aa"
                             validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
+                            background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                         }
-                        Cfg_Hint { text: "Range [0, 1]" }
+                        Text { text: "Range [0, 1]"; color: "#7890a8"; font.pixelSize: 11 }
                     }
 
                     // ── PSO fields ────────────────────────────────────────
                     ColumnLayout {
                         visible: isPSO
                         spacing: 6
-                        Cfg_Label { text: "Swarm size (min)" }
-                        Cfg_Field {
+                        Text { text: "Swarm size (min)"; color: "#c8c8e0"; font.pixelSize: 13; font.bold: true }
+                        TextField {
                             id: swarmField
-                            width: 140
+                            width: 140; font.pixelSize: 14
                             text: psoDefaults.n_nearest.toString()
                             placeholderText: "30"
+                            color: acceptableInput ? "#111122" : "#c0302a"; placeholderTextColor: "#8888aa"
                             validator: IntValidator { bottom: 1; top: 10000 }
+                            background: Rectangle { color: "#dde0f5"; radius: 4; border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"; border.width: 1 }
                         }
-                        Cfg_Hint { text: "Minimum particle count (floor is 30)" }
+                        Text { text: "Minimum particle count (floor is 30)"; color: "#7890a8"; font.pixelSize: 11 }
                     }
                 }
             }

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -530,25 +530,42 @@ ApplicationWindow {
                 // ── Form body ─────────────────────────────────────────────
                 ColumnLayout {
                     Layout.margins: 32
-                    spacing: 24
+                    spacing: 28
+
+                    // Shared TextField style: light background + dark text
+                    component Cfg_Label: Text {
+                        color: "#c8c8e0"; font.pixelSize: 13; font.bold: true
+                    }
+                    component Cfg_Hint: Text {
+                        color: "#7890a8"; font.pixelSize: 11
+                    }
+                    component Cfg_Field: TextField {
+                        font.pixelSize: 14
+                        color: acceptableInput ? "#111122" : "#c0302a"
+                        placeholderTextColor: "#8888aa"
+                        background: Rectangle {
+                            color: "#dde0f5"; radius: 4
+                            border.color: parent.activeFocus ? "#4fc3f7" : "#9090c0"
+                            border.width: 1
+                        }
+                    }
 
                     // ── Common: epochs ────────────────────────────────────
                     ColumnLayout {
                         spacing: 6; Layout.fillWidth: true
-                        Text { text: "Epochs"; color: "#9e9e9e"; font.pixelSize: 12 }
-                        TextField {
+                        Cfg_Label { text: "Epochs" }
+                        Cfg_Field {
                             id: epochsField
-                            Layout.preferredWidth: 200
-                            text: isSA ? saDefaults.epochs : isGA ? gaDefaults.epochs
-                                       : isPSO ? psoDefaults.epochs : isCS ? csDefaults.epochs : fpaDefaults.epochs
+                            Layout.preferredWidth: 220
+                            text: isSA ? saDefaults.epochs.toString()
+                                       : isGA ? gaDefaults.epochs.toString()
+                                       : isPSO ? psoDefaults.epochs.toString()
+                                       : isCS ? csDefaults.epochs.toString()
+                                       : fpaDefaults.epochs.toString()
                             placeholderText: "10000"
-                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
                             validator: IntValidator { bottom: 1; top: 10000000 }
                         }
-                        Text {
-                            text: "Number of iterations the solver will run"
-                            color: "#607d8b"; font.pixelSize: 11
-                        }
+                        Cfg_Hint { text: "Number of iterations the solver will run" }
                     }
 
                     // ── SA fields ─────────────────────────────────────────
@@ -558,41 +575,38 @@ ApplicationWindow {
 
                         ColumnLayout {
                             spacing: 6; Layout.fillWidth: true
-                            Text { text: "Cooling rate"; color: "#9e9e9e"; font.pixelSize: 12 }
-                            TextField {
+                            Cfg_Label { text: "Cooling rate" }
+                            Cfg_Field {
                                 id: crField
-                                Layout.preferredWidth: 200
+                                Layout.preferredWidth: 220
                                 text: saDefaults.cooling_rate.toString()
                                 placeholderText: "0.0001"
-                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
                                 validator: DoubleValidator { bottom: 0.000001; top: 0.999999; notation: DoubleValidator.StandardNotation }
                             }
-                            Text { text: "Must be > 0 and < 1"; color: "#607d8b"; font.pixelSize: 11 }
+                            Cfg_Hint { text: "Must be > 0 and < 1" }
                         }
 
                         RowLayout {
-                            spacing: 24; Layout.fillWidth: true
+                            spacing: 32; Layout.fillWidth: true
                             ColumnLayout {
                                 spacing: 6
-                                Text { text: "Min temperature"; color: "#9e9e9e"; font.pixelSize: 12 }
-                                TextField {
+                                Cfg_Label { text: "Min temperature" }
+                                Cfg_Field {
                                     id: minTField
-                                    width: 160
+                                    width: 180
                                     text: saDefaults.min_temperature.toString()
                                     placeholderText: "0.001"
-                                    color: "#e0e0e0"
                                     validator: DoubleValidator { bottom: 0; notation: DoubleValidator.StandardNotation }
                                 }
                             }
                             ColumnLayout {
                                 spacing: 6
-                                Text { text: "Max temperature"; color: "#9e9e9e"; font.pixelSize: 12 }
-                                TextField {
+                                Cfg_Label { text: "Max temperature" }
+                                Cfg_Field {
                                     id: maxTField
-                                    width: 160
+                                    width: 180
                                     text: saDefaults.max_temperature.toString()
                                     placeholderText: "1000.0"
-                                    color: "#e0e0e0"
                                     validator: DoubleValidator { bottom: 0.000001; notation: DoubleValidator.StandardNotation }
                                 }
                             }
@@ -603,8 +617,8 @@ ApplicationWindow {
                                 var mx = parseFloat(maxTField.text)
                                 return !isNaN(mn) && !isNaN(mx) && mn >= mx
                             }
-                            text: "Min temperature must be < max temperature"
-                            color: "#ef5350"; font.pixelSize: 11
+                            text: "⚠  Min temperature must be less than max temperature"
+                            color: "#ef5350"; font.pixelSize: 12
                         }
                     }
 
@@ -615,32 +629,28 @@ ApplicationWindow {
 
                         ColumnLayout {
                             spacing: 6; Layout.fillWidth: true
-                            Text { text: "Mutation probability"; color: "#9e9e9e"; font.pixelSize: 12 }
-                            TextField {
+                            Cfg_Label { text: "Mutation probability" }
+                            Cfg_Field {
                                 id: mpField
-                                Layout.preferredWidth: 200
-                                text: isGA ? gaDefaults.mutation_probability.toString()
-                                           : isCS ? csDefaults.mutation_probability.toString()
-                                           : fpaDefaults.mutation_probability.toString()
+                                Layout.preferredWidth: 220
+                                text: gaDefaults.mutation_probability.toString()
                                 placeholderText: "0.001"
-                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
                                 validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
                             }
-                            Text { text: "Range [0, 1]"; color: "#607d8b"; font.pixelSize: 11 }
+                            Cfg_Hint { text: "Range [0, 1]" }
                         }
 
                         ColumnLayout {
                             spacing: 6
-                            Text { text: "Elite count (n_elite)"; color: "#9e9e9e"; font.pixelSize: 12 }
-                            TextField {
+                            Cfg_Label { text: "Elite count" }
+                            Cfg_Field {
                                 id: eliteField
-                                width: 120
+                                width: 140
                                 text: gaDefaults.n_elite.toString()
                                 placeholderText: "3"
-                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
                                 validator: IntValidator { bottom: 1; top: 1000 }
                             }
-                            Text { text: "Number of elite solutions preserved each generation"; color: "#607d8b"; font.pixelSize: 11 }
+                            Cfg_Hint { text: "Elite solutions preserved each generation" }
                         }
                     }
 
@@ -648,33 +658,31 @@ ApplicationWindow {
                     ColumnLayout {
                         visible: isCS || isFPA
                         spacing: 6; Layout.fillWidth: true
-                        Text { text: "Mutation probability"; color: "#9e9e9e"; font.pixelSize: 12 }
-                        TextField {
+                        Cfg_Label { text: "Mutation probability" }
+                        Cfg_Field {
                             id: mpField2
-                            Layout.preferredWidth: 200
+                            Layout.preferredWidth: 220
                             text: isCS ? csDefaults.mutation_probability.toString()
                                        : fpaDefaults.mutation_probability.toString()
                             placeholderText: "0.001"
-                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
                             validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
                         }
-                        Text { text: "Range [0, 1]"; color: "#607d8b"; font.pixelSize: 11 }
+                        Cfg_Hint { text: "Range [0, 1]" }
                     }
 
                     // ── PSO fields ────────────────────────────────────────
                     ColumnLayout {
                         visible: isPSO
                         spacing: 6
-                        Text { text: "Swarm size (min)"; color: "#9e9e9e"; font.pixelSize: 12 }
-                        TextField {
+                        Cfg_Label { text: "Swarm size (min)" }
+                        Cfg_Field {
                             id: swarmField
-                            width: 120
+                            width: 140
                             text: psoDefaults.n_nearest.toString()
                             placeholderText: "30"
-                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
                             validator: IntValidator { bottom: 1; top: 10000 }
                         }
-                        Text { text: "Minimum number of particles (effective minimum is 30)"; color: "#607d8b"; font.pixelSize: 11 }
+                        Cfg_Hint { text: "Minimum particle count (floor is 30)" }
                     }
                 }
             }

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -426,22 +426,292 @@ ApplicationWindow {
         }
     }
 
-    // ── Inline component: ConfigPage (placeholder — issue #106) ─────────────
+    // ── Inline component: ConfigPage (issue #106) ───────────────────────────
     component ConfigPage: Page {
         signal backRequested()
         signal solveRequested()
+
         background: Rectangle { color: "#1a1a2e" }
-        ColumnLayout {
-            anchors.centerIn: parent
-            spacing: 16
-            Text { text: "Solver Config"; font.pixelSize: 24; color: "#e0e0e0"; Layout.alignment: Qt.AlignHCenter }
-            Text { text: "Coming in issue #106"; font.pixelSize: 14; color: "#9e9e9e"; Layout.alignment: Qt.AlignHCenter }
-            Text { text: "Solver: " + SolverEngine.selectedSolver; font.pixelSize: 13; color: "#4fc3f7"; Layout.alignment: Qt.AlignHCenter }
+
+        // Defaults matching Rust structs
+        readonly property var saDefaults:  ({ epochs: 10000, cooling_rate: 0.0001, min_temperature: 0.001, max_temperature: 1000.0 })
+        readonly property var gaDefaults:  ({ epochs: 10000, mutation_probability: 0.001, n_elite: 3 })
+        readonly property var psoDefaults: ({ epochs: 10000, n_nearest: 30 })
+        readonly property var csDefaults:  ({ epochs: 10000, mutation_probability: 0.001 })
+        readonly property var fpaDefaults: ({ epochs: 10000, mutation_probability: 0.001 })
+
+        property string alias: SolverEngine.selectedSolver
+        property bool isSA:  alias === "sa"  || alias === "simulated_annealing"
+        property bool isGA:  alias === "ga"  || alias === "genetic_algorithm"
+        property bool isPSO: alias === "pso" || alias === "particle_swarm"
+        property bool isCS:  alias === "cs"  || alias === "cuckoo_search"
+        property bool isFPA: alias === "fpa" || alias === "flower_pollination"
+
+        // Collect current field values as JSON for passing to Rust
+        function collectOpts() {
+            var obj = { epochs: parseInt(epochsField.text) || 10000 }
+            if (isSA) {
+                obj.cooling_rate    = parseFloat(crField.text)   || 0.0001
+                obj.min_temperature = parseFloat(minTField.text) || 0.001
+                obj.max_temperature = parseFloat(maxTField.text) || 1000.0
+            } else if (isGA) {
+                obj.mutation_probability = parseFloat(mpField.text) || 0.001
+                obj.n_elite = parseInt(eliteField.text) || 3
+            } else if (isPSO) {
+                obj.n_nearest = parseInt(swarmField.text) || 30
+            } else if (isCS || isFPA) {
+                obj.mutation_probability = parseFloat(mpField2.text) || 0.001
+            }
+            return JSON.stringify(obj)
+        }
+
+        function hasError() {
+            if (isNaN(parseInt(epochsField.text)) || parseInt(epochsField.text) < 1) return true
+            if (isSA) {
+                var cr = parseFloat(crField.text)
+                if (isNaN(cr) || cr <= 0 || cr >= 1) return true
+                var minT = parseFloat(minTField.text)
+                var maxT = parseFloat(maxTField.text)
+                if (isNaN(minT) || minT < 0) return true
+                if (isNaN(maxT) || maxT <= 0) return true
+                if (minT >= maxT) return true
+            }
+            if (isGA) {
+                var mp = parseFloat(mpField.text)
+                if (isNaN(mp) || mp < 0 || mp > 1) return true
+                if (isNaN(parseInt(eliteField.text)) || parseInt(eliteField.text) < 1) return true
+            }
+            if (isCS || isFPA) {
+                var mp2 = parseFloat(mpField2.text)
+                if (isNaN(mp2) || mp2 < 0 || mp2 > 1) return true
+            }
+            if (isPSO) {
+                if (isNaN(parseInt(swarmField.text)) || parseInt(swarmField.text) < 1) return true
+            }
+            return false
+        }
+
+        ScrollView {
+            id: scrollView
+            anchors.fill: parent
+            anchors.bottomMargin: 64
+            contentWidth: availableWidth
+
+            ColumnLayout {
+                width: scrollView.availableWidth
+                spacing: 0
+
+                // ── Header ────────────────────────────────────────────────
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: 64
+                    color: "#13132b"
+
+                    RowLayout {
+                        anchors { fill: parent; leftMargin: 24; rightMargin: 24 }
+                        Text {
+                            text: "Configure Solver"
+                            font.pixelSize: 20; font.bold: true; color: "#e0e0e0"
+                        }
+                        Item { Layout.fillWidth: true }
+                        Rectangle {
+                            width: solverChip.implicitWidth + 20; height: 28; radius: 14
+                            color: "#1e3a5f"; border.color: "#4fc3f7"; border.width: 1
+                            Text {
+                                id: solverChip
+                                anchors.centerIn: parent
+                                text: SolverEngine.selectedSolver
+                                color: "#4fc3f7"; font.pixelSize: 13
+                            }
+                        }
+                    }
+                }
+
+                // ── Form body ─────────────────────────────────────────────
+                ColumnLayout {
+                    Layout.margins: 32
+                    spacing: 24
+
+                    // ── Common: epochs ────────────────────────────────────
+                    ColumnLayout {
+                        spacing: 6; Layout.fillWidth: true
+                        Text { text: "Epochs"; color: "#9e9e9e"; font.pixelSize: 12 }
+                        TextField {
+                            id: epochsField
+                            Layout.preferredWidth: 200
+                            text: isSA ? saDefaults.epochs : isGA ? gaDefaults.epochs
+                                       : isPSO ? psoDefaults.epochs : isCS ? csDefaults.epochs : fpaDefaults.epochs
+                            placeholderText: "10000"
+                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                            validator: IntValidator { bottom: 1; top: 10000000 }
+                        }
+                        Text {
+                            text: "Number of iterations the solver will run"
+                            color: "#607d8b"; font.pixelSize: 11
+                        }
+                    }
+
+                    // ── SA fields ─────────────────────────────────────────
+                    ColumnLayout {
+                        visible: isSA
+                        spacing: 20; Layout.fillWidth: true
+
+                        ColumnLayout {
+                            spacing: 6; Layout.fillWidth: true
+                            Text { text: "Cooling rate"; color: "#9e9e9e"; font.pixelSize: 12 }
+                            TextField {
+                                id: crField
+                                Layout.preferredWidth: 200
+                                text: saDefaults.cooling_rate.toString()
+                                placeholderText: "0.0001"
+                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                                validator: DoubleValidator { bottom: 0.000001; top: 0.999999; notation: DoubleValidator.StandardNotation }
+                            }
+                            Text { text: "Must be > 0 and < 1"; color: "#607d8b"; font.pixelSize: 11 }
+                        }
+
+                        RowLayout {
+                            spacing: 24; Layout.fillWidth: true
+                            ColumnLayout {
+                                spacing: 6
+                                Text { text: "Min temperature"; color: "#9e9e9e"; font.pixelSize: 12 }
+                                TextField {
+                                    id: minTField
+                                    width: 160
+                                    text: saDefaults.min_temperature.toString()
+                                    placeholderText: "0.001"
+                                    color: "#e0e0e0"
+                                    validator: DoubleValidator { bottom: 0; notation: DoubleValidator.StandardNotation }
+                                }
+                            }
+                            ColumnLayout {
+                                spacing: 6
+                                Text { text: "Max temperature"; color: "#9e9e9e"; font.pixelSize: 12 }
+                                TextField {
+                                    id: maxTField
+                                    width: 160
+                                    text: saDefaults.max_temperature.toString()
+                                    placeholderText: "1000.0"
+                                    color: "#e0e0e0"
+                                    validator: DoubleValidator { bottom: 0.000001; notation: DoubleValidator.StandardNotation }
+                                }
+                            }
+                        }
+                        Text {
+                            visible: {
+                                var mn = parseFloat(minTField.text)
+                                var mx = parseFloat(maxTField.text)
+                                return !isNaN(mn) && !isNaN(mx) && mn >= mx
+                            }
+                            text: "Min temperature must be < max temperature"
+                            color: "#ef5350"; font.pixelSize: 11
+                        }
+                    }
+
+                    // ── GA fields ─────────────────────────────────────────
+                    ColumnLayout {
+                        visible: isGA
+                        spacing: 20; Layout.fillWidth: true
+
+                        ColumnLayout {
+                            spacing: 6; Layout.fillWidth: true
+                            Text { text: "Mutation probability"; color: "#9e9e9e"; font.pixelSize: 12 }
+                            TextField {
+                                id: mpField
+                                Layout.preferredWidth: 200
+                                text: isGA ? gaDefaults.mutation_probability.toString()
+                                           : isCS ? csDefaults.mutation_probability.toString()
+                                           : fpaDefaults.mutation_probability.toString()
+                                placeholderText: "0.001"
+                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                                validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
+                            }
+                            Text { text: "Range [0, 1]"; color: "#607d8b"; font.pixelSize: 11 }
+                        }
+
+                        ColumnLayout {
+                            spacing: 6
+                            Text { text: "Elite count (n_elite)"; color: "#9e9e9e"; font.pixelSize: 12 }
+                            TextField {
+                                id: eliteField
+                                width: 120
+                                text: gaDefaults.n_elite.toString()
+                                placeholderText: "3"
+                                color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                                validator: IntValidator { bottom: 1; top: 1000 }
+                            }
+                            Text { text: "Number of elite solutions preserved each generation"; color: "#607d8b"; font.pixelSize: 11 }
+                        }
+                    }
+
+                    // ── CS / FPA shared mutation field ────────────────────
+                    ColumnLayout {
+                        visible: isCS || isFPA
+                        spacing: 6; Layout.fillWidth: true
+                        Text { text: "Mutation probability"; color: "#9e9e9e"; font.pixelSize: 12 }
+                        TextField {
+                            id: mpField2
+                            Layout.preferredWidth: 200
+                            text: isCS ? csDefaults.mutation_probability.toString()
+                                       : fpaDefaults.mutation_probability.toString()
+                            placeholderText: "0.001"
+                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                            validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
+                        }
+                        Text { text: "Range [0, 1]"; color: "#607d8b"; font.pixelSize: 11 }
+                    }
+
+                    // ── PSO fields ────────────────────────────────────────
+                    ColumnLayout {
+                        visible: isPSO
+                        spacing: 6
+                        Text { text: "Swarm size (min)"; color: "#9e9e9e"; font.pixelSize: 12 }
+                        TextField {
+                            id: swarmField
+                            width: 120
+                            text: psoDefaults.n_nearest.toString()
+                            placeholderText: "30"
+                            color: acceptableInput ? "#e0e0e0" : "#ef5350"
+                            validator: IntValidator { bottom: 1; top: 10000 }
+                        }
+                        Text { text: "Minimum number of particles (effective minimum is 30)"; color: "#607d8b"; font.pixelSize: 11 }
+                    }
+                }
+            }
+        }
+
+        // ── Bottom bar ────────────────────────────────────────────────────
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 56
+            color: "#0d0d1e"
+            z: 10
+
             RowLayout {
-                Layout.alignment: Qt.AlignHCenter
+                anchors { fill: parent; leftMargin: 20; rightMargin: 20 }
                 spacing: 12
+
                 Button { text: "← Back"; onClicked: backRequested() }
-                Button { text: "Solve ▶"; highlighted: true; onClicked: solveRequested() }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                    visible: hasError()
+                    text: "Fix validation errors above"
+                    color: "#ef5350"; font.pixelSize: 12
+                }
+
+                Button {
+                    text: "Solve ▶"
+                    highlighted: true
+                    enabled: !hasError()
+                    onClicked: {
+                        SolverEngine.startSolveWithOpts(FileLoader.filePath, collectOpts())
+                        solveRequested()
+                    }
+                }
             }
         }
     }
@@ -668,10 +938,7 @@ ApplicationWindow {
         id: configComp
         ConfigPage {
             onBackRequested:  stackView.pop()
-            onSolveRequested: {
-                SolverEngine.startSolve(FileLoader.filePath)
-                stackView.push(vizComp)
-            }
+            onSolveRequested: stackView.push(vizComp)
         }
     }
 

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 
 use qtbridge::{QObjectHolder, invoke_method, qobject_impl};
 use teeline::tsp::{
-    self, AppOptions, Solvers, TspProblem,
+    self, AppOptions, GAOptions, CSOptions, FPAOptions, HeuristicOptions, SAOptions,
+    Solvers, TspProblem,
     progress::ProgressMessage,
     tsplib,
 };
@@ -60,16 +61,53 @@ impl SolverEngine {
         self.set_selected_solver(alias);
     }
 
-    /// Reset state and launch the solver on a background thread.
+    /// Reset state and launch the solver with default options.
     #[qslot]
     fn start_solve(&mut self, file_path: String) {
+        self.launch(file_path, AppOptions::default());
+    }
+
+    /// Reset state and launch the solver with options parsed from a JSON object.
+    /// The JSON keys map to the active solver's option fields.
+    #[qslot]
+    fn start_solve_with_opts(&mut self, file_path: String, opts_json: String) {
+        let opts = build_app_options(&self.selected_solver, &opts_json);
+        self.launch(file_path, opts);
+    }
+
+    /// Called on the Qt main thread by the progress-forwarding thread.
+    #[qslot]
+    fn on_progress_update(&mut self, tour_json: String, cost: f32, iteration: i32, elapsed_ms: i32) {
+        self.set_tour_json(tour_json);
+        self.set_best_cost(cost);
+        self.set_iteration(iteration);
+        self.set_elapsed_ms(elapsed_ms);
+    }
+
+    /// Called on the Qt main thread when the solver finishes (or errors).
+    #[qslot]
+    fn on_solve_done(&mut self, tour_json: String, cost: f32, elapsed_ms: i32, _error: String) {
+        self.set_tour_json(tour_json);
+        self.set_best_cost(cost);
+        self.set_elapsed_ms(elapsed_ms);
+        self.set_running(false);
+    }
+
+    /// Stop displaying updates (solver continues in background).
+    #[qslot]
+    fn cancel(&mut self) {
+        self.set_running(false);
+    }
+}
+
+impl SolverEngine {
+    fn launch(&mut self, file_path: String, opts: AppOptions) {
         self.set_running(true);
         self.set_best_cost(0.0);
         self.set_iteration(0);
         self.set_elapsed_ms(0);
         self.set_tour_json("[]".to_string());
 
-        // Two invokers: progress updates and the final done notification.
         let inv_progress = self.get_qml_method_invoker();
         let inv_done = self.get_qml_method_invoker();
         let alias = self.selected_solver.clone();
@@ -78,7 +116,8 @@ impl SolverEngine {
             let solver = match Solvers::from_str(&alias) {
                 Ok(s) => s,
                 Err(_) => {
-                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, format!("Unknown solver: {alias}"));
+                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32,
+                                   format!("Unknown solver: {alias}"));
                     return;
                 }
             };
@@ -100,12 +139,10 @@ impl SolverEngine {
                 }
             };
             let problem = TspProblem::new(cities, distances);
-            let opts = AppOptions::default();
 
             let (tx, rx) = mpsc::channel::<ProgressMessage>();
             let start = Instant::now();
 
-            // Progress-forwarding thread: receives solver updates, fires Qt slots.
             std::thread::spawn(move || {
                 let mut epoch = 0i32;
                 while let Ok(msg) = rx.recv() {
@@ -116,9 +153,7 @@ impl SolverEngine {
                             let ms = start.elapsed().as_millis() as i32;
                             invoke_method!(inv_progress, "onProgressUpdate", tour, cost, epoch, ms);
                         }
-                        ProgressMessage::EpochUpdate(n) => {
-                            epoch = n as i32;
-                        }
+                        ProgressMessage::EpochUpdate(n) => { epoch = n as i32; }
                         ProgressMessage::Done | ProgressMessage::OptimalTour(_) => break,
                         _ => {}
                     }
@@ -137,29 +172,87 @@ impl SolverEngine {
             }
         });
     }
+}
 
-    /// Called on the Qt main thread by the progress-forwarding thread.
-    #[qslot]
-    fn on_progress_update(&mut self, tour_json: String, cost: f32, iteration: i32, elapsed_ms: i32) {
-        self.set_tour_json(tour_json);
-        self.set_best_cost(cost);
-        self.set_iteration(iteration);
-        self.set_elapsed_ms(elapsed_ms);
+// ── Options construction ──────────────────────────────────────────────────────
+
+fn get_f32(v: &serde_json::Value, key: &str, default: f32) -> f32 {
+    v.get(key)
+        .and_then(|x| x.as_f64())
+        .map(|x| x as f32)
+        .unwrap_or(default)
+}
+
+fn get_usize(v: &serde_json::Value, key: &str, default: usize) -> usize {
+    v.get(key)
+        .and_then(|x| x.as_u64())
+        .map(|x| x as usize)
+        .unwrap_or(default)
+}
+
+fn build_heuristic(v: &serde_json::Value) -> HeuristicOptions {
+    let def = HeuristicOptions::default();
+    HeuristicOptions {
+        epochs:        get_usize(v, "epochs",        def.epochs),
+        platoo_epochs: get_usize(v, "platoo_epochs", def.platoo_epochs),
+        n_nearest:     get_usize(v, "n_nearest",     def.n_nearest),
+        verbose:       false,
     }
+}
 
-    /// Called on the Qt main thread when the solver finishes (or errors).
-    #[qslot]
-    fn on_solve_done(&mut self, tour_json: String, cost: f32, elapsed_ms: i32, _error: String) {
-        self.set_tour_json(tour_json);
-        self.set_best_cost(cost);
-        self.set_elapsed_ms(elapsed_ms);
-        self.set_running(false);
-    }
+fn build_app_options(alias: &str, json: &str) -> AppOptions {
+    let v: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Object(Default::default()));
+    let h = build_heuristic(&v);
 
-    /// Stop displaying updates (solver continues in background, harmlessly).
-    #[qslot]
-    fn cancel(&mut self) {
-        self.set_running(false);
+    match alias {
+        "sa" | "simulated_annealing" => {
+            let def = SAOptions::default();
+            AppOptions {
+                sa: Some(SAOptions {
+                    heuristic: h,
+                    cooling_rate:    get_f32(&v, "cooling_rate",    def.cooling_rate),
+                    min_temperature: get_f32(&v, "min_temperature", def.min_temperature),
+                    max_temperature: get_f32(&v, "max_temperature", def.max_temperature),
+                }),
+                ..AppOptions::default()
+            }
+        }
+        "ga" | "genetic_algorithm" => {
+            let def = GAOptions::default();
+            AppOptions {
+                ga: Some(GAOptions {
+                    heuristic: h,
+                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                    n_elite: get_usize(&v, "n_elite", def.n_elite),
+                }),
+                ..AppOptions::default()
+            }
+        }
+        "cs" | "cuckoo_search" => {
+            let def = CSOptions::default();
+            AppOptions {
+                cs: Some(CSOptions {
+                    heuristic: h,
+                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                }),
+                ..AppOptions::default()
+            }
+        }
+        "fpa" | "flower_pollination" => {
+            let def = FPAOptions::default();
+            AppOptions {
+                fpa: Some(FPAOptions {
+                    heuristic: h,
+                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                }),
+                ..AppOptions::default()
+            }
+        }
+        // PSO and all others use HeuristicOptions
+        _ => AppOptions {
+            heuristic: Some(h),
+            ..AppOptions::default()
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- **ConfigPage** replaces the placeholder with a real parameter form, conditionally showing the right fields based on `SolverEngine.selectedSolver`
- **SA**: epochs, cooling_rate (>0, <1), min_temperature, max_temperature (with cross-field validation min < max)
- **GA**: epochs, mutation_probability [0,1], n_elite (int ≥ 1)
- **CS / FPA**: epochs, mutation_probability [0,1]
- **PSO**: epochs, n_nearest/swarm min (used internally as particle count floor)
- Defaults pre-populated from Rust struct defaults (`SAOptions::default()`, `GAOptions::default()`, etc.)
- "Solve ▶" disabled while any field is invalid; inline error hint shown
- **SolverEngine**: `start_solve_with_opts(filePath, optsJson)` slot parses a flat JSON object and builds the correct typed `AppOptions` (`SAOptions`, `GAOptions`, `CSOptions`, `FPAOptions`, or `HeuristicOptions`) before launching the solver thread

## Test plan

- [x] Select SA → "Configure →" → SA fields shown with correct defaults → adjust cooling_rate to 1.0 → "Solve ▶" disabled → reset → solve runs with custom params
- [x] Select GA → "Configure →" → GA fields shown → adjust mutation_probability / n_elite → solve
- [x] Select PSO → "Configure →" → swarm min field shown → solve
- [x] Select CS → "Configure →" → mutation_probability shown → solve
- [x] Select FPA → same as CS
- [x] "← Back" from ConfigPage returns to SolverPage with solver still selected
- [x] `cargo build -p teeline-qt` clean