### PR TITLE
feat(teeline-web): Step 01 file upload UI (#132)

### DIFF
--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -33,8 +33,61 @@
       </nav>
 
       <section id="step-content">
-        <p>Select a step above to begin.</p>
-      </section>
+
+        <!-- Step 01: Load Data -->
+        <section id="step-01" class="step-panel" aria-labelledby="step-01-heading">
+          <h2 id="step-01-heading">Load Data</h2>
+
+          <div class="drop-zones">
+
+            <!-- Required .tsp zone -->
+            <div id="zone-tsp" class="drop-zone drop-zone--required"
+                 role="region" aria-label="TSP problem file (.tsp)">
+              <div id="zone-tsp-idle" class="drop-zone__idle">
+                <p class="drop-zone__hint">Drag a <strong>.tsp</strong> file here</p>
+                <p class="drop-zone__or"><small>or</small></p>
+                <button type="button" class="outline" id="btn-browse-tsp">Browse…</button>
+                <input id="input-tsp" type="file" accept=".tsp" hidden aria-hidden="true" />
+              </div>
+              <div id="zone-tsp-chip" class="drop-zone__chip" hidden>
+                <span class="chip-icon" aria-hidden="true">✓</span>
+                <span class="chip-name" id="tsp-chip-name"></span>
+                <button type="button" class="outline secondary chip-replace"
+                        id="btn-replace-tsp">replace</button>
+              </div>
+            </div>
+
+            <!-- Optional .opt.tour zone -->
+            <div id="zone-opt" class="drop-zone drop-zone--optional"
+                 role="region" aria-label="Optimal tour file (.opt.tour, optional)">
+              <div id="zone-opt-idle" class="drop-zone__idle">
+                <p class="drop-zone__hint">Drag a <strong>.opt.tour</strong> file here</p>
+                <p class="drop-zone__hint-secondary"><small>optional reference tour</small></p>
+              </div>
+              <div id="zone-opt-chip" class="drop-zone__chip" hidden>
+                <span class="chip-icon" aria-hidden="true">✓</span>
+                <span class="chip-name" id="opt-chip-name"></span>
+                <button type="button" class="outline secondary chip-replace"
+                        id="btn-replace-opt">replace</button>
+              </div>
+            </div>
+
+          </div><!-- /.drop-zones -->
+
+          <p id="metadata-line" class="metadata-line" hidden></p>
+          <p id="error-line" class="upload-error" hidden></p>
+
+          <fieldset>
+            <legend>Example datasets</legend>
+            <div class="example-buttons">
+              <button type="button" class="outline secondary" data-example="berlin52">berlin52</button>
+              <button type="button" class="outline secondary" data-example="burma14">burma14</button>
+              <button type="button" class="outline secondary" data-example="ulysses22">ulysses22</button>
+            </div>
+          </fieldset>
+        </section>
+
+      </section><!-- /#step-content -->
     </main>
 
     <script type="module" src="/src/main.ts"></script>

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -88,6 +88,16 @@
               <button type="button" class="outline secondary" data-example="ulysses22">ulysses22</button>
             </div>
           </fieldset>
+
+          <div class="step-actions">
+            <button type="button" id="btn-continue" hidden>Continue →</button>
+          </div>
+        </section>
+
+        <!-- Step 02: Configure (placeholder — issue #124) -->
+        <section id="step-02" class="step-panel" aria-labelledby="step-02-heading" hidden>
+          <h2 id="step-02-heading">Configure</h2>
+          <p class="muted">Solver configuration coming soon.</p>
         </section>
 
       </section><!-- /#step-content -->

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -62,6 +62,9 @@
                  role="region" aria-label="Optimal tour file (.opt.tour, optional)">
               <div id="zone-opt-idle" class="drop-zone__idle">
                 <p class="drop-zone__hint">Drag a <strong>.opt.tour</strong> file here</p>
+                <p class="drop-zone__or"><small>or</small></p>
+                <button type="button" class="outline" id="btn-browse-opt">Browse…</button>
+                <input id="input-opt" type="file" accept=".opt.tour" hidden aria-hidden="true" />
                 <p class="drop-zone__hint-secondary"><small>optional reference tour</small></p>
               </div>
               <div id="zone-opt-chip" class="drop-zone__chip" hidden>

--- a/teeline-web/src/main.css
+++ b/teeline-web/src/main.css
@@ -131,3 +131,10 @@
 }
 
 .example-buttons button { margin: 0; }
+
+/* ---- Step navigation ---- */
+.step-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--pico-spacing);
+}

