### PR TITLE
feat: add Fourier solver docs page and interactive explainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ teeline-qt/.qtcreator/
 teeline-web/dist/
 node_modules/
 .playwright-mcp/
+
+# visual companion brainstorm files
+.superpowers/

--- a/teeline-web/algorithms/fourier/explainer/index.html
+++ b/teeline-web/algorithms/fourier/explainer/index.html
@@ -1,1 +1,19 @@
-<!doctype html><html><head><meta charset="UTF-8"><title>Fourier Explainer — Teeline</title></head><body><p>placeholder</p></body></html>
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fourier Solver — Interactive Explainer — Teeline</title>
+    <meta name="description" content="Interactive walkthrough of the Fourier-basis constructive TSP solver: watch gradient descent shape a closed curve into a valid tour." />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/algorithms/fourier">← Back to Fourier docs</a>
+      </p>
+      <div id="app"></div>
+    </main>
+    <script type="module" src="/src/explainers/fourier-page.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/fourier/explainer/index.html
+++ b/teeline-web/algorithms/fourier/explainer/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="UTF-8"><title>Fourier Explainer — Teeline</title></head><body><p>placeholder</p></body></html>

--- a/teeline-web/algorithms/fourier/explainer/index.html
+++ b/teeline-web/algorithms/fourier/explainer/index.html
@@ -10,7 +10,7 @@
     <div id="topbar"></div>
     <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
       <p style="margin-bottom: 1rem;">
-        <a href="/algorithms/fourier">← Back to Fourier docs</a>
+        <a href="/algorithms/fourier/">← Back to Fourier docs</a>
       </p>
       <div id="app"></div>
     </main>

--- a/teeline-web/algorithms/fourier/index.html
+++ b/teeline-web/algorithms/fourier/index.html
@@ -1,1 +1,185 @@
-<!doctype html><html><head><meta charset="UTF-8"><title>Fourier — Teeline</title></head><body><p>placeholder</p></body></html>
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fourier-basis Solver — Teeline</title>
+    <meta name="description" content="Fourier-basis constructive TSP solver: encodes a tour as a closed curve γ(s) and optimises Fourier coefficients via gradient descent. Argsort decode always yields a valid tour." />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <div class="docs-layout">
+      <nav class="docs-sidebar" id="algo-sidebar" aria-label="Algorithms"></nav>
+      <main class="docs-main">
+
+        <p class="docs-breadcrumb">
+          <a href="/">teeline</a> › Algorithms › Fourier
+        </p>
+
+        <p class="docs-type-badge">Heuristic · constructive</p>
+        <h1>Fourier-basis Constructive Solver</h1>
+
+        <table class="docs-meta-table">
+          <tr><th>Alias</th><td><code>fourier</code></td></tr>
+          <tr><th>Type</th><td>Heuristic — constructive</td></tr>
+          <tr><th>Complexity</th><td><code>O(K_max · epochs · n · M)</code> per run</td></tr>
+        </table>
+
+        <a class="docs-explainer-cta" href="/algorithms/fourier/explainer">
+          ▶ Open interactive explainer →
+        </a>
+
+        <h2>Description</h2>
+        <p>
+          Encodes a TSP tour as a <strong>closed curve in the complex plane</strong> and
+          optimises the Fourier coefficients of that curve with gradient descent. Decoding
+          is a pure argsort: no penalty, no repair step, and no possibility of producing
+          an invalid tour.
+        </p>
+
+        <h3>Curve representation</h3>
+        <p>The tour is the closed curve</p>
+        <pre><code>γ(s) = Σ_{k=-K}^{K} c_k · exp(2πi · k · s),   s ∈ [0, 1)</code></pre>
+        <p>
+          sampled at <code>M</code> evenly-spaced points <code>s_j = j/M</code>. The
+          <code>2K+1</code> complex coefficients <code>c_k</code> are the only free
+          variables; gradient descent moves them so the curve passes near each city.
+        </p>
+
+        <h3>Energy</h3>
+        <pre><code>E(c) = Σ_i  min_j |city_i − γ(s_j)|²   +   λ Σ_k (2πk)² |c_k|²
+         attraction                              tension</code></pre>
+        <ul>
+          <li><strong>Attraction</strong>: each city pulls its nearest curve sample toward it.</li>
+          <li>
+            <strong>Tension</strong>: a smoothness regulariser that weights high-frequency
+            modes proportionally to their squared Fourier frequency, preventing jagged
+            curves that visit no city cleanly.
+          </li>
+        </ul>
+
+        <h3>Coarse-to-fine optimisation loop</h3>
+        <pre><code>initialise c[0] = centroid, c[1] = radius/2, all others = 0
+λ ← opts.lambda
+
+for k_active = 1 … K_max:
+    basis[k][j] = exp(2πi · ks[k] · j/M)   // pre-computed; constant within stage
+
+    repeat opts.epochs times:
+        γ = eval_curve(c, ks, M)
+        grad = attraction_gradient + tension_gradient
+        for k where |ks[k]| ≤ k_active:
+            c[k] -= (lr / n) * grad[k]
+
+    λ *= lambda_decay</code></pre>
+        <p>
+          Unlocking modes one stage at a time lets the optimiser set the overall loop shape
+          (low modes) before refining local detail (high modes), avoiding the saddle points
+          that occur when all modes compete simultaneously.
+        </p>
+
+        <h3>Decode (always valid)</h3>
+        <pre><code>s_i = argmin_j |city_i − γ(s_j)|     // nearest curve sample per city
+tour = argsort(s_i)                    // sort cities by their curve position</code></pre>
+        <p>
+          The argsort gives <strong>array positions</strong> in <code>cities[]</code>,
+          which are then mapped to their <code>.id</code> fields — the same pattern used
+          by Christofides. This guarantees a valid Hamiltonian tour regardless of
+          convergence quality.
+        </p>
+
+        <h2>Options</h2>
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Default</th><th>Range</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>k_max</code></td><td>4</td><td>≥ 1</td><td>Maximum Fourier mode (number of frequency stages)</td></tr>
+            <tr><td><code>m</code></td><td>200</td><td>≥ 2</td><td>Curve sampling resolution (points on γ)</td></tr>
+            <tr><td><code>lambda</code></td><td>0.05</td><td>&gt; 0</td><td>Initial tension weight</td></tr>
+            <tr><td><code>lambda_decay</code></td><td>0.5</td><td>(0, 1)</td><td>Tension multiplier applied at each stage</td></tr>
+            <tr><td><code>lr</code></td><td>0.05</td><td>&gt; 0</td><td>Gradient descent learning rate</td></tr>
+            <tr><td><code>epochs</code></td><td>400</td><td>≥ 1</td><td>Gradient steps per k_active stage</td></tr>
+          </tbody>
+        </table>
+        <p><code>epochs</code> follows the same vocabulary as all other solvers in this codebase.</p>
+
+        <h2>Usage</h2>
+        <pre><code># standalone
+teeline solve fourier -i ./data/tsplib/berlin52.tsp
+
+# as warm-start for 2-opt (recommended)
+teeline pipeline --steps=fourier,2opt -i ./data/tsplib/berlin52.tsp
+
+# as warm-start for LK
+teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp</code></pre>
+
+        <h2>Notes</h2>
+        <ul>
+          <li>
+            <strong><code>init_tour</code> is ignored</strong>: as a purely constructive
+            solver, Fourier does not accept or benefit from a seed tour; the
+            <code>--init-tour</code> pipeline option has no effect on this solver.
+          </li>
+          <li>
+            <strong>f64 internally</strong>: all gradient computation uses <code>f64</code>
+            for numerical stability; coordinates are converted from <code>f32</code> at
+            input and the final tour is <code>Vec&lt;usize&gt;</code> city IDs.
+          </li>
+          <li>
+            <strong>WASM-compatible</strong>: uses <code>num-complex = "0.4"</code>
+            (no_std-compatible, no libm dependency).
+          </li>
+        </ul>
+
+        <h2>Relationship to the Elastic Net</h2>
+        <p>
+          This algorithm is a Fourier-parameterised variant of the
+          <strong>Elastic Net</strong> (Durbin &amp; Willshaw 1987). Both share the same
+          two-term energy (city attraction + curve smoothness/tension) and optimise via
+          gradient descent. The key differences:
+        </p>
+        <table>
+          <thead>
+            <tr><th></th><th>Elastic Net</th><th>This implementation</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Curve representation</td>
+              <td>M explicit node positions</td>
+              <td>2K+1 Fourier coefficients</td>
+            </tr>
+            <tr>
+              <td>Tension term</td>
+              <td>Sum of squared edge lengths</td>
+              <td><code>λ(2πk)²|c_k|²</code> (diagonal in coefficient space)</td>
+            </tr>
+            <tr>
+              <td>Mode schedule</td>
+              <td>Simultaneous + temperature annealing</td>
+              <td>Coarse-to-fine frequency unlocking</td>
+            </tr>
+            <tr>
+              <td>Tour decode</td>
+              <td>Explicit node ordering</td>
+              <td>Argsort of nearest-sample parameter s_i</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>References</h2>
+        <ul>
+          <li>
+            Durbin, R. &amp; Willshaw, D. (1987) — "An analogue approach to the travelling
+            salesman problem using an elastic net method", <em>Nature</em> <strong>326</strong>,
+            689–691. DOI:
+            <a href="https://doi.org/10.1038/326689a0" target="_blank" rel="noopener">10.1038/326689a0</a>
+            (original Elastic Net; this solver is a Fourier-parameterised variant)
+          </li>
+        </ul>
+
+      </main>
+    </div>
+    <script type="module" src="/src/docs-init.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/fourier/index.html
+++ b/teeline-web/algorithms/fourier/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="UTF-8"><title>Fourier — Teeline</title></head><body><p>placeholder</p></body></html>

