### PR TITLE
docs: verify and fix algorithm paper references

### DIFF
--- a/docs/algorithms/bellman-held-karp.md
+++ b/docs/algorithms/bellman-held-karp.md
@@ -23,4 +23,4 @@ teeline solve bellman_karp -i ./data/discopt/tsp_5_1.tsp --verbose
 
 - [Bellman-Held-Karp walkthrough (YouTube)](https://youtu.be/D8aHqaFa8GE)
 - *Algorithms Illuminated, Part 4* — Tim Roughgarden
-- Held, M. & Karp, R. M. (1962) — *A Dynamic Programming Approach to Sequencing Problems*
+- Held, M. & Karp, R. M. (1962) — "A Dynamic Programming Approach to Sequencing Problems", *Journal of the Society for Industrial and Applied Mathematics*, 10(1), 196–210

--- a/docs/algorithms/christofides.md
+++ b/docs/algorithms/christofides.md
@@ -69,5 +69,5 @@ teeline pipeline --steps=christofides,or_opt -i ./data/tsplib/berlin52.tsp
 
 - Christofides, N. (1976) — "Worst-case analysis of a new heuristic for the travelling salesman problem," Carnegie Mellon University report
 - Applegate, D. et al. (2006) — *The Traveling Salesman Problem*, Princeton University Press, Chapter 2
-- Hierholzer, C. & Wiener, C. (1873) — "Ueber die Möglichkeit, einen Linienzug ohne Wiederholung und ohne Unterbrechung zu umfahren", *Mathematische Annalen*
+- Hierholzer, C. & Wiener, C. (1873) — "Ueber die Möglichkeit, einen Linienzug ohne Wiederholung und ohne Unterbrechung zu umfahren", *Mathematische Annalen*, 6(1), 30–32
 - [Christofides algorithm (Wikipedia)](https://en.wikipedia.org/wiki/Christofides_algorithm)

--- a/docs/algorithms/cuckoo-search.md
+++ b/docs/algorithms/cuckoo-search.md
@@ -43,5 +43,5 @@ teeline solve cs -i ./data/tsplib/berlin52.tsp --n_nearest=40 --mutation_probabi
 
 ## References
 
-- Yang, X.-S. & Deb, S. (2009) — *Cuckoo Search via Lévy Flights*
+- Yang, X.-S. & Deb, S. (2009) — "Cuckoo Search via Lévy Flights", *Proc. World Congress on Nature & Biologically Inspired Computing (NaBIC 2009)*, IEEE, pp. 210–214
 - [Cuckoo search (Wikipedia)](https://en.wikipedia.org/wiki/Cuckoo_search)

--- a/docs/algorithms/flower-pollination.md
+++ b/docs/algorithms/flower-pollination.md
@@ -43,5 +43,5 @@ teeline solve fpa -i ./data/tsplib/berlin52.tsp --n_nearest=50 --mutation_probab
 
 ## References
 
-- Yang, X.-S. (2012) — *Flower Pollination Algorithm for Global Optimization*
+- Yang, X.-S. (2012) — "Flower Pollination Algorithm for Global Optimization", in *Unconventional Computation and Natural Computation* (UCNC 2012), LNCS 7445, pp. 240–249, Springer
 - [Flower pollination algorithm (Wikipedia)](https://en.wikipedia.org/wiki/Flower_pollination_algorithm)

--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -117,6 +117,5 @@ optimise via gradient descent. The key differences:
 ## References
 
 - Durbin, R. & Willshaw, D. (1987) — "An analogue approach to the travelling salesman problem
-  using an elastic net method", *Nature* **326**, 689–691 (original Elastic Net)
-- Meijer, H. & Imai, H. (1992) — "The discrete Fourier transform approach to the travelling
-  salesman problem", *Oper. Res. Lett.* (Fourier-basis parameterisation)
+  using an elastic net method", *Nature* **326**, 689–691. DOI: 10.1038/326689a0
+  (original Elastic Net; this solver is a Fourier-parameterised variant)

--- a/docs/algorithms/particle-swarm.md
+++ b/docs/algorithms/particle-swarm.md
@@ -38,5 +38,5 @@ teeline solve pso -i ./data/tsplib/berlin52.tsp --n_nearest=50
 ## References
 
 - [Particle swarm optimisation (Wikipedia)](https://en.wikipedia.org/wiki/Particle_swarm_optimization)
-- Kennedy & Eberhart (1995) — *Particle Swarm Optimization*
-- Clerc, M. (2004) — *Discrete Particle Swarm Optimization, illustrated by the Traveling Salesman Problem*
+- Kennedy, J. & Eberhart, R. (1995) — "Particle Swarm Optimization", *Proc. IEEE ICNN'95*, Vol. 4, pp. 1942–1948. DOI: 10.1109/ICNN.1995.488968
+- Clerc, M. (2004) — "Discrete Particle Swarm Optimization, illustrated by the Traveling Salesman Problem", in *New Optimization Techniques in Engineering*, Springer, pp. 219–239

--- a/docs/algorithms/simulated-annealing.md
+++ b/docs/algorithms/simulated-annealing.md
@@ -42,4 +42,4 @@ teeline solve sa -i ./data/tsplib/berlin52.tsp --cooling_rate=0.003 --max_temper
 
 - *AIMA*, Section 4.1.2 — Simulated Annealing
 - [Simulated annealing (Wikipedia)](https://en.wikipedia.org/wiki/Simulated_annealing)
-- Kirkpatrick, Gelatt & Vecchi (1983) — *Optimization by Simulated Annealing*
+- Kirkpatrick, S., Gelatt, C. D. & Vecchi, M. P. (1983) — "Optimization by Simulated Annealing", *Science*, 220(4598), 671–680. DOI: 10.1126/science.220.4598.671

--- a/docs/algorithms/tabu-search.md
+++ b/docs/algorithms/tabu-search.md
@@ -29,4 +29,4 @@ teeline solve tabu_search -i ./data/tsplib/berlin52.tsp --epochs=500
 
 - [Tabu search (Wikipedia)](https://en.wikipedia.org/wiki/Tabu_search)
 - *Heuristic Search*, Chapter 14.4
-- Glover, F. (1989) — *Tabu Search — Part I*
+- Glover, F. (1989) — "Tabu Search — Part I", *ORSA Journal on Computing*, 1(3), 190–206

--- a/docs/algorithms/three-opt.md
+++ b/docs/algorithms/three-opt.md
@@ -36,4 +36,4 @@ teeline solve 3opt --no-seed -i ./data/tsplib/berlin52.tsp
 ## References
 
 - [3-opt (Wikipedia)](https://en.wikipedia.org/wiki/3-opt)
-- Lin, S. (1965) — *Computer Solutions of the Traveling Salesman Problem*
+- Lin, S. (1965) — "Computer Solutions of the Traveling Salesman Problem", *Bell System Technical Journal*, 44, 2245–2269


### PR DESCRIPTION
## Summary

- Removed one hallucinated citation that could not be found in any academic database
- Enhanced 8 real citations with confirmed journal/venue/DOI details that were previously vague or incomplete

## Changes

### Removed (unverifiable)

- **fourier.md**: Meijer & Imai (1992) "discrete Fourier transform TSP" — not found in ACM DL, IEEE Xplore, DBLP, or Google Scholar; was hallucinated

### Added journal/venue details (all independently verified)

| Doc | Author(s) | Added detail |
|-----|-----------|-------------|
| `bellman-held-karp.md` | Held & Karp (1962) | *J. SIAM*, 10(1), 196–210 |
| `christofides.md` | Hierholzer & Wiener (1873) | *Math. Annalen*, 6(1), 30–32 |
| `cuckoo-search.md` | Yang & Deb (2009) | NaBIC 2009, IEEE, pp. 210–214 |
| `flower-pollination.md` | Yang (2012) | UCNC 2012, LNCS 7445, pp. 240–249, Springer |
| `particle-swarm.md` | Kennedy & Eberhart (1995) | *Proc. IEEE ICNN'95*, pp. 1942–1948 + DOI |
| `particle-swarm.md` | Clerc (2004) | *New Opt. Techniques in Eng.*, Springer, pp. 219–239 |
| `simulated-annealing.md` | Kirkpatrick et al. (1983) | *Science* 220(4598), 671–680 + DOI |
| `tabu-search.md` | Glover (1989) | *ORSA J. Computing*, 1(3), 190–206 |
| `three-opt.md` | Lin (1965) | *Bell Sys. Tech. J.*, 44, 2245–2269 |

## Context

Follow-up to PRs #190 (Fourier solver) and #191 (WASM test perf). PR #190 introduced the hallucinated Meijer & Imai reference; this PR removes it and audits all 16 solver docs for citation quality.

## Test Plan

- [ ] All 9 changed files are documentation only — no code changes
- [ ] Verify `fourier.md` no longer references Meijer & Imai (1992)
- [ ] Verify all remaining references have journal/venue details