### PR TITLE
feat(dev): pre-commit git hooks for Rust, Markdown, YAML, TS, TOML, shell

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+FAILED=0
+
+skip_notice() {
+    echo -e "${YELLOW}[SKIP]${NC} $1 not installed — did you forget to run mise install?"
+}
+
+fail_notice() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    echo "       autofix: $2"
+    FAILED=1
+}
+
+# ── Rust ──────────────────────────────────────────────────────────────────────
+RS_FILES=$(echo "$STAGED" | grep -E '\.rs$' || true)
+if [ -n "$RS_FILES" ]; then
+    echo "[CHECK] cargo fmt"
+    if ! cargo fmt --all --check 2>&1; then
+        fail_notice "cargo fmt: code is not formatted" "cargo fmt"
+    fi
+
+    echo "[CHECK] cargo clippy"
+    if ! cargo clippy --workspace -- -D warnings 2>&1; then
+        fail_notice "cargo clippy: lint errors found" "cargo clippy --workspace --fix"
+    fi
+fi
+
+# ── Markdown ──────────────────────────────────────────────────────────────────
+MD_FILES=$(echo "$STAGED" | grep -E '\.md$' || true)
+if [ -n "$MD_FILES" ]; then
+    if ! command -v markdownlint &>/dev/null; then
+        skip_notice "markdownlint"
+    else
+        echo "[CHECK] markdownlint"
+        if ! echo "$MD_FILES" | xargs markdownlint 2>&1; then
+            fail_notice "markdownlint: issues found in markdown files" "markdownlint --fix <file>"
+        fi
+    fi
+fi
+
+# ── YAML ──────────────────────────────────────────────────────────────────────
+YAML_FILES=$(echo "$STAGED" | grep -E '\.(yml|yaml)$' || true)
+if [ -n "$YAML_FILES" ]; then
+    if ! command -v yamllint &>/dev/null; then
+        skip_notice "yamllint"
+    else
+        echo "[CHECK] yamllint"
+        if ! echo "$YAML_FILES" | xargs yamllint 2>&1; then
+            fail_notice "yamllint: issues found in YAML files" "yamllint <file>  # fix errors manually"
+        fi
+    fi
+fi
+
+# ── TypeScript (teeline-web) ──────────────────────────────────────────────────
+TS_FILES=$(echo "$STAGED" | grep -E 'teeline-web/.*\.(ts|js|tsx)$' || true)
+if [ -n "$TS_FILES" ]; then
+    if [ ! -d "teeline-web/node_modules" ]; then
+        skip_notice "teeline-web/node_modules (run: cd teeline-web && npm install)"
+    else
+        echo "[CHECK] tsc (teeline-web)"
+        if ! npx --prefix teeline-web tsc --noEmit 2>&1; then
+            fail_notice "tsc: TypeScript errors found in teeline-web" "# fix errors manually, then re-run tsc --noEmit to verify"
+        fi
+    fi
+fi
+
+# ── TOML ──────────────────────────────────────────────────────────────────────
+TOML_FILES=$(echo "$STAGED" | grep -E '\.toml$' || true)
+if [ -n "$TOML_FILES" ]; then
+    if ! command -v taplo &>/dev/null; then
+        skip_notice "taplo"
+    else
+        echo "[CHECK] taplo"
+        if ! echo "$TOML_FILES" | xargs taplo fmt --check 2>&1; then
+            fail_notice "taplo: TOML formatting issues found" "taplo fmt"
+        fi
+    fi
+fi
+
+# ── Shell ─────────────────────────────────────────────────────────────────────
+SH_FILES=$(echo "$STAGED" | grep -E '\.sh$' || true)
+if [ -n "$SH_FILES" ]; then
+    if ! command -v shellcheck &>/dev/null; then
+        skip_notice "shellcheck"
+    else
+        echo "[CHECK] shellcheck"
+        if ! echo "$SH_FILES" | xargs shellcheck 2>&1; then
+            fail_notice "shellcheck: issues found in shell scripts" "# fix errors manually"
+        fi
+    fi
+fi
+
+# ── Result ────────────────────────────────────────────────────────────────────
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}Pre-commit checks failed. Fix the issues above and try again.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}[OK]${NC} All pre-commit checks passed."

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+[tools]
+# Lint tools used by .githooks/pre-commit
+# Install all with: mise install
+"npm:markdownlint-cli" = "latest"
+"pipx:yamllint" = "latest"
+"cargo:taplo-cli" = "latest"
+"cargo:shellcheck" = "latest"

