### PR TITLE
fix(dev): use github: backend for shellcheck in .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,4 +4,4 @@
 "npm:markdownlint-cli" = "latest"
 "pipx:yamllint" = "latest"
 "cargo:taplo-cli" = "latest"
-"cargo:shellcheck" = "latest"
+"github:koalaman/shellcheck" = "latest"


### PR DESCRIPTION
## Summary

`cargo:shellcheck` in `.mise.toml` (added in PR #251) fails because shellcheck is not a Rust crate — it's a Haskell binary distributed via GitHub releases.

Fix: switch to `github:koalaman/shellcheck` which is the correct mise backend for GitHub release binaries, and also the preferred form over the deprecated `ubi:` backend.

```
❯ mise install
mise github:koalaman/shellcheck@latest ✓ installed
```

## Test plan
- [x] `mise install` completes without errors or deprecation warnings
- [x] `shellcheck --version` works after install