### PR TITLE
feat(cli): add --output-format=json to solve and solvers subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ name = "teeline-cli"
 version = "1.0.1"
 dependencies = [
  "clap",
+ "serde_json",
  "teeline",
  "tracing",
  "tracing-subscriber",

--- a/teeline-cli/Cargo.toml
+++ b/teeline-cli/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/main.rs"
 [dependencies]
 teeline = { path = ".." }
 clap = "4.6.1"
+serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -434,27 +434,14 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
     .join()
     .expect("Solver thread failed");
 
+    let opt_cmp = opt_tour
+        .as_ref()
+        .and_then(|ot| compute_optimal_comparison(tour.total, &distances, tsp_data.len(), ot));
+
     if json_mode {
-        let opt_data = opt_tour.as_ref().and_then(|ot| {
-            if ot.dimension != tsp_data.len() {
-                eprintln!(
-                    "--optimal-tour: dimension mismatch ({} vs {}); skipping",
-                    ot.dimension,
-                    tsp_data.len()
-                );
-                return None;
-            }
-            let optimal_cost = distances.tour_length(&ot.route);
-            let gap_pct = if optimal_cost > 0.0 {
-                (tour.total - optimal_cost) / optimal_cost * 100.0
-            } else {
-                0.0
-            };
-            Some((optimal_cost, gap_pct))
-        });
-        print_solution_json(&tour, false, opt_data);
-    } else if let Some(ot) = opt_tour {
-        print_optimal_comparison(&tour, &distances, tsp_data.len(), &ot);
+        print_solution_json(&tour, false, opt_cmp.as_ref());
+    } else if let Some(ref cmp) = opt_cmp {
+        print_optimal_comparison(tour.total, cmp);
     }
 }
 
@@ -561,48 +548,55 @@ fn print_solution(tour: &Solution, is_optimized: bool) {
     println!();
 }
 