--- a/teeline-web/src/main.css
+++ b/teeline-web/src/main.css
@@ -30,3 +30,104 @@
   border: 2px solid currentColor;
   flex-shrink: 0;
 }
+
+/* ---- Stepper: done state (step 01 fills orange when file loaded) ---- */
+.stepper-step--done {
+  color: var(--pico-color-orange-500, #e67e22);
+}
+
+.stepper-step--done .stepper-number {
+  background-color: var(--pico-color-orange-500, #e67e22);
+  border-color: var(--pico-color-orange-500, #e67e22);
+  color: #fff;
+}
+
+/* ---- Drop zone grid ---- */
+.drop-zones {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--pico-spacing);
+  margin-bottom: var(--pico-spacing);
+}
+
+@media (max-width: 48em) {
+  .drop-zones { grid-template-columns: 1fr; }
+}
+
+.drop-zone {
+  border: 2px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: var(--pico-spacing);
+  min-height: 9rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.drop-zone--required { border-style: solid; }
+.drop-zone--optional { border-style: dashed; }
+
+.drop-zone--dragover {
+  border-color: var(--pico-primary);
+  background: color-mix(in srgb, var(--pico-primary) 8%, transparent);
+}
+
+.drop-zone--loaded {
+  border-color: var(--pico-color-jade-500, #2a9d8f);
+}
+
+.drop-zone__idle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.drop-zone__hint { margin: 0; }
+.drop-zone__or   { margin: 0; color: var(--pico-muted-color); }
+.drop-zone__hint-secondary { margin: 0.25rem 0 0; color: var(--pico-muted-color); }
+
+/* ---- File chip (success state inside zone) ---- */
+.drop-zone__chip {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.chip-icon  { font-size: 1.25rem; color: var(--pico-color-jade-500, #2a9d8f); }
+.chip-name  { font-weight: 600; word-break: break-all; }
+.chip-replace {
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+/* ---- Metadata + error lines ---- */
+.metadata-line {
+  color: var(--pico-muted-color);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
+.upload-error {
+  color: var(--pico-del-color, #c0392b);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
+/* ---- Example dataset buttons ---- */
+.example-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.example-buttons button { margin: 0; }

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -1,8 +1,10 @@
 import 'htmx.org'
 import '@picocss/pico/css/pico.min.css'
 import './main.css'
+import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
-import type { SolveResult, SolveError } from './worker'
+import type { SolveResult, SolveError, ParseResult } from './worker'
+import { initUpload } from './upload'
 
 const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
 
@@ -32,10 +34,29 @@ export function runSolver(
   })
 }
 
+export function parseFile(input: string): Promise<ParsedProblem> {
+  return new Promise((resolve, reject) => {
+    const handler = (e: MessageEvent<ParseResult | SolveError>) => {
+      worker.removeEventListener('message', handler)
+      if (e.data.type === 'parsed') {
+        resolve(e.data.problem)
+      } else if (e.data.type === 'error') {
+        reject(new Error(e.data.message))
+      }
+    }
+    worker.addEventListener('message', handler)
+    worker.postMessage({ type: 'parse', input })
+  })
+}
+
 // Expose for browser console smoke test and HTMX scripts
 declare global {
   interface Window {
     runSolver: typeof runSolver
+    parseFile: typeof parseFile
   }
 }
 window.runSolver = runSolver
+window.parseFile = parseFile
+
+initUpload(parseFile)

--- a/teeline-web/src/upload.test.ts
+++ b/teeline-web/src/upload.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { formatMetadata, exampleUrl } from './upload'
+import type { ParsedProblem } from 'teeline-wasm'
+
+const cities = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ id: i, x: 0, y: 0 }))
+
+const makeProblem = (overrides: Partial<ParsedProblem> = {}): ParsedProblem => ({
+  name: 'berlin52',
+  comment: '',
+  distanceType: 'EUC_2D',
+  cities: cities(52),
+  ...overrides,
+})
+
+describe('formatMetadata', () => {
+  it('includes city count and distance type', () => {
+    expect(formatMetadata(makeProblem())).toBe('parsed: 52 cities · EUC_2D')
+  })
+
+  it('omits distance type separator when distanceType is empty', () => {
+    expect(formatMetadata(makeProblem({ distanceType: '', cities: cities(5) }))).toBe(
+      'parsed: 5 cities',
+    )
+  })
+
+  it('uses the cities array length, not the name', () => {
+    expect(formatMetadata(makeProblem({ cities: cities(14) }))).toBe('parsed: 14 cities · EUC_2D')
+  })
+
+  it('handles GEO distance type', () => {
+    expect(formatMetadata(makeProblem({ distanceType: 'GEO', cities: cities(22) }))).toBe(
+      'parsed: 22 cities · GEO',
+    )
+  })
+})
+
+describe('exampleUrl', () => {
+  it('returns /examples/<name>.tsp', () => {
+    expect(exampleUrl('berlin52')).toBe('/examples/berlin52.tsp')
+    expect(exampleUrl('burma14')).toBe('/examples/burma14.tsp')
+    expect(exampleUrl('ulysses22')).toBe('/examples/ulysses22.tsp')
+  })
+})

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -28,8 +28,11 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
   const inputOpt      = document.getElementById('input-opt') as HTMLInputElement
   const btnReplaceOpt = document.getElementById('btn-replace-opt')!
 
-  const metaLine  = document.getElementById('metadata-line') as HTMLElement
-  const errorLine = document.getElementById('error-line') as HTMLElement
+  const metaLine   = document.getElementById('metadata-line') as HTMLElement
+  const errorLine  = document.getElementById('error-line') as HTMLElement
+  const btnContinue = document.getElementById('btn-continue') as HTMLButtonElement
+  const step01     = document.getElementById('step-01') as HTMLElement
+  const step02     = document.getElementById('step-02') as HTMLElement
 
   // ---- TSP zone state transitions ----
 
@@ -41,6 +44,7 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
     metaLine.textContent = formatMetadata(parsed)
     metaLine.hidden = false
     errorLine.hidden = true
+    btnContinue.hidden = false
     advanceStepper()
   }
 
@@ -51,8 +55,14 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
     zoneTsp.classList.remove('drop-zone--loaded')
     metaLine.hidden = true
     errorLine.hidden = true
+    btnContinue.hidden = true
     resetStepper()
   }
+
+  btnContinue.addEventListener('click', () => {
+    step01.hidden = true
+    step02.hidden = false
+  })
 
   function showError(msg: string): void {
     errorLine.textContent = `Error: ${msg}`

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -1,0 +1,161 @@
+import type { ParsedProblem } from 'teeline-wasm'
+
+export function formatMetadata(problem: ParsedProblem): string {
+  const cityCount = `${problem.cities.length} cities`
+  const dt = problem.distanceType ? ` · ${problem.distanceType}` : ''
+  return `parsed: ${cityCount}${dt}`
+}
+
+export function exampleUrl(name: string): string {
+  return `/examples/${name}.tsp`
+}
+
+export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>): void {
+  // DOM elements — all pre-built in index.html
+  const zoneTsp       = document.getElementById('zone-tsp')!
+  const tspIdle       = document.getElementById('zone-tsp-idle')!
+  const tspChip       = document.getElementById('zone-tsp-chip') as HTMLElement
+  const tspChipName   = document.getElementById('tsp-chip-name')!
+  const btnBrowse     = document.getElementById('btn-browse-tsp')!
+  const inputTsp      = document.getElementById('input-tsp') as HTMLInputElement
+  const btnReplaceTsp = document.getElementById('btn-replace-tsp')!
+
+  const zoneOpt       = document.getElementById('zone-opt')!
+  const optIdle       = document.getElementById('zone-opt-idle')!
+  const optChip       = document.getElementById('zone-opt-chip') as HTMLElement
+  const optChipName   = document.getElementById('opt-chip-name')!
+  const btnReplaceOpt = document.getElementById('btn-replace-opt')!
+
+  const metaLine  = document.getElementById('metadata-line') as HTMLElement
+  const errorLine = document.getElementById('error-line') as HTMLElement
+
+  // ---- TSP zone state transitions ----
+
+  function showTspLoaded(filename: string, parsed: ParsedProblem): void {
+    tspChipName.textContent = filename
+    tspIdle.hidden = true
+    tspChip.hidden = false
+    zoneTsp.classList.add('drop-zone--loaded')
+    metaLine.textContent = formatMetadata(parsed)
+    metaLine.hidden = false
+    errorLine.hidden = true
+    advanceStepper()
+  }
+
+  function showTspIdle(): void {
+    tspIdle.hidden = false
+    tspChip.hidden = true
+    tspChipName.textContent = ''
+    zoneTsp.classList.remove('drop-zone--loaded')
+    metaLine.hidden = true
+    errorLine.hidden = true
+    resetStepper()
+  }
+
+  function showError(msg: string): void {
+    errorLine.textContent = `Error: ${msg}`
+    errorLine.hidden = false
+    metaLine.hidden = true
+  }
+
+  // ---- Parse a .tsp text string ----
+
+  async function loadTspText(filename: string, text: string): Promise<void> {
+    try {
+      const parsed = await parseFile(text)
+      showTspLoaded(filename, parsed)
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  // ---- Drag-and-drop helper (reusable for both zones) ----
+
+  function setupDragDrop(
+    zone: HTMLElement,
+    onDrop: (filename: string, text: string) => void,
+  ): void {
+    zone.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      zone.classList.add('drop-zone--dragover')
+    })
+    zone.addEventListener('dragleave', () => zone.classList.remove('drop-zone--dragover'))
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault()
+      zone.classList.remove('drop-zone--dragover')
+      const file = (e as DragEvent).dataTransfer?.files[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = () => onDrop(file.name, reader.result as string)
+      reader.readAsText(file)
+    })
+  }
+
+  // ---- Wire TSP zone ----
+
+  setupDragDrop(zoneTsp, loadTspText)
+
+  btnBrowse.addEventListener('click', () => inputTsp.click())
+  inputTsp.addEventListener('change', (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => loadTspText(file.name, reader.result as string)
+    reader.readAsText(file)
+    inputTsp.value = '' // reset so the same file can be re-selected after replace
+  })
+  btnReplaceTsp.addEventListener('click', showTspIdle)
+
+  // ---- Wire opt.tour zone (store only — no parse needed) ----
+
+  setupDragDrop(zoneOpt, (filename) => {
+    optChipName.textContent = filename
+    optIdle.hidden = true
+    optChip.hidden = false
+    zoneOpt.classList.add('drop-zone--loaded')
+  })
+  btnReplaceOpt.addEventListener('click', () => {
+    optIdle.hidden = false
+    optChip.hidden = true
+    optChipName.textContent = ''
+    zoneOpt.classList.remove('drop-zone--loaded')
+  })
+
+  // ---- Wire example dataset buttons ----
+
+  document.querySelectorAll<HTMLButtonElement>('[data-example]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const name = btn.dataset.example!
+      try {
+        const resp = await fetch(exampleUrl(name))
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const text = await resp.text()
+        await loadTspText(`${name}.tsp`, text)
+      } catch (err) {
+        showError(err instanceof Error ? err.message : String(err))
+      }
+    })
+  })
+}
+
+// ---- Stepper helpers (module-private) ----
+
+function advanceStepper(): void {
+  const steps = document.querySelectorAll<HTMLElement>('.stepper-step')
+  if (steps.length < 2) return
+  steps[0].classList.add('stepper-step--done')
+  steps[0].classList.remove('stepper-step--active')
+  steps[0].removeAttribute('aria-current')
+  steps[1].classList.add('stepper-step--active')
+  steps[1].setAttribute('aria-current', 'step')
+}
+
+function resetStepper(): void {
+  const steps = document.querySelectorAll<HTMLElement>('.stepper-step')
+  if (steps.length < 2) return
+  steps[0].classList.remove('stepper-step--done')
+  steps[0].classList.add('stepper-step--active')
+  steps[0].setAttribute('aria-current', 'step')
+  steps[1].classList.remove('stepper-step--active')
+  steps[1].removeAttribute('aria-current')
+}

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -24,6 +24,8 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
   const optIdle       = document.getElementById('zone-opt-idle')!
   const optChip       = document.getElementById('zone-opt-chip') as HTMLElement
   const optChipName   = document.getElementById('opt-chip-name')!
