### PR TITLE
ci: add workflow_dispatch to deploy-web

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
     paths: ['teeline-web/**']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Allows manually triggering the Cloudflare Pages deploy without needing a teeline-web/ code change.