### PR TITLE
fix(ci): force official Qt mirror for install-qt-action

### DIFF
--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -40,6 +40,7 @@ jobs:
           target: desktop
           arch: linux_gcc_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -115,6 +116,7 @@ jobs:
           target: desktop
           arch: win64_msvc2022_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Deploy Qt dependencies
@@ -155,6 +157,7 @@ jobs:
           target: desktop
           arch: clang_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Create .app bundle


### PR DESCRIPTION
## Summary
- Add `extra: '--base https://download.qt.io/'` to all three `install-qt-action` steps (Linux, Windows, macOS)
- Qt 6.11.0 hasn't propagated to all unofficial aqt mirrors yet; the official download server always has it
- Fixes the Windows (and potentially Linux/macOS) build failure: `Failed to locate XML data for Qt version '6.11.0'`

## Test plan
- [ ] Trigger `Build Qt (pre-release / manual)` workflow after merge and verify all three platform steps install Qt 6.11.0 successfully