+  const btnBrowseOpt  = document.getElementById('btn-browse-opt')!
+  const inputOpt      = document.getElementById('input-opt') as HTMLInputElement
   const btnReplaceOpt = document.getElementById('btn-replace-opt')!
 
   const metaLine  = document.getElementById('metadata-line') as HTMLElement
@@ -108,18 +110,30 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
 
   // ---- Wire opt.tour zone (store only — no parse needed) ----
 
-  setupDragDrop(zoneOpt, (filename) => {
+  function showOptLoaded(filename: string): void {
     optChipName.textContent = filename
     optIdle.hidden = true
     optChip.hidden = false
     zoneOpt.classList.add('drop-zone--loaded')
-  })
-  btnReplaceOpt.addEventListener('click', () => {
+  }
+
+  function showOptIdle(): void {
     optIdle.hidden = false
     optChip.hidden = true
     optChipName.textContent = ''
     zoneOpt.classList.remove('drop-zone--loaded')
+  }
+
+  setupDragDrop(zoneOpt, showOptLoaded)
+
+  btnBrowseOpt.addEventListener('click', () => inputOpt.click())
+  inputOpt.addEventListener('change', (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0]
+    if (!file) return
+    showOptLoaded(file.name)
+    inputOpt.value = ''
   })
+  btnReplaceOpt.addEventListener('click', showOptIdle)
 
   // ---- Wire example dataset buttons ----
 


### PR DESCRIPTION
## Summary

- Two drag-and-drop zones side-by-side (desktop) / stacked (mobile): left `.tsp` solid border, right `.opt.tour` dashed border
- On parse success: zone becomes file chip (filename + ✓ + [replace] button); metadata line shows "parsed: N cities · DISTANCE_TYPE"
- Parse errors shown inline below the drop zones (red text)
- Example dataset buttons (berlin52 / burma14 / ulysses22) fetch from `public/examples/` and call the WASM `parse` export
- Stepper step 01 circle fills orange on success; step 02 becomes active; both reset on [replace]
- Uses `parse()` WASM export from PR #153; no TypeScript TSPLIB reimplementation

## Test plan

- [x] Drag a `.tsp` file onto left zone → chip + metadata line appears
- [x] Click Browse… → file picker → select file → chip appears
- [x] Click [replace] → zone returns to idle, stepper resets
- [x] Click each example button (berlin52, burma14, ulysses22) → correct metadata appears
- [x] Drop a non-TSPLIB file → error line appears with message
- [x] Drag a `.opt.tour` file onto right (dashed) zone → chip appears; [replace] resets it
- [x] Verify mobile layout (< 768px): zones stack vertically
- [x] `npm run test` — 15 Vitest tests pass
- [x] `npx tsc --noEmit` — no type errors

Closes #132