### PR TITLE
feat(teeline-web): Task B — WASM Web Worker bridge (#130)

### DIFF
--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "teeline-web",
       "version": "0.1.0",
       "dependencies": {
+        "@bytecodealliance/preview2-shim": "^0.17.9",
         "@picocss/pico": "2.1.1",
         "htmx.org": "2.0.10",
         "teeline-wasm": "file:../teeline-wasm/js-bindings"
@@ -20,12 +21,17 @@
       }
     },
     "../teeline-wasm/js-bindings": {
-      "name": "js-bindings",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.17.9"
       }
+    },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+      "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -9,13 +9,22 @@
       "version": "0.1.0",
       "dependencies": {
         "@picocss/pico": "2.1.1",
-        "htmx.org": "2.0.10"
+        "htmx.org": "2.0.10",
+        "teeline-wasm": "file:../teeline-wasm/js-bindings"
       },
       "devDependencies": {
         "typescript": "6.0.3",
         "vite": "8.0.14",
         "vitest": "4.1.7",
         "wrangler": "4.95.0"
+      }
+    },
+    "../teeline-wasm/js-bindings": {
+      "name": "js-bindings",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "^0.17.9"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -2484,6 +2493,10 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/teeline-wasm": {
+      "resolved": "../teeline-wasm/js-bindings",
+      "link": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@picocss/pico": "2.1.1",
-    "htmx.org": "2.0.10"
+    "htmx.org": "2.0.10",
+    "teeline-wasm": "file:../teeline-wasm/js-bindings"
   },
   "devDependencies": {
     "typescript": "6.0.3",

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -11,6 +11,7 @@
     "deploy": "npm run build && wrangler pages deploy dist/"
   },
   "dependencies": {
+    "@bytecodealliance/preview2-shim": "^0.17.9",
     "@picocss/pico": "2.1.1",
     "htmx.org": "2.0.10",
     "teeline-wasm": "file:../teeline-wasm/js-bindings"

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -1,3 +1,41 @@
 import 'htmx.org'
 import '@picocss/pico/css/pico.min.css'
 import './main.css'
+import { type SolveOptions } from './solver-options'
+import type { SolveResult, SolveError } from './worker'
+
+const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+
+export function runSolver(
+  solver: string,
+  cities: Array<{ id: number; x: number; y: number }>,
+  options: Partial<SolveOptions> = {},
+): Promise<{ total: number; route: number[] }> {
+  return new Promise((resolve, reject) => {
+    const handler = (e: MessageEvent<SolveResult | SolveError>) => {
+      worker.removeEventListener('message', handler)
+      if (e.data.type === 'result') {
+        resolve(e.data.solution)
+        document.dispatchEvent(
+          new CustomEvent('solver:result', { detail: e.data.solution, bubbles: true }),
+        )
+      } else {
+        const err = new Error(e.data.message)
+        reject(err)
+        document.dispatchEvent(
+          new CustomEvent('solver:error', { detail: e.data.message, bubbles: true }),
+        )
+      }
+    }
+    worker.addEventListener('message', handler)
+    worker.postMessage({ type: 'solve', solver, cities, options })
+  })
+}
+
+// Expose for browser console smoke test and HTMX scripts
+declare global {
+  interface Window {
+    runSolver: typeof runSolver
+  }
+}
+window.runSolver = runSolver

--- a/teeline-web/src/solver-options.test.ts
+++ b/teeline-web/src/solver-options.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { defaultSolveOptions } from './solver-options'
+
+describe('defaultSolveOptions', () => {
+  it('returns an object with all required SolveOptions fields', () => {
+    const opts = defaultSolveOptions()
+    expect(typeof opts.epochs).toBe('number')
+    expect(typeof opts.platooEpochs).toBe('number')
+    expect(typeof opts.coolingRate).toBe('number')
+    expect(typeof opts.maxTemperature).toBe('number')
+    expect(typeof opts.minTemperature).toBe('number')
+    expect(typeof opts.mutationProbability).toBe('number')
+    expect(typeof opts.nElite).toBe('number')
+    expect(typeof opts.nNearest).toBe('number')
+  })
+
+  it('minTemperature is less than maxTemperature', () => {
+    const opts = defaultSolveOptions()
+    expect(opts.minTemperature).toBeLessThan(opts.maxTemperature)
+  })
+
+  it('epochs is a positive integer', () => {
+    const opts = defaultSolveOptions()
+    expect(opts.epochs).toBeGreaterThan(0)
+    expect(Number.isInteger(opts.epochs)).toBe(true)
+  })
+})

--- a/teeline-web/src/solver-options.ts
+++ b/teeline-web/src/solver-options.ts
@@ -1,0 +1,23 @@
+export interface SolveOptions {
+  epochs: number
+  platooEpochs: number
+  coolingRate: number
+  maxTemperature: number
+  minTemperature: number
+  mutationProbability: number
+  nElite: number
+  nNearest: number
+}
+
+export function defaultSolveOptions(): SolveOptions {
+  return {
+    epochs: 500,
+    platooEpochs: 50,
+    coolingRate: 0.0001,
+    maxTemperature: 1000.0,
+    minTemperature: 0.001,
+    mutationProbability: 0.05,
+    nElite: 3,
+    nNearest: 5,
+  }
+}

--- a/teeline-web/src/teeline-wasm.d.ts
+++ b/teeline-web/src/teeline-wasm.d.ts
@@ -1,0 +1,23 @@
+declare module 'teeline-wasm' {
+  export interface City {
+    id: number
+    x: number
+    y: number
+  }
+  export interface SolveOptions {
+    epochs: number
+    platooEpochs: number
+    coolingRate: number
+    maxTemperature: number
+    minTemperature: number
+    mutationProbability: number
+    nElite: number
+    nNearest: number
+  }
+  export interface Solution {
+    total: number
+    route: Uint32Array
+  }
+  export function solve(solver: string, cities: Array<City>, options: SolveOptions): Solution
+  export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E }
+}

