### PR TITLE
fix(ci): use direct path for WASM component artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,9 +234,8 @@ jobs:
         run: cargo component build --manifest-path teeline-wasm/Cargo.toml --release
       - name: Package WASM artifact
         run: |
-          WASM_FILE=$(find target/wasm32-wasip1/release -name "*.wasm" | head -1)
           mkdir -p target/distrib
-          cp "$WASM_FILE" target/distrib/teeline-solver.wasm
+          cp target/wasm32-wasip1/release/teeline_wasm.wasm target/distrib/teeline-solver.wasm
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Replace `find target/wasm32-wasip1/release -name "*.wasm" | head -1` with a direct path `target/wasm32-wasip1/release/teeline_wasm.wasm`
- The `find` command was picking up `deps/teeline_wasm.wasm` (plain module) before the component at the top-level path
- This caused the deploy-web jco transpile step to fail: `ComponentError: attempted to parse a wasm module with a component parser`

## Test plan
- [ ] Merge and re-tag v1.0.0 (delete tag + release, re-push tag) to trigger release pipeline
- [ ] Verify `build-wasm-artifact` job packages the correct component WASM
- [ ] Verify deploy-web workflow succeeds after downloading the corrected artifact