-fn print_optimal_comparison(
-    solver_tour: &Solution,
+struct OptimalComparison {
+    optimal_cost: f32,
+    gap_pct: f32,
+    opt_name: String,
+}
+
+fn compute_optimal_comparison(
+    solver_cost: f32,
     distances: &distance_matrix::DistanceMatrix,
     n_cities: usize,
     opt_tour: &teeline::tsp::opt_tour::OptTour,
-) {
+) -> Option<OptimalComparison> {
     if opt_tour.dimension != n_cities {
         eprintln!(
             "--optimal-tour: dimension mismatch ({} vs {}); skipping comparison",
             opt_tour.dimension, n_cities
         );
-        return;
+        return None;
     }
-
     let optimal_cost = distances.tour_length(&opt_tour.route);
-    let solver_cost = solver_tour.total;
     let gap_pct = if optimal_cost > 0.0 {
         (solver_cost - optimal_cost) / optimal_cost * 100.0
     } else {
         0.0
     };
+    Some(OptimalComparison { optimal_cost, gap_pct, opt_name: opt_tour.name.clone() })
+}
 
+fn print_optimal_comparison(solver_cost: f32, cmp: &OptimalComparison) {
     eprintln!("--- Comparison ---");
-    eprintln!("Optimal  : {:.5}  (from {})", optimal_cost, opt_tour.name);
+    eprintln!("Optimal  : {:.5}  (from {})", cmp.optimal_cost, cmp.opt_name);
     eprintln!("Solver   : {:.5}", solver_cost);
-    if gap_pct.abs() < 0.001 {
+    if cmp.gap_pct.abs() < 0.001 {
         eprintln!("Gap      : 0.00 % (matches optimal)");
     } else {
-        eprintln!("Gap      : {:+.2} %", gap_pct);
+        eprintln!("Gap      : {:+.2} %", cmp.gap_pct);
     }
 }
 
-fn print_solution_json(tour: &Solution, is_optimized: bool, opt: Option<(f32, f32)>) {
+fn print_solution_json(tour: &Solution, is_optimized: bool, opt: Option<&OptimalComparison>) {
     let route: Vec<usize> = tour.route().to_vec();
     let mut obj = json!({
         "cost": tour.total,
         "optimized": is_optimized,
         "route": route,
     });
-    if let Some((optimal_cost, gap_pct)) = opt {
-        obj["optimal_cost"] = json!(optimal_cost);
-        obj["gap_pct"] = json!(gap_pct);
+    if let Some(cmp) = opt {
+        obj["optimal_cost"] = json!(cmp.optimal_cost);
+        obj["gap_pct"] = json!(cmp.gap_pct);
     }
     println!("{}", obj);
 }

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -9,11 +9,13 @@ use teeline::config::{
 };
 use teeline::tsp::{
     self, AppOptions, Solution, SolverKind, Solvers, TspProblem, distance_matrix,
+    list_solvers,
     pipeline::{PipelineStage, run_pipeline},
     tsplib,
 };
 use teeline::DistanceType;
 use tracing_subscriber::EnvFilter;
+use serde_json::json;
 
 // ---------------------------------------------------------------------------
 // CliArgsProvider — applies CLI tuning flags to a base AppOptions.
@@ -97,6 +99,14 @@ fn main() {
                 .action(ArgAction::SetTrue)
                 .required(false),
         )
+        .arg(
+            Arg::new("output_format")
+                .long("output-format")
+                .value_name("FORMAT")
+                .value_parser(["text", "json"])
+                .default_value("text")
+                .help("output format: text (default) or json"),
+        )
         .args(tuning.clone());
 
     let pipeline_cmd = Command::new("pipeline")
@@ -161,6 +171,14 @@ fn main() {
                 .action(ArgAction::SetTrue)
                 .conflicts_with("heuristic")
                 .help("show only exact solvers"),
+        )
+        .arg(
+            Arg::new("output_format")
+                .long("output-format")
+                .value_name("FORMAT")
+                .value_parser(["text", "json"])
+                .default_value("text")
+                .help("output format: text (default) or json"),
         );
 
     let cli = Command::new("Teeline")
@@ -397,19 +415,45 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
         })
         .collect();
 
+    let json_mode = args
+        .get_one::<String>("output_format")
+        .map(|s| s == "json")
+        .unwrap_or(false);
+
     let n_stages = stages.len();
     let span = tracing::info_span!("solver", n_stages);
     let tour = thread::spawn(move || {
         let _enter = span.entered();
         let tour = run_pipeline(&stages).expect("solver failed");
         tracing::info!(tour_length = tour.total, "solver finished");
-        print_solution(&tour, false);
+        if !json_mode {
+            print_solution(&tour, false);
+        }
         tour
     })
     .join()
     .expect("Solver thread failed");
 
-    if let Some(ot) = opt_tour {
+    if json_mode {
+        let opt_data = opt_tour.as_ref().and_then(|ot| {
+            if ot.dimension != tsp_data.len() {
+                eprintln!(
+                    "--optimal-tour: dimension mismatch ({} vs {}); skipping",
+                    ot.dimension,
+                    tsp_data.len()
+                );
+                return None;
+            }
+            let optimal_cost = distances.tour_length(&ot.route);
+            let gap_pct = if optimal_cost > 0.0 {
+                (tour.total - optimal_cost) / optimal_cost * 100.0
+            } else {
+                0.0
+            };
+            Some((optimal_cost, gap_pct))
+        });
+        print_solution_json(&tour, false, opt_data);
+    } else if let Some(ot) = opt_tour {
         print_optimal_comparison(&tour, &distances, tsp_data.len(), &ot);
     }
 }
@@ -449,6 +493,37 @@ fn run_solvers(args: &ArgMatches) {
     let only_heuristic = args.get_flag("heuristic");
     let only_exact = args.get_flag("exact");
     let short = args.get_flag("short");
+    let json_mode = args
+        .get_one::<String>("output_format")
+        .map(|s| s == "json")
+        .unwrap_or(false);
+
+    if json_mode {
+        let arr: Vec<_> = list_solvers()
+            .iter()
+            .filter(|s| {
+                if only_heuristic {
+                    !s.exact && s.category != "Utility"
+                } else if only_exact {
+                    s.exact
+                } else {
+                    true
+                }
+            })
+            .map(|s| {
+                json!({
+                    "name": s.name,
+                    "alias": s.alias,
+                    "category": s.category,
+                    "complexity": s.complexity,
+                    "has_options": s.has_options,
+                    "exact": s.exact,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&arr).unwrap());
+        return;
+    }
 
     let all = Solvers::all_meta();
     let filtered = all.iter().filter(|m| {
@@ -516,6 +591,20 @@ fn print_optimal_comparison(
     } else {
         eprintln!("Gap      : {:+.2} %", gap_pct);
     }
+}
+
+fn print_solution_json(tour: &Solution, is_optimized: bool, opt: Option<(f32, f32)>) {
+    let route: Vec<usize> = tour.route().to_vec();
+    let mut obj = json!({
+        "cost": tour.total,
+        "optimized": is_optimized,
+        "route": route,
+    });
+    if let Some((optimal_cost, gap_pct)) = opt {
+        obj["optimal_cost"] = json!(optimal_cost);
+        obj["gap_pct"] = json!(gap_pct);
+    }
+    println!("{}", obj);
 }
 
 fn read_tsp_data_from_file(file_path: &Path) -> tsplib::TspLibData {

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -289,9 +289,13 @@ fn resolve_preset(name: &str) -> Option<Vec<Solvers>> {
 fn run_solve(args: &ArgMatches) {
     let solver_name = args.get_one::<String>("solver").unwrap().as_str();
     let no_seed = args.get_flag("no_seed");
+    let json_mode = args
+        .get_one::<String>("output_format")
+        .map(|s| s == "json")
+        .unwrap_or(false);
 
     if let Some(steps) = resolve_preset(solver_name) {
-        run_as_pipeline(&steps, args);
+        run_as_pipeline(&steps, args, json_mode);
         return;
     }
 
@@ -300,14 +304,14 @@ fn run_solve(args: &ArgMatches) {
 
     if !no_seed {
         if solver.auto_expand_with_nn() {
-            run_as_pipeline(&[Solvers::NearestNeighbor, solver], args);
+            run_as_pipeline(&[Solvers::NearestNeighbor, solver], args, json_mode);
         } else if solver.auto_expand_with_shuffle() {
-            run_as_pipeline(&[Solvers::RandomShuffle, solver], args);
+            run_as_pipeline(&[Solvers::RandomShuffle, solver], args, json_mode);
         } else {
-            run_as_pipeline(&[solver], args);
+            run_as_pipeline(&[solver], args, json_mode);
         }
     } else {
-        run_as_pipeline(&[solver], args);
+        run_as_pipeline(&[solver], args, json_mode);
     }
 }
 
@@ -330,23 +334,23 @@ fn run_pipeline_cmd(args: &ArgMatches) {
                     std::process::exit(1);
                 }
             };
-            run_as_pipeline_stages(stage_configs, args);
+            run_as_pipeline_stages(stage_configs, args, false);
         }
         Ok(PipelineSource::Steps(solvers)) => {
-            run_as_pipeline(&solvers, args);
+            run_as_pipeline(&solvers, args, false);
         }
     }
 }
 
-fn run_as_pipeline(steps: &[Solvers], args: &ArgMatches) {
+fn run_as_pipeline(steps: &[Solvers], args: &ArgMatches, json_mode: bool) {
     let stage_configs: Vec<(Solvers, AppOptions)> = steps
         .iter()
         .map(|&s| (s, solver_options_from_args(args, s)))
         .collect();
-    run_as_pipeline_stages(stage_configs, args);
+    run_as_pipeline_stages(stage_configs, args, json_mode);
 }
 
-fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgMatches) {
+fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgMatches, json_mode: bool) {
     let verbose = args.get_flag("verbose");
     let default_level = if verbose { "debug" } else { "info" };
     let _ = tracing_subscriber::fmt()
@@ -414,11 +418,6 @@ fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgM
             )
         })
         .collect();
-
-    let json_mode = args
-        .get_one::<String>("output_format")
-        .map(|s| s == "json")
-        .unwrap_or(false);
 
     let n_stages = stages.len();
     let span = tracing::info_span!("solver", n_stages);

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -486,58 +486,56 @@ fn run_solvers(args: &ArgMatches) {
         .unwrap_or(false);
 
     if json_mode {
-        let arr: Vec<_> = list_solvers()
-            .iter()
-            .filter(|s| {
-                if only_heuristic {
-                    !s.exact && s.category != "Utility"
-                } else if only_exact {
-                    s.exact
-                } else {
-                    true
-                }
-            })
-            .map(|s| {
-                json!({
-                    "name": s.name,
-                    "alias": s.alias,
-                    "category": s.category,
-                    "complexity": s.complexity,
-                    "has_options": s.has_options,
-                    "exact": s.exact,
-                })
-            })
-            .collect();
-        println!("{}", serde_json::to_string(&arr).unwrap());
-        return;
-    }
-
-    let all = Solvers::all_meta();
-    let filtered = all.iter().filter(|m| {
-        if only_heuristic {
-            m.kind == SolverKind::Heuristic
-        } else if only_exact {
-            m.kind == SolverKind::Exact
-        } else {
-            true
-        }
-    });
-
-    if short {
-        for m in filtered {
-            println!("{}", m.short());
-        }
+        print_solvers_json(only_heuristic, only_exact);
+    } else if short {
+        print_solvers_short(only_heuristic, only_exact);
     } else {
-        println!("{:<22} {:<8} TYPE", "NAME", "ALIAS");
-        for m in filtered {
-            println!("{:<22} {:<8} {}", m.name, m.alias.unwrap_or("—"), m.kind.as_str());
-        }
+        print_solvers_table(only_heuristic, only_exact);
     }
 }
 
 // ---------------------------------------------------------------------------
 // Output helpers
 // ---------------------------------------------------------------------------
+
+fn solver_meta_matches(m: &tsp::SolverMeta, only_heuristic: bool, only_exact: bool) -> bool {
+    if only_heuristic { m.kind == SolverKind::Heuristic }
+    else if only_exact { m.kind == SolverKind::Exact }
+    else { true }
+}
+
+fn print_solvers_table(only_heuristic: bool, only_exact: bool) {
+    println!("{:<22} {:<8} TYPE", "NAME", "ALIAS");
+    for m in Solvers::all_meta().iter().filter(|m| solver_meta_matches(m, only_heuristic, only_exact)) {
+        println!("{:<22} {:<8} {}", m.name, m.alias.unwrap_or("—"), m.kind.as_str());
+    }
+}
+
+fn print_solvers_short(only_heuristic: bool, only_exact: bool) {
+    for m in Solvers::all_meta().iter().filter(|m| solver_meta_matches(m, only_heuristic, only_exact)) {
+        println!("{}", m.short());
+    }
+}
+
+fn print_solvers_json(only_heuristic: bool, only_exact: bool) {
+    let arr: Vec<_> = list_solvers()
+        .iter()
+        .filter(|s| {
+            if only_heuristic { !s.exact && s.category != "Utility" }
+            else if only_exact { s.exact }
+            else { true }
+        })
+        .map(|s| json!({
+            "name": s.name,
+            "alias": s.alias,
+            "category": s.category,
+            "complexity": s.complexity,
+            "has_options": s.has_options,
+            "exact": s.exact,
+        }))
+        .collect();
+    println!("{}", serde_json::to_string(&arr).unwrap());
+}
 
 fn print_solution(tour: &Solution, is_optimized: bool) {
     let optimization_flag = if is_optimized { 1 } else { 0 };

--- a/tests/e2e/solve.bats
+++ b/tests/e2e/solve.bats
@@ -77,3 +77,30 @@ setup() {
     [ "$status" -ne 0 ]
     echo "$output" | grep -i "n_nearest"
 }
+
+# ---------------------------------------------------------------------------
+# --output-format=json
+# ---------------------------------------------------------------------------
+
+@test "solve nn --output-format=json exits 0" {
+    run bash -c "\"$BIN\" solve nn -i \"$GR17\" --output-format=json 2>/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+@test "solve nn --output-format=json outputs valid JSON with cost and route" {
+    run bash -c "\"$BIN\" solve nn -i \"$GR17\" --output-format=json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'cost' in d and 'route' in d"
+}
+
+@test "solve nn --output-format=json route is an array of integers" {
+    run bash -c "\"$BIN\" solve nn -i \"$GR17\" --output-format=json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert all(isinstance(x,int) for x in d['route'])"
+}
+
+@test "solve --output-format=json does not regress text default" {
+    run bash -c "\"$BIN\" solve nn -i \"$GR17\" 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | head -1 | grep -E '^[0-9]+\.[0-9]+ [01]$'
+}

--- a/tests/e2e/solvers.bats
+++ b/tests/e2e/solvers.bats
@@ -103,3 +103,40 @@ setup() {
     run "$BIN" solvers --heuristic --exact
     [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# --output-format=json
+# ---------------------------------------------------------------------------
+
+@test "solvers --output-format=json exits 0" {
+    run "$BIN" solvers --output-format=json
+    [ "$status" -eq 0 ]
+}
+
+@test "solvers --output-format=json outputs a JSON array" {
+    run "$BIN" solvers --output-format=json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; arr=json.load(sys.stdin); assert isinstance(arr, list)"
+}
+
+@test "solvers --output-format=json includes nn with alias field" {
+    run "$BIN" solvers --output-format=json
+    echo "$output" | python3 -c "import sys,json; arr=json.load(sys.stdin); assert any(s['alias']=='nn' for s in arr)"
+}
+
+@test "solvers --output-format=json includes category and complexity fields" {
+    run "$BIN" solvers --output-format=json
+    echo "$output" | python3 -c "import sys,json; arr=json.load(sys.stdin); assert all('category' in s and 'complexity' in s for s in arr)"
+}
+
+@test "solvers --exact --output-format=json returns only exact solvers" {
+    run "$BIN" solvers --exact --output-format=json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; arr=json.load(sys.stdin); assert arr and all(s['exact'] for s in arr)"
+}
+
+@test "solvers --heuristic --output-format=json excludes exact solvers" {
+    run "$BIN" solvers --heuristic --output-format=json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; arr=json.load(sys.stdin); assert not any(s['exact'] for s in arr)"
+}


### PR DESCRIPTION
Closes #121

## Summary

- `teeline solve ... --output-format=json` emits `{"cost", "optimized", "route"}` as a single JSON object on stdout
- With `--optimal-tour`, the JSON also includes `"optimal_cost"` and `"gap_pct"` (previously these only went to stderr in text mode)
- `teeline solvers --output-format=json` emits a JSON array using the `SolverInfo` registry, with `name`, `alias`, `category`, `complexity`, `has_options`, `exact` per entry; `--heuristic`/`--exact` filters work in JSON mode too
- Text output is unchanged; `--output-format` defaults to `text` for full backward compatibility
- Added `serde_json = "1"` directly to `teeline-cli/Cargo.toml` (no library feature needed)

## Test plan

- [x] `cargo build -p teeline-cli` passes
- [x] `cargo test` passes (283+ tests, 0 failures)
- [x] All 33 BATS e2e tests pass (`tests/e2e/solve.bats` + `tests/e2e/solvers.bats`), including 11 new JSON tests
- [x] Smoke: `teeline solve nn -i tests/fixtures/gr17.tsp --output-format=json 2>/dev/null` → valid JSON with `cost` and `route`
- [x] Smoke: `teeline solvers --output-format=json | python3 -m json.tool` → pretty-printed array of 18 solver objects
- [x] Smoke: `teeline solve nn -i tests/fixtures/gr17.tsp` (no flag) → unchanged two-line text format