### PR TITLE
feat(teeline-web): add Reset buttons to load a new dataset (#173)

### DIFF
--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -218,7 +218,8 @@
             </li>
           </ul>
 
-          <div class="step-actions">
+          <div class="step-actions step-actions--spread">
+            <button type="button" id="btn-change-file" class="outline secondary">← Change file</button>
             <button type="button" id="btn-run" disabled>Run Solver</button>
           </div>
         </section>
@@ -307,6 +308,7 @@
           </div>
 
           <div class="step-actions step-actions--spread">
+            <button type="button" id="btn-new-dataset" class="outline secondary">← New dataset</button>
             <button type="button" id="btn-try-again" class="outline secondary">
               ↻ try another solver
             </button>

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -5,7 +5,7 @@ import './main.css'
 import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
 import type { SolveResult, SolveError, ParseResult } from './worker'
-import { initUpload } from './upload'
+import { initUpload, resetUpload } from './upload'
 import { initSolverConfig } from './solver-form'
 import { initResults, updateOptRoute, showRunning, showResult, computeRouteLength } from './results'
 import { buildTourText, buildCsvText, buildJsonText, serializeSvg, triggerDownload } from './download'
@@ -129,6 +129,21 @@ initUpload(
     updateOptRoute(optTourRoute)
   },
 )
+
+// ---- Reset / new dataset ----
+
+function resetToStep01(): void {
+  parsedProblem = null
+  optTourRoute = null
+  resetUpload()
+  ;(document.getElementById('step-01') as HTMLElement).hidden = false
+  ;(document.getElementById('step-02') as HTMLElement).hidden = true
+  ;(document.getElementById('step-04') as HTMLElement).hidden = true
+  ;(document.getElementById('download-actions') as HTMLElement).hidden = true
+}
+
+document.getElementById('btn-change-file')!.addEventListener('click', resetToStep01)
+document.getElementById('btn-new-dataset')!.addEventListener('click', resetToStep01)
 
 // ---- Download wiring ----
 

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -25,6 +25,12 @@ export function parseOptTour(text: string): number[] {
   return route
 }
 
+let _resetFn: (() => void) | null = null
+
+export function resetUpload(): void {
+  _resetFn?.()
+}
+
 export function initUpload(
   parseFile: (input: string) => Promise<ParsedProblem>,
   onProblemLoaded?: (problem: ParsedProblem) => void,
@@ -173,6 +179,9 @@ export function initUpload(
     inputOpt.value = ''
   })
   btnReplaceOpt.addEventListener('click', showOptIdle)
+
+  // ---- Register module-level reset ----
+  _resetFn = () => { showTspIdle(); showOptIdle() }
 
   // ---- Wire example dataset buttons ----
 


### PR DESCRIPTION
Closes #173

## Changes
- `src/upload.ts` — export `resetUpload()` backed by a module-level `_resetFn` registered in `initUpload`; calls existing `showTspIdle()` + `showOptIdle()` which already handle chip/metadata/stepper reset
- `index.html` — add `#btn-change-file` to Step 02 action bar, `#btn-new-dataset` to Step 04 action bar; both bars now use `step-actions--spread` for left/right layout
- `src/main.ts` — import `resetUpload`, add `resetToStep01()` helper, wire both new buttons

## Behaviour
- **← Change file** (Step 02): return to Step 01 without losing nothing, dataset is cleared
- **← New dataset** (Step 04): return to Step 01; run history in sidebar is preserved for the session
- Stepper resets to Step 1 active via `resetStepper()` inside `showTspIdle()`

## Test plan
- [x] Load berlin52 via example button → Continue → verify "← Change file" is visible
- [x] Click "← Change file" → Step 01 shows with blank upload zones, stepper at step 1
- [x] Load burma14 → Continue → Run NN → verify "← New dataset" is visible alongside "↻ try another solver"
- [x] Click "← New dataset" → Step 01 blank, stepper at step 1
- [x] Load a new dataset, run solver — works correctly end-to-end