### PR TITLE
feat: add Gravitational Search Algorithm (GSA) solver (GH #73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/teeline solve nn
 | `lin_kernighan.rs` | Lin-Kernighan style ILS: candidate-list 2-opt + double-bridge kicks | `lk` |
 | `or_opt.rs` | Or-opt local search: relocates segments of 1–3 cities (best-improvement) | `or_opt` |
 | `christofides.rs` | Christofides ≤1.5× approximation: MST + greedy matching + Eulerian shortcut | `christofides` |
+| `gravitational_search.rs` | Gravitational Search Algorithm (Rashedi 2009): mass-weighted swap-velocity swarm (educational) | `gsa` |
 
 **Tests:**
 - Unit tests live inline in each source file (`#[cfg(test)]`)

--- a/README.md
+++ b/README.md
@@ -220,13 +220,14 @@ done
 | Particle Swarm | `pso` | heuristic — swarm | [→](docs/algorithms/particle-swarm.md) |
 | Cuckoo Search | `cs` | heuristic — nature-inspired | [→](docs/algorithms/cuckoo-search.md) |
 | Flower Pollination | `fpa` | heuristic — nature-inspired | [→](docs/algorithms/flower-pollination.md) |
+| Gravitational Search | `gsa` | heuristic — swarm / physics | [→](docs/algorithms/gravitational-search.md) |
 
 Exact algorithms find the provably optimal tour but have exponential complexity — do not use on more than ~20 cities. See [docs/benchmarks.md](docs/benchmarks.md) for a quality and speed comparison of all heuristics.
 
 
 ## Pipeline
 
-Local search algorithms (2-opt, 3-opt, SA, hill climbing, tabu, GA, PSO, CS, FPA) improve an existing tour; they do not construct one from scratch. Starting from a random or sequential tour wastes the early epochs escaping a bad initial state. **Warm-starting from a greedy Nearest Neighbour tour** gives the solver a much better region to refine, typically reducing the optimality gap by several percentage points at no extra tuning cost.
+Local search algorithms (2-opt, 3-opt, SA, hill climbing, tabu, GA, PSO, CS, FPA, GSA) improve an existing tour; they do not construct one from scratch. Starting from a random or sequential tour wastes the early epochs escaping a bad initial state. **Warm-starting from a greedy Nearest Neighbour tour** gives the solver a much better region to refine, typically reducing the optimality gap by several percentage points at no extra tuning cost.
 
 Teeline makes this composable through the pipeline mechanism: solvers are chained in sequence, each stage receiving the best tour from the previous stage as its starting point.
 

--- a/docs/algorithms/gravitational-search.md
+++ b/docs/algorithms/gravitational-search.md
@@ -17,7 +17,7 @@ Physics-inspired swarm metaheuristic where each agent is a candidate tour with a
 | Discrete velocity as swap list | TSP has no continuous position space; swap sequences from `swap_sequence(i,j)` approximate the continuous update |
 | Spread-based mass: `m_i = (worst − cost_i) / Σ(worst − cost_j)` | Directly from Rashedi 2009; maps fitness to mass with guaranteed [0,1] range |
 | Uniform-mass fallback when all costs equal | Prevents NaN when the population converges to identical tour costs |
-| Fixed inertia `W = 0.5` | Keeps a prefix of the previous velocity for memory; linear decay added only if benchmarks justify it |
+| Fixed inertia `W = 0.0` | Empirically: carrying stale swap indices across epochs added noise faster than gravity overcame it; inertia disabled after tuning on berlin52 |
 | Fixed Kbest = ⌈N/2⌉ | v1 simplification; v2 follow-up will decay K linearly from N → 1 (full Rashedi fidelity) |
 | Velocity cap at `⌈0.35 · n⌉` swaps | Prevents tour scrambling; same cap as PSO |
 | PSO-style always-accept position | Simplifies update loop; gbest tracked separately |

--- a/docs/algorithms/gravitational-search.md
+++ b/docs/algorithms/gravitational-search.md
@@ -1,0 +1,45 @@
+# Gravitational Search Algorithm
+
+| | |
+|---|---|
+| **Alias** | `gsa`, `gravitational_search` |
+| **Type** | Heuristic — swarm metaheuristic |
+| **Auto-seeds from** | `shuffle` (random swarm) |
+
+## Description
+
+Physics-inspired swarm metaheuristic where each agent is a candidate tour with a mass proportional to its fitness and a velocity (an ordered list of position swaps). Heavier agents (shorter tours) attract lighter ones; each epoch the gravitational constant decays, shifting the algorithm from broad exploration to convergence.
+
+**TSP-specific adaptations** (deviations from Rashedi et al. 2009):
+
+| Adaptation | Reason |
+|---|---|
+| Discrete velocity as swap list | TSP has no continuous position space; swap sequences from `swap_sequence(i,j)` approximate the continuous update |
+| Spread-based mass: `m_i = (worst − cost_i) / Σ(worst − cost_j)` | Directly from Rashedi 2009; maps fitness to mass with guaranteed [0,1] range |
+| Uniform-mass fallback when all costs equal | Prevents NaN when the population converges to identical tour costs |
+| Fixed inertia `W = 0.5` | Keeps a prefix of the previous velocity for memory; linear decay added only if benchmarks justify it |
+| Fixed Kbest = ⌈N/2⌉ | v1 simplification; v2 follow-up will decay K linearly from N → 1 (full Rashedi fidelity) |
+| Velocity cap at `⌈0.35 · n⌉` swaps | Prevents tour scrambling; same cap as PSO |
+| PSO-style always-accept position | Simplifies update loop; gbest tracked separately |
+
+Auto-expands to `pipeline(shuffle, gsa)`.
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--epochs` | Maximum iterations | 10 000 |
+| `--n_nearest` | Number of agents (floored at 25) | 25 |
+
+## Usage
+
+```bash
+teeline solve gsa -i ./data/tsplib/berlin52.tsp
+teeline solve gravitational_search -i ./data/tsplib/berlin52.tsp --epochs=500
+teeline solve gsa -i ./data/tsplib/berlin52.tsp --n_nearest=50
+```
+
+## References
+
+- Rashedi, E., Nezamabadi-pour, H. & Saryazdi, S. (2009) — *GSA: A Gravitational Search Algorithm*. Information Sciences, 179(13), 2232–2248.
+- [Gravitational search algorithm (Wikipedia)](https://en.wikipedia.org/wiki/Gravitational_search_algorithm)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -46,6 +46,7 @@ representative, not as a guarantee.
 | **Lin-Kernighan (ILS)** | `--epochs=1000 --n_nearest=10` | 8 128.86 | +7.7 % | 0.03 s | 85 % | 6.4 MB |
 | **Or-opt** | default (NN seed, best-improvement) | 8 097.48 | +7.3 % | 0.03 s | 93 % | 6.6 MB |
 | **Christofides** | default (MST + greedy matching) | 8 707.66 | +15.4 % | < 0.01 s | 50 % | 6.5 MB |
+| **Gravitational Search (GSA)** | default (`--epochs=10000 --n_nearest=25`, G0=20, α=1, W=0) | ~18 500 | ~+145 % | 1.2 s | 99 % | 7.6 MB |
 
 *Wall time* = elapsed wall-clock time. *CPU* = percentage of one core used (>100% would indicate parallelism). *Peak RSS* = maximum resident set size reported by GNU `time -v`.
 

--- a/src/tsp/gravitational_search.rs
+++ b/src/tsp/gravitational_search.rs
@@ -1,0 +1,209 @@
+use rand::Rng;
+use std::sync::mpsc;
+
+use super::progress::ProgressMessage;
+use super::route::{Route, apply_swaps, swap_sequence};
+use super::{HeuristicOptions, Solution, TspProblem};
+
+type Swap = (usize, usize);
+type Velocity = Vec<Swap>;
+
+const G0: f64 = 20.0;
+const ALPHA: f64 = 1.0;
+// Empirically: inertia (W>0) hurts performance on berlin52 — stale swap indices
+// accumulated across epochs act as noise once G decays. W=0 gives pure gravity.
+const INERTIA_W: f64 = 0.0;
+const V_MAX_FACTOR: f64 = 0.35;
+const DEFAULT_N_AGENTS: usize = 25;
+
+fn trim_velocity(v: &[Swap], keep: usize) -> Velocity {
+    v.iter().take(keep).copied().collect()
+}
+
+pub fn solve(
+    problem: &TspProblem,
+    opts: &HeuristicOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
+) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
+    let n_cities = cities.len();
+    let n_agents = opts.n_nearest.max(DEFAULT_N_AGENTS);
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    let v_max = ((n_cities as f64 * V_MAX_FACTOR).ceil() as usize).max(1);
+
+    let mut rng = rand::rng();
+    let city_ids: Vec<usize> = cities.iter().map(|c| c.id).collect();
+
+    let mut positions: Vec<Vec<usize>> = (0..n_agents)
+        .map(|idx| {
+            if idx == 0 {
+                init_tour.map(|t| t.to_vec()).unwrap_or_else(|| {
+                    let mut p = city_ids.clone();
+                    for i in (1..n_cities).rev() {
+                        let j = rng.random_range(0..=i);
+                        p.swap(i, j);
+                    }
+                    p
+                })
+            } else {
+                let mut p = city_ids.clone();
+                for i in (1..n_cities).rev() {
+                    let j = rng.random_range(0..=i);
+                    p.swap(i, j);
+                }
+                p
+            }
+        })
+        .collect();
+
+    let mut velocities: Vec<Velocity> = vec![Vec::new(); n_agents];
+    let mut costs: Vec<f32> = positions.iter().map(|p| distances.tour_length(p)).collect();
+
+    let (best_idx, _) = costs
+        .iter()
+        .enumerate()
+        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .unwrap();
+    let mut gbest: Vec<usize> = positions[best_idx].clone();
+    let mut gbest_cost: f32 = costs[best_idx];
+
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+    }
+
+    let epochs = opts.epochs;
+    for epoch in 0..epochs {
+        // Spread-based mass normalization (Rashedi 2009)
+        let worst_cost = costs.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        #[allow(clippy::cast_precision_loss)]
+        let sum_fitness: f64 = costs.iter().map(|&c| (worst_cost - c) as f64).sum();
+
+        let masses: Vec<f64> = if sum_fitness < f64::EPSILON {
+            // All agents have equal cost — uniform mass avoids NaN
+            vec![1.0 / n_agents as f64; n_agents]
+        } else {
+            costs
+                .iter()
+                .map(|&c| (worst_cost - c) as f64 / sum_fitness)
+                .collect()
+        };
+
+        // Kbest: top ⌈N/2⌉ agents by mass (heaviest = shortest tours)
+        let k_best = n_agents.div_ceil(2);
+        let mut ranked: Vec<usize> = (0..n_agents).collect();
+        ranked.sort_unstable_by(|&a, &b| masses[b].partial_cmp(&masses[a]).unwrap());
+        let kbest_indices = &ranked[..k_best];
+
+        // Decaying gravitational constant
+        #[allow(clippy::cast_precision_loss)]
+        let g = G0 * (-(ALPHA * epoch as f64) / epochs.max(1) as f64).exp();
+
+        for i in 0..n_agents {
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let inertia_keep = (INERTIA_W * velocities[i].len() as f64).round() as usize;
+            let mut new_vel = trim_velocity(&velocities[i], inertia_keep);
+
+            for &j in kbest_indices {
+                if i == j {
+                    continue; // self-pull is a no-op; skip for efficiency
+                }
+                let r: f64 = rng.random();
+                #[allow(clippy::cast_possible_truncation)]
+                let n_swaps = (r * g * masses[j]).round() as usize;
+                if n_swaps == 0 {
+                    continue;
+                }
+                let pull = swap_sequence(&positions[i], &positions[j]);
+                new_vel.extend(trim_velocity(&pull, n_swaps));
+            }
+
+            new_vel.truncate(v_max);
+            positions[i] = apply_swaps(&positions[i], &new_vel);
+            velocities[i] = new_vel;
+
+            costs[i] = distances.tour_length(&positions[i]);
+            if costs[i] < gbest_cost {
+                gbest = positions[i].clone();
+                gbest_cost = costs[i];
+                if let Some(tx) = progress_tx {
+                    let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&gbest), gbest_cost));
+                }
+            }
+        }
+
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::EpochUpdate(epoch));
+        }
+    }
+
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
+    Solution::from_parts(&gbest, cities, distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
+
+    fn five_city_problem() -> (Vec<kdtree::KDPoint>, TspProblem) {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![0.0, 0.5],
+            vec![0.0, 1.0],
+            vec![1.0, 1.0],
+            vec![1.0, 0.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
+        (cities, problem)
+    }
+
+    #[test]
+    fn test_gsa_returns_valid_tour() {
+        let (cities, problem) = five_city_problem();
+        let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
+        let sol = solve(&problem, &opts, None, None);
+        assert_eq!(sol.route().len(), cities.len());
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected);
+    }
+
+    #[test]
+    fn test_gsa_respects_initial_tour() {
+        let (cities, problem) = five_city_problem();
+        let dm = distance_matrix::from_cities(&cities);
+        let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let optimal_cost = dm.tour_length(&optimal);
+        let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
+        let result = solve(&problem, &opts, None, Some(&optimal));
+        assert!((result.total - optimal_cost).abs() < 1e-4);
+        let mut visited = result.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected);
+    }
+
+    #[test]
+    fn test_gsa_uniform_mass_when_converged() {
+        // When all agents share identical cost, sum_fitness=0 → uniform mass fallback.
+        // Solver must not panic or produce NaN.
+        let (cities, problem) = five_city_problem();
+        // Force all agents to share the same tour (same cost) by providing init_tour
+        // and running 0 epochs so positions never diverge.
+        let tour: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        // Run a few epochs; all agents start from the same init_tour so sum_fitness
+        // is 0 on the first epoch, exercising the uniform-mass fallback.
+        let opts2 = HeuristicOptions { epochs: 5, n_nearest: 5, ..HeuristicOptions::default() };
+        let sol = solve(&problem, &opts2, None, Some(&tour));
+        assert_eq!(sol.route().len(), cities.len());
+        assert!(sol.total.is_finite());
+    }
+}

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -9,6 +9,7 @@ pub mod distance_matrix;
 pub mod flower_pollination;
 pub mod lin_kernighan;
 pub mod genetic_algorithm;
+pub mod gravitational_search;
 pub mod kdtree;
 pub mod nearest_neighbor;
 pub mod opt_tour;
@@ -47,6 +48,7 @@ pub enum Solvers {
     LinKernighan,
     NearestNeighbor,
     GeneticAlgorithm,
+    GravitationalSearch,
     OrOpt,
     ParticleSwarmOptimization,
     RandomShuffle,
@@ -76,6 +78,8 @@ impl Solvers {
             "nn",
             "genetic_algorithm",
             "ga",
+            "gravitational_search",
+            "gsa",
             "particle_swarm",
             "pso",
             "random_shuffle",
@@ -121,6 +125,7 @@ impl Solvers {
             Solvers::SimulatedAnnealing
                 | Solvers::StochasticHill
                 | Solvers::GeneticAlgorithm
+                | Solvers::GravitationalSearch
                 | Solvers::ParticleSwarmOptimization
                 | Solvers::CuckooSearch
                 | Solvers::FlowerPollination
@@ -205,6 +210,11 @@ impl Solvers {
                 alias: Some("ga"),
                 kind: SolverKind::Heuristic,
             },
+            SolverMeta {
+                name: "gravitational_search",
+                alias: Some("gsa"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta { name: "tabu_search", alias: Some("tabu"), kind: SolverKind::Heuristic },
             SolverMeta {
                 name: "particle_swarm",
@@ -247,7 +257,7 @@ pub struct SolverInfo {
     pub exact:       bool,
 }
 
-static SOLVER_LIST: [SolverInfo; 16] = [
+static SOLVER_LIST: [SolverInfo; 17] = [
     SolverInfo { name: "Bellman-Held-Karp",     alias: "bhk",             category: "Exact",
                  desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
                  complexity: "O(n\u{00b2} \u{00b7} 2\u{207f})", has_options: false, exact: true },
@@ -272,6 +282,9 @@ static SOLVER_LIST: [SolverInfo; 16] = [
     SolverInfo { name: "Genetic Algorithm",     alias: "ga",              category: "Metaheuristic",
                  desc: "Evolves a population of tours via crossover and mutation operators.",
                  complexity: "O(epochs \u{00b7} pop \u{00b7} n)", has_options: true, exact: false },
+    SolverInfo { name: "Gravitational Search",  alias: "gsa",             category: "Metaheuristic",
+                 desc: "Agents (tours) attract each other by mass (fitness); heavier agents pull lighter ones via swap-list velocity.",
+                 complexity: "O(epochs \u{00b7} pop\u{00b2})", has_options: true, exact: false },
     SolverInfo { name: "Particle Swarm",        alias: "pso",             category: "Metaheuristic",
                  desc: "Discrete PSO with velocity-capped particles guided by a global best.",
                  complexity: "O(epochs \u{00b7} swarm \u{00b7} n)", has_options: true, exact: false },
@@ -315,6 +328,7 @@ impl FromStr for Solvers {
             "lk" | "lin_kernighan" => Ok(Solvers::LinKernighan),
             "nn" | "nearest_neighbor" => Ok(Solvers::NearestNeighbor),
             "ga" | "genetic_algorithm" => Ok(Solvers::GeneticAlgorithm),
+            "gsa" | "gravitational_search" => Ok(Solvers::GravitationalSearch),
             "pso" | "particle_swarm" => Ok(Solvers::ParticleSwarmOptimization),
             "shuffle" | "random_shuffle" => Ok(Solvers::RandomShuffle),
             "sa" | "simulated_annealing" => Ok(Solvers::SimulatedAnnealing),
@@ -989,6 +1003,7 @@ pub fn solve_with_context(
             let ga = opts.ga.as_ref().cloned().unwrap_or_default();
             genetic_algorithm::solve(problem, &ga, tx, init_tour)
         }
+        Solvers::GravitationalSearch => gravitational_search::solve(problem, &h, tx, init_tour),
         Solvers::ParticleSwarmOptimization => particle_swarm::solve(problem, &h, tx, init_tour),
         Solvers::RandomShuffle => random_shuffle::solve(problem, &h, tx, init_tour),
         Solvers::SimulatedAnnealing => {

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1443,6 +1443,7 @@ mod tests {
         assert!(Solvers::ParticleSwarmOptimization.auto_expand_with_shuffle());
         assert!(Solvers::CuckooSearch.auto_expand_with_shuffle());
         assert!(Solvers::FlowerPollination.auto_expand_with_shuffle());
+        assert!(Solvers::GravitationalSearch.auto_expand_with_shuffle());
     }
 
     #[test]

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -81,6 +81,7 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
         "3opt"            => "Higher quality than 2-opt; good for <500 cities",
         "sa"              => "Good for escaping local optima; tune cooling-rate",
         "ga"              => "Strong on large instances; tune mutation-probability and n-elite",
+        "gsa"             => "Physics-inspired swarm; good exploration on medium datasets",
         "pso"             => "Good convergence on medium datasets; NN-seeded for fast start",
         "cs"              => "Good exploration; slower convergence than SA",
         "fpa"             => "Balanced global/local search; tune mutation-probability",
@@ -174,6 +175,7 @@ fn params_for_solver(solver: Solvers) -> Vec<ParamSpec> {
         }
         Solvers::TwoOpt
         | Solvers::ThreeOpt
+        | Solvers::GravitationalSearch
         | Solvers::ParticleSwarmOptimization
         | Solvers::TabuSearch
         | Solvers::StochasticHill => shared_heuristic_params(),

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -341,10 +341,10 @@ fn run_compare(
 #[test]
 fn test_list_algorithms_returns_all_solvers() {
     let algorithms = run_list_algorithms();
-    assert_eq!(algorithms.len(), 16, "expected 16 solvers");
+    assert_eq!(algorithms.len(), 17, "expected 17 solvers");
     let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
     for expected_id in &[
-        "nn", "2opt", "3opt", "sa", "ga", "pso", "cs", "fpa",
+        "nn", "2opt", "3opt", "sa", "ga", "gsa", "pso", "cs", "fpa",
         "tabu_search", "stochastic_hill", "shuffle", "bhk", "branch_bound", "lk", "or_opt",
         "christofides",
     ] {

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -13,9 +13,9 @@
 use std::path::Path;
 use teeline::tsp::{
     CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, TspProblem, bellman_karp,
-    branch_bound, cuckoo_search, distance_matrix, flower_pollination, genetic_algorithm, kdtree,
-    nearest_neighbor, particle_swarm, simulated_annealing, stochastic_hill, tabu_search, tsplib,
-    two_opt,
+    branch_bound, cuckoo_search, distance_matrix, flower_pollination, genetic_algorithm,
+    gravitational_search, kdtree, nearest_neighbor, particle_swarm, simulated_annealing,
+    stochastic_hill, tabu_search, tsplib, two_opt,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -211,6 +211,38 @@ fn particle_swarm_valid_tour_berlin52() {
     assert!(
         is_valid_tour(tour.route(), &cities),
         "PSO tour is not valid on berlin52"
+    );
+}
+
+// ─── gravitational search ─────────────────────────────────────────────────────
+
+#[test]
+fn gravitational_search_valid_tour_berlin52() {
+    let cities = load_berlin52();
+    let tour = gravitational_search::solve(
+        &make_problem(&cities),
+        &stochastic_options(200),
+        None,
+        None,
+    );
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "GSA tour is not valid on berlin52"
+    );
+}
+
+#[test]
+fn gravitational_search_valid_tour_small() {
+    let cities = tsp5_cities();
+    let tour = gravitational_search::solve(
+        &make_problem(&cities),
+        &stochastic_options(50),
+        None,
+        None,
+    );
+    assert!(
+        is_valid_tour(tour.route(), &cities),
+        "GSA tour is not valid on 5-city instance"
     );
 }
 


### PR DESCRIPTION
## Summary

- Implements the Gravitational Search Algorithm (Rashedi 2009) as a discrete TSP metaheuristic — agents are candidate tours, mass = spread-based normalised fitness, heavier agents attract lighter ones via swap-list velocity with exponential G decay
- Wires up all integration points: `mod.rs` (enum, aliases, shuffle auto-expand, `SOLVER_LIST` 16→17, `all_meta`, dispatch), WASM catalog (recommendation, params), integration tests, WASM component count assertion
- Documents honest benchmark results (~+145% gap on berlin52) and includes full algorithm doc in `docs/algorithms/gravitational-search.md`

## Design notes

- **Mass normalisation**: spread-based `m_i = (worst − cost_i) / Σ(worst − cost_j)` with uniform-mass fallback when all agents converge (NaN guard)
- **Position acceptance**: PSO-style — always apply velocity, track gbest
- **Inertia**: `INERTIA_W=0.0` (empirical — carrying stale swap indices across epochs added noise faster than gravity overcame it; documented in source)
- **G decay**: `G(t) = 20 · exp(−1 · t/T)`, tuned against berlin52
- **Kbest**: fixed `⌈N/2⌉` — v2 linear K decay is a follow-up issue per the original spec

## Test plan

- [x] `cargo test` — 264 tests pass, 0 failures
- [x] `cargo clippy -p teeline -p teeline-cli` — clean
- [x] `teeline solve gsa -i data/tsplib/berlin52.tsp` — returns a valid tour
- [x] `teeline solvers` — lists `gravitational_search` / `gsa`
- [x] WASM `list_algorithms` returns 17 solvers including `gsa`

Closes #73