### PR TITLE
fix: correct branch_bound pruning and BHK route reconstruction (#137)

### DIFF
--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -156,7 +156,12 @@ fn read_optimal_route(opt: &DPTable, dm: &DistanceMatrix, n: usize, best_val: f3
 }
 
 fn approx(x1: f32, x2: f32) -> bool {
-    (x1 - x2).abs() < f32::EPSILON
+    // f32::EPSILON (~1.2e-7) is the gap between 1.0 and the next f32, not a usable
+    // tolerance for sums of distances. Accumulated rounding over N f32 additions
+    // reaches ~N * ULP(result), which for tour costs ~10-3000 is ~1e-5 to ~3e-4.
+    let diff = (x1 - x2).abs();
+    let scale = x1.abs().max(x2.abs()).max(1.0);
+    diff <= scale * 1e-4
 }
 
 fn show_table(opt: &DPTable) {
@@ -220,6 +225,36 @@ mod tests {
             (solution.total - 4.0).abs() < 1e-3,
             "expected tour length ~4.0, got {}",
             solution.total
+        );
+    }
+
+    #[test]
+    fn test_route_reconstruction_on_larger_instance() {
+        // Regression: read_optimal_route used f32::EPSILON as the comparison
+        // tolerance, which is far too tight for summed f32 distances on 8+ cities.
+        // Accumulated rounding reaches ~1e-6 >> f32::EPSILON, causing the loop
+        // to leave positions as 0, producing repeated cities in the route.
+        let coords: &[&[f32]] = &[
+            &[0.0, 0.0], &[3.0, 1.0], &[1.0, 3.0], &[4.0, 4.0],
+            &[2.0, 0.5], &[0.5, 2.0], &[3.5, 2.5], &[1.5, 4.0],
+        ];
+        let cities: Vec<kdtree::KDPoint> = coords
+            .iter()
+            .enumerate()
+            .map(|(i, c)| kdtree::KDPoint::new_with_id(i + 1, c))
+            .collect();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
+
+        let solution = solve(&problem, &HeuristicOptions::default(), None, None);
+
+        let mut route = solution.route().to_vec();
+        route.sort();
+        assert_eq!(
+            route,
+            vec![1, 2, 3, 4, 5, 6, 7, 8],
+            "BHK must visit every city exactly once; got {:?}",
+            solution.route()
         );
     }
 

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -65,7 +65,7 @@ fn build_evaluator(distances: &DistanceMatrix) -> PathEvaluator {
     Rc::new(move |path: &Path| dm.tour_length(path))
 }
 
-#[allow(clippy::only_used_in_recursion)]
+#[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
 fn backtrack(
     evaluate_fn: &PathEvaluator,
     distances: &DistanceMatrix,

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -7,6 +7,11 @@ use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{HeuristicOptions, Solution, TspProblem};
 
+// NOTE: build_points() assigns 0-indexed city IDs, so this sentinel collides
+// with city ID 0 in unit tests. Currently harmless because the algorithm uses
+// positional indexing (path[k]) and never compares slots to UNVISITED_NODE
+// except in the progress-reporting filter (which may silently drop city 0 from
+// progress updates). TSPLIB files are 1-indexed, so no production impact.
 const UNVISITED_NODE: usize = 0;
 
 type UniqSet = HashSet<usize>;
@@ -39,6 +44,7 @@ pub fn solve(
     let fitness_fn = build_evaluator(distances);
     let (best_path, _best_distance) = backtrack(
         &fitness_fn,
+        distances,
         &mut open_path,
         &unvisited_cities,
         1,
@@ -62,6 +68,7 @@ fn build_evaluator(distances: &DistanceMatrix) -> PathEvaluator {
 #[allow(clippy::only_used_in_recursion)]
 fn backtrack(
     evaluate_fn: &PathEvaluator,
+    distances: &DistanceMatrix,
     path: &mut Path,
     unvisited_cities: &UniqSet,
     k: usize,
@@ -90,7 +97,7 @@ fn backtrack(
         unvisited_cities,
         running_cost,
         best_distance,
-        evaluate_fn,
+        distances,
     );
 
     for candidate in candidates.iter() {
@@ -110,13 +117,16 @@ fn backtrack(
         }
 
         let prev_city = path[k - 1];
-        let next_distance = evaluate_fn(&vec![prev_city, *candidate]);
+        let next_distance = distances
+            .distance_between(prev_city, *candidate)
+            .expect("city ids in path must be in distance matrix");
 
         let mut next_cities = unvisited_cities.clone();
         next_cities.remove(candidate);
 
         let (sub_res, sub_dist) = backtrack(
             evaluate_fn,
+            distances,
             path,
             &next_cities,
             k + 1,
@@ -148,12 +158,14 @@ fn construct_candidates(
     unvisited_cities: &UniqSet,
     running_cost: f32,
     best_distance: f32,
-    evaluate_fn: &PathEvaluator,
+    distances: &DistanceMatrix,
 ) -> Path {
     let mut candidates: Path = vec![];
 
     for city_id in unvisited_cities.iter() {
-        let next_distance = evaluate_fn(&vec![path[k - 1], *city_id]);
+        let next_distance = distances
+            .distance_between(path[k - 1], *city_id)
+            .expect("city ids in path must be in distance matrix");
         if best_distance > running_cost + next_distance {
             candidates.push(*city_id);
         }
@@ -231,6 +243,41 @@ mod tests {
             "B&B tour {} should match BHK tour {}",
             bb_tour.total,
             bhk_tour.total
+        );
+    }
+
+    #[test]
+    fn test_solve_matches_bhk_on_tsp8() {
+        // Uses 1-indexed city IDs (matching TSPLIB convention) to avoid the
+        // UNVISITED_NODE=0 sentinel colliding with city ID 0 from build_points.
+        // Points are arranged so the sorted-ID sequential tour crosses itself —
+        // B&B must find the same optimal as BHK, not just return input order.
+        let coords: &[&[f32]] = &[
+            &[0.0, 0.0],
+            &[3.0, 1.0],
+            &[1.0, 3.0],
+            &[4.0, 4.0],
+            &[2.0, 0.5],
+            &[0.5, 2.0],
+            &[3.5, 2.5],
+            &[1.5, 4.0],
+        ];
+        let cities: Vec<kdtree::KDPoint> = coords
+            .iter()
+            .enumerate()
+            .map(|(i, c)| kdtree::KDPoint::new_with_id(i + 1, c))
+            .collect();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
+
+        let bb = solve(&problem, &HeuristicOptions::default(), None, None);
+        let bhk = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
+
+        assert!(
+            (bb.total - bhk.total).abs() < 1e-3,
+            "B&B tour {:.3} should match BHK optimal {:.3}",
+            bb.total,
+            bhk.total
         );
     }
 }


### PR DESCRIPTION
## Summary

Two bugs fixed together — the BHK bug was masking the B&B regression test.

### branch_bound: doubled edge cost in pruning (root cause of #137)

`construct_candidates` and `backtrack` computed incremental edge cost via `evaluate_fn(&[prev, candidate])`, which calls `dm.tour_length` — a function that **always closes the loop** (adds return-to-start). For a 2-element path this returns `2×d(a,b)`, doubling every accumulated cost.

Result: after the first DFS descent found the sequential input-order tour, the doubled `running_cost` quickly exceeded `best_distance`, pruning every subsequent branch. B&B always returned the unoptimised input order.

**Fix:** pass `&DistanceMatrix` to `backtrack` and `construct_candidates`; replace `evaluate_fn(&[a,b])` with `distances.distance_between(a,b).expect(...)`. `evaluate_fn` is kept for full-solution evaluation only (calling `tour_length` on the complete path is correct there).

### bellman_karp: route reconstruction tolerance too tight

`read_optimal_route` used `approx(x,y)` with `f32::EPSILON ≈ 1.2e-7`. Summed f32 distances over 8+ cities accumulate rounding errors of ~1e-6 to ~1e-5, routinely exceeding this threshold. When the inner loop found no match, `route_ids[i]` stayed at `0`, producing repeated city-1 entries and a spurious tour cost that hid the B&B regression.

**Fix:** relative tolerance `diff <= scale * 1e-4`.

## Test Plan

- [x] TDD: `test_solve_matches_bhk_on_tsp8` written first, confirmed failing (B&B 16.491 vs BHK 12.693 corrupted), then green after fix
- [x] TDD: `test_route_reconstruction_on_larger_instance` written first, confirmed BHK returned repeated cities, then green after `approx` fix
- [x] All existing B&B tests still pass (tsp5 visits-all, optimal, matches-bhk)
- [x] All existing BHK tests still pass (returns-all-cities, optimal-length, 3-city)
- [x] Full `cargo test` suite passes

## Verification

```bash
# burma14 — fixed B&B now finds the correct optimal
./target/debug/teeline solve branch_bound -i ./data/tsplib/burma14.tsp
# expected: 3323 (same as BHK)

# gr17 — fixed B&B should match BHK's 2085
./target/debug/teeline solve branch_bound -i tests/fixtures/gr17.tsp 2>/dev/null
./target/debug/teeline solve bhk -i tests/fixtures/gr17.tsp 2>/dev/null
```

Closes #137