### PR TITLE
fix(ci): download teeline-solver.wasm from latest release in deploy-web

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
     paths: ['teeline-web/**']
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: teeline-web
@@ -21,6 +24,16 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: teeline-web/package-lock.json
+
+      - name: Download WASM component from latest release
+        run: |
+          mkdir -p ../teeline-wasm/js-bindings
+          gh release download --latest --pattern 'teeline-solver.wasm' --output ../teeline-wasm/teeline-solver.wasm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Transpile WASM to JS bindings (jco)
+        run: npx --yes jco@1.19.0 transpile ../teeline-wasm/teeline-solver.wasm -o ../teeline-wasm/js-bindings
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Removes inline Rust build from the deploy workflow
- Downloads the pre-built `teeline-solver.wasm` from the latest GitHub Release (built by the release pipeline)
- Transpiles it to JS bindings with `jco` before `npm ci` + `npm run build`

## How it works

1. `gh release download --latest --pattern 'teeline-solver.wasm'` — fetches the WASM component published by the release pipeline (tagged as `v1.0.0` today)
2. `npx jco@1.19.0 transpile` — produces `teeline_wasm.js`, `teeline_wasm.core.wasm`, and `interfaces/` in `teeline-wasm/js-bindings/`
3. `npm ci` resolves `"teeline-wasm": "file:../teeline-wasm/js-bindings"` from the freshly generated bindings
4. `npm run build` bundles everything; `copy-wasm.mjs` ensures the WASM has a stable (unhashed) name in `dist/assets/`

## Prerequisites

- `v1.0.0` release must be published (triggered today via `git tag v1.0.0`)
- The release pipeline attaches `teeline-solver.wasm` as a release asset

## Test plan

- [ ] Merge after `v1.0.0` release completes and `teeline-solver.wasm` is attached
- [ ] Trigger a deploy (push any change to `teeline-web/**` on master)
- [ ] `gh release download` step finds `teeline-solver.wasm` and downloads it
- [ ] `jco transpile` emits JS bindings into `teeline-wasm/js-bindings/`
- [ ] `npm run build` succeeds; `dist/assets/teeline_wasm.core.wasm` present
- [ ] tspsolver.com: upload a `.tsp` file and run the solver — no console errors