### PR TITLE
feat(teeline-web): Step 02 solver config UI + Step 03 precondition checklist (#133)

### DIFF
--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -94,10 +94,48 @@
           </div>
         </section>
 
-        <!-- Step 02: Configure (placeholder — issue #124) -->
+        <!-- Step 02: Configure -->
         <section id="step-02" class="step-panel" aria-labelledby="step-02-heading" hidden>
-          <h2 id="step-02-heading">Configure</h2>
-          <p class="muted">Solver configuration coming soon.</p>
+          <h2 id="step-02-heading">Configure Solver</h2>
+
+          <div class="solver-pills">
+            <button type="button" class="pill outline secondary" data-solver="nn" aria-current="false">NN</button>
+            <button type="button" class="pill outline secondary" data-solver="2opt" aria-current="false">2-opt</button>
+            <button type="button" class="pill outline secondary" data-solver="sa" aria-current="false">SA</button>
+            <button type="button" class="pill outline secondary" data-solver="ga" aria-current="false">GA</button>
+            <select id="solver-select" aria-label="All solvers">
+              <option value="">All solvers…</option>
+            </select>
+          </div>
+
+          <div id="config-panel" class="config-panel">
+            <p class="muted">Select a solver above to see its options.</p>
+          </div>
+
+          <div class="step-actions">
+            <button type="button" id="btn-to-solve">Continue →</button>
+          </div>
+        </section>
+
+        <!-- Step 03: Solve -->
+        <section id="step-03" class="step-panel" aria-labelledby="step-03-heading" hidden>
+          <h2 id="step-03-heading">Ready to Solve</h2>
+
+          <ul class="checklist" id="precondition-list" role="list">
+            <li class="checklist-item" id="check-problem">problem file loaded</li>
+            <li class="checklist-item" id="check-solver">solver selected</li>
+            <li class="checklist-item checklist-item--optional" id="check-optimal">optimal route (optional)</li>
+          </ul>
+
+          <div class="step-actions">
+            <button type="button" id="btn-run" disabled>Run Solver</button>
+          </div>
+        </section>
+
+        <!-- Step 04: Results (placeholder) -->
+        <section id="step-04" class="step-panel" aria-labelledby="step-04-heading" hidden>
+          <h2 id="step-04-heading">Results</h2>
+          <p class="muted">Tour results will appear here.</p>
         </section>
 
       </section><!-- /#step-content -->

--- a/teeline-web/src/main.css
+++ b/teeline-web/src/main.css
@@ -138,3 +138,118 @@
   justify-content: flex-end;
   margin-top: var(--pico-spacing);
 }
+
+/* ---- Solver quick-pick pills ---- */
+.solver-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: var(--pico-spacing);
+}
+
+.pill {
+  margin: 0;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.pill--active {
+  background-color: var(--pico-primary);
+  border-color: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+}
+
+#solver-select {
+  margin: 0;
+  height: auto;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+}
+
+/* ---- Solver config panel ---- */
+.config-panel {
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: var(--pico-spacing);
+  margin-bottom: var(--pico-spacing);
+  min-height: 5rem;
+}
+
+.solver-kind-badge {
+  font-size: 0.8rem;
+  color: var(--pico-muted-color);
+  margin: 0 0 var(--pico-spacing) 0;
+}
+
+.config-no-params {
+  margin: 0;
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.5rem var(--pico-spacing);
+  align-items: center;
+}
+
+.config-grid label {
+  margin: 0;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.config-grid input[type="number"] {
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  height: auto;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 36em) {
+  .config-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---- Precondition checklist ---- */
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--pico-spacing) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--pico-muted-color);
+  font-size: 0.95rem;
+}
+
+.checklist-item::before {
+  content: '○';
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.checklist-item--met {
+  color: var(--pico-color-jade-500, #2a9d8f);
+}
+
+.checklist-item--met::before {
+  content: '✓';
+}
+
+.checklist-item--optional {
+  font-style: italic;
+}
+
+.checklist-item--optional::after {
+  content: ' (optional)';
+  font-size: 0.8rem;
+  color: var(--pico-muted-color);
+}

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -5,6 +5,7 @@ import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
 import type { SolveResult, SolveError, ParseResult } from './worker'
 import { initUpload } from './upload'
+import { initSolverConfig } from './solver-form'
 
 const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
 
@@ -59,4 +60,22 @@ declare global {
 window.runSolver = runSolver
 window.parseFile = parseFile
 
-initUpload(parseFile)
+let parsedProblem: import('teeline-wasm').ParsedProblem | null = null
+
+initUpload(parseFile, (p) => {
+  parsedProblem = p
+})
+
+initSolverConfig(
+  () => parsedProblem !== null,
+  (solver, options) => {
+    if (!parsedProblem) return
+    const step03 = document.getElementById('step-03') as HTMLElement
+    const step04 = document.getElementById('step-04') as HTMLElement
+    step03.hidden = true
+    step04.hidden = false
+    runSolver(solver, parsedProblem.cities, options).catch((err: Error) => {
+      console.error('Solver error:', err)
+    })
+  },
+)

--- a/teeline-web/src/solver-config.test.ts
+++ b/teeline-web/src/solver-config.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { SOLVERS, solverByAlias, paramsFor } from './solver-config'
+import { defaultSolveOptions } from './solver-options'
+
+describe('SOLVERS array', () => {
+  it('has exactly 13 entries', () => {
+    expect(SOLVERS).toHaveLength(13)
+  })
+
+  it('every entry has non-empty name, alias, kind, and params array', () => {
+    for (const s of SOLVERS) {
+      expect(s.name.length, `${s.alias} name`).toBeGreaterThan(0)
+      expect(s.alias.length, `${s.alias} alias`).toBeGreaterThan(0)
+      expect(s.kind.length, `${s.alias} kind`).toBeGreaterThan(0)
+      expect(Array.isArray(s.params), `${s.alias} params`).toBe(true)
+    }
+  })
+
+  it('aliases are unique', () => {
+    const aliases = SOLVERS.map((s) => s.alias)
+    expect(new Set(aliases).size).toBe(aliases.length)
+  })
+
+  it('bhk and branch_bound have kind exact', () => {
+    expect(solverByAlias('bhk')?.kind).toBe('exact')
+    expect(solverByAlias('branch_bound')?.kind).toBe('exact')
+  })
+
+  it('nn has kind constructive', () => {
+    expect(solverByAlias('nn')?.kind).toBe('constructive')
+  })
+
+  it('2opt and 3opt have kind local-search', () => {
+    expect(solverByAlias('2opt')?.kind).toBe('local-search')
+    expect(solverByAlias('3opt')?.kind).toBe('local-search')
+  })
+
+  it('sa, ga, pso, cs, fpa, stochastic_hill, tabu_search have kind metaheuristic', () => {
+    const metaheuristics = ['sa', 'ga', 'pso', 'cs', 'fpa', 'stochastic_hill', 'tabu_search']
+    for (const alias of metaheuristics) {
+      expect(solverByAlias(alias)?.kind, alias).toBe('metaheuristic')
+    }
+  })
+})
+
+describe('solverByAlias', () => {
+  it('returns correct meta for known aliases', () => {
+    expect(solverByAlias('nn')?.alias).toBe('nn')
+    expect(solverByAlias('sa')?.alias).toBe('sa')
+    expect(solverByAlias('ga')?.alias).toBe('ga')
+    expect(solverByAlias('cs')?.alias).toBe('cs')
+    expect(solverByAlias('fpa')?.alias).toBe('fpa')
+    expect(solverByAlias('2opt')?.alias).toBe('2opt')
+    expect(solverByAlias('bhk')?.alias).toBe('bhk')
+  })
+
+  it('returns undefined for unknown alias', () => {
+    expect(solverByAlias('unknown')).toBeUndefined()
+    expect(solverByAlias('')).toBeUndefined()
+  })
+})
+
+describe('param coverage — exact and constructive solvers', () => {
+  it('bhk, branch_bound, nn have empty params array', () => {
+    expect(paramsFor('bhk')).toHaveLength(0)
+    expect(paramsFor('branch_bound')).toHaveLength(0)
+    expect(paramsFor('nn')).toHaveLength(0)
+  })
+})
+
+describe('param coverage — SA', () => {
+  it('includes epochs, platooEpochs, nNearest, coolingRate, maxTemperature, minTemperature', () => {
+    const keys = paramsFor('sa').map((p) => p.key)
+    expect(keys).toContain('epochs')
+    expect(keys).toContain('platooEpochs')
+    expect(keys).toContain('nNearest')
+    expect(keys).toContain('coolingRate')
+    expect(keys).toContain('maxTemperature')
+    expect(keys).toContain('minTemperature')
+  })
+
+  it('coolingRate has type float with 0 < min and max <= 1', () => {
+    const p = paramsFor('sa').find((p) => p.key === 'coolingRate')!
+    expect(p.type).toBe('float')
+    expect(p.min).toBeGreaterThan(0)
+    expect(p.max).toBeLessThanOrEqual(1)
+  })
+
+  it('maxTemperature has type float with min > 0', () => {
+    const p = paramsFor('sa').find((p) => p.key === 'maxTemperature')!
+    expect(p.type).toBe('float')
+    expect(p.min).toBeGreaterThan(0)
+  })
+})
+
+describe('param coverage — GA', () => {
+  it('includes epochs, mutationProbability, nElite', () => {
+    const keys = paramsFor('ga').map((p) => p.key)
+    expect(keys).toContain('epochs')
+    expect(keys).toContain('mutationProbability')
+    expect(keys).toContain('nElite')
+  })
+
+  it('mutationProbability has type float with min 0 and max 1', () => {
+    const p = paramsFor('ga').find((p) => p.key === 'mutationProbability')!
+    expect(p.type).toBe('float')
+    expect(p.min).toBe(0)
+    expect(p.max).toBe(1)
+  })
+
+  it('nElite has type int', () => {
+    const p = paramsFor('ga').find((p) => p.key === 'nElite')!
+    expect(p.type).toBe('int')
+  })
+})
+
+describe('param coverage — CS and FPA', () => {
+  it('both include mutationProbability', () => {
+    expect(paramsFor('cs').map((p) => p.key)).toContain('mutationProbability')
+    expect(paramsFor('fpa').map((p) => p.key)).toContain('mutationProbability')
+  })
+
+  it('neither includes nElite or temperature params', () => {
+    for (const alias of ['cs', 'fpa']) {
+      const keys = paramsFor(alias).map((p) => p.key)
+      expect(keys, alias).not.toContain('nElite')
+      expect(keys, alias).not.toContain('coolingRate')
+      expect(keys, alias).not.toContain('maxTemperature')
+      expect(keys, alias).not.toContain('minTemperature')
+    }
+  })
+})
+
+describe('all param keys are valid SolveOptions fields', () => {
+  it('every param.key is a key of defaultSolveOptions()', () => {
+    const validKeys = new Set(Object.keys(defaultSolveOptions()))
+    for (const solver of SOLVERS) {
+      for (const param of solver.params) {
+        expect(validKeys.has(param.key), `${solver.alias}.${param.key}`).toBe(true)
+      }
+    }
+  })
+})

--- a/teeline-web/src/solver-config.ts
+++ b/teeline-web/src/solver-config.ts
@@ -1,0 +1,194 @@
+import type { SolveOptions } from './solver-options'
+
+export type SolverKind = 'exact' | 'constructive' | 'local-search' | 'metaheuristic' | 'utility'
+
+export interface SolverParam {
+  key: keyof SolveOptions
+  label: string
+  type: 'int' | 'float'
+  min?: number
+  max?: number
+  step?: number
+  description?: string
+}
+
+export interface SolverMeta {
+  name: string
+  alias: string
+  kind: SolverKind
+  description: string
+  params: SolverParam[]
+}
+
+const SHARED_HEURISTIC_PARAMS: SolverParam[] = [
+  {
+    key: 'epochs',
+    label: 'Epochs',
+    type: 'int',
+    min: 1,
+    description: 'Number of iterations to run',
+  },
+  {
+    key: 'platooEpochs',
+    label: 'Plateau epochs',
+    type: 'int',
+    min: 0,
+    description: 'Stop early after this many epochs without improvement (0 = disabled)',
+  },
+  {
+    key: 'nNearest',
+    label: 'Nearest neighbours',
+    type: 'int',
+    min: 1,
+    description: 'Candidate list size for neighbourhood search',
+  },
+]
+
+const MUTATION_PARAM: SolverParam = {
+  key: 'mutationProbability',
+  label: 'Mutation probability',
+  type: 'float',
+  min: 0,
+  max: 1,
+  step: 0.001,
+  description: 'Probability of applying a random mutation per individual',
+}
+
+export const SOLVERS: SolverMeta[] = [
+  {
+    name: 'Bellman-Held-Karp',
+    alias: 'bhk',
+    kind: 'exact',
+    description: 'Exact dynamic programming. Practical limit ~20 cities.',
+    params: [],
+  },
+  {
+    name: 'Branch & Bound',
+    alias: 'branch_bound',
+    kind: 'exact',
+    description: 'Exact branch-and-bound search. Practical limit ~15 cities.',
+    params: [],
+  },
+  {
+    name: 'Nearest Neighbour',
+    alias: 'nn',
+    kind: 'constructive',
+    description: 'Greedy construction heuristic. Fast, deterministic.',
+    params: [],
+  },
+  {
+    name: '2-opt',
+    alias: '2opt',
+    kind: 'local-search',
+    description: 'Local search: iteratively reverses edges to reduce tour length.',
+    params: SHARED_HEURISTIC_PARAMS,
+  },
+  {
+    name: '3-opt',
+    alias: '3opt',
+    kind: 'local-search',
+    description: 'Local search: considers triple-edge reconnections.',
+    params: SHARED_HEURISTIC_PARAMS,
+  },
+  {
+    name: 'Simulated Annealing',
+    alias: 'sa',
+    kind: 'metaheuristic',
+    description: 'Probabilistically accepts worse solutions to escape local optima.',
+    params: [
+      ...SHARED_HEURISTIC_PARAMS,
+      {
+        key: 'coolingRate',
+        label: 'Cooling rate',
+        type: 'float',
+        min: 0.00001,
+        max: 0.9999,
+        step: 0.00001,
+        description: 'Temperature reduction per epoch (0 < α < 1)',
+      },
+      {
+        key: 'maxTemperature',
+        label: 'Max temperature',
+        type: 'float',
+        min: 0.01,
+        step: 1,
+        description: 'Starting temperature (must be > min temperature)',
+      },
+      {
+        key: 'minTemperature',
+        label: 'Min temperature',
+        type: 'float',
+        min: 0,
+        step: 0.001,
+        description: 'Temperature floor; solver stops when reached',
+      },
+    ],
+  },
+  {
+    name: 'Genetic Algorithm',
+    alias: 'ga',
+    kind: 'metaheuristic',
+    description: 'Evolves a population of tours via crossover and mutation.',
+    params: [
+      ...SHARED_HEURISTIC_PARAMS,
+      MUTATION_PARAM,
+      {
+        key: 'nElite',
+        label: 'Elite count',
+        type: 'int',
+        min: 1,
+        description: 'Number of top individuals preserved unchanged each generation',
+      },
+    ],
+  },
+  {
+    name: 'Particle Swarm',
+    alias: 'pso',
+    kind: 'metaheuristic',
+    description: 'Discrete PSO with velocity-capped, linearly decaying inertia.',
+    params: SHARED_HEURISTIC_PARAMS,
+  },
+  {
+    name: 'Cuckoo Search',
+    alias: 'cs',
+    kind: 'metaheuristic',
+    description: 'Lévy-flight nest search with random nest abandonment.',
+    params: [...SHARED_HEURISTIC_PARAMS, MUTATION_PARAM],
+  },
+  {
+    name: 'Flower Pollination',
+    alias: 'fpa',
+    kind: 'metaheuristic',
+    description: 'Global Lévy-flight toward best; local cross-pollination.',
+    params: [...SHARED_HEURISTIC_PARAMS, MUTATION_PARAM],
+  },
+  {
+    name: 'Stochastic Hill Climb',
+    alias: 'stochastic_hill',
+    kind: 'metaheuristic',
+    description: 'Hill climbing with random restarts.',
+    params: SHARED_HEURISTIC_PARAMS,
+  },
+  {
+    name: 'Tabu Search',
+    alias: 'tabu_search',
+    kind: 'metaheuristic',
+    description: 'Local search with a short-term memory of recently visited solutions.',
+    params: SHARED_HEURISTIC_PARAMS,
+  },
+  {
+    name: 'Random Shuffle',
+    alias: 'shuffle',
+    kind: 'utility',
+    description: 'Baseline: random tour order.',
+    params: [],
+  },
+]
+
+export function solverByAlias(alias: string): SolverMeta | undefined {
+  return SOLVERS.find((s) => s.alias === alias)
+}
+
+export function paramsFor(alias: string): SolverParam[] {
+  return solverByAlias(alias)?.params ?? []
+}

--- a/teeline-web/src/solver-form.ts
+++ b/teeline-web/src/solver-form.ts
@@ -1,0 +1,166 @@
+import { SOLVERS, solverByAlias, paramsFor } from './solver-config'
+import { defaultSolveOptions, type SolveOptions } from './solver-options'
+
+export function initSolverConfig(
+  isProblemLoaded: () => boolean,
+  onSolverReady: (solver: string, options: SolveOptions) => void,
+): void {
+  const step02        = document.getElementById('step-02') as HTMLElement
+  const step03        = document.getElementById('step-03') as HTMLElement
+  const solverSelect  = document.getElementById('solver-select') as HTMLSelectElement
+  const configPanel   = document.getElementById('config-panel') as HTMLElement
+  const btnToSolve    = document.getElementById('btn-to-solve') as HTMLButtonElement
+  const btnRun        = document.getElementById('btn-run') as HTMLButtonElement
+  const checkProblem  = document.getElementById('check-problem') as HTMLElement
+  const checkSolver   = document.getElementById('check-solver') as HTMLElement
+
+  let selectedAlias: string | null = null
+  let currentOptions: SolveOptions = defaultSolveOptions()
+
+  // ---- Populate dropdown ----
+
+  for (const s of SOLVERS) {
+    const opt = document.createElement('option')
+    opt.value = s.alias
+    opt.textContent = `${s.name} (${s.alias})`
+    solverSelect.appendChild(opt)
+  }
+
+  // ---- Solver selection ----
+
+  function selectSolver(alias: string): void {
+    selectedAlias = alias
+    currentOptions = defaultSolveOptions()
+    renderConfigPanel(alias)
+    highlightActivePill(alias)
+    solverSelect.value = alias
+    updateChecklist()
+  }
+
+  function highlightActivePill(alias: string): void {
+    document.querySelectorAll<HTMLButtonElement>('.pill[data-solver]').forEach((btn) => {
+      btn.classList.toggle('pill--active', btn.dataset.solver === alias)
+      btn.ariaCurrent = btn.dataset.solver === alias ? 'true' : 'false'
+    })
+  }
+
+  // ---- Config panel rendering ----
+
+  function renderConfigPanel(alias: string): void {
+    const solver = solverByAlias(alias)
+    const params = paramsFor(alias)
+
+    configPanel.innerHTML = ''
+
+    if (!solver) return
+
+    const kind = document.createElement('p')
+    kind.className = 'solver-kind-badge'
+    kind.textContent = `${solver.kind} · ${solver.description}`
+    configPanel.appendChild(kind)
+
+    if (params.length === 0) {
+      const hint = document.createElement('p')
+      hint.className = 'muted config-no-params'
+      hint.textContent = 'No configurable options for this solver.'
+      configPanel.appendChild(hint)
+      return
+    }
+
+    const grid = document.createElement('div')
+    grid.className = 'config-grid'
+
+    for (const param of params) {
+      const label = document.createElement('label')
+      label.htmlFor = `param-${param.key}`
+      label.textContent = param.label
+
+      const input = document.createElement('input')
+      input.type = 'number'
+      input.id = `param-${param.key}`
+      input.name = param.key
+      input.value = String(currentOptions[param.key])
+      if (param.min !== undefined) input.min = String(param.min)
+      if (param.max !== undefined) input.max = String(param.max)
+      if (param.step !== undefined) input.step = String(param.step)
+      else if (param.type === 'int') input.step = '1'
+      if (param.description) input.title = param.description
+
+      input.addEventListener('input', () => {
+        const raw = parseFloat(input.value)
+        if (!isNaN(raw)) {
+          ;(currentOptions as unknown as Record<string, number>)[param.key] = raw
+        }
+      })
+
+      grid.appendChild(label)
+      grid.appendChild(input)
+    }
+
+    configPanel.appendChild(grid)
+  }
+
+  // ---- Precondition checklist ----
+
+  function updateChecklist(): void {
+    const problemMet = isProblemLoaded()
+    const solverMet  = selectedAlias !== null
+
+    checkProblem.classList.toggle('checklist-item--met', problemMet)
+    checkSolver.classList.toggle('checklist-item--met', solverMet)
+
+    btnRun.disabled = !(problemMet && solverMet)
+  }
+
+  // ---- Wire pills ----
+
+  document.querySelectorAll<HTMLButtonElement>('.pill[data-solver]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const alias = btn.dataset.solver!
+      selectSolver(alias)
+    })
+  })
+
+  // ---- Wire dropdown ----
+
+  solverSelect.addEventListener('change', () => {
+    if (solverSelect.value) selectSolver(solverSelect.value)
+  })
+
+  // ---- Step 02 → Step 03 ----
+
+  btnToSolve.addEventListener('click', () => {
+    step02.hidden = true
+    step03.hidden = false
+    advanceStepper(2)
+    updateChecklist()
+  })
+
+  // ---- Run ----
+
+  btnRun.addEventListener('click', () => {
+    if (!selectedAlias || !isProblemLoaded()) return
+    onSolverReady(selectedAlias, { ...currentOptions })
+    advanceStepper(3)
+  })
+}
+
+// ---- Stepper helpers ----
+
+function advanceStepper(toIndex: number): void {
+  const steps = document.querySelectorAll<HTMLElement>('.stepper-step')
+  steps.forEach((step, i) => {
+    if (i < toIndex) {
+      step.classList.add('stepper-step--done')
+      step.classList.remove('stepper-step--active')
+      step.removeAttribute('aria-current')
+    } else if (i === toIndex) {
+      step.classList.add('stepper-step--active')
+      step.classList.remove('stepper-step--done')
+      step.setAttribute('aria-current', 'step')
+    } else {
+      step.classList.remove('stepper-step--active', 'stepper-step--done')
+      step.removeAttribute('aria-current')
+    }
+  })
+}

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -10,7 +10,10 @@ export function exampleUrl(name: string): string {
   return `/examples/${name}.tsp`
 }
 
