### PR TITLE
fix(teeline-web): serve WASM with correct MIME type on Cloudflare Pages

### DIFF
--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/copy-wasm.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "deploy": "npm run build && wrangler pages deploy dist/"

--- a/teeline-web/public/_headers
+++ b/teeline-web/public/_headers
@@ -1,0 +1,2 @@
+/assets/*.wasm
+  Content-Type: application/wasm

--- a/teeline-web/scripts/copy-wasm.mjs
+++ b/teeline-web/scripts/copy-wasm.mjs
@@ -1,0 +1,15 @@
+import { readdirSync, copyFileSync } from 'fs'
+
+// After vite build, the WASM gets a content hash in its filename but the URL
+// baked into the worker bundle by cargo-component's generated JS keeps the
+// original unhashed name.  Copy to stable name so the worker finds it.
+const files = readdirSync('dist/assets')
+const hashed = files.find((f) => f.startsWith('teeline_wasm.core') && f.endsWith('.wasm'))
+if (hashed && hashed !== 'teeline_wasm.core.wasm') {
+  copyFileSync(`dist/assets/${hashed}`, 'dist/assets/teeline_wasm.core.wasm')
+  console.log(`[copy-wasm] dist/assets/${hashed} → dist/assets/teeline_wasm.core.wasm`)
+} else if (hashed === 'teeline_wasm.core.wasm') {
+  console.log('[copy-wasm] WASM already has stable name, nothing to do')
+} else {
+  console.error('[copy-wasm] WARNING: no teeline_wasm.core*.wasm found in dist/assets')
+}


### PR DESCRIPTION
## Root cause

The app was completely broken on tspsolver.com: example buttons and file upload did nothing. Chrome DevTools revealed the worker crashed at startup:

```
TypeError: Failed to execute 'compile' on 'WebAssembly':
Incorrect response MIME type. Expected 'application/wasm'.
```

Two underlying issues:

**Issue 1 — Missing file:** The URL baked into the worker bundle by cargo-component's generated JS uses the **unhashed** filename (`teeline_wasm.core.wasm`), but Vite emits the binary with a content hash (`teeline_wasm.core-[hash].wasm`). Cloudflare Pages SPA fallback intercepts the unhashed path and returns `text/html`:

```
GET /assets/teeline_wasm.core.wasm  →  200 Content-Type: text/html  (SPA fallback)
```

**Issue 2 — Wrong MIME type:** CF Pages does not set `Content-Type: application/wasm` for `.wasm` files by default.

## Fix

- `scripts/copy-wasm.mjs` — post-build script (added to `package.json` `build`) that copies the hashed WASM asset to a stable `teeline_wasm.core.wasm` alias so the URL the worker expects actually exists
- `public/_headers` — tells CF Pages to serve `/assets/*.wasm` as `application/wasm`

## Test plan

- [ ] Merge and confirm `deploy-web` workflow deploys successfully
- [ ] Open tspsolver.com, click a berlin52 example — page should advance to Configure step
- [ ] Run a solver — tour should render in the SVG canvas