### PR TITLE
feat: Wassette integration (#176)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -541,3 +542,59 @@ jobs:
           path: artifacts/
       - name: Attach Qt artifacts to GitHub Release
         run: gh release upload "${{ needs.plan.outputs.tag }}" artifacts/* --repo "${{ github.repository }}"
+
+  publish-wassette:
+    needs: [plan]
+    if: needs.plan.outputs.publishing == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32-wasip2 target
+        run: rustup target add wasm32-wasip2
+
+      - name: Install cargo-component
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-component
+
+      - name: Build wasip2 component
+        run: |
+          cargo component build \
+            --manifest-path teeline-wasm/Cargo.toml \
+            --target wasm32-wasip2 \
+            --release
+          cp target/wasm32-wasip2/release/teeline_wasm.wasm teeline-solver-wassette.wasm
+
+      - name: Resolve version tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME:-manual}" >> "$GITHUB_OUTPUT"
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@v1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to GHCR
+        run: |
+          oras push ghcr.io/timgluz/teeline/wassette:latest \
+            --artifact-type application/wasm \
+            teeline-solver-wassette.wasm:application/wasm
+
+          VERSION="${{ steps.version.outputs.tag }}"
+          if [[ "$VERSION" != "manual" && "$VERSION" != "" ]]; then
+            oras push "ghcr.io/timgluz/teeline/wassette:${VERSION}" \
+              --artifact-type application/wasm \
+              teeline-solver-wassette.wasm:application/wasm
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,13 +545,15 @@ jobs:
 
   publish-wassette:
     needs: [plan]
-    if: needs.plan.outputs.publishing == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.plan.outputs.publishing == 'true'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -572,10 +574,6 @@ jobs:
             --release
           cp target/wasm32-wasip2/release/teeline_wasm.wasm teeline-solver-wassette.wasm
 
-      - name: Resolve version tag
-        id: version
-        run: echo "tag=${GITHUB_REF_NAME:-manual}" >> "$GITHUB_OUTPUT"
-
       - name: Install ORAS
         uses: oras-project/setup-oras@v1
 
@@ -592,9 +590,8 @@ jobs:
             --artifact-type application/wasm \
             teeline-solver-wassette.wasm:application/wasm
 
-          VERSION="${{ steps.version.outputs.tag }}"
-          if [[ "$VERSION" != "manual" && "$VERSION" != "" ]]; then
-            oras push "ghcr.io/timgluz/teeline/wassette:${VERSION}" \
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            oras push "ghcr.io/timgluz/teeline/wassette:${GITHUB_REF_NAME}" \
               --artifact-type application/wasm \
               teeline-solver-wassette.wasm:application/wasm
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ docs/superpowers/
 # env files
 .env*
 
+# teeline-qt
+teeline-qt/target/
+
 # teeline-web
 teeline-web/dist/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ const result = solve('sa', cities, options);
 
 See **[docs/wasm.md](docs/wasm.md)** for the full interface reference, build instructions, and working examples in JavaScript, Python, Go, and Rust.
 
+The component can also be loaded as a native MCP tool inside Claude via [Wassette](https://microsoft.github.io/wassette/latest/) — paste a `.tsp` file, ask Claude to list algorithms, pick one, and get a tour back without leaving the chat. See **[docs/wassette.md](docs/wassette.md)** for setup.
+
 ---
 
 ## Comparing against a known-optimal tour

--- a/docs/wassette.md
+++ b/docs/wassette.md
@@ -1,0 +1,103 @@
+# Using teeline via Wassette in Claude
+
+[Wassette](https://microsoft.github.io/wassette/latest/) is an open-source MCP server from Microsoft that runs WebAssembly components in a sandboxed environment. It exposes WASM Component Model exports as native MCP tools inside Claude conversations.
+
+## Prerequisites
+
+- Claude Desktop or Claude.ai (Pro or Team)
+- Wassette MCP server — see the [Wassette getting started guide](https://microsoft.github.io/wassette/latest/getting-started/)
+
+## Loading the teeline component
+
+In a Claude conversation, ask Claude to load the teeline component from GHCR:
+
+```
+Load component from oci://ghcr.io/timgluz/teeline/wassette:latest
+```
+
+Claude will confirm when the following tools are available:
+
+| Tool | Description |
+|------|-------------|
+| `list-algorithms` | List all TSP solvers with descriptions and recommendations |
+| `solve` | Solve from a list of city coordinate structs |
+| `parse-and-solve` | Parse a raw TSPLIB/JSON string and solve in one call |
+| `parse` | Parse a TSPLIB file and return structured city data |
+| `compare` | Run multiple solvers side-by-side and return timing + distance |
+
+## Example workflow
+
+1. Attach a `.tsp` file or paste TSPLIB content:
+   ```
+   @berlin52.tsp list the available algorithms and recommend the best one
+   ```
+
+2. Claude calls `list-algorithms` and presents the options with recommendations
+
+3. Pick a solver and solve:
+   ```
+   solve it with 2opt
+   ```
+
+4. Compare two solvers:
+   ```
+   compare nn and 2opt on this dataset
+   ```
+   Claude calls `compare` and shows side-by-side results including solve time in milliseconds.
+
+## Component permissions
+
+The teeline component runs with **zero host permissions** — no filesystem, no network, no environment variables. All computation is sandboxed inside the WASM runtime (`teeline-wasm/policy.yaml` declares this explicitly).
+
+## Input formats
+
+**TSPLIB format:**
+```
+NAME: my_problem
+TYPE: TSP
+DIMENSION: 5
+EDGE_WEIGHT_TYPE: EUC_2D
+NODE_COORD_SECTION
+1 0.0 0.0
+2 1.0 0.0
+3 1.0 1.0
+4 0.0 1.0
+5 0.5 0.5
+EOF
+```
+
+**JSON format:**
+```json
+[{"id": 1, "x": 0.0, "y": 0.0}, {"id": 2, "x": 1.0, "y": 0.0}]
+```
+
+## Solver options
+
+| Option | Example value | Used by |
+|--------|--------------|---------|
+| `epochs` | 200 | all iterative solvers |
+| `platoo-epochs` | 50 | stagnation threshold |
+| `cooling-rate` | 0.0001 | SA |
+| `max-temperature` | 1000.0 | SA |
+| `min-temperature` | 0.001 | SA |
+| `mutation-probability` | 0.001 | GA, CS, FPA |
+| `n-elite` | 3 | GA |
+| `n-nearest` | 3 | NN |
+
+## Publishing a new version
+
+**Automatically:** Every versioned release tag (e.g. `v1.1.0`) triggers the `publish-wassette` CI job, which pushes both `:latest` and `:v1.1.0` to GHCR.
+
+**Manually:** Trigger `workflow_dispatch` on release.yml via the [Actions tab](https://github.com/timgluz/teeline/actions/workflows/release.yml) to build and push `:latest` without creating a full release. Note that `workflow_dispatch` only pushes `:latest` — a versioned tag (e.g. `:v1.1.0`) is only pushed when the workflow runs from a version tag (`GITHUB_REF_TYPE == "tag"`).
+
+## Developing and testing locally
+
+Build the wasip2 component locally and load it directly:
+
+```bash
+# Build
+cargo component build --manifest-path teeline-wasm/Cargo.toml --target wasm32-wasip2
+
+# Load in Claude via Wassette
+# In Claude: Load component from file:///path/to/teeline/target/wasm32-wasip2/debug/teeline_wasm.wasm
+```

--- a/teeline-wasm/policy.yaml
+++ b/teeline-wasm/policy.yaml
@@ -1,0 +1,2 @@
+version: "1.0"
+permissions: {}

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -181,7 +181,7 @@ impl Guest for Component {
                     .into_iter()
                     .map(|algo| CompareResult {
                         algorithm: algo,
-                        solution: Err(format!("parse error: {}", e)),
+                        solution: Err(e.clone()),
                     })
                     .collect();
             }

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -2,7 +2,7 @@
 mod bindings;
 
 use bindings::Guest;
-use bindings::teeline::solver::types::{City, ParsedProblem, Solution, SolveOptions};
+use bindings::teeline::solver::types::{AlgorithmInfo, City, ParsedProblem, Solution, SolveOptions};
 use teeline::tsp::{
     AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
     distance_matrix::DistanceMatrix, kdtree::KDPoint,
@@ -60,6 +60,27 @@ fn kd_to_city(c: &KDPoint) -> City {
     City { id: c.id as u32, x: c.x(), y: c.y() }
 }
 
+fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
+    if info.exact {
+        return format!("⚠️ Only for ≤20 cities — {}", info.complexity);
+    }
+    match info.alias {
+        "nn"              => "Fastest; good first look on any dataset size",
+        "2opt"            => "Best quality/speed tradeoff for most datasets",
+        "3opt"            => "Higher quality than 2-opt; good for <500 cities",
+        "sa"              => "Good for escaping local optima; tune cooling-rate",
+        "ga"              => "Strong on large instances; tune mutation-probability and n-elite",
+        "pso"             => "Good convergence on medium datasets; NN-seeded for fast start",
+        "cs"              => "Good exploration; slower convergence than SA",
+        "fpa"             => "Balanced global/local search; tune mutation-probability",
+        "stochastic_hill" => "Simple baseline; fast on small datasets",
+        "tabu_search"     => "Avoids cycling; good for medium-sized datasets",
+        "shuffle"         => "Baseline only; never produces good tours on its own",
+        _                 => info.category,
+    }
+    .to_string()
+}
+
 fn solve_with_cities(
     solver: &str,
     kd_cities: Vec<KDPoint>,
@@ -86,6 +107,18 @@ fn solve_with_cities(
 }
 
 impl Guest for Component {
+    fn list_algorithms() -> Vec<AlgorithmInfo> {
+        teeline::tsp::list_solvers()
+            .iter()
+            .map(|info| AlgorithmInfo {
+                id: info.alias.to_string(),
+                name: info.name.to_string(),
+                description: format!("{} ({})", info.desc, info.complexity),
+                recommendation: recommendation_for(info),
+            })
+            .collect()
+    }
+
     fn solve(solver: String, cities: Vec<City>, options: SolveOptions) -> Result<Solution, String> {
         let kd_cities: Vec<KDPoint> = cities
             .iter()

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -73,6 +73,7 @@ fn solve_with_cities(
         DistanceMatrix::from_cities(&kd_cities).map_err(|e| format!("distance matrix: {e}"))?;
     let problem = TspProblem::new(kd_cities, distances);
     let opts = build_opts(solver_id, options);
+    let start = std::time::Instant::now();
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         teeline::tsp::solve_problem(solver_id, &problem, &opts)
     }))
@@ -80,6 +81,7 @@ fn solve_with_cities(
     .map(|s| Solution {
         total: s.total,
         route: s.route().iter().map(|&id| id as u32).collect(),
+        duration_ms: start.elapsed().as_millis() as u32,
     })
 }
 

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -2,7 +2,7 @@
 mod bindings;
 
 use bindings::Guest;
-use bindings::teeline::solver::types::{AlgorithmInfo, City, ParsedProblem, Solution, SolveOptions};
+use bindings::teeline::solver::types::{AlgorithmInfo, City, CompareResult, ParsedProblem, Solution, SolveOptions};
 use teeline::tsp::{
     AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
     distance_matrix::DistanceMatrix, kdtree::KDPoint,
@@ -58,6 +58,15 @@ fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
 
 fn kd_to_city(c: &KDPoint) -> City {
     City { id: c.id as u32, x: c.x(), y: c.y() }
+}
+
+fn parse_input_to_kd(input: &str) -> Result<Vec<KDPoint>, String> {
+    if input.trim_start().starts_with('[') {
+        teeline::tsp::tsplib::parse_json_cities(input)
+    } else {
+        let data = teeline::tsp::tsplib::read_from_str(input)?;
+        Ok(data.cities().to_vec())
+    }
 }
 
 fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
@@ -156,13 +165,38 @@ impl Guest for Component {
         input: String,
         options: SolveOptions,
     ) -> Result<Solution, String> {
-        let kd_cities = if input.trim_start().starts_with('[') {
-            teeline::tsp::tsplib::parse_json_cities(&input)?
-        } else {
-            let data = teeline::tsp::tsplib::read_from_str(&input)?;
-            data.cities().to_vec()
-        };
+        let kd_cities = parse_input_to_kd(&input)?;
         solve_with_cities(&solver, kd_cities, &options)
+    }
+
+    fn compare(
+        algorithms: Vec<String>,
+        input: String,
+        options: SolveOptions,
+    ) -> Vec<CompareResult> {
+        let kd_cities = match parse_input_to_kd(&input) {
+            Ok(c) => c,
+            Err(e) => {
+                return algorithms
+                    .into_iter()
+                    .map(|algo| CompareResult {
+                        algorithm: algo,
+                        solution: Err(format!("parse error: {}", e)),
+                    })
+                    .collect();
+            }
+        };
+
+        algorithms
+            .into_iter()
+            .map(|algo| {
+                let sol = solve_with_cities(&algo, kd_cities.clone(), &options);
+                CompareResult {
+                    algorithm: algo,
+                    solution: sol,
+                }
+            })
+            .collect()
     }
 }
 

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -292,6 +292,121 @@ fn test_parse_and_solve_invalid_json_returns_err() {
     assert!(result.is_err(), "invalid JSON must return Err");
 }
 
+// ── list_algorithms and compare helpers ───────────────────────────────────────
+
+const FIVE_CITIES_TSPLIB: &str = "NAME: test\n\
+TYPE: TSP\n\
+DIMENSION: 5\n\
+EDGE_WEIGHT_TYPE: EUC_2D\n\
+NODE_COORD_SECTION\n\
+1 565.0 575.0\n\
+2 25.0 185.0\n\
+3 345.0 750.0\n\
+4 945.0 685.0\n\
+5 845.0 655.0\n\
+EOF\n";
+
+fn run_list_algorithms() -> Vec<crate::teeline::solver::types::AlgorithmInfo> {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    instance.call_list_algorithms(&mut store).unwrap()
+}
+
+fn run_compare(
+    algorithms: &[&str],
+    input: &str,
+) -> Vec<crate::teeline::solver::types::CompareResult> {
+    let engine = make_engine();
+    let component = load_component(&engine);
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).unwrap();
+    let mut store = make_store(&engine);
+    let instance = Solver::instantiate(&mut store, &component, &linker).unwrap();
+    let algos: Vec<String> = algorithms.iter().map(|&s| s.to_string()).collect();
+    instance
+        .call_compare(&mut store, &algos, input, default_options())
+        .unwrap()
+}
+
+// ── list_algorithms tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_list_algorithms_returns_all_solvers() {
+    let algorithms = run_list_algorithms();
+    assert_eq!(algorithms.len(), 13, "expected 13 solvers");
+    let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
+    for expected_id in &[
+        "nn", "2opt", "3opt", "sa", "ga", "pso", "cs", "fpa",
+        "tabu_search", "stochastic_hill", "shuffle", "bhk", "branch_bound",
+    ] {
+        assert!(ids.contains(expected_id), "missing algorithm id: {}", expected_id);
+    }
+}
+
+#[test]
+fn test_list_algorithms_fields_non_empty() {
+    let algorithms = run_list_algorithms();
+    for algo in &algorithms {
+        assert!(!algo.id.is_empty(),             "id empty for {:?}", algo.name);
+        assert!(!algo.name.is_empty(),           "name empty for {}", algo.id);
+        assert!(!algo.description.is_empty(),    "description empty for {}", algo.id);
+        assert!(!algo.recommendation.is_empty(), "recommendation empty for {}", algo.id);
+    }
+}
+
+// ── compare tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_compare_happy_path() {
+    let results = run_compare(&["nn", "2opt"], FIVE_CITIES_TSPLIB);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].algorithm, "nn");
+    assert_eq!(results[1].algorithm, "2opt");
+    for r in &results {
+        let sol = r.solution.as_ref().expect("solver should succeed");
+        assert_valid_tour(sol, 5);
+    }
+}
+
+#[test]
+fn test_compare_preserves_algorithm_order() {
+    let results = run_compare(&["sa", "nn", "ga"], FIVE_CITIES_TSPLIB);
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].algorithm, "sa");
+    assert_eq!(results[1].algorithm, "nn");
+    assert_eq!(results[2].algorithm, "ga");
+}
+
+#[test]
+fn test_compare_unknown_algorithm_returns_error_entry() {
+    let results = run_compare(&["nn", "does_not_exist"], FIVE_CITIES_TSPLIB);
+    assert_eq!(results.len(), 2);
+    assert!(results[0].solution.is_ok(),  "nn should succeed");
+    assert!(results[1].solution.is_err(), "unknown solver should return error entry");
+}
+
+#[test]
+fn test_compare_invalid_input_all_error_entries() {
+    let results = run_compare(&["nn", "2opt"], "not valid tsplib or json");
+    assert_eq!(results.len(), 2);
+    assert!(results[0].solution.is_err(), "should return parse error for nn");
+    assert!(results[1].solution.is_err(), "should return parse error for 2opt");
+}
+
+#[test]
+fn test_compare_json_input() {
+    let results = run_compare(&["nn", "2opt"], &five_cities_json());
+    assert_eq!(results.len(), 2);
+    for r in &results {
+        let sol = r.solution.as_ref().expect("solver should succeed with JSON input");
+        assert_valid_tour(sol, 5);
+    }
+}
+
 // ── parse integration tests ────────────────────────────────────────────────────
 
 fn run_parse(input: &str) -> crate::teeline::solver::types::ParsedProblem {

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -361,7 +361,7 @@ fn test_list_algorithms_fields_non_empty() {
 // ── compare tests ─────────────────────────────────────────────────────────────
 
 #[test]
-fn test_compare_happy_path() {
+fn test_compare_tsplib_input() {
     let results = run_compare(&["nn", "2opt"], FIVE_CITIES_TSPLIB);
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].algorithm, "nn");

--- a/teeline-wasm/wit/world.wit
+++ b/teeline-wasm/wit/world.wit
@@ -21,6 +21,7 @@ interface types {
     record solution {
         total: f32,
         route: list<u32>,
+        duration-ms: u32,
     }
 
     record parsed-problem {
@@ -29,10 +30,22 @@ interface types {
         distance-type: string,
         cities: list<city>,
     }
+
+    record algorithm-info {
+        id: string,
+        name: string,
+        description: string,
+        recommendation: string,
+    }
+
+    record compare-result {
+        algorithm: string,
+        solution: result<solution, string>,
+    }
 }
 
 world solver {
-    use types.{city, solve-options, solution, parsed-problem};
+    use types.{city, solve-options, solution, parsed-problem, algorithm-info, compare-result};
 
     export solve: func(
         solver: string,
@@ -49,4 +62,12 @@ world solver {
     export parse: func(
         input: string,
     ) -> result<parsed-problem, string>;
+
+    export list-algorithms: func() -> list<algorithm-info>;
+
+    export compare: func(
+        algorithms: list<string>,
+        input: string,
+        options: solve-options,
+    ) -> list<compare-result>;
 }


### PR DESCRIPTION
## Summary

- Extends `teeline-wasm` WIT interface with `algorithm-info` and `compare-result` records, `duration-ms` on `solution`, and two new exports: `list-algorithms` and `compare`
- `list-algorithms` maps over the existing `teeline::tsp::list_solvers()` static table — no data duplication
- `compare` parses input once to `Vec<KDPoint>`, then runs N solvers in sequence, returning `Vec<CompareResult>` with per-entry error isolation
- Adds `duration-ms: u32` to every solved `Solution` (timing wraps the solver kernel only)
- Publishes wasip2 component to `ghcr.io/timgluz/teeline/wassette` via ORAS on every version tag
- All 30 WASM component tests pass (23 existing + 7 new)

## Test plan

- [x] `cargo component build --target wasm32-wasip2` — zero errors
- [x] `cargo test -p teeline-wasm --test wasm_component` — 30/30 pass
- [x] `test_list_algorithms_returns_all_solvers` — confirms all 13 solvers present
- [x] `test_list_algorithms_fields_non_empty` — confirms no empty fields
- [x] `test_compare_tsplib_input` + `test_compare_json_input` — both input formats work
- [x] `test_compare_preserves_algorithm_order` — output order matches input order
- [x] `test_compare_unknown_algorithm_returns_error_entry` — per-entry error isolation
- [x] `test_compare_invalid_input_all_error_entries` — parse errors propagate to all entries
- [x] YAML validated: `publish-wassette` CI job parses correctly
- [x] Manual Wassette load: `Load component from file:///…/target/wasm32-wasip2/debug/teeline_wasm.wasm` (verify all 5 tools appear in Claude)
- [x] After merge + tag: verify `oras push` to `ghcr.io/timgluz/teeline/wassette:latest` succeeds

Closes #176