-export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>): void {
+export function initUpload(
+  parseFile: (input: string) => Promise<ParsedProblem>,
+  onProblemLoaded?: (problem: ParsedProblem) => void,
+): void {
   // DOM elements — all pre-built in index.html
   const zoneTsp       = document.getElementById('zone-tsp')!
   const tspIdle       = document.getElementById('zone-tsp-idle')!
@@ -76,6 +79,7 @@ export function initUpload(parseFile: (input: string) => Promise<ParsedProblem>)
     try {
       const parsed = await parseFile(text)
       showTspLoaded(filename, parsed)
+      onProblemLoaded?.(parsed)
     } catch (err) {
       showError(err instanceof Error ? err.message : String(err))
     }


### PR DESCRIPTION
## Summary

- **`src/solver-config.ts`** — pure data module with all 13 solvers, per-solver parameter definitions (kind, label, type, min/max/step), `solverByAlias()` and `paramsFor()` helpers
- **`src/solver-form.ts`** — DOM module wiring solver quick-pick pills (NN · 2-opt · SA · GA), full dropdown, config panel that renders the correct fields per solver with defaults, precondition checklist, and Run button gate
- **`index.html`** — Step 02 (Configure) and Step 03 (Ready to Solve) panels; Step 04 placeholder
- **`main.css`** — styles for pills (active state), config grid, checklist items (○ idle / ✓ met)
- **`upload.ts`** — optional `onProblemLoaded` callback added to `initUpload`
- **`main.ts`** — wires `initSolverConfig` with `parsedProblem` state; dispatches to worker on Run

## Test Plan

- [x] 19 Vitest unit tests in `src/solver-config.test.ts` — all 13 solvers present, kind classification, SA/GA/CS/FPA param correctness, key validity against `SolveOptions`
- [x] Full suite: 34/34 tests pass (`npx vitest run`)
- [x] TypeScript clean: `npx tsc --noEmit`
- [x] Playwright Scenario A — berlin52 → Continue → SA pill → 6 config fields render; Continue → Step 03 shows both checklist items ✓, Run enabled
- [x] Playwright Scenario B — NN pill → "No configurable options for this solver."
- [x] Playwright Scenario C — advance to Step 03 without selecting solver → Run Solver `[disabled]`, "solver selected" shows ○
- [x] Playwright Scenario D — dropdown contains exactly 13 solver options

Closes #133