--- a/teeline-web/src/worker.ts
+++ b/teeline-web/src/worker.ts
@@ -1,0 +1,46 @@
+/// <reference lib="webworker" />
+
+import { solve } from 'teeline-wasm'
+import { defaultSolveOptions, type SolveOptions } from './solver-options'
+
+export interface SolveRequest {
+  type: 'solve'
+  solver: string
+  cities: Array<{ id: number; x: number; y: number }>
+  options: Partial<SolveOptions>
+}
+
+export interface SolveResult {
+  type: 'result'
+  solution: { total: number; route: number[] }
+}
+
+export interface SolveError {
+  type: 'error'
+  message: string
+}
+
+self.onmessage = (e: MessageEvent<SolveRequest>) => {
+  const { type, solver, cities, options } = e.data
+  if (type !== 'solve') return
+
+  const mergedOptions: SolveOptions = { ...defaultSolveOptions(), ...options }
+
+  try {
+    const solution = solve(solver, cities, mergedOptions)
+    const result: SolveResult = {
+      type: 'result',
+      solution: {
+        total: solution.total,
+        route: Array.from(solution.route),  // Uint32Array → plain number[]
+      },
+    }
+    self.postMessage(result)
+  } catch (err) {
+    const error: SolveError = {
+      type: 'error',
+      message: err instanceof Error ? err.message : String(err),
+    }
+    self.postMessage(error)
+  }
+}

--- a/teeline-web/tsconfig.json
+++ b/teeline-web/tsconfig.json
@@ -21,5 +21,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
+  "paths": {
+    "teeline-wasm": ["../teeline-wasm/js-bindings/teeline_wasm"]
+  },
   "include": ["src"]
 }

--- a/teeline-web/tsconfig.json
+++ b/teeline-web/tsconfig.json
@@ -21,8 +21,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "paths": {
-    "teeline-wasm": ["../teeline-wasm/js-bindings/teeline_wasm"]
-  },
   "include": ["src"]
 }

--- a/teeline-web/vite.config.ts
+++ b/teeline-web/vite.config.ts
@@ -5,8 +5,16 @@ export default defineConfig({
   build: {
     outDir: 'dist',
   },
+  resolve: {
+    preserveSymlinks: true,  // follow npm file: symlinks to teeline-wasm
+  },
+  optimizeDeps: {
+    exclude: ['teeline-wasm'],  // don't pre-bundle; WASM needs to stay as-is
+  },
+  worker: {
+    format: 'es',  // ES module workers — required for top-level await in teeline_wasm.js
+  },
   test: {
-    // node env (default) — only import DOM-free modules in tests (e.g. app.ts, not main.ts)
-    // If tests need DOM later, add: environment: 'jsdom', and devDep: jsdom
+    // node env (default) — tests import only DOM-free modules (solver-options.ts)
   },
 })


### PR DESCRIPTION
## Summary

- Adds `teeline-wasm` as a local `file:` dependency (`teeline-wasm/js-bindings/`), installed via npm symlink with `resolve.preserveSymlinks: true` and `optimizeDeps.exclude` in Vite config
- Creates `src/worker.ts` — ES module Web Worker that imports `solve()` from `teeline-wasm`, merges caller options with `defaultSolveOptions()`, and posts back `{ type: 'result', solution }` or `{ type: 'error', message }`
- Updates `src/main.ts` to create the Worker once, expose `runSolver(solver, cities, options?)` as a Promise, dispatch `solver:result` / `solver:error` CustomEvents for HTMX, and attach `window.runSolver` for console access

## Smoke Test Result (Firefox 150)

```js
runSolver('nn', [{id:1,x:565,y:575},{id:2,x:25,y:185},{id:3,x:345,y:750},{id:4,x:945,y:685},{id:5,x:845,y:655}], {})
// → { total: 2607.66, route: [1, 3, 5, 4, 2] }
```

`@bytecodealliance/preview2-shim` filesystem stubs work in browser Workers — `node:fs/promises` is externalized by Vite and never actually called during `solve()`.

## Test Plan

- [x] `cd teeline-web && npm test` — 4 tests passing (app + solver-options)
- [x] `npm run build` — `dist/assets/worker-*.js` + `*.core.wasm` + `*.core2.wasm` present
- [x] `npm run dev` → browser console: `runSolver('nn', [...], {})` resolves with `{ total, route }`
- [x] DOM event fires: `document.addEventListener('solver:result', e => console.log(e.detail))`

## Follow-up ideas

- Extend `teeline-wasm` WIT interface to accept TSPLIB string / JSON directly — avoids WASI filesystem imports entirely and simplifies future Tasks C/D

Closes #130