--- a/teeline-web/algorithms/fourier/index.html
+++ b/teeline-web/algorithms/fourier/index.html
@@ -9,12 +9,18 @@
   <body>
     <div id="topbar"></div>
     <div class="docs-layout">
-      <nav class="docs-sidebar" id="algo-sidebar" aria-label="Algorithms"></nav>
+      <aside class="docs-sidebar">
+        <nav id="algo-sidebar" aria-label="Algorithms"></nav>
+      </aside>
       <main class="docs-main">
 
-        <p class="docs-breadcrumb">
-          <a href="/">teeline</a> › Algorithms › Fourier
-        </p>
+        <nav aria-label="breadcrumb">
+          <ul>
+            <li><a href="/">teeline</a></li>
+            <li>Algorithms</li>
+            <li>Fourier</li>
+          </ul>
+        </nav>
 
         <p class="docs-type-badge">Heuristic · constructive</p>
         <h1>Fourier-basis Constructive Solver</h1>
@@ -25,7 +31,7 @@
           <tr><th>Complexity</th><td><code>O(K_max · epochs · n · M)</code> per run</td></tr>
         </table>
 
-        <a class="docs-explainer-cta" href="/algorithms/fourier/explainer">
+        <a class="docs-explainer-cta" href="/algorithms/fourier/explainer/">
           ▶ Open interactive explainer →
         </a>
 

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -6,6 +6,7 @@
     <title>Teeline TSP Solver</title>
   </head>
   <body>
+    <div id="topbar"></div>
     <header class="container">
       <h1>Teeline TSP Solver</h1>
     </header>

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/browser": "^10.56.0",
         "@sentry/vite-plugin": "^5.3.0",
         "htmx.org": "2.0.10",
