### PR TITLE
fix(release): correct WASM path and scope cargo-dist to teeline-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,8 +224,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Install Rust wasm32-wasip2 target
-        run: rustup target add wasm32-wasip2
+      - name: Install Rust wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
       - name: Install cargo-component
         uses: taiki-e/install-action@v2
         with:
@@ -234,7 +234,7 @@ jobs:
         run: cargo component build --manifest-path teeline-wasm/Cargo.toml --release
       - name: Package WASM artifact
         run: |
-          WASM_FILE=$(find target/wasm32-wasip2/release -name "*.wasm" | head -1)
+          WASM_FILE=$(find target/wasm32-wasip1/release -name "*.wasm" | head -1)
           mkdir -p target/distrib
           cp "$WASM_FILE" target/distrib/teeline-solver.wasm
       - name: Upload WASM artifact

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cargo:."]
+members = ["cargo:./teeline-cli"]
 
 # Config for 'dist'
 [dist]


### PR DESCRIPTION
## Fixes two release pipeline failures

### 1. Wrong WASM target path (`wasm32-wasip2` → `wasm32-wasip1`)

`cargo component build` compiles to `wasm32-wasip1` internally and outputs to `target/wasm32-wasip1/release/teeline_wasm.wasm`. The release workflow was looking in `target/wasm32-wasip2/release/` (no such directory), causing the Package step to fail with `find: 'target/wasm32-wasip2/release': No such file or directory`.

### 2. `teeline-qt` breaking `build-local-artifacts` without Qt

`dist-workspace.toml` used `members = ["cargo:."]` which tells cargo-dist to build all Cargo workspace members, including `teeline-qt`. The `[package.metadata.dist] dist = false` flag in `teeline-qt/Cargo.toml` only skips artifact packaging — it does not prevent cargo-dist from compiling the package. Since `teeline-qt` depends on Qt (`qmake` is required at build time), the build fails on stock CI runners without Qt.

Fix: change `dist-workspace.toml` to `members = ["cargo:./teeline-cli"]` so cargo-dist only builds the CLI binary. Qt builds are handled separately by the dedicated `build-qt-*` jobs.

## Test plan

- [ ] Merge and delete the `v1.0.0` tag + re-tag on master (or re-run the release workflow)
- [ ] `build-local-artifacts` compiles `teeline-cli` successfully across all targets
- [ ] `build-wasm-artifact` finds `target/wasm32-wasip1/release/teeline_wasm.wasm` and copies it as `teeline-solver.wasm`
- [ ] `host` job publishes the GitHub Release with `teeline-solver.wasm` as an asset