### PR TITLE
fix(ci): build teeline-wasm from source in deploy-web workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,6 +22,22 @@ jobs:
           cache: 'npm'
           cache-dependency-path: teeline-web/package-lock.json
 
+      - name: Install Rust wasm32-wasip2 target
+        run: rustup target add wasm32-wasip2
+        working-directory: .
+
+      - name: Install cargo-component
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-component
+
+      - name: Build teeline-wasm
+        run: cargo component build --manifest-path teeline-wasm/Cargo.toml --release
+        working-directory: .
+
+      - name: Transpile WASM to JS bindings (jco)
+        run: npx --yes jco@1.19.0 transpile ../target/wasm32-wasip2/release/teeline_wasm.wasm -o ../teeline-wasm/js-bindings
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

- The teeline-web SPA was broken in production because the WASM binary and its JS bindings were absent from the CI build
- `teeline-wasm/js-bindings/` is fully gitignored (generated artifacts), so `npm ci` + `npm run build` in CI had no WASM to bundle, causing the worker to crash at startup with `failed to match magic number`
- Adds Rust build steps to `deploy-web.yml` before `npm ci` so the JS bindings exist when Vite bundles the worker

## Changes

Inserted four steps into `.github/workflows/deploy-web.yml` before `npm ci`:

1. `rustup target add wasm32-wasip2` — enable the WASI P2 target (not present by default on ubuntu-latest)
2. `taiki-e/install-action@v2 cargo-component` — install the WASM component build tool
3. `cargo component build --manifest-path teeline-wasm/Cargo.toml --release` — compile Rust → `.wasm` component
4. `npx jco@1.19.0 transpile … -o ../teeline-wasm/js-bindings` — transpile component → JS bindings that `npm link` resolves as the `teeline-wasm` package

WASM binaries are NOT committed to git (per project policy); they are built from source on every deploy.

## Test plan

- [ ] Merge triggers `deploy-web` workflow on GitHub Actions
- [ ] Workflow: Rust target install, cargo-component install, `cargo component build` all succeed
- [ ] `jco transpile` emits `teeline_wasm.js`, `teeline_wasm.core.wasm`, and `interfaces/` into `teeline-wasm/js-bindings/`
- [ ] `npm run build` succeeds with no "new URL(…) doesn't exist at build time" Vite warning
- [ ] `copy-wasm.mjs` copies `teeline_wasm.core.<hash>.wasm` → `teeline_wasm.core.wasm` in `dist/assets/`
- [ ] Cloudflare Pages deploy succeeds; `dist/assets/` contains `teeline_wasm.core.wasm`
- [ ] tspsolver.com: upload a `.tsp` file and click Run — solver executes without console errors
- [ ] No WASM MIME errors, no "failed to match magic number" in DevTools console