### PR TITLE
feat(teeline): load solver list dynamically from backend (#118)

### DIFF
--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -180,6 +180,66 @@ impl Solvers {
     }
 }
 
+// ---------------------------------------------------------------------------
+// UI-facing solver metadata (used by teeline-qt)
+// ---------------------------------------------------------------------------
+
+pub struct SolverInfo {
+    pub name:        &'static str,
+    pub alias:       &'static str,
+    pub category:    &'static str,
+    pub desc:        &'static str,
+    pub complexity:  &'static str,
+    pub has_options: bool,
+    pub exact:       bool,
+}
+
+static SOLVER_LIST: [SolverInfo; 13] = [
+    SolverInfo { name: "Bellman-Held-Karp",     alias: "bhk",             category: "Exact",
+                 desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
+                 complexity: "O(n\u{00b2} \u{00b7} 2\u{207f})", has_options: false, exact: true },
+    SolverInfo { name: "Branch & Bound",        alias: "branch_bound",    category: "Exact",
+                 desc: "Exact branch-and-bound with lower-bound pruning.",
+                 complexity: "O(n!)", has_options: false, exact: true },
+    SolverInfo { name: "Nearest Neighbor",      alias: "nn",              category: "Constructive",
+                 desc: "Greedy heuristic: always visit the nearest unvisited city.",
+                 complexity: "O(n\u{00b2})", has_options: false, exact: false },
+    SolverInfo { name: "2-opt",                 alias: "2opt",            category: "Local Search",
+                 desc: "Iteratively reverses sub-tours to remove crossing edges.",
+                 complexity: "O(n\u{00b2}) / pass", has_options: false, exact: false },
+    SolverInfo { name: "3-opt",                 alias: "3opt",            category: "Local Search",
+                 desc: "Extends 2-opt by considering triple-edge reconnections.",
+                 complexity: "O(n\u{00b3}) / pass", has_options: false, exact: false },
+    SolverInfo { name: "Simulated Annealing",   alias: "sa",              category: "Metaheuristic",
+                 desc: "Accepts worse moves with decreasing probability to escape local optima.",
+                 complexity: "O(epochs \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Genetic Algorithm",     alias: "ga",              category: "Metaheuristic",
+                 desc: "Evolves a population of tours via crossover and mutation operators.",
+                 complexity: "O(epochs \u{00b7} pop \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Particle Swarm",        alias: "pso",             category: "Metaheuristic",
+                 desc: "Discrete PSO with velocity-capped particles guided by a global best.",
+                 complexity: "O(epochs \u{00b7} swarm \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Cuckoo Search",         alias: "cs",              category: "Metaheuristic",
+                 desc: "L\u{00e9}vy-flight search with probabilistic nest abandonment.",
+                 complexity: "O(epochs \u{00b7} nests \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Flower Pollination",    alias: "fpa",             category: "Metaheuristic",
+                 desc: "Global L\u{00e9}vy-flight toward best tour; local \u{03b5}-scaled cross-pollination.",
+                 complexity: "O(epochs \u{00b7} pop \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Stochastic Hill Climb", alias: "stochastic_hill", category: "Metaheuristic",
+                 desc: "Random-restart hill climbing to escape local optima.",
+                 complexity: "O(epochs \u{00b7} n)", has_options: false, exact: false },
+    SolverInfo { name: "Tabu Search",           alias: "tabu_search",     category: "Metaheuristic",
+                 desc: "Local search with a memory structure to avoid revisiting solutions.",
+                 complexity: "O(epochs \u{00b7} n)", has_options: false, exact: false },
+    SolverInfo { name: "Random Shuffle",        alias: "shuffle",         category: "Utility",
+                 desc: "Baseline random tour. Useful as a warm-start seed for pipelines.",
+                 complexity: "O(n)", has_options: false, exact: false },
+];
+
+pub fn list_solvers() -> &'static [SolverInfo] {
+    &SOLVER_LIST
+}
+
 impl FromStr for Solvers {
     type Err = &'static str;
 

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -221,48 +221,8 @@ ApplicationWindow {
 
     }
 
-    // ── Solver metadata (static) ────────────────────────────────────────────
-    readonly property var solverList: [
-        { name: "Bellman-Held-Karp",    alias: "bhk",            category: "Exact",
-          desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
-          complexity: "O(n² · 2ⁿ)", hasOptions: false, exact: true },
-        { name: "Branch & Bound",       alias: "branch_bound",   category: "Exact",
-          desc: "Exact branch-and-bound with lower-bound pruning.",
-          complexity: "O(n!)",        hasOptions: false, exact: true },
-        { name: "Nearest Neighbor",     alias: "nn",             category: "Constructive",
-          desc: "Greedy heuristic: always visit the nearest unvisited city.",
-          complexity: "O(n²)",        hasOptions: false, exact: false },
-        { name: "2-opt",                alias: "2opt",           category: "Local Search",
-          desc: "Iteratively reverses sub-tours to remove crossing edges.",
-          complexity: "O(n²) / pass", hasOptions: false, exact: false },
-        { name: "3-opt",                alias: "3opt",           category: "Local Search",
-          desc: "Extends 2-opt by considering triple-edge reconnections.",
-          complexity: "O(n³) / pass", hasOptions: false, exact: false },
-        { name: "Simulated Annealing",  alias: "sa",             category: "Metaheuristic",
-          desc: "Accepts worse moves with decreasing probability to escape local optima.",
-          complexity: "O(epochs · n)", hasOptions: true,  exact: false },
-        { name: "Genetic Algorithm",    alias: "ga",             category: "Metaheuristic",
-          desc: "Evolves a population of tours via crossover and mutation operators.",
-          complexity: "O(epochs · pop · n)", hasOptions: true, exact: false },
-        { name: "Particle Swarm",       alias: "pso",            category: "Metaheuristic",
-          desc: "Discrete PSO with velocity-capped particles guided by a global best.",
-          complexity: "O(epochs · swarm · n)", hasOptions: true, exact: false },
-        { name: "Cuckoo Search",        alias: "cs",             category: "Metaheuristic",
-          desc: "Lévy-flight search with probabilistic nest abandonment.",
-          complexity: "O(epochs · nests · n)", hasOptions: true, exact: false },
-        { name: "Flower Pollination",   alias: "fpa",            category: "Metaheuristic",
-          desc: "Global Lévy-flight toward best tour; local ε-scaled cross-pollination.",
-          complexity: "O(epochs · pop · n)", hasOptions: true, exact: false },
-        { name: "Stochastic Hill Climb",alias: "stochastic_hill",category: "Metaheuristic",
-          desc: "Random-restart hill climbing to escape local optima.",
-          complexity: "O(epochs · n)", hasOptions: false, exact: false },
-        { name: "Tabu Search",          alias: "tabu_search",    category: "Metaheuristic",
-          desc: "Local search with a memory structure to avoid revisiting solutions.",
-          complexity: "O(epochs · n)", hasOptions: false, exact: false },
-        { name: "Random Shuffle",       alias: "shuffle",        category: "Utility",
-          desc: "Baseline random tour. Useful as a warm-start seed for pipelines.",
-          complexity: "O(n)",          hasOptions: false, exact: false },
-    ]
+    // ── Solver metadata — populated from Rust backend at startup (issue #118) ──
+    readonly property var solverList: JSON.parse(SolverEngine.solversJson)
 
     // ── Inline component: SolverPage ────────────────────────────────────────
     // ── Inline component: SolverPage (merged with ConfigPage, issues #104 + #106 + #114) ──

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::mpsc;
 use std::time::Instant;
 
+use serde_json::json;
 use qtbridge::{QObjectHolder, invoke_method, qobject_impl};
 use teeline::tsp::{
     self, AppOptions, GAOptions, CSOptions, FPAOptions, HeuristicOptions, SAOptions,
@@ -19,6 +20,7 @@ pub struct SolverEngine {
     iteration: i32,
     elapsed_ms: i32,
     tour_json: String,
+    solvers_json: String,
 }
 
 impl Default for SolverEngine {
@@ -30,8 +32,25 @@ impl Default for SolverEngine {
             iteration: 0,
             elapsed_ms: 0,
             tour_json: "[]".to_string(),
+            solvers_json: build_solvers_json(),
         }
     }
+}
+
+fn build_solvers_json() -> String {
+    let arr: Vec<serde_json::Value> = teeline::tsp::list_solvers()
+        .iter()
+        .map(|s| json!({
+            "name":       s.name,
+            "alias":      s.alias,
+            "category":   s.category,
+            "desc":       s.desc,
+            "complexity": s.complexity,
+            "hasOptions": s.has_options,
+            "exact":      s.exact
+        }))
+        .collect();
+    serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
 }
 
 #[qobject_impl(Singleton)]
@@ -42,6 +61,7 @@ impl SolverEngine {
     qproperty!("iteration",      Member = iteration,       Write = set_iteration,       Notify = "iterationChanged");
     qproperty!("elapsedMs",      Member = elapsed_ms,      Write = set_elapsed_ms,      Notify = "elapsedMsChanged");
     qproperty!("tourJson",       Member = tour_json,       Write = set_tour_json,       Notify = "tourJsonChanged");
+    qproperty!("solversJson",    Member = solvers_json,    Write = set_solvers_json,    Notify = "solversJsonChanged");
 
     fn set_selected_solver(&mut self, v: String)  { self.selected_solver = v;  self.selected_solver_changed(); }
     fn set_running(&mut self, v: bool)             { self.running = v;           self.running_changed(); }
@@ -49,6 +69,7 @@ impl SolverEngine {
     fn set_iteration(&mut self, v: i32)            { self.iteration = v;         self.iteration_changed(); }
     fn set_elapsed_ms(&mut self, v: i32)           { self.elapsed_ms = v;        self.elapsed_ms_changed(); }
     fn set_tour_json(&mut self, v: String)         { self.tour_json = v;         self.tour_json_changed(); }
+    fn set_solvers_json(&mut self, v: String)      { self.solvers_json = v;      self.solvers_json_changed(); }
 
     #[qsignal] fn selected_solver_changed(&self);
     #[qsignal] fn running_changed(&self);
@@ -56,6 +77,7 @@ impl SolverEngine {
     #[qsignal] fn iteration_changed(&self);
     #[qsignal] fn elapsed_ms_changed(&self);
     #[qsignal] fn tour_json_changed(&self);
+    #[qsignal] fn solvers_json_changed(&self);
 
     #[qslot]
     fn select_solver(&mut self, alias: String) {


### PR DESCRIPTION
## Summary

- Adds `SolverInfo` struct and `list_solvers()` public function to the `teeline` library (`src/tsp/mod.rs`) — all 13 solvers' UI metadata in one place
- `teeline-qt` calls `list_solvers()` at startup and serialises to JSON via `serde_json` (already a dependency); result is exposed as `SolverEngine.solversJson`
- `Main.qml` replaces the 43-line hardcoded solver array with `JSON.parse(SolverEngine.solversJson)` — adding a new solver in future requires zero QML changes

Closes #118

## Test plan

- [x] `cargo test` passes
- [x] `cargo build -p teeline-qt` clean
- [x] Qt app: Solver Picker shows all 13 solvers with correct names, categories, descriptions
- [x] Pipeline Builder popup: solvers appear grouped by category
- [x] Exact-solver warning fires for BHK / Branch & Bound with >20 cities
- [x] Config panel appears only for SA / GA / PSO / CS / FPA (`hasOptions = true`)