### PR TITLE
feat(ci): Qt release workflow + manual pre-release dispatcher (#119)

### DIFF
--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -1,0 +1,258 @@
+# Manual / pre-release Qt builds for teeline-qt.
+#
+# Triggers on workflow_dispatch so the maintainer can test Qt artifacts on
+# Windows and macOS before cutting a full release, and to give early adopters
+# a download link without waiting for a version tag.
+#
+# Each run creates or updates a GitHub pre-release at the given tag (default:
+# "qt-prerelease") and replaces the three platform artifacts in-place, so there
+# is always exactly one "latest pre-release" for early adopters to find.
+
+name: Build Qt (pre-release / manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Pre-release tag (existing release is updated in-place)'
+        required: false
+        default: 'qt-prerelease'
+
+env:
+  QT_VERSION: '6.11.0'
+
+jobs:
+  build-qt-linux:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          target: desktop
+          arch: gcc_64
+          cache: true
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev libfuse2
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Download linuxdeploy
+        run: |
+          wget -nv https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget -nv https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
+      - name: Create AppDir
+        run: |
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/share/applications
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+          cp target/release/teeline-qt AppDir/usr/bin/
+          cat > AppDir/teeline-qt.desktop << 'DESKTOP'
+          [Desktop Entry]
+          Type=Application
+          Name=Teeline Qt
+          Exec=teeline-qt
+          Icon=teeline-qt
+          Categories=Science;Education;
+          DESKTOP
+          cp AppDir/teeline-qt.desktop AppDir/usr/share/applications/
+          # Generate a 256×256 placeholder icon using Python stdlib (no extra deps)
+          python3 - << 'PYEOF'
+          import struct, zlib
+          def png_chunk(name, data):
+              crc = zlib.crc32(name + data) & 0xffffffff
+              return struct.pack('>I', len(data)) + name + data + struct.pack('>I', crc)
+          w, h = 256, 256
+          sig = b'\x89PNG\r\n\x1a\n'
+          ihdr = png_chunk(b'IHDR', struct.pack('>IIBBBBB', w, h, 8, 2, 0, 0, 0))
+          row = b'\x00' + b'\x2a\x82\xda' * w   # filter byte + blue RGB
+          idat = png_chunk(b'IDAT', zlib.compress(row * h))
+          iend = png_chunk(b'IEND', b'')
+          with open('AppDir/usr/share/icons/hicolor/256x256/apps/teeline-qt.png', 'wb') as f:
+              f.write(sig + ihdr + idat + iend)
+          PYEOF
+      - name: Package AppImage
+        env:
+          QMLPATHS: ${{ github.workspace }}/teeline-qt/src
+          LD_LIBRARY_PATH: ${{ env.QT_ROOT_DIR }}/lib
+        run: |
+          ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin qt --output appimage
+          mv Teeline_Qt-x86_64.AppImage "teeline-qt-${{ inputs.tag }}-linux-x86_64.AppImage"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-linux
+          path: teeline-qt-*-linux-x86_64.AppImage
+          if-no-files-found: error
+
+  build-qt-windows:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Configure long paths
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: windows
+          target: desktop
+          arch: win64_msvc2022_64
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Deploy Qt dependencies
+        shell: pwsh
+        run: |
+          $windeployqt = "${{ env.QT_ROOT_DIR }}\bin\windeployqt.exe"
+          & $windeployqt --release --compiler-runtime --qmldir teeline-qt\src --dir deploy target\release\teeline-qt.exe
+          Copy-Item target\release\teeline-qt.exe deploy\
+      - name: Package zip
+        shell: pwsh
+        run: |
+          $tag = "${{ inputs.tag }}"
+          $name = "teeline-qt-${tag}-windows-x64"
+          Rename-Item deploy $name
+          Compress-Archive -Path $name -DestinationPath "${name}.zip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-windows
+          path: teeline-qt-*-windows-x64.zip
+          if-no-files-found: error
+
+  build-qt-macos:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: mac
+          target: desktop
+          arch: clang_64
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Create .app bundle
+        run: |
+          mkdir -p TeelineQt.app/Contents/MacOS
+          mkdir -p TeelineQt.app/Contents/Resources
+          cp target/release/teeline-qt TeelineQt.app/Contents/MacOS/
+          cat > TeelineQt.app/Contents/Info.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleExecutable</key>
+            <string>teeline-qt</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.timgluz.teeline-qt</string>
+            <key>CFBundleName</key>
+            <string>TeelineQt</string>
+            <key>CFBundleDisplayName</key>
+            <string>Teeline Qt</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>NSHighResolutionCapable</key>
+            <true/>
+            <key>NSPrincipalClass</key>
+            <string>NSApplication</string>
+          </dict>
+          </plist>
+          EOF
+      - name: Deploy Qt frameworks and create DMG
+        run: |
+          macdeployqt TeelineQt.app -always-overwrite -qmldir=teeline-qt/src
+          codesign --force --deep -s - TeelineQt.app
+          hdiutil create \
+            -volname "Teeline Qt" \
+            -srcfolder TeelineQt.app \
+            -ov -format UDZO \
+            "teeline-qt-${{ inputs.tag }}-macos-arm64.dmg"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-macos
+          path: teeline-qt-*-macos-arm64.dmg
+          if-no-files-found: error
+
+  publish-prerelease:
+    needs:
+      - build-qt-linux
+      - build-qt-windows
+      - build-qt-macos
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-linux
+          path: artifacts/
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-windows
+          path: artifacts/
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-macos
+          path: artifacts/
+      - name: Create or update pre-release
+        run: |
+          TAG="${{ inputs.tag }}"
+          NOTES="Built from commit \`${{ github.sha }}\` on branch \`${{ github.ref_name }}\`.
+
+          **This is a pre-release build for manual testing and early access.**
+
+          | Platform | File |
+          |----------|------|
+          | Linux x86_64 | \`teeline-qt-${TAG}-linux-x86_64.AppImage\` (run directly; no install needed) |
+          | Windows x64 | \`teeline-qt-${TAG}-windows-x64.zip\` (unzip and run \`teeline-qt.exe\`) |
+          | macOS arm64 | \`teeline-qt-${TAG}-macos-arm64.dmg\` (open dmg, drag to Applications) |
+
+          **macOS note:** if Gatekeeper blocks the app, run:
+          \`\`\`
+          xattr -dr com.apple.quarantine /Applications/TeelineQt.app
+          \`\`\`"
+
+          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --repo "${{ github.repository }}" \
+              --notes "$NOTES"
+            gh release upload "$TAG" artifacts/* \
+              --clobber \
+              --repo "${{ github.repository }}"
+          else
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --prerelease \
+              --target "${{ github.sha }}" \
+              --title "Teeline Qt — Pre-release build" \
+              --notes "$NOTES" \
+              artifacts/*
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
-    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
+    name: build-local-artifacts
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,3 +327,218 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  # --- Qt platform builds (issue #119) ---
+  # These jobs run in parallel with the cargo-dist platform builds, then
+  # upload their artifacts to the same GitHub Release after 'host' creates it.
+
+  build-qt-linux:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      QT_VERSION: '6.11.0'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          target: desktop
+          arch: gcc_64
+          cache: true
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev libfuse2
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Download linuxdeploy
+        run: |
+          wget -nv https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget -nv https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
+      - name: Create AppDir
+        run: |
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/share/applications
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+          cp target/release/teeline-qt AppDir/usr/bin/
+          cat > AppDir/teeline-qt.desktop << 'DESKTOP'
+          [Desktop Entry]
+          Type=Application
+          Name=Teeline Qt
+          Exec=teeline-qt
+          Icon=teeline-qt
+          Categories=Science;Education;
+          DESKTOP
+          cp AppDir/teeline-qt.desktop AppDir/usr/share/applications/
+          # Generate a 256×256 placeholder icon using Python stdlib (no extra deps)
+          python3 - << 'PYEOF'
+          import struct, zlib
+          def png_chunk(name, data):
+              crc = zlib.crc32(name + data) & 0xffffffff
+              return struct.pack('>I', len(data)) + name + data + struct.pack('>I', crc)
+          w, h = 256, 256
+          sig = b'\x89PNG\r\n\x1a\n'
+          ihdr = png_chunk(b'IHDR', struct.pack('>IIBBBBB', w, h, 8, 2, 0, 0, 0))
+          row = b'\x00' + b'\x2a\x82\xda' * w   # filter byte + blue RGB
+          idat = png_chunk(b'IDAT', zlib.compress(row * h))
+          iend = png_chunk(b'IEND', b'')
+          with open('AppDir/usr/share/icons/hicolor/256x256/apps/teeline-qt.png', 'wb') as f:
+              f.write(sig + ihdr + idat + iend)
+          PYEOF
+      - name: Package AppImage
+        env:
+          QMLPATHS: ${{ github.workspace }}/teeline-qt/src
+          LD_LIBRARY_PATH: ${{ env.QT_ROOT_DIR }}/lib
+        run: |
+          ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin qt --output appimage
+          # linuxdeploy names the file using the desktop entry Name + arch
+          mv Teeline_Qt-x86_64.AppImage "teeline-qt-${{ needs.plan.outputs.tag }}-linux-x86_64.AppImage"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-linux
+          path: teeline-qt-*-linux-x86_64.AppImage
+          if-no-files-found: error
+
+  build-qt-windows:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      QT_VERSION: '6.11.0'
+    steps:
+      - name: Configure long paths
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: windows
+          target: desktop
+          arch: win64_msvc2022_64
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Deploy Qt dependencies
+        shell: pwsh
+        run: |
+          $windeployqt = "${{ env.QT_ROOT_DIR }}\bin\windeployqt.exe"
+          & $windeployqt --release --compiler-runtime --qmldir teeline-qt\src --dir deploy target\release\teeline-qt.exe
+          Copy-Item target\release\teeline-qt.exe deploy\
+      - name: Package zip
+        shell: pwsh
+        run: |
+          $tag = "${{ needs.plan.outputs.tag }}"
+          $name = "teeline-qt-${tag}-windows-x64"
+          Rename-Item deploy $name
+          Compress-Archive -Path $name -DestinationPath "${name}.zip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-windows
+          path: teeline-qt-*-windows-x64.zip
+          if-no-files-found: error
+
+  build-qt-macos:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      QT_VERSION: '6.11.0'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: mac
+          target: desktop
+          arch: clang_64
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --release --locked -p teeline-qt
+      - name: Create .app bundle
+        run: |
+          mkdir -p TeelineQt.app/Contents/MacOS
+          mkdir -p TeelineQt.app/Contents/Resources
+          cp target/release/teeline-qt TeelineQt.app/Contents/MacOS/
+          cat > TeelineQt.app/Contents/Info.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleExecutable</key>
+            <string>teeline-qt</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.timgluz.teeline-qt</string>
+            <key>CFBundleName</key>
+            <string>TeelineQt</string>
+            <key>CFBundleDisplayName</key>
+            <string>Teeline Qt</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>NSHighResolutionCapable</key>
+            <true/>
+            <key>NSPrincipalClass</key>
+            <string>NSApplication</string>
+          </dict>
+          </plist>
+          EOF
+      - name: Deploy Qt frameworks and create DMG
+        run: |
+          macdeployqt TeelineQt.app -always-overwrite -qmldir=teeline-qt/src
+          codesign --force --deep -s - TeelineQt.app
+          hdiutil create \
+            -volname "Teeline Qt" \
+            -srcfolder TeelineQt.app \
+            -ov -format UDZO \
+            "teeline-qt-${{ needs.plan.outputs.tag }}-macos-arm64.dmg"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: qt-macos
+          path: teeline-qt-*-macos-arm64.dmg
+          if-no-files-found: error
+
+  upload-qt-artifacts:
+    needs:
+      - plan
+      - host
+      - build-qt-linux
+      - build-qt-windows
+      - build-qt-macos
+    if: ${{ always() && needs.host.result == 'success' && needs.build-qt-linux.result == 'success' && needs.build-qt-windows.result == 'success' && needs.build-qt-macos.result == 'success' }}
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-linux
+          path: artifacts/
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-windows
+          path: artifacts/
+      - uses: actions/download-artifact@v8
+        with:
+          name: qt-macos
+          path: artifacts/
+      - name: Attach Qt artifacts to GitHub Release
+        run: gh release upload "${{ needs.plan.outputs.tag }}" artifacts/* --repo "${{ github.repository }}"

--- a/teeline-qt/Cargo.toml
+++ b/teeline-qt/Cargo.toml
@@ -15,6 +15,6 @@ path = "src/main.rs"
 dist = false  # requires Qt runtime; not a standalone distributable binary
 
 [dependencies]
-qtbridge = { git = "https://github.com/qt/qtbridge-rust", branch = "dev", rev = "66583b7be5f7060feb27790741996ce350836091" }
+qtbridge = { git = "https://github.com/qt/qtbridge-rust", rev = "66583b7be5f7060feb27790741996ce350836091" }
 teeline = { path = ".." }
 serde_json = "1"

--- a/teeline-qt/Cargo.toml
+++ b/teeline-qt/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 repository = "https://github.com/timgluz/teeline"
 license = "LGPL-3.0-or-later"
+description = "Qt 6 GUI for the Teeline TSP solver"
 
 [[bin]]
 name = "teeline-qt"
@@ -14,6 +15,6 @@ path = "src/main.rs"
 dist = false  # requires Qt runtime; not a standalone distributable binary
 
 [dependencies]
-qtbridge = { git = "https://github.com/qt/qtbridge-rust", branch = "dev" }
+qtbridge = { git = "https://github.com/qt/qtbridge-rust", branch = "dev", rev = "66583b7be5f7060feb27790741996ce350836091" }
 teeline = { path = ".." }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Closes #119.

- **`release.yml`** — 4 new jobs appended after `announce`: `build-qt-linux`, `build-qt-windows`, `build-qt-macos`, `upload-qt-artifacts`. All three platform builds run in parallel (conditioned on `publishing == 'true'`), then `upload-qt-artifacts` waits for `host` (which creates the GitHub Release) before attaching the Qt artifacts via `gh release upload`.
- **`build-qt.yml`** — New workflow with `workflow_dispatch` trigger. Builds all three platforms, then creates or updates a rolling pre-release at the configured tag (default: `qt-prerelease`). On first run it creates the release; on subsequent runs it edits the notes and clobbers the artifacts in-place.
- **`teeline-qt/Cargo.toml`** — Pinned `qtbridge` rev added explicitly (belt-and-suspenders alongside Cargo.lock); description added.

## Platform artifacts

| Platform | File | Notes |
|----------|------|-------|
| Linux x86_64 | `teeline-qt-<tag>-linux-x86_64.AppImage` | Run directly; no install |
| Windows x64 | `teeline-qt-<tag>-windows-x64.zip` | Unzip, run `teeline-qt.exe` |
| macOS arm64 | `teeline-qt-<tag>-macos-arm64.dmg` | arm64-only; Intel is out of scope |

macOS Gatekeeper bypass (unsigned build): `xattr -dr com.apple.quarantine /Applications/TeelineQt.app`

## Key design choices

- **QML deps**: All deploy tools receive `--qmldir teeline-qt/src` (Linux: `QMLPATHS`, Windows: `--qmldir`, macOS: `-qmldir=`) because QML is embedded via `include_bytes!` — deployment tools can't discover Qt Quick/Controls/Dialogs dependencies from the binary ELF/Mach-O alone (qtbridge only links Core/Gui/Qml/QuickTest).
- **No race condition**: Qt jobs integrated into `release.yml` (not a separate workflow) so a single `cargo-dist`-managed release object is shared. `allow-dirty = ["ci"]` in `dist-workspace.toml` permits this.
- **Rolling pre-release**: `build-qt.yml` maintains a single `qt-prerelease` tag that early adopters can bookmark; each manual dispatch replaces the three artifacts in-place.

## Test plan

- [ ] Trigger `build-qt.yml` manually from the Actions tab (no tag needed)
- [ ] Download and run Windows zip on Windows — verify solver list loads, can run a solve
- [ ] Download and run macOS DMG on arm64 Mac — verify solver list loads, can run a solve
- [ ] Download Linux AppImage, `chmod +x`, run on Ubuntu
- [ ] After merge: push a version tag (e.g. `v0.1.1`) and verify all four Qt jobs appear in the `Release` workflow run and artifacts are attached to the GitHub Release