### PR TITLE
feat: support GEO distance type for TSPLIB problems (#127)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod config;
 #[cfg(test)]
 mod test;
 pub mod tsp;
+
+pub use tsp::DistanceType;

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -54,11 +54,33 @@
 use std::collections::HashMap;
 
 use super::kdtree::KDPoint;
-use super::{CityTable, NearestResult};
+use super::{CityTable, DistanceType, NearestResult};
+
+fn geo_distance(p1: &KDPoint, p2: &KDPoint) -> f32 {
+    use std::f64::consts::PI;
+    fn to_rad(x: f32) -> f64 {
+        let deg = x.trunc() as f64;
+        let min = (x - x.trunc()) as f64;
+        PI * (deg + 5.0 * min / 3.0) / 180.0
+    }
+    let lat1 = to_rad(p1.coords[0]);
+    let lon1 = to_rad(p1.coords[1]);
+    let lat2 = to_rad(p2.coords[0]);
+    let lon2 = to_rad(p2.coords[1]);
+    let q1 = (lon1 - lon2).cos();
+    let q2 = (lat1 - lat2).cos();
+    let q3 = (lat1 + lat2).cos();
+    const RRR: f64 = 6378.388;
+    (RRR * (0.5 * ((1.0 + q1) * q2 - (1.0 - q1) * q3)).acos() + 1.0).floor() as f32
+}
 
 // to have similar builder as kdtree
 pub fn from_cities(cities: &[KDPoint]) -> DistanceMatrix {
     DistanceMatrix::from_cities(cities).unwrap()
+}
+
+pub fn build(cities: &[KDPoint], dt: DistanceType) -> DistanceMatrix {
+    DistanceMatrix::build(cities, dt).unwrap()
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +116,10 @@ impl DistanceMatrix {
 
     // assumes that cities are already sorted by id and ids are incrementally crowing
     pub fn from_cities(cities: &[KDPoint]) -> Result<Self, &'static str> {
+        Self::build(cities, DistanceType::Euc2D)
+    }
+
+    pub fn build(cities: &[KDPoint], distance_type: DistanceType) -> Result<Self, &'static str> {
         let n = cities.len();
         if n < 2 {
             return Err("distance matrix requires at least 2 points");
@@ -108,7 +134,11 @@ impl DistanceMatrix {
             city_table.insert(i, *pt1);
 
             for pt2 in cities.iter().take(i) {
-                distances.push(pt1.distance(pt2));
+                let d = match distance_type {
+                    DistanceType::Euc2D => pt1.distance(pt2),
+                    DistanceType::Geo => geo_distance(pt1, pt2),
+                };
+                distances.push(d);
             }
         }
 
@@ -400,6 +430,15 @@ mod tests {
 
         let res5 = dm.nearest(&cities[4], 2);
         assert_eq!(cities[0].id, res5.point.id);
+    }
+
+    #[test]
+    fn test_geo_distance_known_pair() {
+        // Issue #127 reference pair: cities A=(16.47, 96.10) & B=(23.70, 96.99)
+        // TSPLIB FAQ great-circle formula (trunc-based, full-precision PI) yields 837.
+        let a = KDPoint::new_with_id(1, &[16.47, 96.10]);
+        let b = KDPoint::new_with_id(2, &[23.70, 96.99]);
+        assert_eq!(geo_distance(&a, &b), 837.0);
     }
 
     // Regression: nearest must work when city IDs are 1-based (as in TSPLIB files like berlin52).

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -108,6 +108,28 @@ impl Solvers {
 }
 
 // ---------------------------------------------------------------------------
+// Distance type — describes how inter-city distances are computed
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DistanceType {
+    #[default]
+    Euc2D,
+    Geo,
+}
+
+impl FromStr for DistanceType {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "EUC_2D" | "EUC2D" => Ok(DistanceType::Euc2D),
+            "GEO" => Ok(DistanceType::Geo),
+            other => Err(format!("unsupported distance type: {other}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Solver catalogue — single source of truth for the `solvers` subcommand
 // ---------------------------------------------------------------------------
 

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use super::CityTable;
+use super::DistanceType;
 use super::distance_matrix::{self, DistanceMatrix};
 use super::kdtree::KDPoint;
 
@@ -29,6 +30,7 @@ pub struct TspLibData {
     cities: Vec<KDPoint>,
     dimension: usize,
     raw_distances: Option<Vec<f32>>,
+    pub distance_type: DistanceType,
 }
 
 impl TspLibData {
@@ -38,6 +40,7 @@ impl TspLibData {
         cities: Vec<KDPoint>,
         dimension: usize,
         raw_distances: Option<Vec<f32>>,
+        distance_type: DistanceType,
     ) -> Self {
         TspLibData {
             name,
@@ -45,7 +48,13 @@ impl TspLibData {
             cities,
             dimension,
             raw_distances,
+            distance_type,
         }
+    }
+
+    pub fn with_distance_type(mut self, dt: DistanceType) -> Self {
+        self.distance_type = dt;
+        self
     }
 
     pub fn cities(&self) -> &[KDPoint] {
@@ -84,7 +93,7 @@ impl TspLibData {
                     .collect();
                 Ok(DistanceMatrix::new(n, dists.clone(), city_table))
             }
-            None => Ok(distance_matrix::from_cities(&self.cities)),
+            None => Ok(distance_matrix::build(&self.cities, self.distance_type)),
         }
     }
 }
@@ -165,6 +174,11 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
         return Err("ATSP (asymmetric TSP) is not supported".to_string());
     }
 
+    let distance_type: DistanceType = metadata
+        .get("EDGE_WEIGHT_TYPE")
+        .and_then(|v| v.trim().parse::<DistanceType>().ok())
+        .unwrap_or_default();
+
     let dimension: usize = metadata
         .get("DIMENSION")
         .and_then(|v| v.trim().parse().ok())
@@ -212,6 +226,7 @@ fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
         cities,
         dimension,
         raw_distances,
+        distance_type,
     );
 
     Ok(dt)
@@ -567,6 +582,24 @@ mod tests {
         assert!((dm.distance_between(1, 2).unwrap() - 1.0).abs() < 1e-3);
         assert!((dm.distance_between(1, 3).unwrap() - 2.0).abs() < 1e-3);
         assert!((dm.distance_between(2, 3).unwrap() - 3.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_process_lines_geo_distance_type() {
+        let cursor = "NAME: geo_case\nEDGE_WEIGHT_TYPE: GEO\nNODE_COORD_SECTION\n1 16.47 96.10\n2 23.70 96.99\nEOF\n".as_bytes();
+        let reader = BufReader::new(cursor);
+        let res = process_lines(reader);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().distance_type, DistanceType::Geo);
+    }
+
+    #[test]
+    fn test_process_lines_unknown_type_falls_back_to_euc2d() {
+        let cursor = "NAME: att_case\nEDGE_WEIGHT_TYPE: ATT\nNODE_COORD_SECTION\n1 2.0 3.0\n2 4.0 5.0\nEOF\n".as_bytes();
+        let reader = BufReader::new(cursor);
+        let res = process_lines(reader);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().distance_type, DistanceType::Euc2D);
     }
 
     #[test]

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -12,6 +12,7 @@ use teeline::tsp::{
     pipeline::{PipelineStage, run_pipeline},
     tsplib,
 };
+use teeline::DistanceType;
 use tracing_subscriber::EnvFilter;
 
 // ---------------------------------------------------------------------------
@@ -230,6 +231,10 @@ fn tuning_args() -> Vec<Arg> {
             .value_name("FILE_PATH")
             .help("path to .opt.tour file; overlays optimal route and prints gap")
             .required(false),
+        Arg::new("distance_type")
+            .long("distance-type")
+            .help("override distance formula: euc_2d, geo (default: from file header)")
+            .required(false),
     ]
 }
 
@@ -335,6 +340,18 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         read_tsp_data_from_file(Path::new(input_file_path.as_str()))
     } else {
         read_tsp_data_from_stdin()
+    };
+
+    let tsp_data = if let Some(dt_str) = args.get_one::<String>("distance_type") {
+        match dt_str.parse::<DistanceType>() {
+            Ok(dt) => tsp_data.with_distance_type(dt),
+            Err(e) => {
+                eprintln!("error: --distance-type: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        tsp_data
     };
 
     tracing::info!(name = %tsp_data.name, comment = %tsp_data.comment,

--- a/tests/fixtures/burma14.tsp
+++ b/tests/fixtures/burma14.tsp
@@ -1,0 +1,26 @@
+NAME: burma14
+TYPE: TSP
+COMMENT: 14-Staedte in Burma (Zaw Win)
+DIMENSION: 14
+EDGE_WEIGHT_TYPE: GEO
+EDGE_WEIGHT_FORMAT: FUNCTION 
+DISPLAY_DATA_TYPE: COORD_DISPLAY
+NODE_COORD_SECTION
+   1  16.47       96.10
+   2  16.47       94.44
+   3  20.09       92.54
+   4  22.39       93.37
+   5  25.23       97.24
+   6  22.00       96.05
+   7  20.47       97.02
+   8  17.20       96.29
+   9  16.30       97.38
+  10  14.05       98.12
+  11  16.53       97.38
+  12  21.52       95.59
+  13  19.41       97.13
+  14  20.09       94.55
+EOF
+
+
+

--- a/tests/test_kdtree_and_distance_matrix.rs
+++ b/tests/test_kdtree_and_distance_matrix.rs
@@ -117,6 +117,30 @@ fn test_tour_length_with_unknown_city_does_not_panic() {
     let _ = dm.tour_length(&[0, 99, 1]); // must not panic
 }
 
+/// burma14.tsp declares EDGE_WEIGHT_TYPE: GEO; verify distance_type is parsed and
+/// that GEO distances are in a realistic range (hundreds of km, not Euclidean ~1.66).
+#[test]
+fn test_burma14_geo_distance_matrix() {
+    let path = std::path::Path::new("data/tsplib/burma14.tsp");
+    let tsp_data = teeline::tsp::tsplib::read_from_file(path).expect("burma14 not found");
+
+    assert_eq!(tsp_data.distance_type, teeline::DistanceType::Geo);
+
+    let dm = tsp_data.distance_matrix().expect("distance matrix");
+
+    // Cities 1=(16.47, 96.10) and 2=(16.47, 94.44) share the same latitude.
+    // Euclidean distance would be ~1.66; GEO distance should be much larger (hundreds of km).
+    let geo_d = dm.distance_between(1, 2).expect("distance between city 1 and 2");
+    assert!(
+        geo_d > 100.0,
+        "GEO distance should be > 100 km, got {geo_d}"
+    );
+    assert!(
+        geo_d < 300.0,
+        "GEO distance should be < 300 km, got {geo_d}"
+    );
+}
+
 /// tour_length_by_pos must return the same result as tour_length for a valid path.
 #[test]
 fn test_tour_length_by_pos_matches_tour_length() {

--- a/tests/test_kdtree_and_distance_matrix.rs
+++ b/tests/test_kdtree_and_distance_matrix.rs
@@ -121,7 +121,7 @@ fn test_tour_length_with_unknown_city_does_not_panic() {
 /// that GEO distances are in a realistic range (hundreds of km, not Euclidean ~1.66).
 #[test]
 fn test_burma14_geo_distance_matrix() {
-    let path = std::path::Path::new("data/tsplib/burma14.tsp");
+    let path = std::path::Path::new("tests/fixtures/burma14.tsp");
     let tsp_data = teeline::tsp::tsplib::read_from_file(path).expect("burma14 not found");
 
     assert_eq!(tsp_data.distance_type, teeline::DistanceType::Geo);


### PR DESCRIPTION
## Summary

- Adds `DistanceType` enum (`Euc2D`, `Geo`) with `FromStr` for CLI parsing
- Parses `EDGE_WEIGHT_TYPE` from TSPLIB headers; auto-selects GEO great-circle formula for the 10 affected files (burma14, ulysses16/22, ali535, gr96–gr666)
- Adds `--distance-type` CLI flag to `solve`/`pipeline` subcommands for manual override
- Keeps KD-tree nearest-neighbor Euclidean (geographic locality is preserved for heuristics)

## Formula

Implements the TSPLIB FAQ great-circle formula exactly, using f64 intermediates for precision:
`d = floor(RRR * acos(0.5 * ((1+q1)*q2 − (1−q1)*q3)) + 1)` where `RRR = 6378.388 km`

## Verification against burma14 (known optimal: 3323)

| Solver | Tour | Gap |
|--------|------|-----|
| `nn` | 4048 | +21.8% — expected for a greedy heuristic |
| `2opt` | 4040 | +21.6% |
| `sa` | 3359 | **+1.1%** — close to optimal ✓ |

NN's 20–25% gap is normal; SA confirms the GEO distances are correct.

## Test Plan

- [x] Unit test: `test_geo_distance_known_pair` — verifies formula for reference coordinates
- [x] Unit test: `test_process_lines_geo_distance_type` — verifies GEO parsed from header
- [x] Unit test: `test_process_lines_unknown_type_falls_back_to_euc2d` — ATT/unknown → Euc2D silently
- [x] Integration test: `test_burma14_geo_distance_matrix` — loads `tests/fixtures/burma14.tsp`, confirms GEO distances are in realistic range (100–300 km vs Euclidean ~1.66)
- [x] All existing tests still pass
- [x] Manual: `./target/debug/teeline solve sa -i ./data/tsplib/burma14.tsp` → tour ≈ 3323–3400
- [x] Manual: `./target/debug/teeline solve nn -i ./data/tsplib/berlin52.tsp` — EUC_2D unchanged
- [x] Manual: `--distance-type euc_2d` override on burma14 produces wrong-but-consistent Euclidean result

Closes #127