### PR TITLE
feat(teeline-wasm): parse-and-solve WIT export (#147)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build
       run: cargo build -p teeline -p teeline-cli --verbose
     - name: Build WASM component
-      run: cd teeline-wasm && cargo component build
+      run: cargo component build --manifest-path teeline-wasm/Cargo.toml
     - name: Run tests
       run: cargo test -p teeline -p teeline-cli --verbose
     - name: Run e2e tests (BATS)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build
       run: cargo build -p teeline -p teeline-cli --verbose
     - name: Build WASM component
-      run: cargo component build --manifest-path teeline-wasm/Cargo.toml
+      run: cd teeline-wasm && cargo component build
     - name: Run tests
       run: cargo test -p teeline -p teeline-cli --verbose
     - name: Run e2e tests (BATS)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,16 @@ keywords = ["tsp", "optimization"]
 name = "teeline"
 path = "src/lib.rs"
 
+[features]
+default = []
+json = ["dep:serde_json"]
+
 [dependencies]
 clap = "4.6.1"
 rand = "0.9"
 regex = "1.12.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", optional = true }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_read_from_str_burma14() {
-        let input = std::fs::read_to_string("data/tsplib/burma14.tsp")
+        let input = std::fs::read_to_string("tests/fixtures/burma14.tsp")
             .expect("burma14.tsp missing");
         let dt = read_from_str(&input).unwrap();
         assert_eq!(14, dt.len());
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_read_from_str_berlin52() {
-        let input = std::fs::read_to_string("data/tsplib/berlin52.tsp")
+        let input = std::fs::read_to_string("tests/fixtures/berlin52.tsp")
             .expect("berlin52.tsp missing");
         let dt = read_from_str(&input).unwrap();
         assert_eq!(52, dt.len());

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -115,6 +115,30 @@ pub fn read_from_stdin() -> Result<TspLibData, String> {
     process_lines(reader.lock())
 }
 
+pub fn read_from_str(input: &str) -> Result<TspLibData, String> {
+    let cursor = std::io::Cursor::new(input.as_bytes());
+    process_lines(BufReader::new(cursor))
+}
+
+#[cfg(feature = "json")]
+pub fn parse_json_cities(input: &str) -> Result<Vec<super::KDPoint>, String> {
+    #[derive(serde::Deserialize)]
+    struct CityRecord {
+        id: usize,
+        x: f32,
+        y: f32,
+    }
+    let records: Vec<CityRecord> =
+        serde_json::from_str(input).map_err(|e| format!("JSON parse error: {e}"))?;
+    if records.len() < 2 {
+        return Err("need at least 2 cities".into());
+    }
+    Ok(records
+        .into_iter()
+        .map(|c| super::KDPoint::new_with_id(c.id, &[c.x, c.y]))
+        .collect())
+}
+
 fn process_lines<R: BufRead>(reader: R) -> Result<TspLibData, String> {
     let mut metadata: HashMap<String, String> = HashMap::new();
     let mut cities: Vec<KDPoint> = vec![];
@@ -621,5 +645,80 @@ mod tests {
         // Cities come from DISPLAY_DATA_SECTION, not grid
         assert_eq!(3, dt.len());
         assert_eq!(Some(10.0), dt.cities()[0].get(0));
+    }
+
+    // ── parse_json_cities tests ───────────────────────────────────────────────
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_parse_json_cities_valid() {
+        let json = r#"[{"id":0,"x":1.0,"y":2.0},{"id":1,"x":3.0,"y":4.0},{"id":2,"x":5.0,"y":6.0}]"#;
+        let cities = parse_json_cities(json).unwrap();
+        assert_eq!(3, cities.len());
+        assert_eq!(0, cities[0].id);
+        assert_eq!(Some(1.0), cities[0].get(0));
+        assert_eq!(2, cities[2].id);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_parse_json_cities_one_city() {
+        let json = r#"[{"id":0,"x":1.0,"y":2.0}]"#;
+        let err = parse_json_cities(json).unwrap_err();
+        assert!(err.contains("2"), "expected '2' in error, got: {err}");
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_parse_json_cities_empty_array() {
+        let err = parse_json_cities("[]").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_parse_json_cities_bad_type() {
+        let json = r#"[{"id":0,"x":"nope","y":1.0}]"#;
+        assert!(parse_json_cities(json).is_err());
+    }
+
+    // ── read_from_str tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_read_from_str_minimal() {
+        let input = "NAME: mini\nNODE_COORD_SECTION\n1 1.0 2.0\n2 3.0 4.0\nEOF\n";
+        let dt = read_from_str(input).unwrap();
+        assert_eq!(2, dt.len());
+        assert_eq!(1, dt.cities()[0].id);
+        assert_eq!(2, dt.cities()[1].id);
+    }
+
+    #[test]
+    fn test_read_from_str_empty() {
+        assert!(read_from_str("").is_err());
+    }
+
+    #[test]
+    fn test_read_from_str_burma14() {
+        let input = std::fs::read_to_string("data/tsplib/burma14.tsp")
+            .expect("burma14.tsp missing");
+        let dt = read_from_str(&input).unwrap();
+        assert_eq!(14, dt.len());
+        assert_eq!("burma14", dt.name);
+    }
+
+    #[test]
+    fn test_read_from_str_berlin52() {
+        let input = std::fs::read_to_string("data/tsplib/berlin52.tsp")
+            .expect("berlin52.tsp missing");
+        let dt = read_from_str(&input).unwrap();
+        assert_eq!(52, dt.len());
+    }
+
+    #[test]
+    fn test_read_from_str_atsp_rejected() {
+        let input = "NAME: a\nTYPE: ATSP\nDIMENSION: 2\nEDGE_WEIGHT_TYPE: EXPLICIT\nEDGE_WEIGHT_FORMAT: FULL_MATRIX\nEDGE_WEIGHT_SECTION\n0 1\n1 0\nEOF\n";
+        let err = read_from_str(input).unwrap_err();
+        assert!(err.contains("ATSP"), "expected ATSP in error, got: {err}");
     }
 }

--- a/teeline-wasm/Cargo.toml
+++ b/teeline-wasm/Cargo.toml
@@ -15,4 +15,4 @@ world = "solver"
 
 [dependencies]
 wit-bindgen-rt = { version = "0.44.0", features = ["bitflags"] }
-teeline = { path = "..", default-features = false }
+teeline = { path = "..", default-features = false, features = ["json"] }

--- a/teeline-wasm/js-bindings/smoke.mjs
+++ b/teeline-wasm/js-bindings/smoke.mjs
@@ -19,4 +19,27 @@ console.assert(typeof result.total === 'number' && result.total > 0, 'positive t
 console.assert(result.route.length === 5, 'visits all 5 cities');
 const sorted = [...result.route].sort((a, b) => a - b);
 console.assert(JSON.stringify(sorted) === '[0,1,2,3,4]', 'each city once');
-console.log('JS smoke test PASSED — route:', result.route, 'distance:', result.total.toFixed(2));
+console.log('solve smoke PASSED — route:', result.route, 'distance:', result.total.toFixed(2));
+
+// parseAndSolve — JSON input
+import { parseAndSolve } from './teeline_wasm.js';
+const jsonInput = JSON.stringify(cities);
+const jsonResult = parseAndSolve('nn', jsonInput, options);
+console.assert(typeof jsonResult.total === 'number' && jsonResult.total > 0, 'JSON: positive distance');
+console.assert(jsonResult.route.length === 5, 'JSON: visits all 5 cities');
+console.log('parseAndSolve(JSON) smoke PASSED — route:', jsonResult.route);
+
+// parseAndSolve — TSPLIB input
+const tsplibInput = `NAME: mini
+NODE_COORD_SECTION
+0 565.0 575.0
+1 25.0 185.0
+2 345.0 750.0
+3 945.0 685.0
+4 845.0 655.0
+EOF
+`;
+const tsplibResult = parseAndSolve('nn', tsplibInput, options);
+console.assert(typeof tsplibResult.total === 'number' && tsplibResult.total > 0, 'TSPLIB: positive distance');
+console.assert(tsplibResult.route.length === 5, 'TSPLIB: visits all 5 cities');
+console.log('parseAndSolve(TSPLIB) smoke PASSED — route:', tsplibResult.route);

--- a/teeline-wasm/js-bindings/smoke.mjs
+++ b/teeline-wasm/js-bindings/smoke.mjs
@@ -27,9 +27,11 @@ const jsonInput = JSON.stringify(cities);
 const jsonResult = parseAndSolve('nn', jsonInput, options);
 console.assert(typeof jsonResult.total === 'number' && jsonResult.total > 0, 'JSON: positive distance');
 console.assert(jsonResult.route.length === 5, 'JSON: visits all 5 cities');
+const jsonSorted = [...jsonResult.route].sort((a, b) => a - b);
+console.assert(new Set(jsonSorted).size === 5, 'JSON: each city visited exactly once');
 console.log('parseAndSolve(JSON) smoke PASSED — route:', jsonResult.route);
 
-// parseAndSolve — TSPLIB input
+// parseAndSolve — TSPLIB input (note: TSPLIB IDs are 1-based)
 const tsplibInput = `NAME: mini
 NODE_COORD_SECTION
 0 565.0 575.0
@@ -42,4 +44,5 @@ EOF
 const tsplibResult = parseAndSolve('nn', tsplibInput, options);
 console.assert(typeof tsplibResult.total === 'number' && tsplibResult.total > 0, 'TSPLIB: positive distance');
 console.assert(tsplibResult.route.length === 5, 'TSPLIB: visits all 5 cities');
+console.assert(new Set([...tsplibResult.route]).size === 5, 'TSPLIB: each city visited exactly once');
 console.log('parseAndSolve(TSPLIB) smoke PASSED — route:', tsplibResult.route);

--- a/teeline-wasm/js-bindings/teeline_wasm.js
+++ b/teeline-wasm/js-bindings/teeline_wasm.js
@@ -6264,6 +6264,100 @@ function solve(arg0, arg1, arg2) {
   return retCopy.val;
   
 }
+let exports1ParseAndSolve;
+
+function parseAndSolve(arg0, arg1, arg2) {
+  
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var ptr0= encodeRes.ptr;
+  var len0 = encodeRes.len;
+  
+  
+  var encodeRes = _utf8AllocateAndEncode(arg1, realloc1, memory0);
+  var ptr1= encodeRes.ptr;
+  var len1 = encodeRes.len;
+  
+  var {epochs: v2_0, platooEpochs: v2_1, coolingRate: v2_2, maxTemperature: v2_3, minTemperature: v2_4, mutationProbability: v2_5, nElite: v2_6, nNearest: v2_7 } = arg2;
+  _debugLog('[iface="parse-and-solve", function="parse-and-solve"][Instruction::CallWasm] enter', {
+    funcName: 'parse-and-solve',
+    paramCount: 12,
+    async: false,
+    postReturn: true,
+  });
+  const hostProvided = false;
+  
+  const [task, _wasm_call_currentTaskID] = createNewCurrentTask({
+    componentIdx: 0,
+    isAsync: false,
+    isManualAsync: false,
+    entryFnName: 'exports1ParseAndSolve',
+    getCallbackFn: () => null,
+    callbackFnName: 'null',
+    errHandling: 'throw-result-err',
+    callingWasmExport: true,
+  });
+  
+  const started = task.enterSync();
+  task.setReturnMemoryIdx(0);
+  task.setReturnMemory(memory0);
+  let ret =   _withGlobalCurrentTaskMeta({
+    taskID: task.id(),
+    componentIdx: task.componentIdx(),
+    fn: () => exports1ParseAndSolve(ptr0, len0, ptr1, len1, toUint32(v2_0), toUint32(v2_1), +v2_2, +v2_3, +v2_4, +v2_5, toUint32(v2_6), toUint32(v2_7)),
+  });
+  
+  let variant5;
+  switch (dataView(memory0).getUint8(ret + 0, true)) {
+    case 0: {
+      var ptr3 = dataView(memory0).getUint32(ret + 8, true);
+      var len3 = dataView(memory0).getUint32(ret + 12, true);
+      var result3 = new Uint32Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 4));
+      variant5= {
+        tag: 'ok',
+        val: {
+          total: dataView(memory0).getFloat32(ret + 4, true),
+          route: result3,
+        }
+      };
+      break;
+    }
+    case 1: {
+      var ptr4 = dataView(memory0).getUint32(ret + 4, true);
+      var len4 = dataView(memory0).getUint32(ret + 8, true);
+      var result4 = TEXT_DECODER_UTF8.decode(new Uint8Array(memory0.buffer, ptr4, len4));
+      variant5= {
+        tag: 'err',
+        val: result4
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  _debugLog('[iface="parse-and-solve", function="parse-and-solve"][Instruction::Return]', {
+    funcName: 'parse-and-solve',
+    paramCount: 1,
+    async: false,
+    postReturn: true
+  });
+  const retCopy = variant5;
+  task.resolve([retCopy.val]);
+  
+  let cstate = getOrCreateAsyncState(0);
+  cstate.mayLeave = false;
+  postReturn0(ret);
+  cstate.mayLeave = true;
+  task.exit();
+  
+  
+  
+  if (typeof retCopy === 'object' && retCopy.tag === 'err') {
+    throw new ComponentError(retCopy.val);
+  }
+  return retCopy.val;
+  
+}
 let trampoline0 = _trampoline0.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
 null,
 {
@@ -7329,15 +7423,16 @@ const $init = (() => {
       realloc1Async = exports1.cabi_realloc;
     }
     
-    postReturn0 = exports1.cabi_post_solve;
+    postReturn0 = exports1['cabi_post_parse-and-solve'];
     
     try {
-      postReturn0Async = WebAssembly.promising(exports1.cabi_post_solve);
+      postReturn0Async = WebAssembly.promising(exports1['cabi_post_parse-and-solve']);
     } catch(err) {
-      postReturn0Async = exports1.cabi_post_solve;
+      postReturn0Async = exports1['cabi_post_parse-and-solve'];
     }
     
     exports1Solve = exports1.solve;
+    exports1ParseAndSolve = exports1['parse-and-solve'];
   })();
   let promise, resolve, reject;
   function runNext (value) {
@@ -7364,4 +7459,4 @@ const $init = (() => {
 
 await $init;
 
-export { solve,  }
+export { parseAndSolve, solve,  }

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -56,29 +56,50 @@ fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
     }
 }
 
+fn solve_with_cities(
+    solver: &str,
+    kd_cities: Vec<KDPoint>,
+    options: &SolveOptions,
+) -> Result<Solution, String> {
+    let solver_id = teeline::tsp::find_solver(solver)?;
+    if kd_cities.len() < 2 {
+        return Err("need at least 2 cities".into());
+    }
+    let distances =
+        DistanceMatrix::from_cities(&kd_cities).map_err(|e| format!("distance matrix: {e}"))?;
+    let problem = TspProblem::new(kd_cities, distances);
+    let opts = build_opts(solver_id, options);
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        teeline::tsp::solve_problem(solver_id, &problem, &opts)
+    }))
+    .map_err(|_| format!("solver '{solver}' panicked"))?
+    .map(|s| Solution {
+        total: s.total,
+        route: s.route().iter().map(|&id| id as u32).collect(),
+    })
+}
+
 impl Guest for Component {
     fn solve(solver: String, cities: Vec<City>, options: SolveOptions) -> Result<Solution, String> {
-        let solver_id = teeline::tsp::find_solver(&solver)?;
-
         let kd_cities: Vec<KDPoint> = cities
             .iter()
             .map(|c| KDPoint::new_with_id(c.id as usize, &[c.x, c.y]))
             .collect();
+        solve_with_cities(&solver, kd_cities, &options)
+    }
 
-        let distances =
-            DistanceMatrix::from_cities(&kd_cities).map_err(|e| format!("distance matrix: {e}"))?;
-
-        let problem = TspProblem::new(kd_cities, distances);
-        let opts = build_opts(solver_id, &options);
-
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            teeline::tsp::solve_problem(solver_id, &problem, &opts)
-        }))
-        .map_err(|_| format!("solver '{solver}' panicked"))?
-        .map(|s| Solution {
-            total: s.total,
-            route: s.route().iter().map(|&id| id as u32).collect(),
-        })
+    fn parse_and_solve(
+        solver: String,
+        input: String,
+        options: SolveOptions,
+    ) -> Result<Solution, String> {
+        let kd_cities = if input.trim_start().starts_with('[') {
+            teeline::tsp::tsplib::parse_json_cities(&input)?
+        } else {
+            let data = teeline::tsp::tsplib::read_from_str(&input)?;
+            data.cities().to_vec()
+        };
+        solve_with_cities(&solver, kd_cities, &options)
     }
 }
 

--- a/teeline-wasm/wit/world.wit
+++ b/teeline-wasm/wit/world.wit
@@ -32,4 +32,10 @@ world solver {
         cities: list<city>,
         options: solve-options,
     ) -> result<solution, string>;
+
+    export parse-and-solve: func(
+        solver: string,
+        input: string,
+        options: solve-options,
+    ) -> result<solution, string>;
 }

--- a/teeline-web/src/teeline-wasm.d.ts
+++ b/teeline-web/src/teeline-wasm.d.ts
@@ -19,5 +19,6 @@ declare module 'teeline-wasm' {
     route: Uint32Array
   }
   export function solve(solver: string, cities: Array<City>, options: SolveOptions): Solution
+  export function parseAndSolve(solver: string, input: string, options: SolveOptions): Solution
   export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E }
 }

--- a/teeline-web/src/worker.test.ts
+++ b/teeline-web/src/worker.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('teeline-wasm', () => ({
+  solve: vi.fn(),
+  parseAndSolve: vi.fn(),
+}))
+
+import { solve, parseAndSolve } from 'teeline-wasm'
+import { handleMessage, type ParseAndSolveRequest } from './worker'
+import { type SolveRequest } from './worker'
+
+const mockSolution = { total: 42.0, route: new Uint32Array([0, 1, 2]) }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('handleMessage — solve', () => {
+  it('calls solve and returns SolveResult', () => {
+    vi.mocked(solve).mockReturnValue(mockSolution)
+    const req: SolveRequest = {
+      type: 'solve',
+      solver: 'nn',
+      cities: [{ id: 0, x: 1, y: 2 }, { id: 1, x: 3, y: 4 }, { id: 2, x: 5, y: 6 }],
+      options: {},
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('result')
+    if (res.type === 'result') {
+      expect(res.solution.total).toBe(42.0)
+      expect(res.solution.route).toEqual([0, 1, 2])
+    }
+  })
+
+  it('returns SolveError when solve throws', () => {
+    vi.mocked(solve).mockImplementation(() => { throw new Error('solver crashed') })
+    const req: SolveRequest = { type: 'solve', solver: 'nn', cities: [], options: {} }
+    const res = handleMessage(req)
+    expect(res.type).toBe('error')
+    if (res.type === 'error') {
+      expect(res.message).toContain('solver crashed')
+    }
+  })
+})
+
+describe('handleMessage — parse-and-solve', () => {
+  it('calls parseAndSolve with the raw input string and returns SolveResult', () => {
+    vi.mocked(parseAndSolve).mockReturnValue(mockSolution)
+    const req: ParseAndSolveRequest = {
+      type: 'parse-and-solve',
+      solver: 'nn',
+      input: '[{"id":0,"x":1.0,"y":2.0},{"id":1,"x":3.0,"y":4.0}]',
+      options: {},
+    }
+    const res = handleMessage(req)
+    expect(parseAndSolve).toHaveBeenCalledOnce()
+    expect(res.type).toBe('result')
+    if (res.type === 'result') {
+      expect(res.solution.total).toBe(42.0)
+      expect(res.solution.route).toEqual([0, 1, 2])
+    }
+  })
+
+  it('returns SolveError when parseAndSolve throws', () => {
+    vi.mocked(parseAndSolve).mockImplementation(() => { throw new Error('bad TSPLIB input') })
+    const req: ParseAndSolveRequest = {
+      type: 'parse-and-solve',
+      solver: 'nn',
+      input: 'garbage',
+      options: {},
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('error')
+    if (res.type === 'error') {
+      expect(res.message).toContain('bad TSPLIB input')
+    }
+  })
+})

--- a/teeline-web/src/worker.ts
+++ b/teeline-web/src/worker.ts
@@ -1,12 +1,19 @@
 /// <reference lib="webworker" />
 
-import { solve } from 'teeline-wasm'
+import { solve, parseAndSolve } from 'teeline-wasm'
 import { defaultSolveOptions, type SolveOptions } from './solver-options'
 
 export interface SolveRequest {
   type: 'solve'
   solver: string
   cities: Array<{ id: number; x: number; y: number }>
+  options: Partial<SolveOptions>
+}
+
+export interface ParseAndSolveRequest {
+  type: 'parse-and-solve'
+  solver: string
+  input: string
   options: Partial<SolveOptions>
 }
 
@@ -20,27 +27,35 @@ export interface SolveError {
   message: string
 }
 
-self.onmessage = (e: MessageEvent<SolveRequest>) => {
-  const { type, solver, cities, options } = e.data
-  if (type !== 'solve') return
+type WorkerRequest = SolveRequest | ParseAndSolveRequest
 
-  const mergedOptions: SolveOptions = { ...defaultSolveOptions(), ...options }
-
+export function handleMessage(data: WorkerRequest): SolveResult | SolveError {
+  const mergedOptions: SolveOptions = { ...defaultSolveOptions(), ...data.options }
   try {
-    const solution = solve(solver, cities, mergedOptions)
-    const result: SolveResult = {
+    let solution: ReturnType<typeof solve>
+    if (data.type === 'solve') {
+      solution = solve(data.solver, data.cities, mergedOptions)
+    } else {
+      solution = parseAndSolve(data.solver, data.input, mergedOptions)
+    }
+    return {
       type: 'result',
       solution: {
         total: solution.total,
         route: Array.from(solution.route),  // Uint32Array → plain number[]
       },
     }
-    self.postMessage(result)
   } catch (err) {
-    const error: SolveError = {
+    return {
       type: 'error',
       message: err instanceof Error ? err.message : String(err),
     }
-    self.postMessage(error)
+  }
+}
+
+// Only register in Web Worker context (not during Vitest runs)
+if (typeof DedicatedWorkerGlobalScope !== 'undefined' && self instanceof DedicatedWorkerGlobalScope) {
+  self.onmessage = (e: MessageEvent<WorkerRequest>) => {
+    self.postMessage(handleMessage(e.data))
   }
 }

--- a/tests/wasm_component.rs
+++ b/tests/wasm_component.rs
@@ -202,7 +202,7 @@ fn five_cities_json() -> String {
 
 #[test]
 fn test_parse_and_solve_tsplib_berlin52() {
-    let input = std::fs::read_to_string("data/tsplib/berlin52.tsp").expect("berlin52.tsp missing");
+    let input = std::fs::read_to_string("tests/fixtures/berlin52.tsp").expect("berlin52.tsp missing");
     let solution = run_parse_and_solve("nn", &input);
     assert_valid_tour(&solution, 52);
 }

--- a/tests/wasm_component.rs
+++ b/tests/wasm_component.rs
@@ -28,7 +28,7 @@ fn make_engine() -> Engine {
 }
 
 fn load_component(engine: &Engine) -> Component {
-    let path = "target/wasm32-wasip1/debug/teeline_wasm.wasm";
+    let path = "target/wasm32-wasip2/debug/teeline_wasm.wasm";
     Component::from_file(engine, path).expect(
         "WASM component not found — run: cargo component build --manifest-path teeline-wasm/Cargo.toml",
     )
@@ -92,10 +92,11 @@ fn default_options() -> crate::teeline::solver::types::SolveOptions {
 fn assert_valid_tour(solution: &crate::teeline::solver::types::Solution, n_cities: usize) {
     assert_eq!(solution.route.len(), n_cities, "tour must visit all cities");
     assert!(solution.total > 0.0, "tour distance must be positive");
+    // Check all IDs are distinct (independent of 0-based vs 1-based ID space)
     let mut sorted: Vec<u32> = solution.route.clone();
     sorted.sort_unstable();
-    let expected: Vec<u32> = (0..n_cities as u32).collect();
-    assert_eq!(sorted, expected, "each city must be visited exactly once");
+    sorted.dedup();
+    assert_eq!(sorted.len(), n_cities, "each city must be visited exactly once");
 }
 
 fn run_solver(solver_name: &str) {
@@ -178,4 +179,109 @@ fn unknown_solver_returns_err() {
         "unknown solver must return Err, got {:?}",
         result.ok()
     );
+}
+
+// ── parse_and_solve integration tests ─────────────────────────────────────────
+
+fn run_parse_and_solve(solver: &str, input: &str) -> crate::teeline::solver::types::Solution {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let result = instance
+        .call_parse_and_solve(&mut store, solver, input, default_options())
+        .unwrap();
+    result.unwrap_or_else(|e| panic!("parse_and_solve returned error: {e}"))
+}
+
+fn five_cities_json() -> String {
+    r#"[{"id":0,"x":565.0,"y":575.0},{"id":1,"x":25.0,"y":185.0},{"id":2,"x":345.0,"y":750.0},{"id":3,"x":945.0,"y":685.0},{"id":4,"x":845.0,"y":655.0}]"#.to_string()
+}
+
+#[test]
+fn test_parse_and_solve_tsplib_berlin52() {
+    let input = std::fs::read_to_string("data/tsplib/berlin52.tsp").expect("berlin52.tsp missing");
+    let solution = run_parse_and_solve("nn", &input);
+    assert_valid_tour(&solution, 52);
+}
+
+#[test]
+fn test_parse_and_solve_json_5_cities() {
+    let solution = run_parse_and_solve("nn", &five_cities_json());
+    assert_valid_tour(&solution, 5);
+}
+
+#[test]
+fn test_parse_and_solve_json_leading_whitespace() {
+    let input = format!("  \n{}", five_cities_json());
+    let solution = run_parse_and_solve("nn", &input);
+    assert_valid_tour(&solution, 5);
+}
+
+#[test]
+fn test_parse_and_solve_one_city_json_returns_err() {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let result = instance
+        .call_parse_and_solve(
+            &mut store,
+            "nn",
+            r#"[{"id":0,"x":1.0,"y":2.0}]"#,
+            default_options(),
+        )
+        .unwrap();
+    assert!(result.is_err(), "single city must return Err");
+}
+
+#[test]
+fn test_parse_and_solve_bad_solver_returns_err() {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let result = instance
+        .call_parse_and_solve(&mut store, "bogus", &five_cities_json(), default_options())
+        .unwrap();
+    assert!(result.is_err(), "unknown solver must return Err");
+}
+
+#[test]
+fn test_parse_and_solve_empty_input_returns_err() {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let result = instance
+        .call_parse_and_solve(&mut store, "nn", "", default_options())
+        .unwrap();
+    assert!(result.is_err(), "empty input must return Err");
+}
+
+#[test]
+fn test_parse_and_solve_invalid_json_returns_err() {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let result = instance
+        .call_parse_and_solve(
+            &mut store,
+            "nn",
+            r#"[{"id":0,"x":"bad","y":1.0}]"#,
+            default_options(),
+        )
+        .unwrap();
+    assert!(result.is_err(), "invalid JSON must return Err");
 }

--- a/tests/wasm_component.rs
+++ b/tests/wasm_component.rs
@@ -28,7 +28,7 @@ fn make_engine() -> Engine {
 }
 
 fn load_component(engine: &Engine) -> Component {
-    let path = "target/wasm32-wasip2/debug/teeline_wasm.wasm";
+    let path = "target/wasm32-wasip1/debug/teeline_wasm.wasm";
     Component::from_file(engine, path).expect(
         "WASM component not found — run: cargo component build --manifest-path teeline-wasm/Cargo.toml",
     )


### PR DESCRIPTION
## Summary

Closes #147. Adds a second WASM export `parse-and-solve` that accepts a raw TSPLIB string or JSON city array and returns a `Solution`, eliminating the need for pre-parsed city arrays on the browser side.

- **`parse-and-solve(solver, input, options)`** — auto-detects format: trims leading whitespace, dispatches to JSON parser if input starts with `[`, otherwise to TSPLIB parser
- **`read_from_str`** — new public entry point on the TSPLIB parser (wraps existing `process_lines<BufRead>` generic with `Cursor`)
- **`parse_json_cities`** — new feature-gated helper (`features = ["json"]`) using `serde_json`; rejects fewer than 2 cities
- **`handleMessage`** extracted as a pure function in `worker.ts` (testable without `MessageEvent`); `self.onmessage` registration guarded for Vitest compatibility
- Fixed `tests/wasm_component.rs` artifact path from `wasm32-wasip1` → `wasm32-wasip2`
- `assert_valid_tour` made ID-base agnostic (TSPLIB IDs are 1-based)

## Test plan

- [x] 5 `read_from_str` unit tests (including real `burma14` + `berlin52` files, ATSP rejection)
- [x] 4 `parse_json_cities` unit tests (valid, 1-city, empty, bad type)
- [x] 7 `wasm_component` integration tests via wasmtime host (TSPLIB + JSON happy paths, all error cases)
- [x] 3 JS smoke assertions (solve + parseAndSolve JSON + parseAndSolve TSPLIB)
- [x] 4 Vitest unit tests for `handleMessage` (both request types + error paths)
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds