### PR TITLE
fix(ci): pin Qt download to official server in release.yml (closes #227)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,6 +352,7 @@ jobs:
           target: desktop
           arch: linux_gcc_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -430,6 +431,7 @@ jobs:
           target: desktop
           arch: win64_msvc2022_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Deploy Qt dependencies
@@ -472,6 +474,7 @@ jobs:
           target: desktop
           arch: clang_64
           cache: true
+          extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Create .app bundle


### PR DESCRIPTION
## Problem

`release.yml` Qt install steps hit third-party mirrors via aqt's default mirror selection. On Windows, the `qt6_6110` repository index hadn't propagated to all mirrors yet, causing `build-qt-windows` to fail with:

```
ERROR: Failed to locate XML data for Qt version '6.11.0'.
```

## Fix

`build-qt.yml` already uses `extra: '--base https://download.qt.io/'` to force aqt to use the official Qt download server, which always has the index for current versions. This PR applies the same flag to all three `jurplel/install-qt-action@v4` steps in `release.yml` (linux, windows, macos) for consistency.

## Why not mirror / retry / LTS downgrade

The root cause is mirror propagation lag, not a missing Qt version. Pinning the canonical download server is the minimal targeted fix — no version change, no added retry action, no third-party mirror dependency.

## Changes

- `.github/workflows/release.yml` — add `extra: '--base https://download.qt.io/'` to `build-qt-linux`, `build-qt-windows`, and `build-qt-macos` jobs (3 lines)