### PR TITLE
feat(branch_bound): restrict candidates to k-nearest via KD-tree (#142)

### DIFF
--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::mpsc;
 
 use super::distance_matrix::DistanceMatrix;
+use super::kdtree::{self, KDPoint, KDTree};
 use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{HeuristicOptions, Solution, TspProblem};
@@ -20,7 +21,7 @@ type PathEvaluator = Rc<dyn Fn(&Path) -> f32>;
 
 pub fn solve(
     problem: &TspProblem,
-    _opts: &HeuristicOptions,
+    opts: &HeuristicOptions,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
     init_tour: Option<&[usize]>,
 ) -> Solution {
@@ -48,16 +49,31 @@ pub fn solve(
         .map(|t| distances.tour_length(t))
         .unwrap_or(f32::MAX);
 
+    let n_nearest = opts.n_nearest;
+    // Gate: only build KD-tree when n_nearest actually restricts the candidate
+    // set. When n_nearest >= n_cities every city is a candidate anyway — skip
+    // the overhead and keep exact B&B behaviour.
+    let kd_tree: Option<KDTree> = if n_nearest > 0 && n_nearest < n_cities {
+        Some(kdtree::from_cities(cities))
+    } else {
+        None
+    };
+    let city_map: HashMap<usize, KDPoint> =
+        cities.iter().map(|p| (p.id, *p)).collect();
+
     let fitness_fn = build_evaluator(distances);
     let (best_path, best_distance) = backtrack(
         &fitness_fn,
         distances,
+        &city_map,
         &mut open_path,
         &unvisited_cities,
         1,
         0.0,
         initial_upper_bound,
         progress_tx,
+        kd_tree.as_ref(),
+        n_nearest,
     );
 
     if let Some(tx) = progress_tx {
@@ -86,12 +102,15 @@ fn build_evaluator(distances: &DistanceMatrix) -> PathEvaluator {
 fn backtrack(
     evaluate_fn: &PathEvaluator,
     distances: &DistanceMatrix,
+    city_map: &HashMap<usize, KDPoint>,
     path: &mut Path,
     unvisited_cities: &UniqSet,
     k: usize,
     running_cost: f32,
     upper_bound: f32,
     progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    kd: Option<&KDTree>,
+    n_nearest: usize,
 ) -> (Path, f32) {
     let mut best_path = path.clone();
     let mut best_distance = upper_bound;
@@ -115,6 +134,9 @@ fn backtrack(
         running_cost,
         best_distance,
         distances,
+        city_map,
+        kd,
+        n_nearest,
     );
 
     for candidate in candidates.iter() {
@@ -144,12 +166,15 @@ fn backtrack(
         let (sub_res, sub_dist) = backtrack(
             evaluate_fn,
             distances,
+            city_map,
             path,
             &next_cities,
             k + 1,
             running_cost + next_distance,
             best_distance,
             progress_tx,
+            kd,
+            n_nearest,
         );
 
         if sub_dist < best_distance {
@@ -176,15 +201,46 @@ fn construct_candidates(
     running_cost: f32,
     best_distance: f32,
     distances: &DistanceMatrix,
+    city_map: &HashMap<usize, KDPoint>,
+    kd: Option<&KDTree>,
+    n_nearest: usize,
 ) -> Path {
     if unvisited_cities.is_empty() {
         return vec![];
     }
 
+    // When a KD-tree is available, restrict candidates to the n_nearest
+    // geometrically-closest unvisited cities. Fall back to the full unvisited
+    // set only if zero neighbors survive the intersection (last few cities in
+    // the tour where all geometric neighbors are already visited).
+    let candidate_ids: Vec<usize> = match kd {
+        Some(tree) => {
+            let current_id = path[k - 1];
+            let current_pt = city_map
+                .get(&current_id)
+                .expect("current city must be in city_map");
+
+            let restricted: Vec<usize> = tree
+                .nearest(current_pt, n_nearest)
+                .nearest()
+                .iter()
+                .map(|item| item.point.id)
+                .filter(|id| unvisited_cities.contains(id))
+                .collect();
+
+            if restricted.is_empty() {
+                unvisited_cities.iter().copied().collect()
+            } else {
+                restricted
+            }
+        }
+        None => unvisited_cities.iter().copied().collect(),
+    };
+
     // MST of {start_city} ∪ unvisited is a lower bound on the minimum cost of
     // completing the tour from any candidate through the remaining cities back
-    // to the start. The node set is identical for all candidates (see plan),
-    // so the MST is computed once and reused.
+    // to the start. Computed on ALL remaining unvisited cities (not just the
+    // restricted candidates) so the bound stays valid.
     let start_city = path[0];
     let mst_nodes: Vec<usize> = std::iter::once(start_city)
         .chain(unvisited_cities.iter().copied())
@@ -193,7 +249,7 @@ fn construct_candidates(
 
     // Score each candidate by its lower bound, then sort ascending so the most
     // promising branches are explored first (tightens best_distance faster).
-    let mut scored: Vec<(f32, usize)> = unvisited_cities
+    let mut scored: Vec<(f32, usize)> = candidate_ids
         .iter()
         .filter_map(|&city_id| {
             let next_dist = distances
@@ -285,7 +341,9 @@ mod tests {
     #[test]
     fn test_solve_finds_optimal_tour_on_tsp5() {
         let problem = tsp5_problem();
-        let tour = solve(&problem, &HeuristicOptions::default(), None, None);
+        // n_nearest=0: no KD restriction — exact B&B.
+        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let tour = solve(&problem, &opts, None, None);
 
         assert!(
             (tour.total - 4.0).abs() < 1e-3,
@@ -297,7 +355,8 @@ mod tests {
     #[test]
     fn test_solve_matches_bellman_karp_on_tsp5() {
         let problem = tsp5_problem();
-        let bb_tour = solve(&problem, &HeuristicOptions::default(), None, None);
+        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let bb_tour = solve(&problem, &opts, None, None);
         let bhk_tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(
@@ -332,7 +391,9 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
 
-        let bb = solve(&problem, &HeuristicOptions::default(), None, None);
+        // n_nearest=0: no KD restriction — exact B&B.
+        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let bb = solve(&problem, &opts, None, None);
         let bhk = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
         assert!(
@@ -348,13 +409,15 @@ mod tests {
         // When a good init_tour is provided the upper bound is seeded tightly,
         // pruning more branches early. The result must still be the exact optimal.
         let problem = tsp5_problem();
-        let without_seed = solve(&problem, &HeuristicOptions::default(), None, None);
+        // n_nearest=0: no KD restriction — exact B&B.
+        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let without_seed = solve(&problem, &opts, None, None);
 
         // Use the unseeded result as the init_tour for the second run.
         let seed_route = without_seed.route().to_vec();
         let with_seed = solve(
             &problem,
-            &HeuristicOptions::default(),
+            &opts,
             None,
             Some(&seed_route),
         );
@@ -380,5 +443,61 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let mst = prim_mst(&[1, 2, 3], &dm);
         assert!((mst - 7.0).abs() < 1e-3, "MST of 3-4-5 triangle should be 7, got {mst}");
+    }
+
+    #[test]
+    fn test_n_nearest_3_finds_same_optimal_on_tsp5() {
+        // n_nearest=3 < 5 cities — KD restriction is active, but tsp5 is
+        // simple enough that the optimal successor is always within the 3
+        // nearest, so the result must match exact B&B.
+        let problem = tsp5_problem();
+        let restricted_opts = HeuristicOptions { n_nearest: 3, ..Default::default() };
+        let exact_opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+
+        let restricted = solve(&problem, &restricted_opts, None, None);
+        let exact = solve(&problem, &exact_opts, None, None);
+
+        assert!(
+            (restricted.total - exact.total).abs() < 1e-3,
+            "n_nearest=3 tour {:.3} should match exact {:.3}",
+            restricted.total,
+            exact.total,
+        );
+    }
+
+    #[test]
+    fn test_n_nearest_visits_all_cities_on_tsp8() {
+        // Same 8-city layout as test_solve_matches_bhk_on_tsp8.
+        // With n_nearest=4, the KD restriction is active (4 < 8).
+        let coords: &[&[f32]] = &[
+            &[0.0, 0.0], &[3.0, 1.0], &[1.0, 3.0], &[4.0, 4.0],
+            &[2.0, 0.5], &[0.5, 2.0], &[3.5, 2.5], &[1.5, 4.0],
+        ];
+        let cities: Vec<kdtree::KDPoint> = coords
+            .iter()
+            .enumerate()
+            .map(|(i, c)| kdtree::KDPoint::new_with_id(i + 1, c))
+            .collect();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
+
+        let restricted_opts = HeuristicOptions { n_nearest: 4, ..Default::default() };
+        let tour = solve(&problem, &restricted_opts, None, None);
+
+        // All 8 cities visited exactly once.
+        let mut visited: Vec<usize> = tour.route().to_vec();
+        visited.sort();
+        assert_eq!(visited, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+        // Gap vs unrestricted B&B should be < 10%.
+        let exact_opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let exact = solve(&problem, &exact_opts, None, None);
+        let gap = (tour.total - exact.total) / exact.total;
+        assert!(
+            gap < 0.10,
+            "n_nearest=4 gap {:.1}% should be < 10% vs exact {:.3}",
+            gap * 100.0,
+            exact.total,
+        );
     }
 }

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -194,6 +194,7 @@ fn is_solution(path: &Path, k: usize, n_cities: usize) -> bool {
     k == n_cities && k > 1 && uniq_ids.len() == n_cities
 }
 
+#[allow(clippy::too_many_arguments)]
 fn construct_candidates(
     path: &Path,
     k: usize,


### PR DESCRIPTION
## Summary

- Wires `HeuristicOptions.n_nearest` into `branch_bound::solve()`, which previously ignored it (`_opts` prefix)
- When `n_nearest > 0 && n_nearest < n_cities`, `construct_candidates()` restricts the candidate set to the `n_nearest` geometrically-closest unvisited cities via a KD-tree query instead of scoring all remaining cities
- Falls back to full unvisited set only when zero KD-tree neighbors survive the intersection (occurs in the last few cities of the tour where all geometric neighbors are already visited)
- MST lower bound still computed on **all** remaining unvisited cities — keeps the bound valid regardless of candidate restriction
- `HashMap<usize, KDPoint>` built once in `solve()` for O(1) city lookup per depth (avoids O(N²) linear scans)
- Gate: `n_nearest >= n_cities` → KD-tree skipped entirely (no restriction needed, exact B&B preserved for small instances)

## Test plan

- [x] 4 existing exactness tests updated to use `n_nearest: 0` explicitly (since `HeuristicOptions::default()` sets `n_nearest=3`, which now activates KD restriction for instances with > 3 cities)
- [x] `test_n_nearest_3_finds_same_optimal_on_tsp5` — restricted B&B matches exact B&B on tsp5
- [x] `test_n_nearest_visits_all_cities_on_tsp8` — all 8 cities visited, gap < 10% vs exact on tsp8
- [x] `cargo test -p teeline branch_bound` — 9 tests pass
- [x] `cargo test` — full suite clean
- [x] Smoke: `teeline solve branch_bound -i tests/fixtures/gr17.tsp` and `--n_nearest 5` both produce valid tours

Closes #142