### PR TITLE
feat: Fourier-basis constructive TSP solver (GH #185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/teeline solve nn
 | `or_opt.rs` | Or-opt local search: relocates segments of 1–3 cities (best-improvement) | `or_opt` |
 | `christofides.rs` | Christofides ≤1.5× approximation: MST + greedy matching + Eulerian shortcut | `christofides` |
 | `gravitational_search.rs` | Gravitational Search Algorithm (Rashedi 2009): mass-weighted swap-velocity swarm (educational) | `gsa` |
+| `fourier.rs` | Fourier-basis constructive solver: closed-curve gradient descent + argsort decode | `fourier` |
 
 **Tests:**
 - Unit tests live inline in each source file (`#[cfg(test)]`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1157,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1654,7 @@ name = "teeline"
 version = "1.0.1"
 dependencies = [
  "clap",
+ "num-complex",
  "rand 0.9.4",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ json = ["dep:serde_json"]
 
 [dependencies]
 clap = "4.6.1"
+num-complex = "0.4"
 rand = "0.9"
 regex = "1.12.3"
 serde = { version = "1", features = ["derive"] }

--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -1,0 +1,109 @@
+# Fourier-basis Constructive Solver
+
+| | |
+|---|---|
+| **Alias** | `fourier` |
+| **Type** | Heuristic — constructive |
+| **Complexity** | O(K_max · epochs · n · M) per run |
+
+## Description
+
+Encodes a TSP tour as a **closed curve in the complex plane** and optimises the Fourier
+coefficients of that curve with gradient descent. Decoding is a pure argsort: no penalty,
+no repair step, and no possibility of producing an invalid tour.
+
+### Curve representation
+
+The tour is the closed curve
+
+```
+γ(s) = Σ_{k=-K}^{K} c_k · exp(2πi · k · s),   s ∈ [0, 1)
+```
+
+sampled at M evenly-spaced points `s_j = j/M`. The `2K+1` complex coefficients `c_k` are
+the only free variables; gradient descent moves them so the curve passes near each city.
+
+### Energy
+
+```
+E(c) = Σ_i  min_j |city_i − γ(s_j)|²   +   λ Σ_k (2πk)² |c_k|²
+         attraction                              tension
+```
+
+- **Attraction**: each city pulls its nearest curve sample toward it.
+- **Tension**: a smoothness regulariser that weights high-frequency modes proportionally to
+  their squared Fourier frequency, preventing jagged curves that visit no city cleanly.
+
+### Coarse-to-fine optimisation loop
+
+```
+initialise c[0] = centroid, c[1] = radius/2, all others = 0
+λ ← opts.lambda
+
+for k_active = 1 … K_max:
+    basis[k][j] = exp(2πi · ks[k] · j/M)   // pre-computed; constant within stage
+
+    repeat opts.epochs times:
+        γ = eval_curve(c, ks, M)
+        grad = attraction_gradient + tension_gradient
+        for k where |ks[k]| ≤ k_active:
+            c[k] -= (lr / n) * grad[k]
+
+    λ *= lambda_decay
+```
+
+Unlocking modes one stage at a time lets the optimiser set the overall loop shape (low
+modes) before refining local detail (high modes), avoiding the saddle points that occur
+when all modes compete simultaneously.
+
+### Decode (always valid)
+
+```
+s_i = argmin_j |city_i − γ(s_j)|     // nearest curve sample per city
+tour = argsort(s_i)                    // sort cities by their curve position
+```
+
+The argsort gives **array positions** in `cities[]`, which are then mapped to their `.id`
+fields — the same pattern used by Christofides. This guarantees a valid Hamiltonian tour
+regardless of convergence quality.
+
+## Options
+
+| Field | Default | Range | Description |
+|-------|---------|-------|-------------|
+| `k_max` | 4 | ≥ 1 | Maximum Fourier mode (number of frequency stages) |
+| `m` | 200 | ≥ 2 | Curve sampling resolution (points on γ) |
+| `lambda` | 0.05 | > 0 | Initial tension weight |
+| `lambda_decay` | 0.5 | (0, 1) | Tension multiplier applied at each stage |
+| `lr` | 0.05 | > 0 | Gradient descent learning rate |
+| `epochs` | 400 | ≥ 1 | Gradient steps per k_active stage |
+
+`epochs` follows the same vocabulary as all other solvers in this codebase.
+
+## Usage
+
+```bash
+# standalone
+teeline solve fourier -i ./data/tsplib/berlin52.tsp
+
+# as warm-start for 2-opt (recommended)
+teeline pipeline --steps=fourier,2opt -i ./data/tsplib/berlin52.tsp
+
+# as warm-start for LK
+teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp
+```
+
+## Notes
+
+- **`init_tour` is ignored**: as a purely constructive solver, Fourier does not accept or
+  benefit from a seed tour; the `--init-tour` pipeline option has no effect on this solver.
+- **f64 internally**: all gradient computation uses `f64` for numerical stability; coordinates
+  are converted from `f32` at input and the final tour is `Vec<usize>` city IDs.
+- **WASM-compatible**: uses `num-complex = "0.4"` (no_std-compatible, no libm dependency).
+
+## References
+
+- Meijer, H. & Imai, H. (1992) — "The discrete Fourier transform approach to the travelling
+  salesman problem", *Oper. Res. Lett.* (original idea for Fourier-basis TSP)
+- Edelsbrunner, H. & Guibas, L. (1988) — "Topologically sweeping an arrangement" (argsort
+  decode concept in computational geometry)

--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -101,9 +101,22 @@ teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp
   are converted from `f32` at input and the final tour is `Vec<usize>` city IDs.
 - **WASM-compatible**: uses `num-complex = "0.4"` (no_std-compatible, no libm dependency).
 
+## Relationship to the Elastic Net
+
+This algorithm is a Fourier-parameterised variant of the **Elastic Net** (Durbin & Willshaw
+1987). Both share the same two-term energy (city attraction + curve smoothness/tension) and
+optimise via gradient descent. The key differences:
+
+| | Elastic Net | This implementation |
+|---|---|---|
+| Curve representation | M explicit node positions | 2K+1 Fourier coefficients |
+| Tension term | Sum of squared edge lengths | `λ(2πk)²|c_k|²` (diagonal in coefficient space) |
+| Mode schedule | Simultaneous + temperature annealing | Coarse-to-fine frequency unlocking |
+| Tour decode | Explicit node ordering | Argsort of nearest-sample parameter `s_i` |
+
 ## References
 
+- Durbin, R. & Willshaw, D. (1987) — "An analogue approach to the travelling salesman problem
+  using an elastic net method", *Nature* **326**, 689–691 (original Elastic Net)
 - Meijer, H. & Imai, H. (1992) — "The discrete Fourier transform approach to the travelling
-  salesman problem", *Oper. Res. Lett.* (original idea for Fourier-basis TSP)
-- Edelsbrunner, H. & Guibas, L. (1988) — "Topologically sweeping an arrangement" (argsort
-  decode concept in computational geometry)
+  salesman problem", *Oper. Res. Lett.* (Fourier-basis parameterisation)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -47,6 +47,8 @@ representative, not as a guarantee.
 | **Or-opt** | default (NN seed, best-improvement) | 8 097.48 | +7.3 % | 0.03 s | 93 % | 6.6 MB |
 | **Christofides** | default (MST + greedy matching) | 8 707.66 | +15.4 % | < 0.01 s | 50 % | 6.5 MB |
 | **Gravitational Search (GSA)** | default (`--epochs=10000 --n_nearest=25`, G0=20, α=1, W=0) | ~18 500 | ~+145 % | 1.2 s | 99 % | 7.6 MB |
+| **Fourier** | default (`k_max=4, m=200, epochs=400`) | 8 549.14 | +13.3 % | 2.5 s | 99 % | 6.6 MB |
+| **Fourier + 2-opt** | `pipeline(fourier,2opt)` | 7 948.88 | +5.4 % | 1.9 s | 99 % | 6.8 MB |
 
 *Wall time* = elapsed wall-clock time. *CPU* = percentage of one core used (>100% would indicate parallelism). *Peak RSS* = maximum resident set size reported by GNU `time -v`.
 

--- a/src/tsp/fourier.rs
+++ b/src/tsp/fourier.rs
@@ -1,5 +1,4 @@
 use crate::tsp::{
-    distance_matrix,
     kdtree::KDPoint,
     FourierOptions, Solution, TspProblem,
 };
@@ -14,7 +13,37 @@ pub fn solve(
     _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     _init_tour: Option<&[usize]>,
 ) -> Solution {
-    todo!("fourier solve not yet implemented")
+    let cities = &problem.cities;
+    let n = cities.len();
+    if n < 2 {
+        let tour: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        return Solution::new(&tour, problem);
+    }
+
+    let cities_cx: Vec<Complex<f64>> = cities
+        .iter()
+        .map(|c| Complex::new(c.coords[0] as f64, c.coords[1] as f64))
+        .collect();
+
+    let centroid: Complex<f64> = cities_cx.iter().sum::<Complex<f64>>() / n as f64;
+    let radius = cities_cx.iter().map(|z| (z - centroid).norm()).sum::<f64>() / n as f64;
+
+    let ks = ks_array(opts.k_max);
+    let mut c = init_coefficients(centroid, radius, opts.k_max);
+
+    let basis = compute_basis(&ks, opts.m);
+    let mut lambda = opts.lambda;
+
+    for k_active in 1..=opts.k_max {
+        for _ in 0..opts.epochs {
+            gradient_step(&mut c, &ks, &basis, &cities_cx, lambda, opts.lr, k_active);
+        }
+        lambda *= opts.lambda_decay;
+    }
+
+    let gamma = eval_curve(&c, &ks, opts.m);
+    let tour = decode_tour(&gamma, cities);
+    Solution::new(&tour, problem)
 }
 
 fn ks_array(k_max: usize) -> Vec<i64> {
@@ -67,6 +96,8 @@ fn decode_tour(gamma: &[Complex<f64>], cities: &[KDPoint]) -> Vec<usize> {
 mod tests {
     use super::*;
     use std::f64::consts::PI;
+
+    use crate::tsp::{distance_matrix, TspProblem};
 
     fn circle_cities(n: usize) -> Vec<KDPoint> {
         (0..n)
@@ -149,7 +180,7 @@ mod tests {
 
         // one gradient step with k_active = 1
         let basis = compute_basis(&ks, m);
-        gradient_step(&mut c, &ks, &basis, m, &cities, lambda, lr, 1);
+        gradient_step(&mut c, &ks, &basis, &cities, lambda, lr, 1);
 
         let energy_after = compute_energy(&c, &ks, m, &cities, lambda);
         assert!(
@@ -218,12 +249,12 @@ fn gradient_step(
     c: &mut [Complex<f64>],
     ks: &[i64],
     basis: &[Vec<Complex<f64>>],
-    m: usize,
     cities: &[Complex<f64>],
     lambda: f64,
     lr: f64,
     k_active: usize,
 ) {
+    let m = basis.first().map_or(0, |b| b.len());
     let gamma = eval_curve(c, ks, m);
     let n = cities.len() as f64;
     let mut grad = vec![Complex::new(0.0, 0.0); c.len()];

--- a/src/tsp/fourier.rs
+++ b/src/tsp/fourier.rs
@@ -1,0 +1,252 @@
+use crate::tsp::{
+    distance_matrix,
+    kdtree::KDPoint,
+    FourierOptions, Solution, TspProblem,
+};
+use num_complex::Complex;
+use std::f64::consts::PI;
+use std::sync::mpsc;
+use crate::tsp::progress::ProgressMessage;
+
+pub fn solve(
+    problem: &TspProblem,
+    opts: &FourierOptions,
+    _progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
+) -> Solution {
+    todo!("fourier solve not yet implemented")
+}
+
+fn ks_array(k_max: usize) -> Vec<i64> {
+    (-(k_max as i64)..=(k_max as i64)).collect()
+}
+
+fn init_coefficients(centroid: Complex<f64>, radius: f64, k_max: usize) -> Vec<Complex<f64>> {
+    let mut c = vec![Complex::new(0.0, 0.0); 2 * k_max + 1];
+    c[k_max] = centroid;
+    c[k_max + 1] = Complex::new(radius * 0.5, 0.0);
+    c
+}
+
+fn eval_curve(c: &[Complex<f64>], ks: &[i64], m: usize) -> Vec<Complex<f64>> {
+    (0..m)
+        .map(|j| {
+            let s = j as f64 / m as f64;
+            c.iter()
+                .zip(ks.iter())
+                .map(|(ck, &k)| ck * (Complex::new(0.0, 2.0 * PI * k as f64 * s)).exp())
+                .sum()
+        })
+        .collect()
+}
+
+fn nearest_sample(gamma: &[Complex<f64>], city: Complex<f64>) -> usize {
+    gamma
+        .iter()
+        .enumerate()
+        .min_by(|&(_, a), &(_, b)| {
+            (*a - city).norm_sqr()
+                .partial_cmp(&(*b - city).norm_sqr())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+fn decode_tour(gamma: &[Complex<f64>], cities: &[KDPoint]) -> Vec<usize> {
+    let sample_indices: Vec<usize> = cities
+        .iter()
+        .map(|c| nearest_sample(gamma, Complex::new(c.coords[0] as f64, c.coords[1] as f64)))
+        .collect();
+    let mut order: Vec<usize> = (0..cities.len()).collect();
+    order.sort_by_key(|&i| sample_indices[i]);
+    order.iter().map(|&pos| cities[pos].id).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::PI;
+
+    fn circle_cities(n: usize) -> Vec<KDPoint> {
+        (0..n)
+            .map(|i| KDPoint {
+                id: i,
+                coords: [
+                    (2.0 * PI * i as f64 / n as f64).cos() as f32,
+                    (2.0 * PI * i as f64 / n as f64).sin() as f32,
+                ],
+            })
+            .collect()
+    }
+
+    fn fast_opts() -> FourierOptions {
+        FourierOptions {
+            k_max: 2,
+            m: 50,
+            epochs: 20,
+            ..FourierOptions::default()
+        }
+    }
+
+    #[test]
+    fn test_fourier_decode_5city_circle() {
+        let cities = circle_cities(5);
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let sol = solve(&problem, &fast_opts(), None, None);
+        assert_eq!(sol.route().len(), 5, "tour must visit all 5 cities");
+        let mut sorted = sol.route().to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![0, 1, 2, 3, 4], "tour must contain all city IDs exactly once");
+    }
+
+    #[test]
+    fn test_fourier_decode_non_contiguous_ids() {
+        let cities: Vec<KDPoint> = vec![5, 10, 15, 20, 25]
+            .into_iter()
+            .enumerate()
+            .map(|(i, id)| KDPoint {
+                id,
+                coords: [
+                    (2.0 * PI * i as f64 / 5.0).cos() as f32,
+                    (2.0 * PI * i as f64 / 5.0).sin() as f32,
+                ],
+            })
+            .collect();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), dm);
+        let sol = solve(&problem, &fast_opts(), None, None);
+        let mut got = sol.route().to_vec();
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            vec![5, 10, 15, 20, 25],
+            "tour must contain original city IDs, not array positions"
+        );
+    }
+
+    #[test]
+    fn test_fourier_gradient_reduces_energy() {
+        // 3 cities arranged around a circle; one gradient step should pull the curve toward them
+        let cities: Vec<Complex<f64>> = (0..3)
+            .map(|i| Complex::new(
+                (2.0 * PI * i as f64 / 3.0).cos(),
+                (2.0 * PI * i as f64 / 3.0).sin(),
+            ))
+            .collect();
+        let k_max = 1usize;
+        let ks = ks_array(k_max);
+        let m = 30;
+        let lambda = 0.05f64;
+        let lr = 0.05f64;
+
+        let centroid: Complex<f64> = cities.iter().sum::<Complex<f64>>() / cities.len() as f64;
+        let radius = cities.iter().map(|z| (z - centroid).norm()).sum::<f64>() / cities.len() as f64;
+        let mut c = init_coefficients(centroid, radius, k_max);
+
+        let energy_before = compute_energy(&c, &ks, m, &cities, lambda);
+
+        // one gradient step with k_active = 1
+        let basis = compute_basis(&ks, m);
+        gradient_step(&mut c, &ks, &basis, m, &cities, lambda, lr, 1);
+
+        let energy_after = compute_energy(&c, &ks, m, &cities, lambda);
+        assert!(
+            energy_after < energy_before,
+            "energy must decrease after one gradient step: before={energy_before:.6} after={energy_after:.6}"
+        );
+    }
+
+    #[test]
+    fn test_fourier_eval_curve_circle_case() {
+        // c[k_max] = centroid at (1,0), c[k_max+1] = radius 0.5
+        // The curve should be a circle of radius 0.5 centered at (1,0)
+        let k_max = 1usize;
+        let ks = ks_array(k_max);
+        let centroid = Complex::new(1.0, 0.0);
+        let radius = 1.0f64;
+        let c = init_coefficients(centroid, radius, k_max);
+        let m = 100;
+        let gamma = eval_curve(&c, &ks, m);
+        let max_dist_from_centroid = gamma.iter()
+            .map(|g| (g - centroid).norm())
+            .fold(0.0f64, f64::max);
+        // c[k_max+1] = radius*0.5, so the curve traces a circle of radius ~0.5
+        assert!(
+            (max_dist_from_centroid - 0.5).abs() < 0.05,
+            "curve should have max radius ~0.5 from centroid, got {max_dist_from_centroid:.4}"
+        );
+    }
+
+    fn compute_energy(
+        c: &[Complex<f64>],
+        ks: &[i64],
+        m: usize,
+        cities: &[Complex<f64>],
+        lambda: f64,
+    ) -> f64 {
+        let gamma = eval_curve(c, ks, m);
+        let attraction: f64 = cities.iter()
+            .map(|&z| {
+                gamma.iter()
+                    .map(|&g| (g - z).norm_sqr())
+                    .fold(f64::MAX, f64::min)
+            })
+            .sum();
+        let tension: f64 = c.iter().zip(ks.iter())
+            .map(|(ck, &k)| lambda * (2.0 * PI * k as f64).powi(2) * ck.norm_sqr())
+            .sum();
+        attraction + tension
+    }
+}
+
+fn compute_basis(ks: &[i64], m: usize) -> Vec<Vec<Complex<f64>>> {
+    ks.iter()
+        .map(|&k| {
+            (0..m)
+                .map(|j| {
+                    let s = j as f64 / m as f64;
+                    (Complex::new(0.0, 2.0 * PI * k as f64 * s)).exp()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn gradient_step(
+    c: &mut [Complex<f64>],
+    ks: &[i64],
+    basis: &[Vec<Complex<f64>>],
+    m: usize,
+    cities: &[Complex<f64>],
+    lambda: f64,
+    lr: f64,
+    k_active: usize,
+) {
+    let gamma = eval_curve(c, ks, m);
+    let n = cities.len() as f64;
+    let mut grad = vec![Complex::new(0.0, 0.0); c.len()];
+
+    // attraction gradient
+    for &city in cities {
+        let j = nearest_sample(&gamma, city);
+        let err = gamma[j] - city;
+        for (ki, gk) in grad.iter_mut().enumerate() {
+            *gk += err * basis[ki][j].conj();
+        }
+    }
+
+    // tension gradient
+    for (ki, gk) in grad.iter_mut().enumerate() {
+        let k = ks[ki] as f64;
+        *gk += lambda * (2.0 * PI * k).powi(2) * c[ki];
+    }
+
+    // update active modes
+    for (ki, ck) in c.iter_mut().enumerate() {
+        if (ks[ki].unsigned_abs() as usize) <= k_active {
+            *ck -= (lr / n) * grad[ki];
+        }
+    }
+}

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -46,6 +46,7 @@ pub enum Solvers {
     Christofides,
     CuckooSearch,
     FlowerPollination,
+    Fourier,
     LinKernighan,
     NearestNeighbor,
     GeneticAlgorithm,
@@ -73,6 +74,7 @@ impl Solvers {
             "cuckoo_search",
             "fpa",
             "flower_pollination",
+            "fourier",
             "lk",
             "lin_kernighan",
             "nearest_neighbor",
@@ -130,6 +132,7 @@ impl Solvers {
                 | Solvers::ParticleSwarmOptimization
                 | Solvers::CuckooSearch
                 | Solvers::FlowerPollination
+                | Solvers::Fourier
         )
     }
 }
@@ -228,6 +231,7 @@ impl Solvers {
                 alias: Some("fpa"),
                 kind: SolverKind::Heuristic,
             },
+            SolverMeta { name: "fourier", alias: Some("fourier"), kind: SolverKind::Heuristic },
             SolverMeta {
                 name: "lin_kernighan",
                 alias: Some("lk"),
@@ -258,7 +262,7 @@ pub struct SolverInfo {
     pub exact:       bool,
 }
 
-static SOLVER_LIST: [SolverInfo; 17] = [
+static SOLVER_LIST: [SolverInfo; 18] = [
     SolverInfo { name: "Bellman-Held-Karp",     alias: "bhk",             category: "Exact",
                  desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
                  complexity: "O(n\u{00b2} \u{00b7} 2\u{207f})", has_options: false, exact: true },
@@ -268,6 +272,9 @@ static SOLVER_LIST: [SolverInfo; 17] = [
     SolverInfo { name: "Christofides",          alias: "christofides",    category: "Approximation",
                  desc: "\u{2264}1.5\u{00d7} approximation via MST + greedy matching + Eulerian shortcut (EUC_2D only).",
                  complexity: "O(n\u{00b2})", has_options: false, exact: false },
+    SolverInfo { name: "Fourier",               alias: "fourier",         category: "Constructive",
+                 desc: "Closed-curve Fourier-basis gradient descent with argsort decode.",
+                 complexity: "O(K\u{00b7}epochs\u{00b7}n\u{00b7}M)", has_options: true, exact: false },
     SolverInfo { name: "Nearest Neighbor",      alias: "nn",              category: "Constructive",
                  desc: "Greedy heuristic: always visit the nearest unvisited city.",
                  complexity: "O(n\u{00b2})", has_options: false, exact: false },
@@ -326,6 +333,7 @@ impl FromStr for Solvers {
             "christofides" | "chr" => Ok(Solvers::Christofides),
             "cs" | "cuckoo_search" => Ok(Solvers::CuckooSearch),
             "fpa" | "flower_pollination" => Ok(Solvers::FlowerPollination),
+            "fourier" => Ok(Solvers::Fourier),
             "lk" | "lin_kernighan" => Ok(Solvers::LinKernighan),
             "nn" | "nearest_neighbor" => Ok(Solvers::NearestNeighbor),
             "ga" | "genetic_algorithm" => Ok(Solvers::GeneticAlgorithm),
@@ -1102,6 +1110,10 @@ pub fn solve_with_context(
             let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
             flower_pollination::solve(problem, &fpa, tx, init_tour)
         }
+        Solvers::Fourier => {
+            let f = opts.fourier.as_ref().cloned().unwrap_or_default();
+            fourier::solve(problem, &f, tx, init_tour)
+        }
         Solvers::LinKernighan => {
             let lk = opts.lk.as_ref().cloned().unwrap_or_default();
             lin_kernighan::solve(problem, &lk, tx, init_tour)
@@ -1552,6 +1564,7 @@ mod tests {
         assert!(Solvers::ParticleSwarmOptimization.auto_expand_with_shuffle());
         assert!(Solvers::CuckooSearch.auto_expand_with_shuffle());
         assert!(Solvers::FlowerPollination.auto_expand_with_shuffle());
+        assert!(Solvers::Fourier.auto_expand_with_shuffle());
         assert!(Solvers::GravitationalSearch.auto_expand_with_shuffle());
     }
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -7,6 +7,7 @@ pub mod convert;
 pub mod cuckoo_search;
 pub mod distance_matrix;
 pub mod flower_pollination;
+pub mod fourier;
 pub mod lin_kernighan;
 pub mod genetic_algorithm;
 pub mod gravitational_search;
@@ -912,6 +913,112 @@ impl LKOptions {
 }
 
 // ---------------------------------------------------------------------------
+// FourierOptions
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FourierOptions {
+    pub k_max: usize,       // max Fourier mode, default 4
+    pub m: usize,           // curve sampling resolution, default 200
+    pub lambda: f64,        // initial tension weight, default 0.05
+    pub lambda_decay: f64,  // tension decay multiplier per k_active stage, default 0.5
+    pub lr: f64,            // gradient learning rate, default 0.05
+    pub epochs: usize,      // gradient steps per k_active stage, default 400
+}
+
+impl Default for FourierOptions {
+    fn default() -> Self {
+        FourierOptions {
+            k_max: 4,
+            m: 200,
+            lambda: 0.05,
+            lambda_decay: 0.5,
+            lr: 0.05,
+            epochs: 400,
+        }
+    }
+}
+
+impl FourierOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.k_max == 0 {
+            return Err("k_max must be >= 1".to_string());
+        }
+        if self.m < 2 {
+            return Err("m must be >= 2".to_string());
+        }
+        if self.lambda <= 0.0 {
+            return Err("lambda must be > 0".to_string());
+        }
+        if self.lambda_decay <= 0.0 || self.lambda_decay >= 1.0 {
+            return Err("lambda_decay must be in (0, 1)".to_string());
+        }
+        if self.lr <= 0.0 {
+            return Err("lr must be > 0".to_string());
+        }
+        if self.epochs == 0 {
+            return Err("epochs must be >= 1".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut f = FourierOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "k_max" => {
+                    f.k_max = v.as_integer()
+                        .ok_or_else(|| format!("config: `k_max` must be an integer, got {v}"))?
+                        as usize;
+                }
+                "m" => {
+                    f.m = v.as_integer()
+                        .ok_or_else(|| format!("config: `m` must be an integer, got {v}"))?
+                        as usize;
+                }
+                "lambda" => {
+                    f.lambda = v.as_float()
+                        .or_else(|| v.as_integer().map(|i| i as f64))
+                        .ok_or_else(|| format!("config: `lambda` must be a float, got {v}"))?;
+                }
+                "lambda_decay" => {
+                    f.lambda_decay = v.as_float()
+                        .or_else(|| v.as_integer().map(|i| i as f64))
+                        .ok_or_else(|| format!("config: `lambda_decay` must be a float, got {v}"))?;
+                }
+                "lr" => {
+                    f.lr = v.as_float()
+                        .or_else(|| v.as_integer().map(|i| i as f64))
+                        .ok_or_else(|| format!("config: `lr` must be a float, got {v}"))?;
+                }
+                "epochs" => {
+                    f.epochs = v.as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [fourier] — valid: k_max, m, lambda, lambda_decay, lr, epochs"
+                    ));
+                }
+            }
+        }
+        f.validate()?;
+        Ok(f)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
+        let mut f = FourierOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            f.epochs = v.parse::<usize>()
+                .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
+        }
+        f.validate()?;
+        Ok(f)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // AppOptions — pure config shell; no runtime state
 // ---------------------------------------------------------------------------
 
@@ -924,6 +1031,7 @@ pub struct AppOptions {
     pub cs: Option<CSOptions>,
     pub fpa: Option<FPAOptions>,
     pub lk: Option<LKOptions>,
+    pub fourier: Option<FourierOptions>,
     pub heuristic: Option<HeuristicOptions>,
 }
 
@@ -1238,6 +1346,7 @@ mod tests {
             cs: None,
             fpa: None,
             lk: None,
+            fourier: None,
             heuristic: None,
         };
         drop(a);

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -6,8 +6,8 @@ use bindings::teeline::solver::types::{
     AlgorithmInfo, City, CompareResult, ParamSpec, ParsedProblem, Solution, SolveOptions,
 };
 use teeline::tsp::{
-    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers, TspProblem,
-    distance_matrix::DistanceMatrix, kdtree::KDPoint,
+    AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, SAOptions,
+    Solvers, TspProblem, distance_matrix::DistanceMatrix, kdtree::KDPoint,
 };
 
 struct Component;
@@ -51,6 +51,13 @@ fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
             }),
             ..AppOptions::default()
         },
+        Solvers::Fourier => AppOptions {
+            fourier: Some(FourierOptions {
+                epochs: o.epochs as usize,
+                ..FourierOptions::default()
+            }),
+            ..AppOptions::default()
+        },
         _ => AppOptions {
             heuristic: Some(heuristic),
             ..AppOptions::default()
@@ -89,6 +96,7 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
         "tabu_search"     => "Avoids cycling; good for medium-sized datasets",
         "shuffle"         => "Baseline only; never produces good tours on its own",
         "christofides"    => "Only solver with a proven \u{2264}1.5\u{00d7} bound; ideal warm-start for pipeline(christofides,lk)",
+        "fourier"         => "Constructive Fourier-basis solver; best as warm-start: pipeline(fourier,2opt)",
         _                 => info.category,
     }
     .to_string()
@@ -97,7 +105,7 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
 fn kind_for(solver: Solvers) -> String {
     match solver {
         Solvers::BellmanKarp | Solvers::BranchBound       => "exact",
-        Solvers::NearestNeighbor | Solvers::Christofides   => "constructive",
+        Solvers::NearestNeighbor | Solvers::Christofides | Solvers::Fourier => "constructive",
         Solvers::TwoOpt | Solvers::ThreeOpt                => "local-search",
         Solvers::RandomShuffle                             => "utility",
         _                                                  => "metaheuristic",
@@ -179,6 +187,7 @@ fn params_for_solver(solver: Solvers) -> Vec<ParamSpec> {
         | Solvers::ParticleSwarmOptimization
         | Solvers::TabuSearch
         | Solvers::StochasticHill => shared_heuristic_params(),
+        Solvers::Fourier => vec![pi("epochs", "Gradient steps per stage", 1.0)],
         _ => vec![],
     }
 }

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -341,12 +341,12 @@ fn run_compare(
 #[test]
 fn test_list_algorithms_returns_all_solvers() {
     let algorithms = run_list_algorithms();
-    assert_eq!(algorithms.len(), 17, "expected 17 solvers");
+    assert_eq!(algorithms.len(), 18, "expected 18 solvers");
     let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
     for expected_id in &[
         "nn", "2opt", "3opt", "sa", "ga", "gsa", "pso", "cs", "fpa",
         "tabu_search", "stochastic_hill", "shuffle", "bhk", "branch_bound", "lk", "or_opt",
-        "christofides",
+        "christofides", "fourier",
     ] {
         assert!(ids.contains(expected_id), "missing algorithm id: {}", expected_id);
     }
@@ -588,6 +588,26 @@ fn test_list_algorithms_christofides_kind_and_recommendation() {
         chr.recommendation, "Approximation",
         "recommendation must not be the bare category name"
     );
+}
+
+#[test]
+fn test_list_algorithms_fourier_kind_and_params() {
+    let algorithms = run_list_algorithms();
+    let f = algorithms.iter().find(|a| a.id == "fourier").expect("fourier missing");
+    assert_eq!(f.kind, "constructive", "fourier must be 'constructive'");
+    assert_eq!(f.params.len(), 1, "fourier must have exactly 1 param (epochs)");
+    assert_eq!(f.params[0].key, "epochs", "fourier param must be 'epochs'");
+    assert_eq!(f.params[0].value_type, "int", "epochs must be int type");
+    assert!(
+        f.recommendation.len() > 20,
+        "fourier recommendation must be a real description; got: '{}'",
+        f.recommendation
+    );
+}
+
+#[test]
+fn test_fourier() {
+    run_solver("fourier");
 }
 
 #[test]

--- a/tests/fourier_test.rs
+++ b/tests/fourier_test.rs
@@ -1,0 +1,108 @@
+/// Integration tests for the Fourier-basis TSP solver.
+///
+/// Fast tests use minimal settings (k_max=2, m=50, epochs=10) for quick structural validation.
+/// The quality test is #[ignore] and requires: cargo test --test fourier_test -- --include-ignored
+use std::path::Path;
+use teeline::tsp::{FourierOptions, TspProblem, distance_matrix, kdtree, tsplib};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn load_tsp(fixture: &str) -> tsplib::TspLibData {
+    let path = Path::new("tests/fixtures").join(fixture);
+    tsplib::read_from_file(&path).unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
+}
+
+fn make_problem(cities: Vec<kdtree::KDPoint>) -> TspProblem {
+    let dm = distance_matrix::from_cities(&cities);
+    TspProblem::new(cities, dm)
+}
+
+fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
+    let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+    expected.sort_unstable();
+    let mut got = route.to_vec();
+    got.sort_unstable();
+    got == expected
+}
+
+fn fast_opts() -> FourierOptions {
+    FourierOptions {
+        k_max: 2,
+        m: 50,
+        epochs: 10,
+        ..FourierOptions::default()
+    }
+}
+
+// ─── fast structural tests ────────────────────────────────────────────────────
+
+#[test]
+fn fourier_valid_tour_berlin52() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let sol = teeline::tsp::fourier::solve(&problem, &fast_opts(), None, None);
+    assert_eq!(sol.route().len(), 52, "tour must visit all 52 cities");
+    assert!(
+        is_valid_tour(sol.route(), &cities),
+        "tour must contain every city exactly once"
+    );
+    assert!(sol.total > 0.0, "tour distance must be positive");
+    assert!(sol.total.is_finite(), "tour distance must be finite");
+}
+
+#[test]
+fn fourier_valid_tour_small() {
+    // Cities with non-contiguous IDs to validate the argsort → city ID mapping
+    let cities: Vec<kdtree::KDPoint> = vec![5usize, 10, 15, 20, 25]
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| {
+            use std::f32::consts::PI;
+            kdtree::KDPoint {
+                id,
+                coords: [
+                    (2.0 * PI * i as f32 / 5.0).cos(),
+                    (2.0 * PI * i as f32 / 5.0).sin(),
+                ],
+            }
+        })
+        .collect();
+    let problem = make_problem(cities.clone());
+    let sol = teeline::tsp::fourier::solve(&problem, &fast_opts(), None, None);
+    let mut got = sol.route().to_vec();
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        vec![5, 10, 15, 20, 25],
+        "tour must contain original city IDs [5,10,15,20,25], not array positions [0..4]"
+    );
+}
+
+// ─── slow quality test ────────────────────────────────────────────────────────
+
+/// Run with: cargo test --test fourier_test -- --include-ignored
+#[test]
+#[ignore = "slow quality check; run with: cargo test --test fourier_test -- --include-ignored"]
+fn fourier_quality_berlin52() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let opts = FourierOptions {
+        k_max: 4,
+        m: 200,
+        epochs: 400,
+        ..FourierOptions::default()
+    };
+    let sol = teeline::tsp::fourier::solve(&problem, &opts, None, None);
+    assert!(
+        is_valid_tour(sol.route(), &cities),
+        "quality run must still produce a valid tour"
+    );
+    // Fourier is a constructive solver; NN gets ~8981 (+19%). Threshold ≤13000 (~+72%)
+    // catches broken implementations while allowing for the expected constructive-solver range.
+    // Calibrate tighter after benchmarks are collected.
+    assert!(
+        sol.total <= 13_000.0,
+        "Fourier quality check: got {:.1}, want ≤13000 (constructive baseline; optimal=7542)",
+        sol.total,
+    );
+}

--- a/tests/fourier_test.rs
+++ b/tests/fourier_test.rs
@@ -97,12 +97,11 @@ fn fourier_quality_berlin52() {
         is_valid_tour(sol.route(), &cities),
         "quality run must still produce a valid tour"
     );
-    // Fourier is a constructive solver; NN gets ~8981 (+19%). Threshold ≤13000 (~+72%)
-    // catches broken implementations while allowing for the expected constructive-solver range.
-    // Calibrate tighter after benchmarks are collected.
+    // Fourier consistently produces 8549 (+13.3%) on berlin52 with default settings.
+    // Threshold ≤9200 (+21.9%) gives ~7% headroom above observed cost.
     assert!(
-        sol.total <= 13_000.0,
-        "Fourier quality check: got {:.1}, want ≤13000 (constructive baseline; optimal=7542)",
+        sol.total <= 9_200.0,
+        "Fourier quality check: got {:.1}, want ≤9200 (~+21.9% above optimal 7544); typical is ~8549",
         sol.total,
     );
 }


### PR DESCRIPTION
## Summary

- New `fourier` solver (`src/tsp/fourier.rs`): encodes tour as a closed curve `γ(s) = Σ c_k · exp(2πiks)`, optimises Fourier coefficients via gradient descent, decodes via argsort (always a valid permutation)
- Coarse-to-fine loop: modes unlocked one stage at a time (`k_active = 1..=k_max`) with decaying tension regulariser
- WASM integration: `kind=constructive`, `params=[epochs]`, recommendation string, `build_opts` arm
- docs/algorithms/fourier.md: full algorithm description, options table, usage examples
- Benchmarks: 8549 (+13.3%, 2.5s) standalone; 7949 (+5.4%, 1.9s) as `pipeline(fourier,2opt)`
- `num-complex = "0.4"` added (WASM-compatible, no_std-friendly)
- Quality test calibrated from ≤13000 → ≤9200 based on measured results

## Test Plan

- [x] 4 unit tests in `src/tsp/fourier.rs` (circle decode, non-contiguous IDs, gradient energy reduction, eval_curve circle case)
- [x] 3 integration tests in `tests/fourier_test.rs` (valid tour berlin52, valid tour non-contiguous IDs, `#[ignore]` quality check at ≤9200)
- [x] 2 WASM tests: `test_fourier` (runs solver end-to-end), `test_list_algorithms_fourier_kind_and_params`
- [x] 322 library tests pass; 43 WASM component tests pass
- [x] `cargo clippy` clean (gradient_step reduced from 8 to 7 params by deriving `m` from `basis[0].len()`)
- [x] `teeline solve fourier -i data/tsplib/berlin52.tsp` produces valid output
- [x] `teeline pipeline --steps=fourier,2opt` improves tour from 8549 → 7949