+        "preact": "^10.29.2",
         "teeline-wasm": "file:../teeline-wasm/js-bindings"
       },
       "devDependencies": {
@@ -3272,6 +3273,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/progress": {

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -17,6 +17,7 @@
     "@sentry/browser": "^10.56.0",
     "@sentry/vite-plugin": "^5.3.0",
     "htmx.org": "2.0.10",
+    "preact": "^10.29.2",
     "teeline-wasm": "file:../teeline-wasm/js-bindings"
   },
   "devDependencies": {

--- a/teeline-web/src/algorithms-sidebar.test.ts
+++ b/teeline-web/src/algorithms-sidebar.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { renderSidebarHtml } from './algorithms-sidebar'
 
 describe('renderSidebarHtml', () => {
+  it('wraps output in a ul element', () => {
+    const html = renderSidebarHtml(null)
+    expect(html.trimStart()).toMatch(/^<ul>/)
+  })
+
   it('renders all four solver group labels', () => {
     const html = renderSidebarHtml(null)
     expect(html).toContain('Exact')

--- a/teeline-web/src/algorithms-sidebar.test.ts
+++ b/teeline-web/src/algorithms-sidebar.test.ts
@@ -12,7 +12,7 @@ describe('renderSidebarHtml', () => {
 
   it('renders fourier as an anchor when not current', () => {
     const html = renderSidebarHtml(null)
-    expect(html).toContain('href="/algorithms/fourier"')
+    expect(html).toContain('href="/algorithms/fourier/"')
   })
 
   it('marks the current solver with aria-current="page"', () => {
@@ -27,13 +27,13 @@ describe('renderSidebarHtml', () => {
 
   it('renders current solver as span (not anchor)', () => {
     const html = renderSidebarHtml('fourier')
-    // When fourier is current, it should NOT have a link to /algorithms/fourier
-    expect(html).not.toContain('href="/algorithms/fourier"')
+    // When fourier is current, it should NOT have a link to /algorithms/fourier/
+    expect(html).not.toContain('href="/algorithms/fourier/"')
   })
 
   it('renders non-paged solvers as plain text (no link)', () => {
     const html = renderSidebarHtml(null)
     // bhk has no docs page yet — should be a span, not an anchor
-    expect(html).not.toContain('href="/algorithms/bhk"')
+    expect(html).not.toContain('href="/algorithms/bhk/"')
   })
 })

--- a/teeline-web/src/algorithms-sidebar.test.ts
+++ b/teeline-web/src/algorithms-sidebar.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { renderSidebarHtml } from './algorithms-sidebar'
+
+describe('renderSidebarHtml', () => {
+  it('renders all four solver group labels', () => {
+    const html = renderSidebarHtml(null)
+    expect(html).toContain('Exact')
+    expect(html).toContain('Constructive')
+    expect(html).toContain('Local search')
+    expect(html).toContain('Metaheuristic')
+  })
+
+  it('renders fourier as an anchor when not current', () => {
+    const html = renderSidebarHtml(null)
+    expect(html).toContain('href="/algorithms/fourier"')
+  })
+
+  it('marks the current solver with aria-current="page"', () => {
+    const html = renderSidebarHtml('fourier')
+    expect(html).toContain('aria-current="page"')
+  })
+
+  it('does not add aria-current when currentId is null', () => {
+    const html = renderSidebarHtml(null)
+    expect(html).not.toContain('aria-current="page"')
+  })
+
+  it('renders current solver as span (not anchor)', () => {
+    const html = renderSidebarHtml('fourier')
+    // When fourier is current, it should NOT have a link to /algorithms/fourier
+    expect(html).not.toContain('href="/algorithms/fourier"')
+  })
+
+  it('renders non-paged solvers as plain text (no link)', () => {
+    const html = renderSidebarHtml(null)
+    // bhk has no docs page yet — should be a span, not an anchor
+    expect(html).not.toContain('href="/algorithms/bhk"')
+  })
+})

--- a/teeline-web/src/algorithms-sidebar.ts
+++ b/teeline-web/src/algorithms-sidebar.ts
@@ -1,0 +1,31 @@
+import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from './solver-groups'
+
+export function renderSidebarHtml(currentId: string | null): string {
+  return SOLVER_GROUPS.map(g => {
+    const items = g.ids.map(id => {
+      const meta = SOLVER_META[id]
+      if (!meta) return ''
+      const isCurrent = id === currentId
+      const inner = isCurrent
+        ? `<span aria-current="page">${meta.name}</span>`
+        : PAGED_SOLVERS.has(id)
+          ? `<a href="/algorithms/${id}">${meta.name}</a>`
+          : `<span>${meta.name}</span>`
+      const currentClass = isCurrent ? ' sidebar-item--current' : ''
+      return `<li class="sidebar-item${currentClass}">${inner}</li>`
+    }).join('')
+    return `
+      <li class="sidebar-group">
+        <span class="sidebar-group-label">${g.label}</span>
+        <ul>${items}</ul>
+      </li>`
+  }).join('')
+}
+
+export function initSidebar(containerId = 'algo-sidebar'): void {
+  const el = document.getElementById(containerId)
+  if (!el) return
+  const match = window.location.pathname.match(/^\/algorithms\/([^/]+)/)
+  const currentId = match ? match[1] : null
+  el.innerHTML = renderSidebarHtml(currentId)
+}

--- a/teeline-web/src/algorithms-sidebar.ts
+++ b/teeline-web/src/algorithms-sidebar.ts
@@ -1,7 +1,7 @@
 import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from './solver-groups'
 
 export function renderSidebarHtml(currentId: string | null): string {
-  return SOLVER_GROUPS.map(g => {
+  const groups = SOLVER_GROUPS.map(g => {
     const items = g.ids.map(id => {
       const meta = SOLVER_META[id]
       if (!meta) return ''
@@ -20,6 +20,7 @@ export function renderSidebarHtml(currentId: string | null): string {
         <ul>${items}</ul>
       </li>`
   }).join('')
+  return `<ul>${groups}</ul>`
 }
 
 export function initSidebar(containerId = 'algo-sidebar'): void {

--- a/teeline-web/src/algorithms-sidebar.ts
+++ b/teeline-web/src/algorithms-sidebar.ts
@@ -9,7 +9,7 @@ export function renderSidebarHtml(currentId: string | null): string {
       const inner = isCurrent
         ? `<span aria-current="page">${meta.name}</span>`
         : PAGED_SOLVERS.has(id)
-          ? `<a href="/algorithms/${id}">${meta.name}</a>`
+          ? `<a href="/algorithms/${id}/">${meta.name}</a>`
           : `<span>${meta.name}</span>`
       const currentClass = isCurrent ? ' sidebar-item--current' : ''
       return `<li class="sidebar-item${currentClass}">${inner}</li>`

--- a/teeline-web/src/docs-init.ts
+++ b/teeline-web/src/docs-init.ts
@@ -1,0 +1,7 @@
+import '@picocss/pico/css/pico.min.css'
+import './docs.css'
+import { initTopbar } from './topbar'
+import { initSidebar } from './algorithms-sidebar'
+
+initTopbar()
+initSidebar()

--- a/teeline-web/src/docs.css
+++ b/teeline-web/src/docs.css
@@ -1,0 +1,225 @@
+/* ---- Topbar ---- */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--pico-spacing);
+  height: 48px;
+  background: var(--pico-card-background-color, #fff);
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.topbar-logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-decoration: none;
+  color: var(--pico-color);
+}
+
+.topbar-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.topbar-github {
+  font-size: 0.875rem;
+  color: var(--pico-muted-color);
+  text-decoration: none;
+}
+
+.topbar-github:hover { color: var(--pico-primary); }
+
+/* ---- Algorithms dropdown ---- */
+.topbar-dropdown { position: relative; }
+
+.algo-menu-toggle {
+  background: none;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--pico-primary);
+  font-family: inherit;
+  line-height: 1;
+}
+
+.algo-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  min-width: 220px;
+  background: var(--pico-card-background-color, #fff);
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: 0.5rem 0;
+  list-style: none;
+  margin: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 200;
+}
+
+.algo-menu[hidden] { display: none; }
+
+.algo-group { padding: 0; }
+
+.algo-group-label {
+  display: block;
+  padding: 0.4rem 1rem 0.2rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pico-muted-color);
+}
+
+.algo-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.algo-group ul li a,
+.algo-group ul li span {
+  display: block;
+  padding: 0.3rem 1rem 0.3rem 1.25rem;
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: var(--pico-color);
+}
+
+.algo-group ul li a:hover {
+  background: color-mix(in srgb, var(--pico-primary) 8%, transparent);
+  color: var(--pico-primary);
+}
+
+/* ---- Docs two-column layout ---- */
+.docs-layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  min-height: calc(100vh - 48px);
+}
+
+.docs-sidebar {
+  border-right: 1px solid var(--pico-muted-border-color);
+  padding: 1.5rem 0;
+  position: sticky;
+  top: 48px;
+  height: calc(100vh - 48px);
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+}
+
+.docs-main {
+  padding: 2rem 2.5rem;
+  max-width: 800px;
+}
+
+@media (max-width: 768px) {
+  .docs-layout { grid-template-columns: 1fr; }
+  .docs-sidebar { display: none; }
+}
+
+/* ---- Sidebar nav items ---- */
+.sidebar-group {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.25rem 0;
+}
+
+.sidebar-group-label {
+  display: block;
+  padding: 0.4rem 1rem 0.2rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pico-muted-color);
+}
+
+.sidebar-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar-item a,
+.sidebar-item span {
+  display: block;
+  padding: 0.25rem 1rem;
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: var(--pico-color);
+}
+
+.sidebar-item a:hover {
+  color: var(--pico-primary);
+  background: color-mix(in srgb, var(--pico-primary) 6%, transparent);
+}
+
+.sidebar-item--current span {
+  color: var(--pico-primary);
+  font-weight: 600;
+  border-left: 2px solid var(--pico-primary);
+  padding-left: calc(1rem - 2px);
+}
+
+/* ---- Docs content ---- */
+.docs-breadcrumb {
+  font-size: 0.8rem;
+  color: var(--pico-muted-color);
+  margin: 0 0 1.25rem;
+}
+
+.docs-breadcrumb a {
+  color: var(--pico-muted-color);
+  text-decoration: none;
+}
+
+.docs-breadcrumb a:hover { color: var(--pico-primary); }
+
+.docs-type-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  color: var(--pico-primary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+.docs-explainer-cta {
+  display: inline-block;
+  padding: 0.6rem 1.25rem;
+  background: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+  border-radius: var(--pico-border-radius);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin: 1rem 0 2rem;
+}
+
+.docs-explainer-cta:hover { opacity: 0.88; }
+
+.docs-meta-table {
+  border-collapse: collapse;
+  margin-bottom: 1.75rem;
+  font-size: 0.9rem;
+}
+
+.docs-meta-table th,
+.docs-meta-table td {
+  padding: 0.3rem 0;
+  vertical-align: top;
+}
+
+.docs-meta-table th {
+  color: var(--pico-muted-color);
+  font-weight: 500;
+  white-space: nowrap;
+  padding-right: 2rem;
+}

--- a/teeline-web/src/docs.css
+++ b/teeline-web/src/docs.css
@@ -49,13 +49,17 @@
 
 .docs-sidebar {
   border-right: 1px solid var(--pico-muted-border-color);
-  padding: 1.5rem 0;
   position: sticky;
   top: 48px;
   height: calc(100vh - 48px);
   overflow-y: auto;
-  list-style: none;
   margin: 0;
+  padding: 0;
+}
+
+/* PicoCSS aside>nav stacks items vertically; suppress its default spacing */
+.docs-sidebar nav {
+  padding: 0.75rem 0;
 }
 
 .docs-main {
@@ -113,19 +117,6 @@
 }
 
 /* ---- Docs content ---- */
-.docs-breadcrumb {
-  font-size: 0.8rem;
-  color: var(--pico-muted-color);
-  margin: 0 0 1.25rem;
-}
-
-.docs-breadcrumb a {
-  color: var(--pico-muted-color);
-  text-decoration: none;
-}
-
-.docs-breadcrumb a:hover { color: var(--pico-primary); }
-
 .docs-type-badge {
   display: inline-block;
   font-size: 0.75rem;

--- a/teeline-web/src/docs.css
+++ b/teeline-web/src/docs.css
@@ -89,6 +89,8 @@
 .algo-group ul li {
   display: block;
   width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .algo-group ul li a,

--- a/teeline-web/src/docs.css
+++ b/teeline-web/src/docs.css
@@ -60,6 +60,8 @@
   margin: 0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   z-index: 200;
+  display: flex;
+  flex-direction: column;
 }
 
 .algo-menu[hidden] { display: none; }
@@ -80,6 +82,13 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.algo-group ul li {
+  display: block;
+  width: 100%;
 }
 
 .algo-group ul li a,
@@ -89,6 +98,7 @@
   font-size: 0.875rem;
   text-decoration: none;
   color: var(--pico-color);
+  white-space: nowrap;
 }
 
 .algo-group ul li a:hover {

--- a/teeline-web/src/docs.css
+++ b/teeline-web/src/docs.css
@@ -1,8 +1,5 @@
 /* ---- Topbar ---- */
 .topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: 0 var(--pico-spacing);
   height: 48px;
   background: var(--pico-card-background-color, #fff);
@@ -10,6 +7,12 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  /* PicoCSS nav handles the flex layout of the inner ul elements */
+}
+
+/* Remove PicoCSS nav's default margin so it fits in 48px */
+.topbar ul {
+  margin-bottom: 0;
 }
 
 .topbar-logo {
@@ -19,93 +22,22 @@
   color: var(--pico-color);
 }
 
-.topbar-links {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.topbar-github {
-  font-size: 0.875rem;
-  color: var(--pico-muted-color);
-  text-decoration: none;
-}
-
-.topbar-github:hover { color: var(--pico-primary); }
-
-/* ---- Algorithms dropdown ---- */
-.topbar-dropdown { position: relative; }
-
-.algo-menu-toggle {
-  background: none;
-  border: none;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  cursor: pointer;
-  color: var(--pico-primary);
-  font-family: inherit;
-  line-height: 1;
-}
-
-.algo-menu {
-  position: absolute;
+/* Right-align the dropdown under the Algorithms button */
+.topbar details.dropdown > ul {
   right: 0;
-  top: calc(100% + 4px);
-  min-width: 220px;
-  background: var(--pico-card-background-color, #fff);
-  border: 1px solid var(--pico-muted-border-color);
-  border-radius: var(--pico-border-radius);
-  padding: 0.5rem 0;
-  list-style: none;
-  margin: 0;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  z-index: 200;
-  display: flex;
-  flex-direction: column;
+  left: auto;
 }
 
-.algo-menu[hidden] { display: none; }
-
-.algo-group { padding: 0; }
-
+/* Group headers inside the Algorithms dropdown */
 .algo-group-label {
   display: block;
-  padding: 0.4rem 1rem 0.2rem;
+  padding: 0.5rem 0.75rem 0.1rem;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--pico-muted-color);
-}
-
-.algo-group ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.algo-group ul li {
-  display: block;
-  width: 100%;
-  margin: 0;
-  padding: 0;
-}
-
-.algo-group ul li a,
-.algo-group ul li span {
-  display: block;
-  padding: 0.3rem 1rem 0.3rem 1.25rem;
-  font-size: 0.875rem;
-  text-decoration: none;
-  color: var(--pico-color);
-  white-space: nowrap;
-}
-
-.algo-group ul li a:hover {
-  background: color-mix(in srgb, var(--pico-primary) 8%, transparent);
-  color: var(--pico-primary);
+  pointer-events: none;
 }
 
 /* ---- Docs two-column layout ---- */

--- a/teeline-web/src/explainers/fourier-page.ts
+++ b/teeline-web/src/explainers/fourier-page.ts
@@ -5,4 +5,7 @@ import { render, h } from 'preact'
 import FourierExplainer from './fourier'
 
 initTopbar()
-render(h(FourierExplainer, null), document.getElementById('app')!)
+const appEl = document.getElementById('app')
+if (appEl) {
+  render(h(FourierExplainer, null), appEl)
+}

--- a/teeline-web/src/explainers/fourier-page.ts
+++ b/teeline-web/src/explainers/fourier-page.ts
@@ -1,0 +1,8 @@
+import '@picocss/pico/css/pico.min.css'
+import '../docs.css'
+import { initTopbar } from '../topbar'
+import { render, h } from 'preact'
+import FourierExplainer from './fourier'
+
+initTopbar()
+render(h(FourierExplainer, null), document.getElementById('app')!)

--- a/teeline-web/src/explainers/fourier.tsx
+++ b/teeline-web/src/explainers/fourier.tsx
@@ -1,0 +1,579 @@
+import { useState, useRef, useEffect, useMemo, useCallback } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+/**
+ * FourierExplainer
+ * ------------------------------------------------------------
+ * Interactive walkthrough of teeline's Fourier-basis constructive
+ * solver (docs/algorithms/fourier.md).
+ *
+ * Zero extra dependencies: plain React + inline SVG + a single
+ * <style> block. Drop this file into teeline-web and render
+ * <FourierExplainer /> anywhere.
+ * ------------------------------------------------------------
+ */
+
+// ---------------------------------------------------------------
+// Fixed demo instance: 15 "cities" laid out on a 300x300 canvas.
+// Small enough to animate smoothly in-browser.
+// ---------------------------------------------------------------
+const CITIES: [number, number][] = [
+  [40, 60], [80, 30], [140, 20], [200, 40], [250, 70], [270, 130],
+  [250, 200], [200, 250], [140, 270], [80, 250], [40, 200], [20, 130],
+  [150, 150], [100, 100], [200, 100],
+];
+const K_MAX = 4;
+const N_COEFFS = 2 * K_MAX + 1; // index ki -> k = ki - K_MAX
+const M = 72; // curve sampling resolution
+const SCALE = 300; // canvas size; coeffs are computed in [0,1] space, then scaled
+
+// ---------------------------------------------------------------
+// Core math: γ(s) = Σ_{k=-K}^{K} c_k · e^{2πiks}, with c_k = a_k + i·b_k
+// ---------------------------------------------------------------
+function curvePoints(a: number[], b: number[], kActiveMax = K_MAX, m = M): [number, number][] {
+  const pts: [number, number][] = new Array(m);
+  for (let j = 0; j < m; j++) {
+    const s = j / m;
+    let x = 0, y = 0;
+    for (let ki = 0; ki < N_COEFFS; ki++) {
+      const k = ki - K_MAX;
+      if (Math.abs(k) > kActiveMax) continue;
+      const theta = 2 * Math.PI * k * s;
+      const c = Math.cos(theta), si = Math.sin(theta);
+      x += a[ki] * c - b[ki] * si;
+      y += a[ki] * si + b[ki] * c;
+    }
+    pts[j] = [x * SCALE, y * SCALE];
+  }
+  return pts;
+}
+
+// init in [0,1] city-coordinate space
+function initCoeffsNormalized(): { a: number[]; b: number[] } {
+  const a = new Array(N_COEFFS).fill(0) as number[];
+  const b = new Array(N_COEFFS).fill(0) as number[];
+  const cities01 = CITIES.map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+  let cx = 0, cy = 0;
+  cities01.forEach(([x, y]) => { cx += x; cy += y; });
+  cx /= cities01.length; cy /= cities01.length;
+  let r = 0;
+  cities01.forEach(([x, y]) => { r += Math.hypot(x - cx, y - cy); });
+  r /= cities01.length;
+  a[K_MAX] = cx; b[K_MAX] = cy;     // c_0 = centroid
+  a[K_MAX + 1] = r / 2;             // c_1 = radius / 2
+  return { a, b };
+}
+
+function energy(a: number[], b: number[], lambda: number, kActiveMax: number, cities01: [number, number][]): { eAttr: number; eTen: number; total: number } {
+  const pts = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+  let eAttr = 0;
+  for (const [cx, cy] of cities01) {
+    let best = Infinity;
+    for (const [px, py] of pts) {
+      const d = (cx - px) ** 2 + (cy - py) ** 2;
+      if (d < best) best = d;
+    }
+    eAttr += best;
+  }
+  let eTen = 0;
+  for (let ki = 0; ki < N_COEFFS; ki++) {
+    const k = ki - K_MAX;
+    eTen += (2 * Math.PI * k) ** 2 * (a[ki] ** 2 + b[ki] ** 2);
+  }
+  return { eAttr, eTen: lambda * eTen, total: eAttr + lambda * eTen };
+}
+
+function gradStep(a: number[], b: number[], kActiveMax: number, lambda: number, lr: number, cities01: [number, number][]): { a: number[]; b: number[] } {
+  const pts01 = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+  const gradA = new Array(N_COEFFS).fill(0) as number[];
+  const gradB = new Array(N_COEFFS).fill(0) as number[];
+  // attraction: each city pulls its nearest curve sample
+  for (const [cx, cy] of cities01) {
+    let best = Infinity, bestJ = 0;
+    for (let j = 0; j < pts01.length; j++) {
+      const [px, py] = pts01[j];
+      const d = (cx - px) ** 2 + (cy - py) ** 2;
+      if (d < best) { best = d; bestJ = j; }
+    }
+    const s = bestJ / pts01.length;
+    const [px, py] = pts01[bestJ];
+    const dx = cx - px, dy = cy - py;
+    for (let ki = 0; ki < N_COEFFS; ki++) {
+      const k = ki - K_MAX;
+      if (Math.abs(k) > kActiveMax) continue;
+      const theta = 2 * Math.PI * k * s;
+      const cth = Math.cos(theta), sth = Math.sin(theta);
+      gradA[ki] += -2 * dx * cth - 2 * dy * sth;
+      gradB[ki] += 2 * dx * sth - 2 * dy * cth;
+    }
+  }
+  // tension: penalise high-frequency modes
+  for (let ki = 0; ki < N_COEFFS; ki++) {
+    const k = ki - K_MAX;
+    if (Math.abs(k) > kActiveMax) continue;
+    const w = 2 * lambda * (2 * Math.PI * k) ** 2;
+    gradA[ki] += w * a[ki];
+    gradB[ki] += w * b[ki];
+  }
+  const n = cities01.length;
+  const nextA = a.slice(), nextB = b.slice();
+  for (let ki = 0; ki < N_COEFFS; ki++) {
+    const k = ki - K_MAX;
+    if (Math.abs(k) > kActiveMax) continue;
+    nextA[ki] -= (lr / n) * gradA[ki];
+    nextB[ki] -= (lr / n) * gradB[ki];
+  }
+  return { a: nextA, b: nextB };
+}
+
+function decodeTour(a: number[], b: number[], kActiveMax: number, cities01: [number, number][]): { order: number[]; sVals: number[] } {
+  const pts01 = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+  const sVals = cities01.map(([cx, cy]) => {
+    let best = Infinity, bestJ = 0;
+    for (let j = 0; j < pts01.length; j++) {
+      const [px, py] = pts01[j];
+      const d = (cx - px) ** 2 + (cy - py) ** 2;
+      if (d < best) { best = d; bestJ = j; }
+    }
+    return bestJ / pts01.length;
+  });
+  const order = cities01.map((_: [number, number], i: number) => i).sort((i: number, j: number) => sVals[i] - sVals[j]);
+  return { order, sVals };
+}
+
+// ---------------------------------------------------------------
+// Shared hyperparameters (mirroring docs/algorithms/fourier.md defaults,
+// scaled for normalized [0,1] city coordinates)
+// ---------------------------------------------------------------
+const LAMBDA0 = 0.05;
+const LAMBDA_DECAY = 0.5;
+const LR = 0.05;
+const EPOCHS_PER_STAGE = 90;
+const STEPS_PER_TICK = 2;
+
+const CITIES01 = CITIES.map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+
+// ---------------------------------------------------------------
+// SVG sub-components
+// ---------------------------------------------------------------
+interface CurveSVGProps {
+  curve: [number, number][];
+  showCities?: boolean;
+  tour?: [number, number][] | null;
+  highlightSample?: ComponentChildren;
+  children?: ComponentChildren;
+}
+
+function CurveSVG({ curve, showCities = true, tour = null, highlightSample = null, children }: CurveSVGProps) {
+  const path = curve.length
+    ? "M " + curve.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" L ") + " Z"
+    : "";
+  return (
+    <svg viewBox="0 0 300 300" className="fx-canvas" role="img" aria-label="Fourier curve and cities">
+      <rect x="0" y="0" width="300" height="300" className="fx-bg" />
+      {tour && tour.length > 1 && (
+        <polyline
+          className="fx-tour"
+          points={tour.map(([x, y]) => `${x},${y}`).join(" ")}
+        />
+      )}
+      {path && <path d={path} className="fx-curve" />}
+      {showCities && CITIES.map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r="4.5" className="fx-city" />
+      ))}
+      {highlightSample}
+      {children}
+    </svg>
+  );
+}
+
+interface SparklineProps {
+  values: number[];
+  max?: number;
+}
+
+function Sparkline({ values, max }: SparklineProps) {
+  if (!values.length) return null;
+  const w = 300, h = 60;
+  const m = max ?? Math.max(...values, 1e-9);
+  const pts = values.map((v, i) => {
+    const x = (i / Math.max(values.length - 1, 1)) * w;
+    const y = h - (v / m) * (h - 4) - 2;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} className="fx-spark" preserveAspectRatio="none">
+      <polyline points={pts.join(" ")} className="fx-spark-line" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------
+// Tab 1: Idea — what the curve + decode actually do
+// ---------------------------------------------------------------
+function IdeaTab() {
+  // a nicely-converged coefficient set, precomputed for illustration
+  const a = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04];
+  const b = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02];
+  const curve = useMemo(() => curvePoints(a, b), []);
+  const { order } = useMemo(() => decodeTour(a, b, K_MAX, CITIES01), []);
+  const tour = order.map(i => CITIES[i]).concat([CITIES[order[0]]]);
+
+  return (
+    <div className="fx-tab">
+      <CurveSVG curve={curve} tour={tour} />
+      <div className="fx-prose">
+        <p>
+          Every tour is drawn as a single closed curve in the plane,
+          <code> γ(s) = Σ c_k · e^{"{2πiks}"}</code>, sampled at <code>M</code> points.
+          A small set of complex coefficients <code>c_k</code> (here <code>2K+1 = 9</code> of them)
+          is the <em>entire</em> search space &mdash; gradient descent only ever moves these
+          9 numbers.
+        </p>
+        <p>
+          To turn the curve into a tour, every city snaps to its nearest sample point on
+          the loop (<strong>argsort decode</strong>, dashed line above). Because a sort can
+          never produce duplicates or skip a city, the result is <em>always</em> a valid
+          Hamiltonian tour &mdash; even before training finishes.
+        </p>
+        <p className="fx-note">
+          Try the other two tabs: <strong>Modes</strong> shows what each frequency
+          contributes to the loop shape, and <strong>Train</strong> runs the actual
+          coarse-to-fine gradient descent live in your browser.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// Tab 2: Modes — coarse-to-fine intuition via partial sums
+// ---------------------------------------------------------------
+function ModesTab() {
+  const targetA = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04];
+  const targetB = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02];
+  const [kActive, setKActive] = useState(0);
+
+  const curve = useMemo(() => curvePoints(targetA, targetB, kActive), [kActive]);
+
+  const descriptions = [
+    "k = 0 only: a single point at the centroid c₀. The curve hasn't opened up yet.",
+    "± k = 1 added: the curve becomes a single loop (an ellipse-ish ring) enclosing the cities.",
+    "± k = 2 added: the loop can now bend into a rounder, asymmetric shape.",
+    "± k = 3 added: finer wiggles let the loop hug clusters of cities more closely.",
+    "± k = 4 added (k_max): the full default resolution — enough detail for berlin52-scale instances.",
+  ];
+
+  return (
+    <div className="fx-tab">
+      <CurveSVG curve={curve} />
+      <div className="fx-prose">
+        <p>
+          The coarse-to-fine loop in <code>fourier.md</code> unlocks one frequency pair
+          (<code>±k</code>) at a time. Slide through the stages below to see how each
+          added mode refines the loop — exactly the order the optimiser itself follows.
+        </p>
+        <div className="fx-row">
+          <input
+            type="range" min={0} max={K_MAX} step={1} value={kActive}
+            onChange={(e) => setKActive(Number((e.target as HTMLInputElement).value))}
+            className="fx-slider"
+            aria-label="active modes"
+          />
+          <span className="fx-mono">k_active = {kActive}</span>
+        </div>
+        <p className="fx-caption">{descriptions[kActive]}</p>
+        <p className="fx-note">
+          Why this order? Low modes set the overall loop shape; unlocking high modes too
+          early creates competing gradients and saddle points. Coarse-to-fine avoids that
+          by giving each frequency band its own optimisation stage.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// Tab 3: Train & Decode — live coarse-to-fine gradient descent
+// ---------------------------------------------------------------
+function TrainTab() {
+  const stateRef = useRef(initCoeffsNormalized());
+  const [coeffs, setCoeffs] = useState(stateRef.current);
+  const [kActive, setKActive] = useState(1);
+  const [lambda, setLambda] = useState(LAMBDA0);
+  const [epoch, setEpoch] = useState(0);
+  const [history, setHistory] = useState<number[]>([]);
+  const [playing, setPlaying] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const reset = useCallback(() => {
+    stateRef.current = initCoeffsNormalized();
+    setCoeffs(stateRef.current);
+    setKActive(1);
+    setLambda(LAMBDA0);
+    setEpoch(0);
+    setHistory([]);
+    setDone(false);
+    setPlaying(false);
+  }, []);
+
+  const stepOnce = useCallback(() => {
+    let { a, b } = stateRef.current;
+    let curKActive = kActive, curLambda = lambda, curEpoch = epoch, curDone = done;
+    if (curDone) return;
+    for (let s = 0; s < STEPS_PER_TICK; s++) {
+      ({ a, b } = gradStep(a, b, curKActive, curLambda, LR, CITIES01));
+      curEpoch += 1;
+      if (curEpoch >= EPOCHS_PER_STAGE) {
+        curEpoch = 0;
+        if (curKActive < K_MAX) {
+          curKActive += 1;
+          curLambda *= LAMBDA_DECAY;
+        } else {
+          curDone = true;
+          break;
+        }
+      }
+    }
+    stateRef.current = { a, b };
+    setCoeffs({ a, b });
+    setKActive(curKActive);
+    setLambda(curLambda);
+    setEpoch(curEpoch);
+    const e = energy(a, b, curLambda, curKActive, CITIES01);
+    setHistory(h => [...h.slice(-149), e.total]);
+    if (curDone) { setDone(true); setPlaying(false); }
+  }, [kActive, lambda, epoch, done]);
+
+  useEffect(() => {
+    if (!playing) return;
+    const id = setInterval(stepOnce, 60);
+    return () => clearInterval(id);
+  }, [playing, stepOnce]);
+
+  const curve = useMemo(() => curvePoints(coeffs.a, coeffs.b, kActive), [coeffs, kActive]);
+  const { order } = useMemo(
+    () => decodeTour(coeffs.a, coeffs.b, kActive, CITIES01),
+    [coeffs, kActive]
+  );
+  const tour = order.map(i => CITIES[i]).concat([CITIES[order[0]]]);
+  const stageProgress = Math.round((epoch / EPOCHS_PER_STAGE) * 100);
+  const totalEnergy = history.length ? history[history.length - 1] : null;
+
+  return (
+    <div className="fx-tab">
+      <CurveSVG curve={curve} tour={tour} />
+      <div className="fx-prose">
+        <div className="fx-controls">
+          <button className="fx-btn fx-btn-primary" onClick={() => setPlaying(p => !p)} disabled={done}>
+            {playing ? "Pause" : done ? "Converged" : "Play"}
+          </button>
+          <button className="fx-btn" onClick={stepOnce} disabled={playing || done}>Step</button>
+          <button className="fx-btn" onClick={reset}>Reset</button>
+        </div>
+
+        <div className="fx-stagebar" aria-hidden="true">
+          {Array.from({ length: K_MAX }, (_, i) => i + 1).map(stage => (
+            <div
+              key={stage}
+              className={"fx-stage" + (stage < kActive || done ? " fx-stage-done" : stage === kActive ? " fx-stage-active" : "")}
+              style={stage === kActive && !done ? { "--p": `${stageProgress}%` } as preact.JSX.CSSProperties : undefined}
+            >
+              <span>k≤{stage}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="fx-statgrid">
+          <div>
+            <div className="fx-statlabel">stage</div>
+            <div className="fx-mono">k_active = {kActive}{done ? " (done)" : ` / ${K_MAX}`}</div>
+          </div>
+          <div>
+            <div className="fx-statlabel">λ (tension weight)</div>
+            <div className="fx-mono">{lambda.toFixed(4)}</div>
+          </div>
+          <div>
+            <div className="fx-statlabel">energy E(c)</div>
+            <div className="fx-mono">{totalEnergy !== null ? totalEnergy.toFixed(4) : "—"}</div>
+          </div>
+        </div>
+
+        <Sparkline values={history} />
+        <p className="fx-caption">
+          Energy decreases within each stage; small jumps at stage boundaries are expected
+          &mdash; new modes (and a smaller λ) are unlocked, briefly changing the loss
+          landscape before the optimiser re-settles.
+        </p>
+        <p className="fx-note">
+          The dashed line is the <strong>decode</strong> step re-run on the current curve:
+          each city snaps to its nearest sample, then cities are sorted by that sample's
+          position <code>s ∈ [0,1)</code> to get the tour. It's always a valid tour, even
+          mid-training.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+type TabId = "idea" | "modes" | "train";
+
+interface TabDef {
+  id: TabId;
+  label: string;
+  Component: () => preact.JSX.Element;
+}
+
+const TABS: TabDef[] = [
+  { id: "idea", label: "Idea", Component: IdeaTab },
+  { id: "modes", label: "Modes", Component: ModesTab },
+  { id: "train", label: "Train & decode", Component: TrainTab },
+];
+
+export default function FourierExplainer() {
+  const [tab, setTab] = useState<TabId>("idea");
+  const Active = TABS.find(t => t.id === tab)!.Component;
+
+  return (
+    <div className="fx-root">
+      <style>{CSS}</style>
+      <header className="fx-header">
+        <div className="fx-eyebrow">teeline · algorithms/fourier.md</div>
+        <h2 className="fx-title">Fourier-basis constructive solver</h2>
+        <p className="fx-sub">
+          A tour is a closed curve γ(s) = Σ c_k·e^{"{2πiks}"}; gradient descent shapes the
+          curve, an argsort decodes it into a valid tour.
+        </p>
+      </header>
+
+      <nav className="fx-tabs" role="tablist">
+        {TABS.map(t => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            className={"fx-tabbtn" + (tab === t.id ? " fx-tabbtn-active" : "")}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <Active />
+
+      <footer className="fx-footer">
+        <span className="fx-mono">cities: {CITIES.length}</span>
+        <span className="fx-mono">k_max: {K_MAX}</span>
+        <span className="fx-mono">M: {M}</span>
+        <span className="fx-mono">lr: {LR}</span>
+        <span className="fx-mono">λ₀: {LAMBDA0}</span>
+      </footer>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// Styles — self-contained, scoped via fx- prefix
+// ---------------------------------------------------------------
+const CSS = `
+.fx-root {
+  --bg: #0d1117;
+  --panel: #11161d;
+  --line: #232b36;
+  --text: #d8dee9;
+  --muted: #7c8aa0;
+  --curve: #5ee6c8;
+  --city: #f2a154;
+  --tour: #e0626b;
+  --accent: #5ee6c8;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+}
+.fx-root * { box-sizing: border-box; }
+.fx-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85em; }
+
+.fx-header { margin-bottom: 14px; }
+.fx-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.fx-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.fx-sub { margin: 0; color: var(--muted); font-size: 0.92rem; line-height: 1.5; }
+
+.fx-tabs { display: flex; gap: 6px; margin-bottom: 14px; border-bottom: 1px solid var(--line); }
+.fx-tabbtn {
+  background: transparent; border: none; color: var(--muted);
+  font-size: 0.9rem; padding: 8px 12px; cursor: pointer;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+  font-family: inherit;
+}
+.fx-tabbtn:hover { color: var(--text); }
+.fx-tabbtn-active { color: var(--text); border-bottom-color: var(--accent); }
+
+.fx-tab { display: flex; flex-direction: column; gap: 14px; }
+@media (min-width: 620px) {
+  .fx-tab { flex-direction: row; align-items: flex-start; }
+  .fx-canvas, .fx-spark { flex: 0 0 300px; }
+  .fx-prose { flex: 1 1 auto; min-width: 0; }
+}
+
+.fx-canvas { width: 100%; max-width: 300px; border-radius: 8px; border: 1px solid var(--line); display: block; }
+.fx-bg { fill: var(--panel); }
+.fx-curve { fill: none; stroke: var(--curve); stroke-width: 2; stroke-linejoin: round; }
+.fx-city { fill: var(--city); stroke: var(--bg); stroke-width: 1; }
+.fx-tour { fill: none; stroke: var(--tour); stroke-width: 1.2; stroke-dasharray: 4 3; opacity: 0.85; }
+
+.fx-prose p { margin: 0 0 10px; font-size: 0.92rem; line-height: 1.55; }
+.fx-prose code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.88em; color: var(--accent); background: rgba(94,230,200,0.08); padding: 1px 4px; border-radius: 4px; }
+.fx-caption { color: var(--muted); font-size: 0.85rem; }
+.fx-note { font-size: 0.85rem; color: var(--muted); border-left: 2px solid var(--line); padding-left: 10px; }
+
+.fx-row { display: flex; align-items: center; gap: 10px; margin: 8px 0; }
+.fx-slider { flex: 1; accent-color: var(--accent); }
+
+.fx-controls { display: flex; gap: 8px; margin-bottom: 10px; }
+.fx-btn {
+  background: var(--panel); color: var(--text); border: 1px solid var(--line);
+  border-radius: 6px; padding: 6px 14px; font-size: 0.85rem; cursor: pointer;
+  font-family: inherit;
+}
+.fx-btn:hover:not(:disabled) { border-color: var(--accent); }
+.fx-btn:disabled { opacity: 0.45; cursor: default; }
+.fx-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+.fx-stagebar { display: flex; gap: 4px; margin-bottom: 10px; }
+.fx-stage {
+  flex: 1; height: 22px; border: 1px solid var(--line); border-radius: 5px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.7rem;
+  color: var(--muted); position: relative; overflow: hidden;
+}
+.fx-stage span { z-index: 1; }
+.fx-stage-done { border-color: var(--curve); color: var(--curve); }
+.fx-stage-active {
+  color: var(--text); border-color: var(--accent);
+}
+.fx-stage-active::before {
+  content: ""; position: absolute; inset: 0; width: var(--p, 0%);
+  background: rgba(94,230,200,0.18); transition: width 60ms linear;
+}
+
+.fx-statgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 10px; }
+.fx-statlabel { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px; }
+
+.fx-spark { width: 100%; max-width: 300px; height: 60px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); display: block; margin-bottom: 6px; }
+.fx-spark-line { fill: none; stroke: var(--tour); stroke-width: 1.5; }
+
+.fx-footer { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted); }
+`;

--- a/teeline-web/src/explainers/fourier.tsx
+++ b/teeline-web/src/explainers/fourier.tsx
@@ -481,15 +481,15 @@ export default function FourierExplainer() {
 // ---------------------------------------------------------------
 const CSS = `
 .fx-root {
-  --bg: #0d1117;
-  --panel: #11161d;
-  --line: #232b36;
-  --text: #d8dee9;
-  --muted: #7c8aa0;
-  --curve: #5ee6c8;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --curve: #0969da;
   --city: #f2a154;
   --tour: #e0626b;
-  --accent: #5ee6c8;
+  --accent: #0969da;
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   background: var(--bg);
   color: var(--text);
@@ -535,7 +535,7 @@ const CSS = `
 .fx-tour { fill: none; stroke: var(--tour); stroke-width: 1.2; stroke-dasharray: 4 3; opacity: 0.85; }
 
 .fx-prose p { margin: 0 0 10px; font-size: 0.92rem; line-height: 1.55; }
-.fx-prose code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.88em; color: var(--accent); background: rgba(94,230,200,0.08); padding: 1px 4px; border-radius: 4px; }
+.fx-prose code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.88em; color: var(--accent); background: rgba(9,105,218,0.08); padding: 1px 4px; border-radius: 4px; }
 .fx-caption { color: var(--muted); font-size: 0.85rem; }
 .fx-note { font-size: 0.85rem; color: var(--muted); border-left: 2px solid var(--line); padding-left: 10px; }
 
@@ -566,7 +566,7 @@ const CSS = `
 }
 .fx-stage-active::before {
   content: ""; position: absolute; inset: 0; width: var(--p, 0%);
-  background: rgba(94,230,200,0.18); transition: width 60ms linear;
+  background: rgba(9,105,218,0.15); transition: width 60ms linear;
 }
 
 .fx-statgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 10px; }

--- a/teeline-web/src/main.css
+++ b/teeline-web/src/main.css
@@ -1,3 +1,7 @@
+body {
+  padding-top: 48px;
+}
+
 /* PicoCSS 2.x has no built-in stepper — minimal custom layout */
 .stepper {
   display: flex;

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -2,6 +2,8 @@ import './sentry.js'
 import 'htmx.org'
 import '@picocss/pico/css/pico.min.css'
 import './main.css'
+import './docs.css'
+import { initTopbar } from './topbar'
 import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
 import type { SolveResult, SolveError, ParseResult, AlgorithmsResult, VersionResult, WorkerReadyMessage } from './worker'
@@ -9,6 +11,8 @@ import { initUpload, resetUpload } from './upload'
 import { initSolverConfig } from './solver-form'
 import { initResults, updateOptRoute, showRunning, showResult, computeRouteLength } from './results'
 import { buildTourText, buildCsvText, buildJsonText, serializeSvg, triggerDownload } from './download'
+
+initTopbar()
 
 const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
 

--- a/teeline-web/src/solver-groups.test.ts
+++ b/teeline-web/src/solver-groups.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { SOLVER_META, SOLVER_GROUPS, PAGED_SOLVERS } from './solver-groups'
+
+describe('SOLVER_META', () => {
+  it('contains exactly 16 solvers', () => {
+    expect(Object.keys(SOLVER_META)).toHaveLength(16)
+  })
+
+  it('every entry has id and name', () => {
+    for (const [key, meta] of Object.entries(SOLVER_META)) {
+      expect(meta.id).toBe(key)
+      expect(meta.name.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('SOLVER_GROUPS', () => {
+  it('contains exactly 4 groups', () => {
+    expect(SOLVER_GROUPS).toHaveLength(4)
+  })
+
+  it('every group has a non-empty label and ids', () => {
+    for (const g of SOLVER_GROUPS) {
+      expect(g.label.length).toBeGreaterThan(0)
+      expect(g.ids.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('has no duplicate IDs across groups', () => {
+    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    expect(allIds).toHaveLength(new Set(allIds).size)
+  })
+
+  it('every ID in groups exists in SOLVER_META', () => {
+    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    for (const id of allIds) {
+      expect(SOLVER_META, `missing SOLVER_META entry for "${id}"`).toHaveProperty(id)
+    }
+  })
+
+  it('every SOLVER_META entry appears in exactly one group', () => {
+    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    for (const id of Object.keys(SOLVER_META)) {
+      expect(allIds, `"${id}" not found in any group`).toContain(id)
+    }
+  })
+})
+
+describe('PAGED_SOLVERS', () => {
+  it('every paged ID exists in SOLVER_META', () => {
+    for (const id of PAGED_SOLVERS) {
+      expect(SOLVER_META, `PAGED_SOLVERS has "${id}" but SOLVER_META does not`).toHaveProperty(id)
+    }
+  })
+})

--- a/teeline-web/src/solver-groups.ts
+++ b/teeline-web/src/solver-groups.ts
@@ -5,7 +5,7 @@ export interface SolverMeta {
 
 export const SOLVER_META: Record<string, SolverMeta> = {
   'bhk':          { id: 'bhk',          name: 'Bellman-Held-Karp' },
-  'b&b':          { id: 'b&b',          name: 'Branch & Bound' },
+  'branch_bound': { id: 'branch_bound', name: 'Branch & Bound' },
   'nn':           { id: 'nn',           name: 'Nearest Neighbor' },
   'fourier':      { id: 'fourier',      name: 'Fourier' },
   'christofides': { id: 'christofides', name: 'Christofides' },
@@ -28,7 +28,7 @@ export interface SolverGroup {
 }
 
 export const SOLVER_GROUPS: SolverGroup[] = [
-  { label: 'Exact',         ids: ['bhk', 'b&b'] },
+  { label: 'Exact',         ids: ['bhk', 'branch_bound'] },
   { label: 'Constructive',  ids: ['nn', 'fourier', 'christofides'] },
   { label: 'Local search',  ids: ['2opt', '3opt', 'or_opt', 'lk'] },
   { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa'] },

--- a/teeline-web/src/solver-groups.ts
+++ b/teeline-web/src/solver-groups.ts
@@ -1,0 +1,37 @@
+export interface SolverMeta {
+  id: string
+  name: string
+}
+
+export const SOLVER_META: Record<string, SolverMeta> = {
+  'bhk':          { id: 'bhk',          name: 'Bellman-Held-Karp' },
+  'b&b':          { id: 'b&b',          name: 'Branch & Bound' },
+  'nn':           { id: 'nn',           name: 'Nearest Neighbor' },
+  'fourier':      { id: 'fourier',      name: 'Fourier' },
+  'christofides': { id: 'christofides', name: 'Christofides' },
+  '2opt':         { id: '2opt',         name: '2-opt' },
+  '3opt':         { id: '3opt',         name: '3-opt' },
+  'or_opt':       { id: 'or_opt',       name: 'Or-opt' },
+  'lk':           { id: 'lk',           name: 'Lin-Kernighan' },
+  'sa':           { id: 'sa',           name: 'Simulated Annealing' },
+  'tabu':         { id: 'tabu',         name: 'Tabu Search' },
+  'ga':           { id: 'ga',           name: 'Genetic Algorithm' },
+  'pso':          { id: 'pso',          name: 'Particle Swarm' },
+  'cs':           { id: 'cs',           name: 'Cuckoo Search' },
+  'fpa':          { id: 'fpa',          name: 'Flower Pollination' },
+  'gsa':          { id: 'gsa',          name: 'Gravitational Search' },
+}
+
+export interface SolverGroup {
+  label: string
+  ids: string[]
+}
+
+export const SOLVER_GROUPS: SolverGroup[] = [
+  { label: 'Exact',         ids: ['bhk', 'b&b'] },
+  { label: 'Constructive',  ids: ['nn', 'fourier', 'christofides'] },
+  { label: 'Local search',  ids: ['2opt', '3opt', 'or_opt', 'lk'] },
+  { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa'] },
+]
+
+export const PAGED_SOLVERS = new Set<string>(['fourier'])

--- a/teeline-web/src/topbar.test.ts
+++ b/teeline-web/src/topbar.test.ts
@@ -12,9 +12,10 @@ describe('renderTopbarHtml', () => {
     expect(html).toContain('teeline')
   })
 
-  it('includes Algorithms toggle button', () => {
+  it('includes Algorithms dropdown (details/summary)', () => {
     expect(html).toContain('Algorithms')
-    expect(html).toContain('aria-haspopup')
+    expect(html).toContain('<details')
+    expect(html).toContain('<summary>')
   })
 
   it('includes a link to the fourier solver page', () => {

--- a/teeline-web/src/topbar.test.ts
+++ b/teeline-web/src/topbar.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { renderTopbarHtml } from './topbar'
+
+describe('renderTopbarHtml', () => {
+  const html = renderTopbarHtml()
+
+  it('includes a link to the home page', () => {
+    expect(html).toContain('href="/"')
+  })
+
+  it('includes the site name', () => {
+    expect(html).toContain('teeline')
+  })
+
+  it('includes Algorithms toggle button', () => {
+    expect(html).toContain('Algorithms')
+    expect(html).toContain('aria-haspopup')
+  })
+
+  it('includes a link to the fourier solver page', () => {
+    expect(html).toContain('/algorithms/fourier')
+  })
+
+  it('groups solvers by category', () => {
+    expect(html).toContain('Exact')
+    expect(html).toContain('Constructive')
+    expect(html).toContain('Local search')
+    expect(html).toContain('Metaheuristic')
+  })
+
+  it('includes a GitHub link', () => {
+    expect(html).toContain('github.com')
+  })
+})

--- a/teeline-web/src/topbar.test.ts
+++ b/teeline-web/src/topbar.test.ts
@@ -19,7 +19,7 @@ describe('renderTopbarHtml', () => {
   })
 
   it('includes a link to the fourier solver page', () => {
-    expect(html).toContain('/algorithms/fourier')
+    expect(html).toContain('/algorithms/fourier/')
   })
 
   it('groups solvers by category', () => {

--- a/teeline-web/src/topbar.ts
+++ b/teeline-web/src/topbar.ts
@@ -24,7 +24,7 @@ export function renderTopbarHtml(): string {
         <div class="topbar-dropdown">
           <button
             class="algo-menu-toggle"
-            aria-haspopup="true"
+            aria-haspopup="menu"
             aria-expanded="false"
             aria-controls="algo-menu"
           >Algorithms ▾</button>

--- a/teeline-web/src/topbar.ts
+++ b/teeline-web/src/topbar.ts
@@ -1,7 +1,8 @@
 import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from './solver-groups'
 
 export function renderTopbarHtml(): string {
-  const groupsHtml = SOLVER_GROUPS.map(g => {
+  const dropdownItems = SOLVER_GROUPS.map(g => {
+    const label = `<li class="algo-group-label"><strong>${g.label}</strong></li>`
     const items = g.ids.map(id => {
       const meta = SOLVER_META[id]
       if (!meta) return ''
@@ -10,35 +11,30 @@ export function renderTopbarHtml(): string {
         : `<span>${meta.name}</span>`
       return `<li>${inner}</li>`
     }).join('')
-    return `
-      <li class="algo-group">
-        <span class="algo-group-label">${g.label}</span>
-        <ul>${items}</ul>
-      </li>`
+    return label + items
   }).join('')
 
   return `
     <nav class="topbar" aria-label="Site navigation">
-      <a class="topbar-logo" href="/">teeline</a>
-      <div class="topbar-links">
-        <div class="topbar-dropdown">
-          <button
-            class="algo-menu-toggle"
-            aria-haspopup="menu"
-            aria-expanded="false"
-            aria-controls="algo-menu"
-          >Algorithms ▾</button>
-          <ul class="algo-menu" id="algo-menu" hidden role="menu">
-            ${groupsHtml}
-          </ul>
-        </div>
-        <a
-          class="topbar-github"
-          href="https://github.com/timgluz/teeline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >GitHub ↗</a>
-      </div>
+      <ul>
+        <li><a class="topbar-logo" href="/">teeline</a></li>
+      </ul>
+      <ul>
+        <li>
+          <details class="dropdown">
+            <summary>Algorithms</summary>
+            <ul>
+              ${dropdownItems}
+            </ul>
+          </details>
+        </li>
+        <li>
+          <a href="https://github.com/timgluz/teeline"
+             target="_blank"
+             rel="noopener noreferrer"
+          >GitHub ↗</a>
+        </li>
+      </ul>
     </nav>`
 }
 
@@ -47,20 +43,11 @@ export function initTopbar(containerId = 'topbar'): void {
   if (!el) return
   el.innerHTML = renderTopbarHtml()
 
-  const toggle = el.querySelector<HTMLButtonElement>('.algo-menu-toggle')
-  const menu   = el.querySelector<HTMLElement>('.algo-menu')
-  if (!toggle || !menu) return
-
-  toggle.addEventListener('click', () => {
-    const isOpen = !menu.hidden
-    menu.hidden = isOpen
-    toggle.setAttribute('aria-expanded', String(!isOpen))
-  })
-
+  // Close the dropdown when clicking outside the topbar
   document.addEventListener('click', (e) => {
-    if (!el.contains(e.target as Node)) {
-      menu.hidden = true
-      toggle.setAttribute('aria-expanded', 'false')
+    const details = el.querySelector<HTMLDetailsElement>('details.dropdown')
+    if (details && !el.contains(e.target as Node)) {
+      details.removeAttribute('open')
     }
   })
 }

--- a/teeline-web/src/topbar.ts
+++ b/teeline-web/src/topbar.ts
@@ -1,0 +1,66 @@
+import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from './solver-groups'
+
+export function renderTopbarHtml(): string {
+  const groupsHtml = SOLVER_GROUPS.map(g => {
+    const items = g.ids.map(id => {
+      const meta = SOLVER_META[id]
+      if (!meta) return ''
+      const inner = PAGED_SOLVERS.has(id)
+        ? `<a href="/algorithms/${id}">${meta.name}</a>`
+        : `<span>${meta.name}</span>`
+      return `<li>${inner}</li>`
+    }).join('')
+    return `
+      <li class="algo-group">
+        <span class="algo-group-label">${g.label}</span>
+        <ul>${items}</ul>
+      </li>`
+  }).join('')
+
+  return `
+    <nav class="topbar" aria-label="Site navigation">
+      <a class="topbar-logo" href="/">teeline</a>
+      <div class="topbar-links">
+        <div class="topbar-dropdown">
+          <button
+            class="algo-menu-toggle"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="algo-menu"
+          >Algorithms ▾</button>
+          <ul class="algo-menu" id="algo-menu" hidden role="menu">
+            ${groupsHtml}
+          </ul>
+        </div>
+        <a
+          class="topbar-github"
+          href="https://github.com/timgluz/teeline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >GitHub ↗</a>
+      </div>
+    </nav>`
+}
+
+export function initTopbar(containerId = 'topbar'): void {
+  const el = document.getElementById(containerId)
+  if (!el) return
+  el.innerHTML = renderTopbarHtml()
+
+  const toggle = el.querySelector<HTMLButtonElement>('.algo-menu-toggle')
+  const menu   = el.querySelector<HTMLElement>('.algo-menu')
+  if (!toggle || !menu) return
+
+  toggle.addEventListener('click', () => {
+    const isOpen = !menu.hidden
+    menu.hidden = isOpen
+    toggle.setAttribute('aria-expanded', String(!isOpen))
+  })
+
+  document.addEventListener('click', (e) => {
+    if (!el.contains(e.target as Node)) {
+      menu.hidden = true
+      toggle.setAttribute('aria-expanded', 'false')
+    }
+  })
+}

--- a/teeline-web/src/topbar.ts
+++ b/teeline-web/src/topbar.ts
@@ -7,7 +7,7 @@ export function renderTopbarHtml(): string {
       const meta = SOLVER_META[id]
       if (!meta) return ''
       const inner = PAGED_SOLVERS.has(id)
-        ? `<a href="/algorithms/${id}">${meta.name}</a>`
+        ? `<a href="/algorithms/${id}/">${meta.name}</a>`
         : `<span>${meta.name}</span>`
       return `<li>${inner}</li>`
     }).join('')

--- a/teeline-web/tsconfig.json
+++ b/teeline-web/tsconfig.json
@@ -5,6 +5,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
 
     /* Bundler mode */
     "moduleResolution": "Bundler",

--- a/teeline-web/vite.config.ts
+++ b/teeline-web/vite.config.ts
@@ -5,27 +5,43 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   build: {
     outDir: 'dist',
-    sourcemap: true
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        fourier: 'algorithms/fourier/index.html',
+        fourierExplainer: 'algorithms/fourier/explainer/index.html',
+      },
+    },
   },
 
   resolve: {
-    preserveSymlinks: true,  // follow npm file: symlinks to teeline-wasm
+    preserveSymlinks: true,
+    alias: {
+      'react': 'preact/compat',
+      'react-dom': 'preact/compat',
+      'react-dom/client': 'preact/compat',
+    },
+  },
+
+  esbuild: {
+    jsxImportSource: 'preact',
   },
 
   optimizeDeps: {
-    exclude: ['teeline-wasm'],  // don't pre-bundle; WASM needs to stay as-is
+    exclude: ['teeline-wasm'],
   },
 
   worker: {
-    format: 'es',  // ES module workers — required for top-level await in teeline_wasm.js
+    format: 'es',
   },
 
   test: {
-    // node env (default) — tests import only DOM-free modules (solver-options.ts)
+    // node env (default) — tests import only DOM-free modules
   },
 
   plugins: [sentryVitePlugin({
     org: "timo-sulg",
     project: "javascript"
-  })]
+  })],
 })


### PR DESCRIPTION
## Summary

- Adds persistent topbar (logo · grouped Algorithms dropdown · GitHub link) to all pages, including the existing solver app
- Adds `/algorithms/fourier` static docs page with two-column layout: grouped algorithm sidebar (left) + full docs content (right)
- Adds `/algorithms/fourier/explainer` interactive Preact explainer page (adapted from FourierExplainer prototype)
- Adds Preact via Vite alias (`react → preact/compat`) — minimal change to the explainer component
- Adds shared `topbar.ts` + `algorithms-sidebar.ts` + `solver-groups.ts` vanilla-TS modules (unit-tested, node env) for reuse across all future solver docs pages
- Converts Vite to MPA (Multi-Page App) — each solver page is a real static HTML file at its natural URL

## Architecture

`solver-groups.ts` is the single source of truth for all 16 solvers and their groupings. Both `topbar.ts` and `algorithms-sidebar.ts` import `PAGED_SOLVERS` from it — add a new solver's ID there when its docs page is merged.

## Follow-up
- Hamburger menu for mobile sidebar (#follow-up)
- Markdown-to-HTML build pipeline for next solver page
- Interactive explainers for other solvers

## Test plan
- [x] `cd teeline-web && npm test` passes (solver-groups, topbar, algorithms-sidebar + existing tests)
- [x] `npm run build` succeeds, all three HTML entries in `dist/`
- [x] `/` — topbar visible above stepper, Algorithms dropdown opens grouped, solver workflow unchanged
- [x] `/algorithms/fourier` — two-column layout, sidebar highlights Fourier under Constructive, explainer CTA links to explainer page
- [x] `/algorithms/fourier/explainer` — FourierExplainer renders, all three tabs (Idea / Modes / Train & decode) work, Play button animates