### PR TITLE
feat(teeline-web): Task H — Cloudflare Pages CI + Sentry tunnel (#136)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,35 @@
+name: deploy-web
+
+on:
+  push:
+    branches: [master]
+    paths: ['teeline-web/**']
+
+defaults:
+  run:
+    working-directory: teeline-web
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: teeline-web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        run: npx wrangler pages deploy dist/
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/teeline-web/README.md
+++ b/teeline-web/README.md
@@ -1,0 +1,68 @@
+# teeline-web
+
+Browser-based TSP solver — upload a `.tsp` file, configure a solver, and download the optimised tour in `.tour`, `.csv`, `.json`, or `.svg` format. Powered by a Rust/WASM solver core running in a Web Worker.
+
+Live at **[tspsolver.com](https://tspsolver.com)** (Cloudflare Pages).
+
+## Local Development
+
+```bash
+npm ci
+npm run dev      # Vite dev server at http://localhost:5173
+npm test         # Vitest unit tests
+npm run build    # TypeScript check + production build → dist/
+```
+
+## Deployment
+
+Pushes to `master` that touch `teeline-web/**` automatically trigger the [`deploy-web`](../.github/workflows/deploy-web.yml) GitHub Actions workflow, which builds and deploys to Cloudflare Pages.
+
+### Required GitHub Secrets
+
+Add these in **GitHub → repo Settings → Secrets and variables → Actions**:
+
+| Secret | How to obtain |
+|--------|--------------|
+| `CLOUDFLARE_API_TOKEN` | [CF Dashboard](https://dash.cloudflare.com) → My Profile → API Tokens → **Create Token** → use the **Edit Cloudflare Pages** template (or custom token with *Cloudflare Pages: Edit* permission) |
+| `CLOUDFLARE_ACCOUNT_ID` | [CF Dashboard](https://dash.cloudflare.com) → select your account → the Account ID appears in the right sidebar |
+
+`SENTRY_AUTH_TOKEN` is optional — the build succeeds without it; Sentry source map uploads are simply skipped.
+
+### Manual Deploy
+
+```bash
+npm run deploy   # builds then runs wrangler pages deploy dist/
+```
+
+## Cloudflare MCP
+
+The [Cloudflare API MCP server](https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/) exposes 2500+ Cloudflare API endpoints via `search()` and `execute()` tools, letting you manage Pages deployments, custom domains, and environment variables directly from Claude Code.
+
+It is already configured in `.mcp.json` (project root):
+
+```json
+"cloudflare-api": {
+  "type": "http",
+  "url": "https://mcp.cloudflare.com/mcp"
+}
+```
+
+On first use, Claude Code will prompt you to authenticate with your Cloudflare account.
+
+## Architecture
+
+```
+teeline-web/
+├── src/
+│   ├── main.ts          # app bootstrap + state
+│   ├── upload.ts        # Step 01 — drag-drop file upload
+│   ├── solver-form.ts   # Step 02 — solver config + checklist
+│   ├── canvas.ts        # SVG tour rendering
+│   ├── results.ts       # Step 03 — results table + run history
+│   ├── download.ts      # .tour / .csv / .json / .svg export
+│   └── worker.ts        # WASM Web Worker bridge
+├── functions/
+│   └── tunnel.js        # Cloudflare Pages Function — Sentry event proxy
+└── public/
+    └── examples/        # bundled berlin52, burma14, ulysses22 datasets
+```

--- a/teeline-web/functions/tunnel.js
+++ b/teeline-web/functions/tunnel.js
@@ -1,0 +1,26 @@
+// Cloudflare Pages Function — proxies Sentry envelope events to bypass ad blockers.
+// Validates DSN host + project ID before forwarding to prevent abuse.
+
+const SENTRY_HOST = 'o4511523471228928.ingest.de.sentry.io'
+const ALLOWED_PROJECT_IDS = ['4511523482107984']
+
+export async function onRequest({ request }) {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 })
+  }
+  try {
+    const body = await request.text()
+    const header = JSON.parse(body.split('\n')[0])
+    const dsn = new URL(header.dsn)
+    const projectId = dsn.pathname.replace('/', '')
+    if (dsn.hostname !== SENTRY_HOST || !ALLOWED_PROJECT_IDS.includes(projectId)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+    return fetch(`https://${SENTRY_HOST}/api/${projectId}/envelope/`, {
+      method: 'POST',
+      body,
+    })
+  } catch {
+    return new Response('Bad Request', { status: 400 })
+  }
+}


### PR DESCRIPTION
## Summary

- **deploy-web.yml**: GitHub Actions workflow that auto-deploys teeline-web to Cloudflare Pages on every push to `master` that touches `teeline-web/**`
- **functions/tunnel.js**: Cloudflare Pages Function that proxies Sentry envelope events to bypass ad-blocker 404s on `/tunnel` (validates DSN host + project ID before forwarding)
- **teeline-web/README.md**: project docs with local dev instructions, required GitHub secrets table, deploy guide, Cloudflare MCP section, and architecture overview

## Required secrets (set before first merge)

| Secret | Where to obtain |
|--------|----------------|
| `CLOUDFLARE_API_TOKEN` | CF Dashboard → My Profile → API Tokens → **Edit Cloudflare Pages** template |
| `CLOUDFLARE_ACCOUNT_ID` | CF Dashboard → right sidebar → Account ID |

`SENTRY_AUTH_TOKEN` is optional — build succeeds without it.

## Test plan

- [ ] Merge and confirm `deploy-web` workflow triggers in GitHub Actions
- [ ] Verify deployment completes with a `pages.dev` URL
- [ ] Confirm `/tunnel` no longer returns 404 in production (Sentry events received)

Closes #136