--- a/README.md
+++ b/README.md
@@ -387,6 +387,33 @@ task bench:berlin52      # compare all approximate solvers on berlin52 (release 
 task build:wasm          # build the WebAssembly component
 ```
 
+### Git hooks
+
+Run once after cloning to activate the pre-commit hooks:
+
+```bash
+bash scripts/setup-hooks.sh
+# or, if you have go-task installed:
+task setup
+```
+
+The hook checks only the files you've staged, so it's fast:
+
+| Staged files | Check | Autofix |
+|---|---|---|
+| `*.rs` | `cargo fmt --check` + `cargo clippy -D warnings` | `cargo fmt` / `cargo clippy --fix` |
+| `*.md` | `markdownlint` | `markdownlint --fix <file>` |
+| `*.yml` / `*.yaml` | `yamllint` | fix manually |
+| `teeline-web/*.ts` | `tsc --noEmit` | fix manually |
+| `*.toml` | `taplo fmt --check` | `taplo fmt` |
+| `*.sh` | `shellcheck` | fix manually |
+
+Rust checks always run (Rust toolchain is assumed). The others are skipped silently if the tool is not installed and print a reminder to run `mise install`. Install all optional tools at once with [mise](https://mise.jdx.dev/):
+
+```bash
+mise install
+```
+
 The `qt:` namespace proxies into `teeline-qt/Taskfile.yml` (requires Qt 6 at `~/Qt/6.11.1/gcc_64`):
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,6 +77,11 @@ tasks:
       - echo "=== berlin52 (optimal 7542) ==="
       - for solver in $(./target/release/teeline solvers --heuristic --short); do printf "%-12s " $solver; ./target/release/teeline solve $solver -i tests/fixtures/berlin52.tsp 2>/dev/null | head -1; done
 
+  setup:
+    desc: Configure local dev environment (install git hooks)
+    cmds:
+      - bash scripts/setup-hooks.sh
+
   clean:
     desc: Remove build artifacts
     cmds:

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Configure local git hooks for teeline.
+# Run once after cloning: bash scripts/setup-hooks.sh
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+git config core.hooksPath .githooks
+chmod +x "$REPO_ROOT/.githooks/pre-commit"
+
+echo "Git hooks configured (.githooks/pre-commit is now active)."
+echo "Run 'mise install' to ensure all lint tools are available."


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` that scopes checks to **staged files only**, so only the relevant linter runs per commit
- Adds `scripts/setup-hooks.sh` for one-time hook activation
- Adds `task setup` in Taskfile as a convenience alias for the script
- Adds `.mise.toml` declaring the optional lint tools

## Hook behaviour

| Files staged | Check | Always runs? |
|---|---|---|
| `*.rs` | `cargo fmt --check` + `cargo clippy --workspace -D warnings` | Yes (Rust toolchain assumed present) |
| `*.md` | `markdownlint` | Skip-with-notice if not installed |
| `*.yml` / `*.yaml` | `yamllint` | Skip-with-notice if not installed |
| `teeline-web/*.ts` | `npx tsc --noEmit` | Skip if `node_modules` missing |
| `*.toml` | `taplo fmt --check` | Skip-with-notice if not installed |
| `*.sh` | `shellcheck` | Skip-with-notice if not installed |

Missing tools print: `did you forget to run mise install?`  
On failure the autofix command is shown before exiting 1.

## Setup

```bash
# one-time, after cloning
bash scripts/setup-hooks.sh
# or
task setup

# install optional lint tools
mise install
```

## Test plan

- [x] Hook exits 0 with no staged files
- [x] Hook ran on its own commit — shellcheck passed, yamllint/taplo skipped with mise notice
- [x] `shellcheck .githooks/pre-commit scripts/setup-hooks.sh` clean
- [x] `cargo clippy --workspace` clean