### PR TITLE
feat(web): LK interactive explainer (closes #232)

### DIFF
--- a/teeline-web/algorithms/lk/explainer/index.html
+++ b/teeline-web/algorithms/lk/explainer/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lin-Kernighan ILS — Interactive Explainer — Teeline</title>
+    <meta name="description" content="Watch simplified 2-opt local search and double-bridge perturbation run step-by-step in your browser." />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/algorithms/lk/">← Back to LK docs</a>
+      </p>
+      <div id="app"></div>
+    </main>
+    <script type="module" src="/src/explainers/lk-page.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/lk/index.html
+++ b/teeline-web/algorithms/lk/index.html
@@ -23,7 +23,8 @@
         </nav>
 
                 <p class="docs-type-badge">Heuristic — iterated local search</p>
-                        <h1>Lin-Kernighan ILS</h1>
+                        <a class="docs-explainer-cta" href="/algorithms/lk/explainer/">▶ Open interactive explainer →</a>
+                <h1>Lin-Kernighan ILS</h1>
 <table class="docs-meta-table">
   <thead><tr><th></th><th></th></tr></thead>
   <tbody>

--- a/teeline-web/src/explainers/lk-page.ts
+++ b/teeline-web/src/explainers/lk-page.ts
@@ -1,0 +1,11 @@
+import '@picocss/pico/css/pico.min.css'
+import '../docs.css'
+import { initTopbar } from '../topbar'
+import { render, h } from 'preact'
+import LKExplainer from './lk.tsx'
+
+initTopbar()
+const appEl = document.getElementById('app')
+if (appEl) {
+  render(h(LKExplainer, null), appEl)
+}

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -1,7 +1,7 @@
 // teeline-web/src/explainers/lk.test.ts
 import { describe, it, expect } from 'vitest'
 import {
-  CITIES, euclidDist, buildDistMatrix, tourDist, nnTour, DIST, INIT_TOUR,
+  CITIES, euclidDist, buildDistMatrix, tourDist, DIST, INIT_TOUR,
 } from './lk'
 
 describe('euclidDist', () => {

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -63,10 +63,10 @@ describe('DIST', () => {
 })
 
 describe('doubleBridge', () => {
-  const rand = lcgRand(42)
   const tour = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
   it('output has same length as input', () => {
+    const rand = lcgRand(42)
     const { result } = doubleBridge(tour, rand)
     expect(result.length).toBe(tour.length)
   })

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -1,0 +1,62 @@
+// teeline-web/src/explainers/lk.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  CITIES, euclidDist, buildDistMatrix, tourDist, nnTour, DIST, INIT_TOUR,
+} from './lk'
+
+describe('euclidDist', () => {
+  it('returns 5 for 3-4-5 triangle', () => {
+    expect(euclidDist([0, 0], [3, 4])).toBeCloseTo(5)
+  })
+  it('returns 0 for same point', () => {
+    expect(euclidDist([10, 20], [10, 20])).toBe(0)
+  })
+})
+
+describe('buildDistMatrix', () => {
+  const cities: [number, number][] = [[0, 0], [3, 4], [6, 8]]
+  const m = buildDistMatrix(cities)
+  it('is symmetric', () => {
+    expect(m[0][1]).toBeCloseTo(m[1][0])
+    expect(m[1][2]).toBeCloseTo(m[2][1])
+  })
+  it('has zero diagonal', () => {
+    expect(m[0][0]).toBe(0)
+    expect(m[1][1]).toBe(0)
+  })
+  it('first edge matches euclidDist', () => {
+    expect(m[0][1]).toBeCloseTo(euclidDist(cities[0], cities[1]))
+  })
+})
+
+describe('tourDist', () => {
+  it('sums edges correctly for 3-city tour', () => {
+    const cities: [number, number][] = [[0, 0], [3, 0], [3, 4]]
+    const dist = buildDistMatrix(cities)
+    // tour [0,1,2]: 0→1=3, 1→2=4, 2→0=5 → total 12
+    expect(tourDist([0, 1, 2], dist)).toBeCloseTo(12)
+  })
+})
+
+describe('nnTour', () => {
+  it('visits all cities', () => {
+    const sorted = [...INIT_TOUR].sort((a, b) => a - b)
+    expect(sorted).toEqual([...Array(CITIES.length).keys()])
+  })
+  it('has no duplicates', () => {
+    expect(new Set(INIT_TOUR).size).toBe(CITIES.length)
+  })
+  it('starts from city 0', () => {
+    expect(INIT_TOUR[0]).toBe(0)
+  })
+  it('has correct length', () => {
+    expect(INIT_TOUR.length).toBe(CITIES.length)
+  })
+})
+
+describe('DIST', () => {
+  it('is square matrix of size 15', () => {
+    expect(DIST.length).toBe(15)
+    expect(DIST[0].length).toBe(15)
+  })
+})

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   CITIES, euclidDist, buildDistMatrix, tourDist, DIST, INIT_TOUR,
+  doubleBridge, lcgRand,
 } from './lk'
 
 describe('euclidDist', () => {
@@ -58,5 +59,50 @@ describe('DIST', () => {
   it('is square matrix of size 15', () => {
     expect(DIST.length).toBe(15)
     expect(DIST[0].length).toBe(15)
+  })
+})
+
+describe('doubleBridge', () => {
+  const rand = lcgRand(42)
+  const tour = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+  it('output has same length as input', () => {
+    const { result } = doubleBridge(tour, rand)
+    expect(result.length).toBe(tour.length)
+  })
+
+  it('output contains same cities (just reordered)', () => {
+    const rand2 = lcgRand(99)
+    const { result } = doubleBridge(tour, rand2)
+    expect([...result].sort((a, b) => a - b)).toEqual(tour)
+  })
+
+  it('p1 < p2 < p3 and all within bounds', () => {
+    const rand3 = lcgRand(7)
+    const n = tour.length
+    const { p1, p2, p3 } = doubleBridge(tour, rand3)
+    expect(p1).toBeGreaterThanOrEqual(1)
+    expect(p2).toBeGreaterThan(p1)
+    expect(p3).toBeGreaterThan(p2)
+    expect(p3).toBeLessThan(n)
+  })
+})
+
+describe('lcgRand', () => {
+  it('returns values in [0,1)', () => {
+    const r = lcgRand(1)
+    for (let i = 0; i < 20; i++) {
+      const v = r()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+
+  it('same seed produces same sequence', () => {
+    const r1 = lcgRand(42)
+    const r2 = lcgRand(42)
+    for (let i = 0; i < 5; i++) {
+      expect(r1()).toBe(r2())
+    }
   })
 })

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   CITIES, euclidDist, buildDistMatrix, tourDist, DIST, INIT_TOUR,
-  doubleBridge, lcgRand, computeLocalSearchFrames,
+  doubleBridge, lcgRand, computeLocalSearchFrames, computeILSFrames,
 } from './lk'
 
 describe('euclidDist', () => {
@@ -142,5 +142,35 @@ describe('computeLocalSearchFrames', () => {
     for (let i = 1; i < swapFrames.length; i++) {
       expect(swapFrames[i].dist).toBeLessThan(swapFrames[i - 1].dist + 1e-9)
     }
+  })
+})
+
+describe('computeILSFrames', () => {
+  const rand = lcgRand(42)
+  const frames = computeILSFrames(INIT_TOUR, DIST, 30, 5, rand)
+
+  it('last frame has overlay starting with "Done"', () => {
+    expect(frames[frames.length - 1].overlay).toMatch(/^Done/)
+  })
+
+  it('has at least one bridge_cut frame (highlight === "bridge")', () => {
+    expect(frames.some(f => f.highlight === 'bridge')).toBe(true)
+  })
+
+  it('bestDist is non-increasing across frames', () => {
+    let prev = frames[0].bestDist
+    for (const f of frames) {
+      expect(f.bestDist).toBeLessThanOrEqual(prev + 1e-9)
+      prev = f.bestDist
+    }
+  })
+
+  it('final bestDist is no worse than initial tour distance', () => {
+    const initD = frames[0].currentDist
+    expect(frames[frames.length - 1].bestDist).toBeLessThanOrEqual(initD + 1e-9)
+  })
+
+  it('all tour arrays have length 15', () => {
+    expect(frames.every(f => f.tour.length === 15)).toBe(true)
   })
 })

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   CITIES, euclidDist, buildDistMatrix, tourDist, DIST, INIT_TOUR,
-  doubleBridge, lcgRand,
+  doubleBridge, lcgRand, computeLocalSearchFrames,
 } from './lk'
 
 describe('euclidDist', () => {
@@ -103,6 +103,44 @@ describe('lcgRand', () => {
     const r2 = lcgRand(42)
     for (let i = 0; i < 5; i++) {
       expect(r1()).toBe(r2())
+    }
+  })
+})
+
+describe('computeLocalSearchFrames', () => {
+  const frames = computeLocalSearchFrames(INIT_TOUR, DIST)
+
+  it('last frame has overlay "Local optimum"', () => {
+    expect(frames[frames.length - 1].overlay).toBe('Local optimum')
+  })
+
+  it('last frame has no scan or swap edges', () => {
+    const last = frames[frames.length - 1]
+    expect(last.scanEdges).toBeNull()
+    expect(last.swapEdges).toBeNull()
+  })
+
+  it('swap frames have isScan = false', () => {
+    const swapFrames = frames.filter(f => f.swapEdges !== null)
+    expect(swapFrames.every(f => !f.isScan)).toBe(true)
+  })
+
+  it('scan frames have isScan = true', () => {
+    const scanFrames = frames.filter(f => f.scanEdges !== null)
+    expect(scanFrames.every(f => f.isScan)).toBe(true)
+  })
+
+  it('final tour distance is no worse than initial', () => {
+    const initDist = tourDist(INIT_TOUR, DIST)
+    const finalDist = frames[frames.length - 1].dist
+    expect(finalDist).toBeLessThanOrEqual(initDist + 1e-9)
+  })
+
+  it('all swap frames have improving dist (each swap reduces distance)', () => {
+    const swapFrames = frames.filter(f => f.swapEdges !== null)
+    expect(swapFrames.length).toBeGreaterThan(0) // NN tour should have crossings
+    for (let i = 1; i < swapFrames.length; i++) {
+      expect(swapFrames[i].dist).toBeLessThan(swapFrames[i - 1].dist + 1e-9)
     }
   })
 })

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -61,3 +61,23 @@ export function lcgRand(seed: number): () => number {
 // Pre-computed constants used by both tabs.
 export const DIST = buildDistMatrix(CITIES);
 export const INIT_TOUR = nnTour(CITIES, DIST);
+
+// Port of lin_kernighan.rs::double_bridge.
+// Returns the kicked tour plus the three cut positions used,
+// so callers can highlight the cut cities in the animation.
+export function doubleBridge(
+  tour: number[],
+  rand: () => number
+): { result: number[]; p1: number; p2: number; p3: number } {
+  const n = tour.length;
+  const p1 = 1 + Math.floor(rand() * Math.floor(n / 4));
+  const p2 = p1 + 1 + Math.floor(rand() * Math.floor(n / 4));
+  const p3 = p2 + 1 + Math.floor(rand() * Math.floor(n / 4));
+  const result = [
+    ...tour.slice(0, p1),
+    ...tour.slice(p2, p3),
+    ...tour.slice(p1, p2),
+    ...tour.slice(p3),
+  ];
+  return { result, p1, p2, p3 };
+}

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -81,3 +81,86 @@ export function doubleBridge(
   ];
   return { result, p1, p2, p3 };
 }
+
+// Each [from, to] pair is a city index pair forming one edge.
+export type EdgePair = [[number, number], [number, number]];
+
+export interface LSFrame {
+  tour: number[];
+  scanEdges: EdgePair | null;   // edges being considered (gray dashed in Step mode)
+  swapEdges: EdgePair | null;   // new edges just accepted (green flash)
+  dist: number;
+  overlay: string | null;       // label overlaid on SVG ("Local optimum")
+  isScan: boolean;              // true → skip this frame in Run mode
+}
+
+// Pre-computes all 2-opt animation frames (first-improvement, single restart per swap).
+// scan events are interleaved so Step mode can show them; Run mode skips isScan frames.
+export function computeLocalSearchFrames(
+  initTour: number[],
+  dist: number[][]
+): LSFrame[] {
+  const frames: LSFrame[] = [];
+  const tour = [...initTour];
+  const n = tour.length;
+  let currentDist = tourDist(tour, dist);
+
+  let foundImprovement = true;
+  while (foundImprovement) {
+    foundImprovement = false;
+    outer:
+    for (let i = 0; i < n - 1; i++) {
+      for (let j = i + 2; j < n; j++) {
+        if (i === 0 && j === n - 1) continue; // would reverse entire tour
+
+        // Scan frame: show the two candidate edges (old edges that might be removed)
+        frames.push({
+          tour: [...tour],
+          scanEdges: [[tour[i], tour[i + 1]], [tour[j], tour[(j + 1) % n]]],
+          swapEdges: null,
+          dist: currentDist,
+          overlay: null,
+          isScan: true,
+        });
+
+        const removed = dist[tour[i]][tour[i + 1]] + dist[tour[j]][tour[(j + 1) % n]];
+        const added   = dist[tour[i]][tour[j]]     + dist[tour[i + 1]][tour[(j + 1) % n]];
+        const gain = removed - added;
+
+        if (gain > 1e-10) {
+          // Record new edges before applying reversal
+          const newEdge1: [number, number] = [tour[i],     tour[j]];
+          const newEdge2: [number, number] = [tour[i + 1], tour[(j + 1) % n]];
+
+          // Apply 2-opt reversal: reverse segment [i+1 .. j]
+          tour.splice(i + 1, j - i, ...tour.slice(i + 1, j + 1).reverse());
+          currentDist = tourDist(tour, dist);
+
+          frames.push({
+            tour: [...tour],
+            scanEdges: null,
+            swapEdges: [newEdge1, newEdge2],
+            dist: currentDist,
+            overlay: null,
+            isScan: false,
+          });
+
+          foundImprovement = true;
+          break outer; // restart scan from i=0 after each swap
+        }
+      }
+    }
+  }
+
+  // Terminal frame
+  frames.push({
+    tour: [...tour],
+    scanEdges: null,
+    swapEdges: null,
+    dist: currentDist,
+    overlay: "Local optimum",
+    isScan: false,
+  });
+
+  return frames;
+}

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -96,6 +96,9 @@ export interface LSFrame {
 
 // Pre-computes all 2-opt animation frames (first-improvement, single restart per swap).
 // scan events are interleaved so Step mode can show them; Run mode skips isScan frames.
+// How many non-improving "miss" scan frames to show before each accepted swap.
+const PREVIEW_SCANS = 2;
+
 export function computeLocalSearchFrames(
   initTour: number[],
   dist: number[][]
@@ -108,59 +111,50 @@ export function computeLocalSearchFrames(
   let foundImprovement = true;
   while (foundImprovement) {
     foundImprovement = false;
+
+    // First pass: collect up to PREVIEW_SCANS non-improving pairs, then find the winner.
+    const misses: EdgePair[] = [];
+    let winI = -1, winJ = -1;
+
     outer:
     for (let i = 0; i < n - 1; i++) {
       for (let j = i + 2; j < n; j++) {
-        if (i === 0 && j === n - 1) continue; // would reverse entire tour
-
-        // Scan frame: show the two candidate edges (old edges that might be removed)
-        frames.push({
-          tour: [...tour],
-          scanEdges: [[tour[i], tour[i + 1]], [tour[j], tour[(j + 1) % n]]],
-          swapEdges: null,
-          dist: currentDist,
-          overlay: null,
-          isScan: true,
-        });
-
+        if (i === 0 && j === n - 1) continue;
         const removed = dist[tour[i]][tour[i + 1]] + dist[tour[j]][tour[(j + 1) % n]];
         const added   = dist[tour[i]][tour[j]]     + dist[tour[i + 1]][tour[(j + 1) % n]];
-        const gain = removed - added;
-
-        if (gain > 1e-10) {
-          // Record new edges before applying reversal
-          const newEdge1: [number, number] = [tour[i],     tour[j]];
-          const newEdge2: [number, number] = [tour[i + 1], tour[(j + 1) % n]];
-
-          // Apply 2-opt reversal: reverse segment [i+1 .. j]
-          tour.splice(i + 1, j - i, ...tour.slice(i + 1, j + 1).reverse());
-          currentDist = tourDist(tour, dist);
-
-          frames.push({
-            tour: [...tour],
-            scanEdges: null,
-            swapEdges: [newEdge1, newEdge2],
-            dist: currentDist,
-            overlay: null,
-            isScan: false,
-          });
-
-          foundImprovement = true;
-          break outer; // restart scan from i=0 after each swap
+        if (removed - added > 1e-10) { winI = i; winJ = j; break outer; }
+        if (misses.length < PREVIEW_SCANS) {
+          misses.push([[tour[i], tour[i + 1]], [tour[j], tour[(j + 1) % n]]]);
         }
       }
     }
+
+    if (winI === -1) break; // no improvement found in this pass
+
+    // Emit miss scan frames (showing "still looking...")
+    for (const edges of misses) {
+      frames.push({ tour: [...tour], scanEdges: edges, swapEdges: null, dist: currentDist, overlay: null, isScan: true });
+    }
+
+    // Emit winning pair as scan frame (showing "found it!")
+    frames.push({
+      tour: [...tour],
+      scanEdges: [[tour[winI], tour[winI + 1]], [tour[winJ], tour[(winJ + 1) % n]]],
+      swapEdges: null, dist: currentDist, overlay: null, isScan: true,
+    });
+
+    // Apply 2-opt reversal and emit swap frame
+    const newEdge1: [number, number] = [tour[winI],     tour[winJ]];
+    const newEdge2: [number, number] = [tour[winI + 1], tour[(winJ + 1) % n]];
+    tour.splice(winI + 1, winJ - winI, ...tour.slice(winI + 1, winJ + 1).reverse());
+    currentDist = tourDist(tour, dist);
+    frames.push({ tour: [...tour], scanEdges: null, swapEdges: [newEdge1, newEdge2], dist: currentDist, overlay: null, isScan: false });
+
+    foundImprovement = true;
   }
 
   // Terminal frame
-  frames.push({
-    tour: [...tour],
-    scanEdges: null,
-    swapEdges: null,
-    dist: currentDist,
-    overlay: "Local optimum",
-    isScan: false,
-  });
+  frames.push({ tour: [...tour], scanEdges: null, swapEdges: null, dist: currentDist, overlay: "Local optimum", isScan: false });
 
   return frames;
 }

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -164,3 +164,171 @@ export function computeLocalSearchFrames(
 
   return frames;
 }
+
+export interface ILSFrame {
+  tour: number[];
+  bestTour: number[];
+  swapEdges: EdgePair | null;
+  bridgePoints: [number, number, number] | null; // city indices at cut positions
+  phase: string;
+  currentDist: number;
+  bestDist: number;
+  restarts: number;
+  plateauCount: number;
+  overlay: string | null;
+  highlight: 'swap' | 'bridge' | 'best' | null;
+}
+
+// Number of duplicate frames for visual hold on bridge_cut and new_best events.
+const ILS_HOLD = 3;
+
+// Pre-computes all ILS animation frames: NN → 2-opt → [kick → 2-opt → accept/reject]*.
+// No scan events — Tab 2 shows only accepted swaps and ILS events.
+export function computeILSFrames(
+  initTour: number[],
+  dist: number[][],
+  maxEpochs: number,
+  plateauLimit: number,
+  rand: () => number
+): ILSFrame[] {
+  const frames: ILSFrame[] = [];
+
+  let currentTour = [...initTour];
+  let bestTour = [...initTour];
+  let currentDist = tourDist(currentTour, dist);
+  let bestDist = currentDist;
+  let restarts = 0;
+  let plateauCount = 0;
+  const n = currentTour.length;
+
+  // Helper: run first-improvement 2-opt on `t` in place, emitting swap frames.
+  function runPass(t: number[], phase: string): void {
+    let improved = true;
+    while (improved) {
+      improved = false;
+      outer:
+      for (let i = 0; i < n - 1; i++) {
+        for (let j = i + 2; j < n; j++) {
+          if (i === 0 && j === n - 1) continue;
+          const removed = dist[t[i]][t[i + 1]] + dist[t[j]][t[(j + 1) % n]];
+          const added   = dist[t[i]][t[j]]     + dist[t[i + 1]][t[(j + 1) % n]];
+          if (removed - added > 1e-10) {
+            const e1: [number, number] = [t[i],     t[j]];
+            const e2: [number, number] = [t[i + 1], t[(j + 1) % n]];
+            t.splice(i + 1, j - i, ...t.slice(i + 1, j + 1).reverse());
+            currentDist = tourDist(t, dist);
+            frames.push({
+              tour: [...t], bestTour: [...bestTour],
+              swapEdges: [e1, e2], bridgePoints: null,
+              phase, currentDist, bestDist, restarts, plateauCount,
+              overlay: null, highlight: 'swap',
+            });
+            improved = true;
+            break outer;
+          }
+        }
+      }
+    }
+  }
+
+  // Initial pass
+  frames.push({
+    tour: [...currentTour], bestTour: [...bestTour],
+    swapEdges: null, bridgePoints: null,
+    phase: 'LK pass', currentDist, bestDist, restarts, plateauCount,
+    overlay: null, highlight: null,
+  });
+  runPass(currentTour, 'LK pass');
+  currentDist = tourDist(currentTour, dist);
+
+  if (currentDist < bestDist) {
+    bestDist = currentDist;
+    bestTour = [...currentTour];
+    plateauCount = 0;
+  }
+  for (let h = 0; h < ILS_HOLD; h++) {
+    frames.push({
+      tour: [...currentTour], bestTour: [...bestTour],
+      swapEdges: null, bridgePoints: null,
+      phase: 'New best!', currentDist, bestDist, restarts, plateauCount,
+      overlay: null, highlight: 'best',
+    });
+  }
+
+  // ILS loop
+  for (let epoch = 0; epoch < maxEpochs; epoch++) {
+    // Kick
+    const { result: kicked, p1, p2, p3 } = doubleBridge(bestTour, rand);
+    currentTour = kicked;
+    currentDist = tourDist(currentTour, dist);
+    restarts++;
+    const bridgePoints: [number, number, number] = [bestTour[p1], bestTour[p2], bestTour[p3]];
+
+    for (let h = 0; h < ILS_HOLD; h++) {
+      frames.push({
+        tour: [...currentTour], bestTour: [...bestTour],
+        swapEdges: null, bridgePoints,
+        phase: 'Double-bridge kick', currentDist, bestDist, restarts, plateauCount,
+        overlay: null, highlight: 'bridge',
+      });
+    }
+
+    // Optimise kicked tour
+    frames.push({
+      tour: [...currentTour], bestTour: [...bestTour],
+      swapEdges: null, bridgePoints: null,
+      phase: 'LK pass', currentDist, bestDist, restarts, plateauCount,
+      overlay: null, highlight: null,
+    });
+    runPass(currentTour, 'LK pass');
+    currentDist = tourDist(currentTour, dist);
+
+    // Local optimum label
+    frames.push({
+      tour: [...currentTour], bestTour: [...bestTour],
+      swapEdges: null, bridgePoints: null,
+      phase: 'Local optimum', currentDist, bestDist, restarts, plateauCount,
+      overlay: 'Local optimum', highlight: null,
+    });
+
+    // Accept / reject
+    if (currentDist < bestDist - 1e-10) {
+      bestDist = currentDist;
+      bestTour = [...currentTour];
+      plateauCount = 0;
+      for (let h = 0; h < ILS_HOLD; h++) {
+        frames.push({
+          tour: [...currentTour], bestTour: [...bestTour],
+          swapEdges: null, bridgePoints: null,
+          phase: 'New best!', currentDist, bestDist, restarts, plateauCount,
+          overlay: null, highlight: 'best',
+        });
+      }
+    } else {
+      plateauCount++;
+      frames.push({
+        tour: [...currentTour], bestTour: [...bestTour],
+        swapEdges: null, bridgePoints: null,
+        phase: 'Plateau', currentDist, bestDist, restarts, plateauCount,
+        overlay: null, highlight: null,
+      });
+      if (plateauCount >= plateauLimit) {
+        frames.push({
+          tour: [...bestTour], bestTour: [...bestTour],
+          swapEdges: null, bridgePoints: null,
+          phase: 'Done', currentDist: bestDist, bestDist, restarts, plateauCount,
+          overlay: 'Done — plateau limit reached', highlight: null,
+        });
+        return frames;
+      }
+    }
+  }
+
+  frames.push({
+    tour: [...bestTour], bestTour: [...bestTour],
+    swapEdges: null, bridgePoints: null,
+    phase: 'Done', currentDist: bestDist, bestDist, restarts, plateauCount,
+    overlay: 'Done — max epochs', highlight: null,
+  });
+  return frames;
+}

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -1,0 +1,63 @@
+// teeline-web/src/explainers/lk.ts
+
+// Fixed 15-city layout, 300×300 canvas.
+// Ring of 12 + 3 interior: NN tour creates crossing edges (2-opt fodder);
+// ring structure gives clean 4-segment double-bridge cuts.
+export const CITIES: [number, number][] = [
+  [ 40,  60], [ 80,  30], [140,  20], [200,  40], [250,  70],
+  [270, 130], [250, 200], [200, 250], [140, 270], [ 80, 250],
+  [ 40, 200], [ 20, 130], [150, 150], [100, 100], [200, 100],
+];
+
+export function euclidDist(a: [number, number], b: [number, number]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1]);
+}
+
+export function buildDistMatrix(cities: [number, number][]): number[][] {
+  const n = cities.length;
+  return Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => euclidDist(cities[i], cities[j]))
+  );
+}
+
+export function tourDist(tour: number[], dist: number[][]): number {
+  const n = tour.length;
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    total += dist[tour[i]][tour[(i + 1) % n]];
+  }
+  return total;
+}
+
+export function nnTour(cities: [number, number][], dist: number[][]): number[] {
+  const n = cities.length;
+  const visited = new Array<boolean>(n).fill(false);
+  const tour = [0];
+  visited[0] = true;
+  for (let step = 1; step < n; step++) {
+    const last = tour[step - 1];
+    let bestJ = -1, bestD = Infinity;
+    for (let j = 0; j < n; j++) {
+      if (!visited[j] && dist[last][j] < bestD) {
+        bestD = dist[last][j];
+        bestJ = j;
+      }
+    }
+    tour.push(bestJ);
+    visited[bestJ] = true;
+  }
+  return tour;
+}
+
+// Linear congruential generator — seeded for reproducible animations.
+export function lcgRand(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(1664525, s) + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+// Pre-computed constants used by both tabs.
+export const DIST = buildDistMatrix(CITIES);
+export const INIT_TOUR = nnTour(CITIES, DIST);

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -253,3 +253,72 @@ function PhaseIndicator({ phase }: { phase: string }) {
     : ''
   return <div className={`lk-phase ${cls}`}>{phase}</div>
 }
+
+// ── LocalSearchTab ────────────────────────────────────────────────────────────
+
+function LocalSearchTab() {
+  const frames = useMemo(() => computeLocalSearchFrames(INIT_TOUR, DIST), [])
+  const [idx, setIdx] = useState(0)
+  const [playing, setPlaying] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2) // default 150ms
+
+  const speed = SPEED_STEPS[speedIdx]
+  const frame: LSFrame = frames[Math.min(idx, frames.length - 1)]
+  const done = idx >= frames.length - 1
+
+  // Advance one event; skip scan frames only while playing
+  const advance = useCallback((skipScan: boolean) => {
+    setIdx(i => {
+      let next = i + 1
+      if (skipScan) {
+        while (next < frames.length - 1 && frames[next].isScan) next++
+      }
+      if (next >= frames.length) { setPlaying(false); return frames.length - 1 }
+      return next
+    })
+  }, [frames])
+
+  useEffect(() => {
+    if (!playing) return
+    const id = setInterval(() => advance(true), speed)
+    return () => clearInterval(id)
+  }, [playing, speed, advance])
+
+  const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
+  const handleStep = useCallback(() => { setPlaying(false); advance(false) }, [advance])
+  const handleReset = useCallback(() => {
+    setPlaying(false)
+    setIdx(0)
+  }, [])
+
+  const swapCount = frames.slice(0, idx + 1).filter(f => f.swapEdges !== null).length
+
+  return (
+    <div className="lk-tab">
+      <TourSVG
+        tour={frame.tour}
+        scanEdges={frame.scanEdges}
+        swapEdges={frame.swapEdges}
+        overlay={frame.overlay}
+      />
+      <div className="lk-prose">
+        <Controls
+          playing={playing} done={done} speedIdx={speedIdx}
+          onPlayPause={handlePlayPause} onStep={handleStep}
+          onReset={handleReset} onSpeedChange={setSpeedIdx}
+        />
+        <StatsPanel stats={[
+          { label: 'Distance', value: frame.dist },
+          { label: 'Swaps accepted', value: swapCount },
+        ]} />
+        <p className="lk-note">
+          This shows simplified <strong>2-opt</strong> local search. Press{' '}
+          <strong>Step</strong> to see each candidate pair scanned;{' '}
+          <strong>Run</strong> skips to accepted swaps only.{' '}
+          The actual LK solver uses depth-k chain moves —{' '}
+          <a href="/algorithms/lk/">see the docs</a>.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -1,0 +1,191 @@
+// teeline-web/src/explainers/lk.tsx
+import { useState, useEffect, useCallback, useMemo } from 'preact/hooks'
+import type { LSFrame, ILSFrame } from './lk'
+import {
+  CITIES, DIST, INIT_TOUR,
+  computeLocalSearchFrames, computeILSFrames,
+  lcgRand,
+} from './lk'
+
+// ── TourSVG ──────────────────────────────────────────────────────────────────
+
+interface TourSVGProps {
+  tour: number[]
+  scanEdges?: [[number, number], [number, number]] | null
+  swapEdges?: [[number, number], [number, number]] | null
+  bestTour?: number[] | null
+  bridgePoints?: [number, number, number] | null
+  highlight?: 'swap' | 'bridge' | 'best' | null
+  overlay?: string | null
+}
+
+function TourSVG({
+  tour, scanEdges = null, swapEdges = null,
+  bestTour = null, bridgePoints = null, highlight = null, overlay = null,
+}: TourSVGProps) {
+  const cities = CITIES
+
+  function edgePath(cityA: number, cityB: number) {
+    const [x1, y1] = cities[cityA]
+    const [x2, y2] = cities[cityB]
+    return { x1, y1, x2, y2 }
+  }
+
+  const n = tour.length
+  const tourEdges = Array.from({ length: n }, (_, i) => ({
+    ...edgePath(tour[i], tour[(i + 1) % n]),
+    key: `${tour[i]}-${tour[(i + 1) % n]}`,
+  }))
+
+  const bestEdges = bestTour
+    ? Array.from({ length: bestTour.length }, (_, i) => ({
+        ...edgePath(bestTour[i], bestTour[(i + 1) % bestTour.length]),
+        key: `b${bestTour[i]}-${bestTour[(i + 1) % bestTour.length]}`,
+      }))
+    : []
+
+  const tourColor = highlight === 'best' ? '#e8a000' : '#e0626b'
+
+  return (
+    <svg viewBox="0 0 300 300" className="lk-canvas" role="img" aria-label="TSP tour visualisation">
+      <rect x="0" y="0" width="300" height="300" className="lk-bg" />
+
+      {/* Best-tour underlay (thin dashed) */}
+      {bestEdges.map(e => (
+        <line key={e.key} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2} className="lk-best-edge" />
+      ))}
+
+      {/* Current tour */}
+      {tourEdges.map(e => (
+        <line key={e.key} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2}
+          className="lk-tour-edge"
+          style={{ stroke: tourColor, transition: 'stroke 0.25s ease' }} />
+      ))}
+
+      {/* Scan edges (gray dashed — shown in Step mode) */}
+      {scanEdges?.map(([a, b], idx) => {
+        const [x1, y1] = cities[a]
+        const [x2, y2] = cities[b]
+        return <line key={idx} x1={x1} y1={y1} x2={x2} y2={y2} className="lk-scan-edge" />
+      })}
+
+      {/* Swap edges (green — new edges accepted) */}
+      {swapEdges?.map(([a, b], idx) => {
+        const [x1, y1] = cities[a]
+        const [x2, y2] = cities[b]
+        return <line key={idx} x1={x1} y1={y1} x2={x2} y2={y2} className="lk-swap-edge" />
+      })}
+
+      {/* Bridge cut circles */}
+      {bridgePoints?.map((cityId, idx) => {
+        const [cx, cy] = cities[cityId]
+        return <circle key={idx} cx={cx} cy={cy} r="10" className="lk-bridge-circle" />
+      })}
+
+      {/* City dots */}
+      {cities.map(([cx, cy], i) => (
+        <circle key={i} cx={cx} cy={cy} r="5" className="lk-city" />
+      ))}
+
+      {/* Overlay label */}
+      {overlay && (
+        <text x="150" y="155" className="lk-overlay">{overlay}</text>
+      )}
+    </svg>
+  )
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const CSS = `
+.lk-root {
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --accent: #0969da;
+  --green: #1a7f37;
+  --red: #cf222e;
+  --gold: #e8a000;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+}
+.lk-root * { box-sizing: border-box; }
+.lk-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85em; }
+
+.lk-header { margin-bottom: 14px; }
+.lk-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.lk-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; }
+.lk-sub { margin: 0; color: var(--muted); font-size: 0.92rem; line-height: 1.5; }
+
+.lk-tabs { display: flex; gap: 6px; margin-bottom: 14px; border-bottom: 1px solid var(--line); }
+.lk-tabbtn {
+  background: transparent; border: none; color: var(--muted);
+  font-size: 0.9rem; padding: 8px 12px; cursor: pointer;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+  font-family: inherit;
+}
+.lk-tabbtn:hover { color: var(--text); }
+.lk-tabbtn-active { color: var(--text); border-bottom-color: var(--accent); }
+
+.lk-tab { display: flex; flex-direction: column; gap: 14px; }
+@media (min-width: 620px) {
+  .lk-tab { flex-direction: row; align-items: flex-start; }
+  .lk-canvas { flex: 0 0 300px; }
+  .lk-prose { flex: 1 1 auto; min-width: 0; }
+}
+
+.lk-canvas { width: 100%; max-width: 300px; border-radius: 8px; border: 1px solid var(--line); display: block; }
+.lk-bg { fill: var(--panel); }
+.lk-tour-edge { stroke-width: 1.8; }
+.lk-best-edge { stroke: #aaa; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.5; }
+.lk-scan-edge { stroke: #999; stroke-width: 1.5; stroke-dasharray: 5 3; opacity: 0.7; }
+.lk-swap-edge { stroke: #1a7f37; stroke-width: 2.5; opacity: 0.9; }
+.lk-bridge-circle { fill: none; stroke: #cf222e; stroke-width: 2; stroke-dasharray: 4 3; opacity: 0.85; }
+.lk-city { fill: #f2a154; stroke: #fff; stroke-width: 1.5; }
+.lk-overlay {
+  text-anchor: middle; dominant-baseline: middle;
+  font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; font-weight: 600;
+  fill: var(--text); paint-order: stroke; stroke: var(--panel); stroke-width: 4;
+}
+
+.lk-prose p { margin: 0 0 10px; font-size: 0.92rem; line-height: 1.55; }
+.lk-note { font-size: 0.85rem; color: var(--muted); border-left: 2px solid var(--line); padding-left: 10px; }
+
+.lk-controls { display: flex; gap: 8px; align-items: center; margin-bottom: 10px; flex-wrap: wrap; }
+.lk-btn {
+  background: var(--panel); color: var(--text); border: 1px solid var(--line);
+  border-radius: 6px; padding: 6px 14px; font-size: 0.85rem; cursor: pointer;
+  font-family: inherit;
+}
+.lk-btn:hover:not(:disabled) { border-color: var(--accent); }
+.lk-btn:disabled { opacity: 0.45; cursor: default; }
+.lk-btn-primary { color: var(--accent); border-color: var(--accent); }
+.lk-speed-label { font-size: 0.8rem; color: var(--muted); white-space: nowrap; }
+.lk-slider { accent-color: var(--accent); width: 80px; }
+
+.lk-statgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-bottom: 10px; }
+.lk-statlabel { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px; }
+
+.lk-phase {
+  display: inline-block; padding: 3px 10px; border-radius: 12px;
+  font-size: 0.8rem; font-weight: 600; margin-bottom: 10px;
+  background: var(--panel); border: 1px solid var(--line); color: var(--text);
+}
+.lk-phase-bridge { background: #fff0f0; border-color: var(--red); color: var(--red); }
+.lk-phase-best   { background: #fff8e0; border-color: var(--gold); color: #7a5000; }
+.lk-phase-pass   { background: #f0f8ff; border-color: var(--accent); color: var(--accent); }
+
+.lk-footer { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted); }
+`

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -1,5 +1,5 @@
 // teeline-web/src/explainers/lk.tsx
-import { useState, useEffect, useCallback, useMemo } from 'preact/hooks'
+import { useState, useCallback, useMemo } from 'preact/hooks'
 import type { LSFrame, ILSFrame } from './lk'
 import {
   CITIES, DIST, INIT_TOUR,
@@ -173,8 +173,6 @@ const CSS = `
 .lk-btn:hover:not(:disabled) { border-color: var(--accent); }
 .lk-btn:disabled { opacity: 0.45; cursor: default; }
 .lk-btn-primary { color: var(--accent); border-color: var(--accent); }
-.lk-speed-label { font-size: 0.8rem; color: var(--muted); white-space: nowrap; }
-.lk-slider { accent-color: var(--accent); width: 80px; }
 
 .lk-statgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-bottom: 10px; }
 .lk-statlabel { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px; }
@@ -203,36 +201,20 @@ const CSS = `
 
 // ── Controls ──────────────────────────────────────────────────────────────────
 
-const SPEED_STEPS = [600, 300, 150, 80, 30] // ms per tick
-
 interface ControlsProps {
-  playing: boolean
   done: boolean
-  speedIdx: number
   canStepBack: boolean
-  onPlayPause: () => void
   onStepBack: () => void
   onStep: () => void
   onReset: () => void
-  onSpeedChange: (idx: number) => void
 }
 
-function Controls({ playing, done, speedIdx, canStepBack, onPlayPause, onStepBack, onStep, onReset, onSpeedChange }: ControlsProps) {
+function Controls({ done, canStepBack, onStepBack, onStep, onReset }: ControlsProps) {
   return (
     <div className="lk-controls">
-      <button className="lk-btn lk-btn-primary" onClick={onPlayPause} disabled={done}>
-        {playing ? '⏸ Pause' : done ? '⏹ Done' : '▶ Run'}
-      </button>
       <button className="lk-btn" onClick={onStepBack} disabled={!canStepBack}>◀ Back</button>
-      <button className="lk-btn" onClick={onStep} disabled={done}>Step ▶</button>
+      <button className="lk-btn lk-btn-primary" onClick={onStep} disabled={done}>Step ▶</button>
       <button className="lk-btn" onClick={onReset}>↺ Reset</button>
-      <span className="lk-speed-label">Speed:</span>
-      <input
-        type="range" min={0} max={4} step={1} value={speedIdx}
-        className="lk-slider"
-        aria-label="animation speed"
-        onChange={e => onSpeedChange(Number((e.target as HTMLInputElement).value))}
-      />
     </div>
   )
 }
@@ -336,45 +318,15 @@ function ILSStatusLine({ frame }: { frame: ILSFrame }) {
 function LocalSearchTab() {
   const frames = useMemo(() => computeLocalSearchFrames(INIT_TOUR, DIST), [])
   const [idx, setIdx] = useState(0)
-  const [playing, setPlaying] = useState(false)
-  const [speedIdx, setSpeedIdx] = useState(2) // default 150ms
 
-  const speed = SPEED_STEPS[speedIdx]
   const frame: LSFrame = frames[Math.min(idx, frames.length - 1)]
   const done = idx >= frames.length - 1
 
-  // Advance one event; skip scan frames only while playing
-  const advance = useCallback((skipScan: boolean) => {
-    setIdx(i => {
-      let next = i + 1
-      if (skipScan) {
-        while (next < frames.length - 1 && frames[next].isScan) next++
-      }
-      if (next >= frames.length) { setPlaying(false); return frames.length - 1 }
-      return next
-    })
+  const handleStep = useCallback(() => {
+    setIdx(i => Math.min(i + 1, frames.length - 1))
   }, [frames])
-
-  useEffect(() => {
-    if (!playing) return
-    const id = setInterval(() => advance(true), speed)
-    return () => clearInterval(id)
-  }, [playing, speed, advance])
-
-  const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
-  const handleStep = useCallback(() => { setPlaying(false); advance(true) }, [advance])
-  const handleStepBack = useCallback(() => {
-    setPlaying(false)
-    setIdx(i => {
-      let prev = i - 1
-      while (prev > 0 && frames[prev].isScan) prev--
-      return Math.max(0, prev)
-    })
-  }, [frames])
-  const handleReset = useCallback(() => {
-    setPlaying(false)
-    setIdx(0)
-  }, [])
+  const handleStepBack = useCallback(() => setIdx(i => Math.max(0, i - 1)), [frames])
+  const handleReset = useCallback(() => setIdx(0), [])
 
   const swapCount = frames.slice(0, idx + 1).filter(f => f.swapEdges !== null).length
 
@@ -391,10 +343,8 @@ function LocalSearchTab() {
       </div>
       <div className="lk-prose">
         <Controls
-          playing={playing} done={done} speedIdx={speedIdx}
-          canStepBack={idx > 0}
-          onPlayPause={handlePlayPause} onStepBack={handleStepBack} onStep={handleStep}
-          onReset={handleReset} onSpeedChange={setSpeedIdx}
+          done={done} canStepBack={idx > 0}
+          onStepBack={handleStepBack} onStep={handleStep} onReset={handleReset}
         />
         <LSStatusLine frame={frame} />
         <StatsPanel stats={[
@@ -403,10 +353,9 @@ function LocalSearchTab() {
           { label: 'Step', value: `${idx + 1} / ${frames.length}` },
         ]} />
         <p className="lk-note">
-          This shows simplified <strong>2-opt</strong> local search. Press{' '}
-          <strong>Step</strong> to see each candidate pair scanned;{' '}
-          <strong>Run</strong> skips to accepted swaps only.{' '}
-          The actual LK solver uses depth-k chain moves —{' '}
+          This shows simplified <strong>2-opt</strong> local search: scan candidate
+          pairs, swap when one improves the tour, repeat until no gain is found.{' '}
+          The actual LK solver chains deeper moves —{' '}
           <a href="/algorithms/lk/">see the docs</a>.
         </p>
       </div>
@@ -424,31 +373,15 @@ function ILSTab() {
     []
   )
   const [idx, setIdx] = useState(0)
-  const [playing, setPlaying] = useState(false)
-  const [speedIdx, setSpeedIdx] = useState(2)
 
-  const speed = SPEED_STEPS[speedIdx]
   const frame: ILSFrame = frames[Math.min(idx, frames.length - 1)]
   const done = idx >= frames.length - 1
 
-  const advance = useCallback(() => {
-    setIdx(i => {
-      const next = i + 1
-      if (next >= frames.length) { setPlaying(false); return frames.length - 1 }
-      return next
-    })
+  const handleStep = useCallback(() => {
+    setIdx(i => Math.min(i + 1, frames.length - 1))
   }, [frames])
-
-  useEffect(() => {
-    if (!playing) return
-    const id = setInterval(advance, speed)
-    return () => clearInterval(id)
-  }, [playing, speed, advance])
-
-  const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
-  const handleStep = useCallback(() => { setPlaying(false); advance() }, [advance])
-  const handleStepBack = useCallback(() => { setPlaying(false); setIdx(i => Math.max(0, i - 1)) }, [])
-  const handleReset = useCallback(() => { setPlaying(false); setIdx(0) }, [])
+  const handleStepBack = useCallback(() => setIdx(i => Math.max(0, i - 1)), [])
+  const handleReset = useCallback(() => setIdx(0), [])
 
   return (
     <div className="lk-tab">
@@ -466,10 +399,8 @@ function ILSTab() {
       <div className="lk-prose">
         <PhaseIndicator phase={frame.phase} />
         <Controls
-          playing={playing} done={done} speedIdx={speedIdx}
-          canStepBack={idx > 0}
-          onPlayPause={handlePlayPause} onStepBack={handleStepBack} onStep={handleStep}
-          onReset={handleReset} onSpeedChange={setSpeedIdx}
+          done={done} canStepBack={idx > 0}
+          onStepBack={handleStepBack} onStep={handleStep} onReset={handleReset}
         />
         <ILSStatusLine frame={frame} />
         <StatsPanel stats={[

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -322,3 +322,113 @@ function LocalSearchTab() {
     </div>
   )
 }
+
+// ── ILSTab ────────────────────────────────────────────────────────────────────
+
+const ILS_RAND_SEED = 2026
+
+function ILSTab() {
+  const frames = useMemo(
+    () => computeILSFrames(INIT_TOUR, DIST, 30, 5, lcgRand(ILS_RAND_SEED)),
+    []
+  )
+  const [idx, setIdx] = useState(0)
+  const [playing, setPlaying] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2)
+
+  const speed = SPEED_STEPS[speedIdx]
+  const frame: ILSFrame = frames[Math.min(idx, frames.length - 1)]
+  const done = idx >= frames.length - 1
+
+  const advance = useCallback(() => {
+    setIdx(i => {
+      const next = i + 1
+      if (next >= frames.length) { setPlaying(false); return frames.length - 1 }
+      return next
+    })
+  }, [frames])
+
+  useEffect(() => {
+    if (!playing) return
+    const id = setInterval(advance, speed)
+    return () => clearInterval(id)
+  }, [playing, speed, advance])
+
+  const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
+  const handleStep = useCallback(() => { setPlaying(false); advance() }, [advance])
+  const handleReset = useCallback(() => { setPlaying(false); setIdx(0) }, [])
+
+  return (
+    <div className="lk-tab">
+      <TourSVG
+        tour={frame.tour}
+        bestTour={frame.bestTour}
+        swapEdges={frame.swapEdges}
+        bridgePoints={frame.bridgePoints}
+        highlight={frame.highlight}
+        overlay={frame.overlay}
+      />
+      <div className="lk-prose">
+        <PhaseIndicator phase={frame.phase} />
+        <Controls
+          playing={playing} done={done} speedIdx={speedIdx}
+          onPlayPause={handlePlayPause} onStep={handleStep}
+          onReset={handleReset} onSpeedChange={setSpeedIdx}
+        />
+        <StatsPanel stats={[
+          { label: 'Current dist', value: frame.currentDist },
+          { label: 'Best dist', value: frame.bestDist },
+          { label: 'Restarts', value: frame.restarts },
+          { label: `Plateau (limit ${5})`, value: frame.plateauCount },
+        ]} />
+        <p className="lk-note">
+          Dashed gray line = best tour found so far.
+          Gold = new best; red circles = double-bridge cut points.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ── LKExplainer root ──────────────────────────────────────────────────────────
+
+type TabId = 'ls' | 'ils'
+
+export default function LKExplainer() {
+  const [tab, setTab] = useState<TabId>('ls')
+
+  return (
+    <div className="lk-root">
+      <style>{CSS}</style>
+      <header className="lk-header">
+        <div className="lk-eyebrow">teeline · algorithms/lk</div>
+        <h2 className="lk-title">Lin-Kernighan ILS — interactive explainer</h2>
+        <p className="lk-sub">
+          Local Search shows simplified 2-opt edge swaps. ILS adds double-bridge
+          kicks to escape local optima.
+        </p>
+      </header>
+
+      <nav className="lk-tabs" role="tablist">
+        {([['ls', 'Local Search'], ['ils', 'ILS']] as [TabId, string][]).map(([id, label]) => (
+          <button
+            key={id} role="tab" aria-selected={tab === id}
+            className={'lk-tabbtn' + (tab === id ? ' lk-tabbtn-active' : '')}
+            onClick={() => setTab(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {/* Keep both tabs mounted so per-tab playback state is preserved on switch */}
+      <div style={{ display: tab === 'ls' ? 'block' : 'none' }}><LocalSearchTab /></div>
+      <div style={{ display: tab === 'ils' ? 'block' : 'none' }}><ILSTab /></div>
+
+      <footer className="lk-footer">
+        <span className="lk-mono">cities: {CITIES.length}</span>
+        <span className="lk-mono">algorithm: 2-opt + double-bridge ILS</span>
+      </footer>
+    </div>
+  )
+}

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -189,3 +189,67 @@ const CSS = `
 
 .lk-footer { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted); }
 `
+
+// ── Controls ──────────────────────────────────────────────────────────────────
+
+const SPEED_STEPS = [600, 300, 150, 80, 30] // ms per tick
+
+interface ControlsProps {
+  playing: boolean
+  done: boolean
+  speedIdx: number
+  onPlayPause: () => void
+  onStep: () => void
+  onReset: () => void
+  onSpeedChange: (idx: number) => void
+}
+
+function Controls({ playing, done, speedIdx, onPlayPause, onStep, onReset, onSpeedChange }: ControlsProps) {
+  return (
+    <div className="lk-controls">
+      <button className="lk-btn lk-btn-primary" onClick={onPlayPause} disabled={done}>
+        {playing ? '⏸ Pause' : done ? '⏹ Done' : '▶ Run'}
+      </button>
+      <button className="lk-btn" onClick={onStep} disabled={done}>⏭ Step</button>
+      <button className="lk-btn" onClick={onReset}>↺ Reset</button>
+      <span className="lk-speed-label">Speed:</span>
+      <input
+        type="range" min={0} max={4} step={1} value={speedIdx}
+        className="lk-slider"
+        aria-label="animation speed"
+        onChange={e => onSpeedChange(Number((e.target as HTMLInputElement).value))}
+      />
+    </div>
+  )
+}
+
+// ── StatsPanel ────────────────────────────────────────────────────────────────
+
+interface StatEntry { label: string; value: string | number }
+
+function StatsPanel({ stats }: { stats: StatEntry[] }) {
+  return (
+    <div className="lk-statgrid">
+      {stats.map(({ label, value }) => (
+        <div key={label}>
+          <div className="lk-statlabel">{label}</div>
+          <div className="lk-mono">
+            {typeof value === 'number'
+              ? Number.isInteger(value) ? value : value.toFixed(1)
+              : value}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── PhaseIndicator ────────────────────────────────────────────────────────────
+
+function PhaseIndicator({ phase }: { phase: string }) {
+  const cls = phase.includes('bridge') ? 'lk-phase-bridge'
+    : phase.includes('best') || phase.includes('New') ? 'lk-phase-best'
+    : phase.includes('LK') ? 'lk-phase-pass'
+    : ''
+  return <div className={`lk-phase ${cls}`}>{phase}</div>
+}

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -142,7 +142,8 @@ const CSS = `
 .lk-tab { display: flex; flex-direction: column; gap: 14px; }
 @media (min-width: 620px) {
   .lk-tab { flex-direction: row; align-items: flex-start; }
-  .lk-canvas { flex: 0 0 300px; }
+  .lk-canvas-col { flex: 0 0 300px; }
+  .lk-canvas { width: 300px; }
   .lk-prose { flex: 1 1 auto; min-width: 0; }
 }
 
@@ -150,7 +151,7 @@ const CSS = `
 .lk-bg { fill: var(--panel); }
 .lk-tour-edge { stroke-width: 1.8; }
 .lk-best-edge { stroke: #aaa; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.5; }
-.lk-scan-edge { stroke: #999; stroke-width: 1.5; stroke-dasharray: 5 3; opacity: 0.7; }
+.lk-scan-edge { stroke: #e8a000; stroke-width: 4; opacity: 0.55; }
 .lk-swap-edge { stroke: #1a7f37; stroke-width: 2.5; opacity: 0.9; }
 .lk-bridge-circle { fill: none; stroke: #cf222e; stroke-width: 2; stroke-dasharray: 4 3; opacity: 0.85; }
 .lk-city { fill: #f2a154; stroke: #fff; stroke-width: 1.5; }
@@ -188,6 +189,16 @@ const CSS = `
 .lk-phase-pass   { background: #f0f8ff; border-color: var(--accent); color: var(--accent); }
 
 .lk-footer { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted); }
+
+.lk-canvas-col { display: flex; flex-direction: column; gap: 6px; }
+.lk-legend { display: flex; flex-wrap: wrap; gap: 6px 12px; padding: 6px 8px; background: var(--panel); border-radius: 6px; border: 1px solid var(--line); }
+.lk-legend-item { display: flex; align-items: center; gap: 5px; font-size: 0.75rem; color: var(--muted); white-space: nowrap; }
+
+.lk-status { min-height: 1.5em; margin-bottom: 6px; font-size: 0.82rem; font-style: italic; color: var(--muted); }
+.lk-status-swap { color: var(--green); font-style: normal; font-weight: 500; }
+.lk-status-best { color: var(--gold); font-style: normal; font-weight: 600; }
+.lk-status-bridge { color: var(--red); font-style: normal; font-weight: 500; }
+.lk-status-done  { color: var(--text); font-style: normal; font-weight: 500; }
 `
 
 // ── Controls ──────────────────────────────────────────────────────────────────
@@ -198,19 +209,22 @@ interface ControlsProps {
   playing: boolean
   done: boolean
   speedIdx: number
+  canStepBack: boolean
   onPlayPause: () => void
+  onStepBack: () => void
   onStep: () => void
   onReset: () => void
   onSpeedChange: (idx: number) => void
 }
 
-function Controls({ playing, done, speedIdx, onPlayPause, onStep, onReset, onSpeedChange }: ControlsProps) {
+function Controls({ playing, done, speedIdx, canStepBack, onPlayPause, onStepBack, onStep, onReset, onSpeedChange }: ControlsProps) {
   return (
     <div className="lk-controls">
       <button className="lk-btn lk-btn-primary" onClick={onPlayPause} disabled={done}>
         {playing ? '⏸ Pause' : done ? '⏹ Done' : '▶ Run'}
       </button>
-      <button className="lk-btn" onClick={onStep} disabled={done}>⏭ Step</button>
+      <button className="lk-btn" onClick={onStepBack} disabled={!canStepBack}>◀ Back</button>
+      <button className="lk-btn" onClick={onStep} disabled={done}>Step ▶</button>
       <button className="lk-btn" onClick={onReset}>↺ Reset</button>
       <span className="lk-speed-label">Speed:</span>
       <input
@@ -254,6 +268,69 @@ function PhaseIndicator({ phase }: { phase: string }) {
   return <div className={`lk-phase ${cls}`}>{phase}</div>
 }
 
+// ── TourLegend ────────────────────────────────────────────────────────────────
+
+function TourLegend({ mode }: { mode: 'ls' | 'ils' }) {
+  return (
+    <div className="lk-legend">
+      <span className="lk-legend-item">
+        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#e0626b" strokeWidth="2" /></svg>
+        Tour
+      </span>
+      <span className="lk-legend-item">
+        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#e8a000" strokeWidth="4" opacity="0.55" /></svg>
+        Candidate pair
+      </span>
+      <span className="lk-legend-item">
+        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#1a7f37" strokeWidth="2.5" /></svg>
+        Accepted swap
+      </span>
+      {mode === 'ils' && (
+        <span className="lk-legend-item">
+          <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#aaa" strokeWidth="1" strokeDasharray="4 3" /></svg>
+          Best tour
+        </span>
+      )}
+      {mode === 'ils' && (
+        <span className="lk-legend-item">
+          <svg width="16" height="16" style={{ marginRight: 2 }}>
+            <circle cx="8" cy="8" r="5" fill="none" stroke="#cf222e" strokeWidth="1.5" strokeDasharray="3 2" />
+          </svg>
+          Bridge cut
+        </span>
+      )}
+    </div>
+  )
+}
+
+// ── Status lines ─────────────────────────────────────────────────────────────
+
+function LSStatusLine({ frame }: { frame: LSFrame }) {
+  const cls = frame.overlay ? 'lk-status-done'
+    : frame.swapEdges ? 'lk-status-swap'
+    : ''
+  const msg = frame.overlay
+    ?? (frame.swapEdges ? 'Improvement found — swapping edges ✓'
+    : 'Scanning candidate pair — no improvement yet, step further')
+  return <div className={`lk-status ${cls}`}>{msg}</div>
+}
+
+function ILSStatusLine({ frame }: { frame: ILSFrame }) {
+  const cls = frame.overlay ? 'lk-status-done'
+    : frame.highlight === 'best' ? 'lk-status-best'
+    : frame.highlight === 'bridge' ? 'lk-status-bridge'
+    : frame.highlight === 'swap' ? 'lk-status-swap'
+    : ''
+  const msg = frame.overlay
+    ?? (frame.highlight === 'best' ? 'New best tour found! ✓'
+    : frame.highlight === 'bridge' ? 'Double-bridge kick applied — escaping local optimum'
+    : frame.highlight === 'swap' ? 'Improvement found — swapping edges ✓'
+    : frame.phase === 'Plateau' ? `Plateau ${frame.plateauCount} of 5 — no improvement, will kick again`
+    : frame.phase === 'Local optimum' ? 'Local optimum reached — comparing to best tour'
+    : 'Running 2-opt local search...')
+  return <div className={`lk-status ${cls}`}>{msg}</div>
+}
+
 // ── LocalSearchTab ────────────────────────────────────────────────────────────
 
 function LocalSearchTab() {
@@ -285,7 +362,15 @@ function LocalSearchTab() {
   }, [playing, speed, advance])
 
   const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
-  const handleStep = useCallback(() => { setPlaying(false); advance(false) }, [advance])
+  const handleStep = useCallback(() => { setPlaying(false); advance(true) }, [advance])
+  const handleStepBack = useCallback(() => {
+    setPlaying(false)
+    setIdx(i => {
+      let prev = i - 1
+      while (prev > 0 && frames[prev].isScan) prev--
+      return Math.max(0, prev)
+    })
+  }, [frames])
   const handleReset = useCallback(() => {
     setPlaying(false)
     setIdx(0)
@@ -295,21 +380,27 @@ function LocalSearchTab() {
 
   return (
     <div className="lk-tab">
-      <TourSVG
-        tour={frame.tour}
-        scanEdges={frame.scanEdges}
-        swapEdges={frame.swapEdges}
-        overlay={frame.overlay}
-      />
+      <div className="lk-canvas-col">
+        <TourSVG
+          tour={frame.tour}
+          scanEdges={frame.scanEdges}
+          swapEdges={frame.swapEdges}
+          overlay={frame.overlay}
+        />
+        <TourLegend mode="ls" />
+      </div>
       <div className="lk-prose">
         <Controls
           playing={playing} done={done} speedIdx={speedIdx}
-          onPlayPause={handlePlayPause} onStep={handleStep}
+          canStepBack={idx > 0}
+          onPlayPause={handlePlayPause} onStepBack={handleStepBack} onStep={handleStep}
           onReset={handleReset} onSpeedChange={setSpeedIdx}
         />
+        <LSStatusLine frame={frame} />
         <StatsPanel stats={[
           { label: 'Distance', value: frame.dist },
           { label: 'Swaps accepted', value: swapCount },
+          { label: 'Step', value: `${idx + 1} / ${frames.length}` },
         ]} />
         <p className="lk-note">
           This shows simplified <strong>2-opt</strong> local search. Press{' '}
@@ -356,34 +447,40 @@ function ILSTab() {
 
   const handlePlayPause = useCallback(() => setPlaying(p => !p), [])
   const handleStep = useCallback(() => { setPlaying(false); advance() }, [advance])
+  const handleStepBack = useCallback(() => { setPlaying(false); setIdx(i => Math.max(0, i - 1)) }, [])
   const handleReset = useCallback(() => { setPlaying(false); setIdx(0) }, [])
 
   return (
     <div className="lk-tab">
-      <TourSVG
-        tour={frame.tour}
-        bestTour={frame.bestTour}
-        swapEdges={frame.swapEdges}
-        bridgePoints={frame.bridgePoints}
-        highlight={frame.highlight}
-        overlay={frame.overlay}
-      />
+      <div className="lk-canvas-col">
+        <TourSVG
+          tour={frame.tour}
+          bestTour={frame.bestTour}
+          swapEdges={frame.swapEdges}
+          bridgePoints={frame.bridgePoints}
+          highlight={frame.highlight}
+          overlay={frame.overlay}
+        />
+        <TourLegend mode="ils" />
+      </div>
       <div className="lk-prose">
         <PhaseIndicator phase={frame.phase} />
         <Controls
           playing={playing} done={done} speedIdx={speedIdx}
-          onPlayPause={handlePlayPause} onStep={handleStep}
+          canStepBack={idx > 0}
+          onPlayPause={handlePlayPause} onStepBack={handleStepBack} onStep={handleStep}
           onReset={handleReset} onSpeedChange={setSpeedIdx}
         />
+        <ILSStatusLine frame={frame} />
         <StatsPanel stats={[
           { label: 'Current dist', value: frame.currentDist },
           { label: 'Best dist', value: frame.bestDist },
-          { label: 'Restarts', value: frame.restarts },
+          { label: 'Epoch', value: frame.restarts },
           { label: `Plateau (limit ${5})`, value: frame.plateauCount },
+          { label: 'Step', value: `${idx + 1} / ${frames.length}` },
         ]} />
         <p className="lk-note">
-          Dashed gray line = best tour found so far.
-          Gold = new best; red circles = double-bridge cut points.
+          Gold tour = new best found. Red dashed circles mark the double-bridge cut points.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds two-tab Preact + inline SVG explainer at `/algorithms/lk/explainer/` — **Local Search** tab animates simplified 2-opt with candidate scanning in Step mode; **ILS** tab shows double-bridge kicks with phase indicator and best-tour underlay
- Pure algorithm logic in `lk.ts` (27 Vitest unit tests, all seeded/deterministic), Preact components in `lk.tsx` — precomputed frame arrays so the player just steps through an index
- Docs CTA wired up automatically via `existsSync` in `build-docs.mjs`; Vite MPA discovers the new `index.html` via existing glob — no config changes needed

## Test Plan

- [x] `npm test` passes (106/106)
- [x] `npm run build:check` exits 0
- [x] `/algorithms/lk/explainer/` loads with two tabs, tour visible
- [x] Step mode shows gray dashed scan edges; Run mode skips to accepted swaps
- [x] ILS tab phase badge changes (LK pass → Double-bridge kick → New best! etc.)
- [x] Tab switch preserves per-tab playback position
- [x] `/algorithms/lk/` docs page shows "▶ Open interactive explainer →" CTA