### PR TITLE
chore(ci): dedicated build-wasm job + move wasm_component tests to teeline-wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,16 +18,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Install cargo-component
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-component
-    - name: Add wasm32-wasip2 target
-      run: rustup target add wasm32-wasip2
     - name: Build
       run: cargo build -p teeline -p teeline-cli --verbose
-    - name: Build WASM component
-      run: cargo component build --manifest-path teeline-wasm/Cargo.toml
     - name: Run tests
       run: cargo test -p teeline -p teeline-cli --verbose
     - name: Run e2e tests (BATS)
@@ -44,6 +36,28 @@ jobs:
         files: lcov.info
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install cargo-component
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-component
+    - name: Add wasm32-wasip2 target
+      run: rustup target add wasm32-wasip2
+    - name: Build WASM component
+      run: cd teeline-wasm && cargo component build
+    - name: Upload WASM artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: teeline-wasm-debug
+        path: target/wasm32-wasip2/debug/teeline_wasm.wasm
+    - name: Run wasm_component integration tests
+      run: cargo test -p teeline-wasm --test wasm_component
 
   build-qt:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Add wasm32-wasip2 target
       run: rustup target add wasm32-wasip2
     - name: Build WASM component
-      run: cd teeline-wasm && cargo component build
+      run: cd teeline-wasm && cargo component build --target wasm32-wasip2
     - name: Upload WASM artifact
       uses: actions/upload-artifact@v4
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,11 +1826,10 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "serde",
+ "serde_json",
  "toml",
  "tracing",
  "tracing-subscriber",
- "wasmtime",
- "wasmtime-wasi",
 ]
 
 [[package]]
@@ -1857,6 +1856,8 @@ name = "teeline-wasm"
 version = "0.1.0"
 dependencies = [
  "teeline",
+ "wasmtime",
+ "wasmtime-wasi",
  "wit-bindgen-rt",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,6 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[dev-dependencies]
-wasmtime = { version = "36", features = ["component-model"] }
-wasmtime-wasi = "36"
-
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/teeline-wasm/Cargo.toml
+++ b/teeline-wasm/Cargo.toml
@@ -16,3 +16,7 @@ world = "solver"
 [dependencies]
 wit-bindgen-rt = { version = "0.44.0", features = ["bitflags"] }
 teeline = { path = "..", default-features = false, features = ["json"] }
+
+[dev-dependencies]
+wasmtime = { version = "36", features = ["component-model"] }
+wasmtime-wasi = "36"

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -4,7 +4,7 @@ use wasmtime_wasi::{WasiCtxBuilder, WasiCtxView, WasiView};
 
 wasmtime::component::bindgen!({
     world: "solver",
-    path: "teeline-wasm/wit",
+    path: "wit",
 });
 
 struct HostState {
@@ -28,9 +28,12 @@ fn make_engine() -> Engine {
 }
 
 fn load_component(engine: &Engine) -> Component {
-    let path = "target/wasm32-wasip1/debug/teeline_wasm.wasm";
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../target/wasm32-wasip2/debug/teeline_wasm.wasm"
+    );
     Component::from_file(engine, path).expect(
-        "WASM component not found — run: cargo component build --manifest-path teeline-wasm/Cargo.toml",
+        "WASM component not found — run: cd teeline-wasm && cargo component build",
     )
 }
 
@@ -92,7 +95,6 @@ fn default_options() -> crate::teeline::solver::types::SolveOptions {
 fn assert_valid_tour(solution: &crate::teeline::solver::types::Solution, n_cities: usize) {
     assert_eq!(solution.route.len(), n_cities, "tour must visit all cities");
     assert!(solution.total > 0.0, "tour distance must be positive");
-    // Check all IDs are distinct (independent of 0-based vs 1-based ID space)
     let mut sorted: Vec<u32> = solution.route.clone();
     sorted.sort_unstable();
     sorted.dedup();
@@ -202,7 +204,11 @@ fn five_cities_json() -> String {
 
 #[test]
 fn test_parse_and_solve_tsplib_berlin52() {
-    let input = std::fs::read_to_string("tests/fixtures/berlin52.tsp").expect("berlin52.tsp missing");
+    let input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/berlin52.tsp"
+    ))
+    .expect("berlin52.tsp missing");
     let solution = run_parse_and_solve("nn", &input);
     assert_valid_tour(&solution, 52);
 }


### PR DESCRIPTION
Closes #151

## Summary

- Moves `tests/wasm_component.rs` → `teeline-wasm/tests/wasm_component.rs` so the WASM integration tests live in the correct package
- Updates `bindgen!` path from `"teeline-wasm/wit"` → `"wit"` (now resolved relative to the `teeline-wasm` crate root)
- Updates WASM artifact path to use `env!("CARGO_MANIFEST_DIR")` and the correct `wasm32-wasip2` output dir
- Updates `berlin52.tsp` fixture path to use `env!("CARGO_MANIFEST_DIR")`
- Moves `wasmtime` / `wasmtime-wasi` dev-deps from root `Cargo.toml` → `teeline-wasm/Cargo.toml`
- Adds a parallel `build-wasm` CI job (`cargo-component` build + artifact upload + 19 integration tests)
- Removes WASM build steps (`Install cargo-component`, `Add wasm32-wasip2 target`, `Build WASM component`) from the `build` job

## Test plan

- [x] `cargo test -p teeline -p teeline-cli` passes (no wasmtime dep needed)
- [x] `build` CI job green (no WASM steps, faster)
- [x] `build-wasm` CI job green (WASM build + 19 integration tests via wasmtime host)