### PR TITLE
fix(teeline-web): bundle sentry.js via Vite instead of bare script tag

### DIFF
--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -289,6 +289,5 @@
     </main>
 
     <script type="module" src="/src/main.ts"></script>
-    <script src="/src/sentry.js"></script>
   </body>
 </html>

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -1,3 +1,4 @@
+import './sentry.js'
 import 'htmx.org'
 import '@picocss/pico/css/pico.min.css'
 import './main.css'


### PR DESCRIPTION
## Problems fixed

### 1. sentry.js MIME mismatch (console error, non-blocking)

`<script src="/src/sentry.js">` in `index.html` is a non-module script tag — Vite copies it verbatim into the built HTML without processing. In production `/src/sentry.js` doesn't exist; Cloudflare Pages returns the SPA fallback with `Content-Type: text/html`, which browsers block under strict MIME type checking.

**Fix:** Remove the bare `<script>` tag; add `import './sentry.js'` as the first import in `main.ts` so Vite bundles it into the main JS chunk.

### 2. WASM MIME type / missing file (app fully broken — worker crashes)

The URL baked into the worker bundle by cargo-component's generated JS keeps the **unhashed** filename (`teeline_wasm.core.wasm`), but Vite emits the binary with a content hash (`teeline_wasm.core-[hash].wasm`). Cloudflare Pages SPA fallback intercepts the unhashed path and returns `text/html`, so `WebAssembly.compile()` fails.

Additionally, CF Pages does not set `Content-Type: application/wasm` by default.

**Fix 1:** `scripts/copy-wasm.mjs` (runs as post-build step in `package.json`) copies the hashed WASM to a stable `teeline_wasm.core.wasm` alias so both filenames exist in `dist/assets/`.

**Fix 2:** `public/_headers` sets `Content-Type: application/wasm` for `/assets/*.wasm`.

## Verified via Chrome DevTools on tspsolver.com
- `/assets/teeline_wasm.core.wasm` → 200 `text/html` (SPA fallback, file missing) ✓ confirmed bug
- Worker error: `Incorrect response MIME type. Expected 'application/wasm'` ✓ confirmed root cause

Closes #136 (follow-on)