### PR TITLE
docs: add subproject READMEs and Subprojects section in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Teeline is a solver for the symmetric Traveling Salesman Problem, written in Rus
 
 It is a work in progress. It already implements all algorithms typically covered by a CS algorithms course. More advanced algorithms will be added once the code structure and interfaces have stabilised.
 
+## Subprojects
+
+| Subproject | Description |
+|---|---|
+| [teeline-cli](teeline-cli/README.md) | Command-line solver — reads TSPLIB files, prints the best tour found |
+| [teeline-qt](teeline-qt/README.md) | Qt 6 desktop GUI with live solver visualization and a pipeline builder |
+| [teeline-wasm](teeline-wasm/README.md) | WebAssembly Component Model build — callable from JS, Python, Go, and Rust |
+
+The `teeline` crate at the root is the pure solver library shared by all three.
+
 ## Backstory
 
 It all started from the ["In Pursuit of the Traveling Salesman"](https://www.amazon.de/Pursuit-Traveling-Salesman-Mathematics-Computation-ebook/dp/B0073X0IR2/) book — a fantastic read that covers the history of the problem and the big ideas behind the Concorde solver. I was genuinely surprised that Linear Programming works so well here and can provide exact solutions for very large instances.

--- a/teeline-cli/README.md
+++ b/teeline-cli/README.md
@@ -1,0 +1,30 @@
+# teeline-cli
+
+Command-line interface for the Teeline TSP solver. Reads city data in TSPLIB format (from a file or stdin) and prints the best tour found.
+
+## Build
+
+```bash
+cargo build -p teeline-cli          # debug
+cargo build -p teeline-cli --release  # optimised
+```
+
+## Usage
+
+```bash
+# solve from a file
+teeline solve nn -i data/tsplib/berlin52.tsp
+
+# chain solvers in a pipeline
+teeline solve classic -i data/tsplib/berlin52.tsp
+
+# compare against a known-optimal tour
+teeline solve ga -i data/tsplib/berlin52.tsp \
+    --optimal-tour data/tsplib/berlin52.opt.tour
+
+# list available solvers
+teeline solvers
+teeline solvers --heuristic --short
+```
+
+Full documentation is in the [root README](../README.md).

--- a/teeline-qt/README.md
+++ b/teeline-qt/README.md
@@ -1,0 +1,25 @@
+# teeline-qt
+
+Qt 6 / QML desktop GUI for the Teeline TSP solver. Provides live visualization of the solver's progress, a solver picker with configuration panels, and a multi-stage pipeline builder.
+
+## Requirements
+
+- Qt 6.7 or later
+- Rust toolchain (the solver engine is compiled into the binary via `qtbridge`)
+
+## Build
+
+```bash
+cargo build -p teeline-qt          # debug
+cargo build -p teeline-qt --release  # optimised
+```
+
+Or open `teeline-qt/` in Qt Creator and build from there.
+
+## Features
+
+- **Welcome screen** — drag-and-drop or browse for a `.tsp` file
+- **Solver picker** — lists all available solvers grouped by category with descriptions and complexity
+- **Config panel** — tuning parameters (epochs, temperatures, mutation probability, …) for solvers that support them
+- **Visualization** — live canvas that animates the solver's improving tour
+- **Pipeline builder** — chain multiple solvers; each stage warm-starts from the previous result

--- a/teeline-wasm/README.md
+++ b/teeline-wasm/README.md
@@ -1,0 +1,26 @@
+# teeline-wasm
+
+WebAssembly Component Model build of the Teeline TSP solver. Exposes a single typed `solve` function callable from Go, Python, JavaScript, Rust, and any WIT-compatible runtime.
+
+## Build
+
+Requires [cargo-component](https://github.com/bytecodealliance/cargo-component):
+
+```bash
+cargo component build --manifest-path teeline-wasm/Cargo.toml --release
+```
+
+The component is written to `target/wasm32-wasip2/release/teeline_wasm.wasm`.
+
+## Usage (JavaScript via jco)
+
+```bash
+# transpile to JS bindings
+npx jco transpile target/wasm32-wasip2/release/teeline_wasm.wasm -o js-bindings
+
+# call from Node.js
+import { solve } from './js-bindings/teeline_wasm.js';
+const result = solve('sa', cities, options);
+```
+
+See [docs/wasm.md](../docs/wasm.md) for the full interface reference and working examples in JavaScript, Python, Go, and Rust.


### PR DESCRIPTION
## Summary

- Adds a **Subprojects** table near the top of the root `README.md` linking to the three crates
- Creates `teeline-cli/README.md` — build/usage quick-start for the CLI
- Creates `teeline-qt/README.md` — requirements, build, and feature list for the Qt GUI
- Creates `teeline-wasm/README.md` — build, transpile, and usage quick-start for the WASM component

## Test plan

- [x] All links in the table are relative paths that resolve correctly from the repo root on GitHub
- [x] Each subproject README links back to the root README or relevant docs