### PR TITLE
fix(ci): allow dependabot bot in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'dependabot[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: 'dependabot[bot]'` to the `claude-code-action` step in `claude-code-review.yml`

## Problem
The claude-review action was rejecting Dependabot PRs (e.g. #148) with:
```
Error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

## Fix
Added `allowed_bots: 'dependabot[bot]'` to explicitly permit Dependabot-triggered runs.

## Test plan
- [ ] Re-run the claude-review action on PR #148 and confirm it no longer errors with the bot rejection message