### PR TITLE
feat(web): compare tours via WASM — gap%, shared/solver-only/optimal-only edges (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules/
 
 # visual companion brainstorm files
 .superpowers/
+.worktrees/

--- a/src/tsp/bellman_karp.rs
+++ b/src/tsp/bellman_karp.rs
@@ -235,8 +235,14 @@ mod tests {
         // Accumulated rounding reaches ~1e-6 >> f32::EPSILON, causing the loop
         // to leave positions as 0, producing repeated cities in the route.
         let coords: &[&[f32]] = &[
-            &[0.0, 0.0], &[3.0, 1.0], &[1.0, 3.0], &[4.0, 4.0],
-            &[2.0, 0.5], &[0.5, 2.0], &[3.5, 2.5], &[1.5, 4.0],
+            &[0.0, 0.0],
+            &[3.0, 1.0],
+            &[1.0, 3.0],
+            &[4.0, 4.0],
+            &[2.0, 0.5],
+            &[0.5, 2.0],
+            &[3.5, 2.5],
+            &[1.5, 4.0],
         ];
         let cities: Vec<kdtree::KDPoint> = coords
             .iter()

--- a/src/tsp/branch_bound.rs
+++ b/src/tsp/branch_bound.rs
@@ -58,8 +58,7 @@ pub fn solve(
     } else {
         None
     };
-    let city_map: HashMap<usize, KDPoint> =
-        cities.iter().map(|p| (p.id, *p)).collect();
+    let city_map: HashMap<usize, KDPoint> = cities.iter().map(|p| (p.id, *p)).collect();
 
     let fitness_fn = build_evaluator(distances);
     let (best_path, best_distance) = backtrack(
@@ -257,7 +256,11 @@ fn construct_candidates(
                 .distance_between(path[k - 1], city_id)
                 .expect("city ids in path must be in distance matrix");
             let lb = running_cost + next_dist + mst;
-            if best_distance > lb { Some((lb, city_id)) } else { None }
+            if best_distance > lb {
+                Some((lb, city_id))
+            } else {
+                None
+            }
         })
         .collect();
     scored.sort_by(|a, b| a.0.total_cmp(&b.0));
@@ -343,7 +346,10 @@ mod tests {
     fn test_solve_finds_optimal_tour_on_tsp5() {
         let problem = tsp5_problem();
         // n_nearest=0: no KD restriction — exact B&B.
-        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
         let tour = solve(&problem, &opts, None, None);
 
         assert!(
@@ -356,7 +362,10 @@ mod tests {
     #[test]
     fn test_solve_matches_bellman_karp_on_tsp5() {
         let problem = tsp5_problem();
-        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
         let bb_tour = solve(&problem, &opts, None, None);
         let bhk_tour = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
@@ -393,7 +402,10 @@ mod tests {
         let problem = TspProblem::new(cities, dm);
 
         // n_nearest=0: no KD restriction — exact B&B.
-        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
         let bb = solve(&problem, &opts, None, None);
         let bhk = bellman_karp::solve(&problem, &HeuristicOptions::default(), None, None);
 
@@ -411,17 +423,15 @@ mod tests {
         // pruning more branches early. The result must still be the exact optimal.
         let problem = tsp5_problem();
         // n_nearest=0: no KD restriction — exact B&B.
-        let opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
         let without_seed = solve(&problem, &opts, None, None);
 
         // Use the unseeded result as the init_tour for the second run.
         let seed_route = without_seed.route().to_vec();
-        let with_seed = solve(
-            &problem,
-            &opts,
-            None,
-            Some(&seed_route),
-        );
+        let with_seed = solve(&problem, &opts, None, Some(&seed_route));
 
         assert!(
             (with_seed.total - without_seed.total).abs() < 1e-3,
@@ -436,14 +446,17 @@ mod tests {
         // 3 cities: right triangle with legs 3 and 4. MST picks the two shorter
         // edges (3+4=7) and excludes the hypotenuse (5). Uses 1-indexed IDs to
         // avoid UNVISITED_NODE=0 collision with city ID 0 from build_points.
-        let cities: Vec<kdtree::KDPoint> = [
-            [0.0f32, 0.0], [3.0, 0.0], [0.0, 4.0],
-        ].iter().enumerate()
-         .map(|(i, c)| kdtree::KDPoint::new_with_id(i + 1, c))
-         .collect();
+        let cities: Vec<kdtree::KDPoint> = [[0.0f32, 0.0], [3.0, 0.0], [0.0, 4.0]]
+            .iter()
+            .enumerate()
+            .map(|(i, c)| kdtree::KDPoint::new_with_id(i + 1, c))
+            .collect();
         let dm = distance_matrix::from_cities(&cities);
         let mst = prim_mst(&[1, 2, 3], &dm);
-        assert!((mst - 7.0).abs() < 1e-3, "MST of 3-4-5 triangle should be 7, got {mst}");
+        assert!(
+            (mst - 7.0).abs() < 1e-3,
+            "MST of 3-4-5 triangle should be 7, got {mst}"
+        );
     }
 
     #[test]
@@ -452,8 +465,14 @@ mod tests {
         // simple enough that the optimal successor is always within the 3
         // nearest, so the result must match exact B&B.
         let problem = tsp5_problem();
-        let restricted_opts = HeuristicOptions { n_nearest: 3, ..Default::default() };
-        let exact_opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let restricted_opts = HeuristicOptions {
+            n_nearest: 3,
+            ..Default::default()
+        };
+        let exact_opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
 
         let restricted = solve(&problem, &restricted_opts, None, None);
         let exact = solve(&problem, &exact_opts, None, None);
@@ -471,8 +490,14 @@ mod tests {
         // Same 8-city layout as test_solve_matches_bhk_on_tsp8.
         // With n_nearest=4, the KD restriction is active (4 < 8).
         let coords: &[&[f32]] = &[
-            &[0.0, 0.0], &[3.0, 1.0], &[1.0, 3.0], &[4.0, 4.0],
-            &[2.0, 0.5], &[0.5, 2.0], &[3.5, 2.5], &[1.5, 4.0],
+            &[0.0, 0.0],
+            &[3.0, 1.0],
+            &[1.0, 3.0],
+            &[4.0, 4.0],
+            &[2.0, 0.5],
+            &[0.5, 2.0],
+            &[3.5, 2.5],
+            &[1.5, 4.0],
         ];
         let cities: Vec<kdtree::KDPoint> = coords
             .iter()
@@ -482,7 +507,10 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let problem = TspProblem::new(cities, dm);
 
-        let restricted_opts = HeuristicOptions { n_nearest: 4, ..Default::default() };
+        let restricted_opts = HeuristicOptions {
+            n_nearest: 4,
+            ..Default::default()
+        };
         let tour = solve(&problem, &restricted_opts, None, None);
 
         // All 8 cities visited exactly once.
@@ -491,7 +519,10 @@ mod tests {
         assert_eq!(visited, vec![1, 2, 3, 4, 5, 6, 7, 8]);
 
         // Gap vs unrestricted B&B should be < 10%.
-        let exact_opts = HeuristicOptions { n_nearest: 0, ..Default::default() };
+        let exact_opts = HeuristicOptions {
+            n_nearest: 0,
+            ..Default::default()
+        };
         let exact = solve(&problem, &exact_opts, None, None);
         let gap = (tour.total - exact.total) / exact.total;
         assert!(

--- a/src/tsp/christofides.rs
+++ b/src/tsp/christofides.rs
@@ -40,7 +40,10 @@ pub fn solve(
 
     // Step 2: Identify odd-degree vertices.
     let odd = odd_degree_nodes(&mst_edges, n);
-    debug_assert!(odd.len().is_multiple_of(2), "handshaking lemma: odd-degree count must be even");
+    debug_assert!(
+        odd.len().is_multiple_of(2),
+        "handshaking lemma: odd-degree count must be even"
+    );
 
     // Step 3: Greedy minimum-weight perfect matching on odd-degree nodes.
     let matching = greedy_matching(&odd, distances, n);
@@ -71,7 +74,7 @@ pub fn solve(
 /// Returns MST edges as `(pos_a, pos_b)` position-index pairs.
 fn prim_mst(n: usize, distances: &super::distance_matrix::DistanceMatrix) -> Vec<(usize, usize)> {
     let mut in_mst = vec![false; n];
-    let mut key = vec![f32::MAX; n];   // minimum edge weight to bring each vertex into the tree
+    let mut key = vec![f32::MAX; n]; // minimum edge weight to bring each vertex into the tree
     let mut parent = vec![usize::MAX; n];
     key[0] = 0.0;
 
@@ -81,7 +84,11 @@ fn prim_mst(n: usize, distances: &super::distance_matrix::DistanceMatrix) -> Vec
         // Minimum-key vertex not yet in MST.
         let u = (0..n)
             .filter(|&i| !in_mst[i])
-            .min_by(|&a, &b| key[a].partial_cmp(&key[b]).unwrap_or(std::cmp::Ordering::Equal))
+            .min_by(|&a, &b| {
+                key[a]
+                    .partial_cmp(&key[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
             .expect("at least one non-MST vertex remains");
 
         in_mst[u] = true;
@@ -280,7 +287,10 @@ mod tests {
             .iter()
             .map(|&(u, v)| problem.distances.distance_by_pos(u, v).unwrap())
             .sum();
-        assert!((weight - 4.0).abs() < 1e-3, "chain MST weight must be 4.0, got {weight}");
+        assert!(
+            (weight - 4.0).abs() < 1e-3,
+            "chain MST weight must be 4.0, got {weight}"
+        );
     }
 
     // ------------------------------------------------------------------
@@ -292,7 +302,11 @@ mod tests {
         // MST: (0-1), (1-2), (1-3) → degrees: 0→1, 1→3, 2→1, 3→1 → odd: {0,1,2,3} = 4, even.
         let mst = vec![(0, 1), (1, 2), (1, 3)];
         let odd = odd_degree_nodes(&mst, 4);
-        assert_eq!(odd.len() % 2, 0, "odd-degree count must be even (handshaking lemma)");
+        assert_eq!(
+            odd.len() % 2,
+            0,
+            "odd-degree count must be even (handshaking lemma)"
+        );
     }
 
     #[test]
@@ -312,8 +326,7 @@ mod tests {
     #[test]
     fn greedy_matching_covers_all_odd_nodes() {
         // 5-node layout; verify each odd-degree node appears exactly once in the matching.
-        let problem =
-            make_problem(&[[0., 0.], [1., 0.], [2., 0.], [1., 1.], [3., 0.]]);
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [1., 1.], [3., 0.]]);
         let n = problem.cities.len();
         let mst = prim_mst(n, &problem.distances);
         let odd = odd_degree_nodes(&mst, n);
@@ -336,8 +349,7 @@ mod tests {
 
     #[test]
     fn eulerian_circuit_length_equals_edges_plus_one() {
-        let problem =
-            make_problem(&[[0., 0.], [1., 0.], [2., 0.], [1., 1.], [3., 0.]]);
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [1., 1.], [3., 0.]]);
         let n = problem.cities.len();
         let mst = prim_mst(n, &problem.distances);
         let odd = odd_degree_nodes(&mst, n);
@@ -365,7 +377,11 @@ mod tests {
         assert_eq!(tour.len(), n, "shortcut must produce n-city tour");
         let mut sorted = tour.clone();
         sorted.sort_unstable();
-        assert_eq!(sorted, vec![0, 1, 2, 3, 4], "tour must be a permutation of 0..n");
+        assert_eq!(
+            sorted,
+            vec![0, 1, 2, 3, 4],
+            "tour must be a permutation of 0..n"
+        );
     }
 
     // ------------------------------------------------------------------
@@ -383,14 +399,7 @@ mod tests {
     #[test]
     fn christofides_all_cities_visited_once() {
         // 6-city problem: validate tour is a valid permutation.
-        let problem = make_problem(&[
-            [0., 0.],
-            [1., 0.],
-            [5., 5.],
-            [2., 0.],
-            [3., 0.],
-            [4., 1.],
-        ]);
+        let problem = make_problem(&[[0., 0.], [1., 0.], [5., 5.], [2., 0.], [3., 0.], [4., 1.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         let mut visited = sol.route().to_vec();
         visited.sort_unstable();
@@ -401,13 +410,7 @@ mod tests {
     #[test]
     fn christofides_tour_cost_matches_reported() {
         // Reported total must match the sum of edge distances in the tour.
-        let problem = make_problem(&[
-            [0., 0.],
-            [1., 0.],
-            [2., 0.],
-            [3., 0.],
-            [4., 0.],
-        ]);
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [3., 0.], [4., 0.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         let route = sol.route();
         let n = route.len();

--- a/src/tsp/comparison.rs
+++ b/src/tsp/comparison.rs
@@ -1,5 +1,5 @@
-use std::collections::{HashMap, HashSet};
 use crate::tsp::kdtree::KDPoint;
+use std::collections::{HashMap, HashSet};
 
 pub struct ComparisonStats {
     pub optimal_cost: f32,
@@ -72,10 +72,22 @@ mod tests {
 
     fn square_cities() -> Vec<KDPoint> {
         vec![
-            KDPoint { id: 1, coords: [0.0, 0.0] },
-            KDPoint { id: 2, coords: [1.0, 0.0] },
-            KDPoint { id: 3, coords: [1.0, 1.0] },
-            KDPoint { id: 4, coords: [0.0, 1.0] },
+            KDPoint {
+                id: 1,
+                coords: [0.0, 0.0],
+            },
+            KDPoint {
+                id: 2,
+                coords: [1.0, 0.0],
+            },
+            KDPoint {
+                id: 3,
+                coords: [1.0, 1.0],
+            },
+            KDPoint {
+                id: 4,
+                coords: [0.0, 1.0],
+            },
         ]
     }
 
@@ -98,13 +110,22 @@ mod tests {
         // Solver:  [1,2,4,3] — edges {1-2, 2-4, 3-4, 1-3} — crosses diagonals = 2+2√2
         let cities = square_cities();
         let optimal = vec![1, 2, 3, 4];
-        let solver  = vec![1, 2, 4, 3];
+        let solver = vec![1, 2, 4, 3];
         let stats = compare_tours(&solver, &optimal, &cities);
 
-        assert!(stats.gap_pct > 0.0, "solver has a crossing edge, must be worse");
-        assert_eq!(stats.shared_edges, 2,        "edges (1-2) and (3-4) are shared");
-        assert_eq!(stats.solver_only_edges, 2,   "solver has extra (2-4) and (1-3)");
-        assert_eq!(stats.optimal_only_edges, 2,  "optimal has (2-3) and (1-4) not in solver");
+        assert!(
+            stats.gap_pct > 0.0,
+            "solver has a crossing edge, must be worse"
+        );
+        assert_eq!(stats.shared_edges, 2, "edges (1-2) and (3-4) are shared");
+        assert_eq!(
+            stats.solver_only_edges, 2,
+            "solver has extra (2-4) and (1-3)"
+        );
+        assert_eq!(
+            stats.optimal_only_edges, 2,
+            "optimal has (2-3) and (1-4) not in solver"
+        );
         // Invariant: shared + solver_only == n
         assert_eq!(stats.shared_edges + stats.solver_only_edges, optimal.len());
     }
@@ -129,6 +150,9 @@ mod tests {
         let mut sorted_route: Vec<usize> = opt.route.clone();
         sorted_route.sort_unstable();
         let stats2 = compare_tours(&sorted_route, &opt.route, cities);
-        assert!(stats2.gap_pct > 0.0, "ID-sorted route must be worse than the known optimal");
+        assert!(
+            stats2.gap_pct > 0.0,
+            "ID-sorted route must be worse than the known optimal"
+        );
     }
 }

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -179,7 +179,10 @@ impl DistanceMatrix {
         let from = pos1.max(pos2);
         let to = pos1.min(pos2);
         let idx = from * (from - 1) / 2 + to;
-        self.items.get(idx).copied().ok_or("distance index out of range")
+        self.items
+            .get(idx)
+            .copied()
+            .ok_or("distance index out of range")
     }
 
     /// returns distance between city n and m
@@ -190,8 +193,16 @@ impl DistanceMatrix {
         if city_id1 == city_id2 {
             return Ok(0.0);
         }
-        let pos1 = self.city_idx.get(&city_id1).copied().ok_or("city_id1 not in index")?;
-        let pos2 = self.city_idx.get(&city_id2).copied().ok_or("city_id2 not in index")?;
+        let pos1 = self
+            .city_idx
+            .get(&city_id1)
+            .copied()
+            .ok_or("city_id1 not in index")?;
+        let pos2 = self
+            .city_idx
+            .get(&city_id2)
+            .copied()
+            .ok_or("city_id2 not in index")?;
         self.distance_by_pos(pos1, pos2)
     }
 
@@ -266,10 +277,16 @@ impl DistanceMatrix {
     fn distances_from_index(&self, pos: usize) -> Vec<f32> {
         let mut distances = Vec::with_capacity(self.n);
         for i in 0..pos {
-            distances.push(self.distance_by_pos(pos, i).expect("valid position in distances_from_index"));
+            distances.push(
+                self.distance_by_pos(pos, i)
+                    .expect("valid position in distances_from_index"),
+            );
         }
         for i in pos..self.n {
-            distances.push(self.distance_by_pos(i, pos).expect("valid position in distances_from_index"));
+            distances.push(
+                self.distance_by_pos(i, pos)
+                    .expect("valid position in distances_from_index"),
+            );
         }
         distances
     }

--- a/src/tsp/fourier.rs
+++ b/src/tsp/fourier.rs
@@ -1,11 +1,8 @@
-use crate::tsp::{
-    kdtree::KDPoint,
-    FourierOptions, Solution, TspProblem,
-};
+use crate::tsp::progress::ProgressMessage;
+use crate::tsp::{FourierOptions, Solution, TspProblem, kdtree::KDPoint};
 use num_complex::Complex;
 use std::f64::consts::PI;
 use std::sync::mpsc;
-use crate::tsp::progress::ProgressMessage;
 
 pub fn solve(
     problem: &TspProblem,
@@ -74,7 +71,8 @@ fn nearest_sample(gamma: &[Complex<f64>], city: Complex<f64>) -> usize {
         .iter()
         .enumerate()
         .min_by(|&(_, a), &(_, b)| {
-            (*a - city).norm_sqr()
+            (*a - city)
+                .norm_sqr()
                 .partial_cmp(&(*b - city).norm_sqr())
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
@@ -97,7 +95,7 @@ mod tests {
     use super::*;
     use std::f64::consts::PI;
 
-    use crate::tsp::{distance_matrix, TspProblem};
+    use crate::tsp::{TspProblem, distance_matrix};
 
     fn circle_cities(n: usize) -> Vec<KDPoint> {
         (0..n)
@@ -129,7 +127,11 @@ mod tests {
         assert_eq!(sol.route().len(), 5, "tour must visit all 5 cities");
         let mut sorted = sol.route().to_vec();
         sorted.sort_unstable();
-        assert_eq!(sorted, vec![0, 1, 2, 3, 4], "tour must contain all city IDs exactly once");
+        assert_eq!(
+            sorted,
+            vec![0, 1, 2, 3, 4],
+            "tour must contain all city IDs exactly once"
+        );
     }
 
     #[test]
@@ -161,10 +163,12 @@ mod tests {
     fn test_fourier_gradient_reduces_energy() {
         // 3 cities arranged around a circle; one gradient step should pull the curve toward them
         let cities: Vec<Complex<f64>> = (0..3)
-            .map(|i| Complex::new(
-                (2.0 * PI * i as f64 / 3.0).cos(),
-                (2.0 * PI * i as f64 / 3.0).sin(),
-            ))
+            .map(|i| {
+                Complex::new(
+                    (2.0 * PI * i as f64 / 3.0).cos(),
+                    (2.0 * PI * i as f64 / 3.0).sin(),
+                )
+            })
             .collect();
         let k_max = 1usize;
         let ks = ks_array(k_max);
@@ -173,7 +177,8 @@ mod tests {
         let lr = 0.05f64;
 
         let centroid: Complex<f64> = cities.iter().sum::<Complex<f64>>() / cities.len() as f64;
-        let radius = cities.iter().map(|z| (z - centroid).norm()).sum::<f64>() / cities.len() as f64;
+        let radius =
+            cities.iter().map(|z| (z - centroid).norm()).sum::<f64>() / cities.len() as f64;
         let mut c = init_coefficients(centroid, radius, k_max);
 
         let energy_before = compute_energy(&c, &ks, m, &cities, lambda);
@@ -200,7 +205,8 @@ mod tests {
         let c = init_coefficients(centroid, radius, k_max);
         let m = 100;
         let gamma = eval_curve(&c, &ks, m);
-        let max_dist_from_centroid = gamma.iter()
+        let max_dist_from_centroid = gamma
+            .iter()
             .map(|g| (g - centroid).norm())
             .fold(0.0f64, f64::max);
         // c[k_max+1] = radius*0.5, so the curve traces a circle of radius ~0.5
@@ -218,14 +224,18 @@ mod tests {
         lambda: f64,
     ) -> f64 {
         let gamma = eval_curve(c, ks, m);
-        let attraction: f64 = cities.iter()
+        let attraction: f64 = cities
+            .iter()
             .map(|&z| {
-                gamma.iter()
+                gamma
+                    .iter()
                     .map(|&g| (g - z).norm_sqr())
                     .fold(f64::MAX, f64::min)
             })
             .sum();
-        let tension: f64 = c.iter().zip(ks.iter())
+        let tension: f64 = c
+            .iter()
+            .zip(ks.iter())
             .map(|(ck, &k)| lambda * (2.0 * PI * k as f64).powi(2) * ck.norm_sqr())
             .sum();
         attraction + tension

--- a/src/tsp/gravitational_search.rs
+++ b/src/tsp/gravitational_search.rs
@@ -165,7 +165,11 @@ mod tests {
     #[test]
     fn test_gsa_returns_valid_tour() {
         let (cities, problem) = five_city_problem();
-        let opts = HeuristicOptions { epochs: 20, n_nearest: 5, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 20,
+            n_nearest: 5,
+            ..HeuristicOptions::default()
+        };
         let sol = solve(&problem, &opts, None, None);
         assert_eq!(sol.route().len(), cities.len());
         let mut visited = sol.route().to_vec();
@@ -181,7 +185,10 @@ mod tests {
         let dm = distance_matrix::from_cities(&cities);
         let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
         let optimal_cost = dm.tour_length(&optimal);
-        let opts = HeuristicOptions { epochs: 0, ..HeuristicOptions::default() };
+        let opts = HeuristicOptions {
+            epochs: 0,
+            ..HeuristicOptions::default()
+        };
         let result = solve(&problem, &opts, None, Some(&optimal));
         assert!((result.total - optimal_cost).abs() < 1e-4);
         let mut visited = result.route().to_vec();
@@ -201,7 +208,11 @@ mod tests {
         let tour: Vec<usize> = cities.iter().map(|c| c.id).collect();
         // Run a few epochs; all agents start from the same init_tour so sum_fitness
         // is 0 on the first epoch, exercising the uniform-mass fallback.
-        let opts2 = HeuristicOptions { epochs: 5, n_nearest: 5, ..HeuristicOptions::default() };
+        let opts2 = HeuristicOptions {
+            epochs: 5,
+            n_nearest: 5,
+            ..HeuristicOptions::default()
+        };
         let sol = solve(&problem, &opts2, None, Some(&tour));
         assert_eq!(sol.route().len(), cities.len());
         assert!(sol.total.is_finite());

--- a/src/tsp/kdtree.rs
+++ b/src/tsp/kdtree.rs
@@ -139,7 +139,12 @@ pub(crate) struct KDNode {
 
 impl KDNode {
     #[cfg(test)]
-    pub(crate) fn new(point: KDPoint, depth: usize, left: Option<KDNode>, right: Option<KDNode>) -> Self {
+    pub(crate) fn new(
+        point: KDPoint,
+        depth: usize,
+        left: Option<KDNode>,
+        right: Option<KDNode>,
+    ) -> Self {
         KDNode {
             point,
             depth,
@@ -148,7 +153,12 @@ impl KDNode {
         }
     }
 
-    pub(crate) fn from_subtrees(point: KDPoint, depth: usize, left: KDSubTree, right: KDSubTree) -> Self {
+    pub(crate) fn from_subtrees(
+        point: KDPoint,
+        depth: usize,
+        left: KDSubTree,
+        right: KDSubTree,
+    ) -> Self {
         KDNode {
             point,
             depth,
@@ -187,7 +197,9 @@ impl KDNode {
         }
 
         let split_dist = self.point.split_distance(target_point, self.level_coord());
-        if acc.search_radius() > split_dist && let Some(branch) = further_branch {
+        if acc.search_radius() > split_dist
+            && let Some(branch) = further_branch
+        {
             branch.nearest(target_point, acc);
         }
     }
@@ -234,11 +246,17 @@ pub struct KDPoint {
 
 impl KDPoint {
     pub fn new(coords: &[f32]) -> Self {
-        KDPoint { id: 0, coords: [coords[0], coords[1]] }
+        KDPoint {
+            id: 0,
+            coords: [coords[0], coords[1]],
+        }
     }
 
     pub fn new_with_id(id: usize, coords: &[f32]) -> Self {
-        KDPoint { id, coords: [coords[0], coords[1]] }
+        KDPoint {
+            id,
+            coords: [coords[0], coords[1]],
+        }
     }
 
     pub fn dim(&self) -> usize {

--- a/src/tsp/lin_kernighan.rs
+++ b/src/tsp/lin_kernighan.rs
@@ -1,15 +1,19 @@
+use crate::tsp::progress::ProgressMessage;
 use crate::tsp::{
+    HeuristicOptions, LKOptions, Solution, TspProblem,
     distance_matrix::{self, DistanceMatrix},
     kdtree::KDPoint,
     nearest_neighbor,
     route::Route,
-    HeuristicOptions, Solution, LKOptions, TspProblem,
 };
-use std::sync::mpsc;
-use crate::tsp::progress::ProgressMessage;
 use rand::RngExt;
+use std::sync::mpsc;
 
-pub(crate) fn build_candidates(cities: &[KDPoint], dm: &DistanceMatrix, k: usize) -> Vec<Vec<usize>> {
+pub(crate) fn build_candidates(
+    cities: &[KDPoint],
+    dm: &DistanceMatrix,
+    k: usize,
+) -> Vec<Vec<usize>> {
     let n = cities.len();
     let k = k.min(n.saturating_sub(1));
     let max_id = cities.iter().map(|c| c.id).max().unwrap_or(0);
@@ -52,7 +56,9 @@ pub fn solve(
             epochs: 1,
             ..HeuristicOptions::default()
         };
-        nearest_neighbor::solve(problem, &nn_opts, None, None).route().to_vec()
+        nearest_neighbor::solve(problem, &nn_opts, None, None)
+            .route()
+            .to_vec()
     };
 
     if best_tour.len() < 4 {
@@ -60,7 +66,13 @@ pub fn solve(
     }
 
     let mut init_pos = make_pos(&best_tour);
-    lk_pass(&mut best_tour, &mut init_pos, &candidates, &dm, opts.max_depth);
+    lk_pass(
+        &mut best_tour,
+        &mut init_pos,
+        &candidates,
+        &dm,
+        opts.max_depth,
+    );
     drop(init_pos);
     let mut best_dist = tour_distance(&best_tour, &dm);
     send_progress(progress_tx, &best_tour, best_dist);
@@ -70,7 +82,13 @@ pub fn solve(
     for _ in 0..opts.heuristic.epochs {
         let mut candidate = double_bridge(&best_tour, &mut rng);
         let mut cand_pos = make_pos(&candidate);
-        lk_pass(&mut candidate, &mut cand_pos, &candidates, &dm, opts.max_depth);
+        lk_pass(
+            &mut candidate,
+            &mut cand_pos,
+            &candidates,
+            &dm,
+            opts.max_depth,
+        );
         let dist = tour_distance(&candidate, &dm);
         if dist < best_dist {
             best_tour = candidate;
@@ -304,8 +322,17 @@ fn find_lk_chain(
         used[t_break] = true;
 
         if find_lk_chain(
-            t1, t_break, g2, depth + 1, max_depth,
-            chain, used, next, prev, dm, candidates,
+            t1,
+            t_break,
+            g2,
+            depth + 1,
+            max_depth,
+            chain,
+            used,
+            next,
+            prev,
+            dm,
+            candidates,
         ) {
             return true;
         }
@@ -346,8 +373,7 @@ fn find_lk_move(
             used[t2] = true;
 
             let found = find_lk_chain(
-                t1, t2, g0, 0, max_depth,
-                &mut chain, &mut used, next, prev, dm, candidates,
+                t1, t2, g0, 0, max_depth, &mut chain, &mut used, next, prev, dm, candidates,
             );
 
             if found {
@@ -549,7 +575,10 @@ mod tests {
     #[test]
     fn tour_distance_sums_consecutive_edges() {
         let pts: Vec<KDPoint> = (0..4)
-            .map(|i| KDPoint { id: i, coords: [i as f32, 0.0] })
+            .map(|i| KDPoint {
+                id: i,
+                coords: [i as f32, 0.0],
+            })
             .collect();
         let dm = distance_matrix::from_cities(&pts);
         let tour = vec![0usize, 1, 2, 3];
@@ -619,7 +648,10 @@ mod tests {
     fn is_single_cycle_valid_and_invalid() {
         let tour = vec![0usize, 1, 2, 3];
         let (next, _) = flat_to_next_prev(&tour, 3);
-        assert!(is_single_cycle(0, &next, 4), "valid tour must be a single cycle");
+        assert!(
+            is_single_cycle(0, &next, 4),
+            "valid tour must be a single cycle"
+        );
 
         // Break the cycle manually: next[2] = 2 (self-loop), making it invalid
         let mut bad_next = next.clone();
@@ -632,10 +664,22 @@ mod tests {
     #[test]
     fn find_lk_move_improves_crossed_tour() {
         let pts: Vec<KDPoint> = vec![
-            KDPoint { id: 0, coords: [0.0, 0.0] },
-            KDPoint { id: 1, coords: [1.0, 0.0] },
-            KDPoint { id: 2, coords: [1.0, 1.0] },
-            KDPoint { id: 3, coords: [0.0, 1.0] },
+            KDPoint {
+                id: 0,
+                coords: [0.0, 0.0],
+            },
+            KDPoint {
+                id: 1,
+                coords: [1.0, 0.0],
+            },
+            KDPoint {
+                id: 2,
+                coords: [1.0, 1.0],
+            },
+            KDPoint {
+                id: 3,
+                coords: [0.0, 1.0],
+            },
         ];
         let dm = distance_matrix::from_cities(&pts);
         let candidates = build_candidates(&pts, &dm, 3);
@@ -644,13 +688,19 @@ mod tests {
         let (next, prev) = flat_to_next_prev(&tour, max_id);
         let city_ids: Vec<usize> = tour.clone();
         let chain = find_lk_move(&next, &prev, &dm, &candidates, 1, &city_ids);
-        assert!(chain.is_some(), "must find an improvement in a crossed tour");
+        assert!(
+            chain.is_some(),
+            "must find an improvement in a crossed tour"
+        );
     }
 
     #[test]
     fn find_lk_move_returns_none_for_optimal_tour() {
         let pts: Vec<KDPoint> = (0..4)
-            .map(|i| KDPoint { id: i, coords: [i as f32, 0.0] })
+            .map(|i| KDPoint {
+                id: i,
+                coords: [i as f32, 0.0],
+            })
             .collect();
         let dm = distance_matrix::from_cities(&pts);
         let candidates = build_candidates(&pts, &dm, 3);
@@ -668,10 +718,22 @@ mod tests {
     fn apply_lk_chain_consistency_after_depth1_move() {
         // Same crossed-square setup as above
         let pts: Vec<KDPoint> = vec![
-            KDPoint { id: 0, coords: [0.0, 0.0] },
-            KDPoint { id: 1, coords: [1.0, 0.0] },
-            KDPoint { id: 2, coords: [1.0, 1.0] },
-            KDPoint { id: 3, coords: [0.0, 1.0] },
+            KDPoint {
+                id: 0,
+                coords: [0.0, 0.0],
+            },
+            KDPoint {
+                id: 1,
+                coords: [1.0, 0.0],
+            },
+            KDPoint {
+                id: 2,
+                coords: [1.0, 1.0],
+            },
+            KDPoint {
+                id: 3,
+                coords: [0.0, 1.0],
+            },
         ];
         let dm = distance_matrix::from_cities(&pts);
         let candidates = build_candidates(&pts, &dm, 3);
@@ -684,7 +746,10 @@ mod tests {
             .expect("must find improvement");
         apply_lk_chain(&chain, &mut tour, &mut pos);
         let after = tour_distance(&tour, &dm);
-        assert!(after < before, "tour must improve: before={before} after={after}");
+        assert!(
+            after < before,
+            "tour must improve: before={before} after={after}"
+        );
         // pos consistency
         for (rank, &city) in tour.iter().enumerate() {
             assert_eq!(pos[city], rank, "pos[{city}] must equal {rank}");
@@ -705,7 +770,10 @@ mod tests {
         (0..6)
             .map(|i| {
                 let angle = i as f32 * PI / 3.0;
-                KDPoint { id: i, coords: [angle.cos(), angle.sin()] }
+                KDPoint {
+                    id: i,
+                    coords: [angle.cos(), angle.sin()],
+                }
             })
             .collect()
     }
@@ -747,9 +815,15 @@ mod tests {
         if let Some(chain) = find_lk_move(&next, &prev, &dm, &candidates, 2, &city_ids) {
             apply_lk_chain(&chain, &mut tour_mut, &mut pos);
             let after = tour_distance(&tour_mut, &dm);
-            assert!(after < before, "depth-2 move must improve tour: before={before} after={after}");
+            assert!(
+                after < before,
+                "depth-2 move must improve tour: before={before} after={after}"
+            );
             let (new_next, _) = flat_to_next_prev(&tour_mut, max_id);
-            assert!(is_single_cycle(tour_mut[0], &new_next, 6), "result must be a single cycle");
+            assert!(
+                is_single_cycle(tour_mut[0], &new_next, 6),
+                "result must be a single cycle"
+            );
         }
         // If no depth-2 move found, the tour may already be LK-optimal — not a failure
     }
@@ -759,10 +833,22 @@ mod tests {
     #[test]
     fn lk_pass_improves_crossed_tour() {
         let pts: Vec<KDPoint> = vec![
-            KDPoint { id: 0, coords: [0.0, 0.0] },
-            KDPoint { id: 1, coords: [1.0, 0.0] },
-            KDPoint { id: 2, coords: [1.0, 1.0] },
-            KDPoint { id: 3, coords: [0.0, 1.0] },
+            KDPoint {
+                id: 0,
+                coords: [0.0, 0.0],
+            },
+            KDPoint {
+                id: 1,
+                coords: [1.0, 0.0],
+            },
+            KDPoint {
+                id: 2,
+                coords: [1.0, 1.0],
+            },
+            KDPoint {
+                id: 3,
+                coords: [0.0, 1.0],
+            },
         ];
         let dm = distance_matrix::from_cities(&pts);
         let cands = build_candidates(&pts, &dm, 3);
@@ -772,26 +858,38 @@ mod tests {
         let improved = lk_pass(&mut tour, &mut pos, &cands, &dm, 1);
         let after = tour_distance(&tour, &dm);
         assert!(improved, "lk_pass must return true when it improved");
-        assert!(after < before, "tour must be shorter: before={before} after={after}");
+        assert!(
+            after < before,
+            "tour must be shorter: before={before} after={after}"
+        );
     }
 
     #[test]
     fn lk_pass_returns_false_for_optimal_tour() {
         let pts: Vec<KDPoint> = (0..4)
-            .map(|i| KDPoint { id: i, coords: [i as f32, 0.0] })
+            .map(|i| KDPoint {
+                id: i,
+                coords: [i as f32, 0.0],
+            })
             .collect();
         let dm = distance_matrix::from_cities(&pts);
         let cands = build_candidates(&pts, &dm, 3);
         let mut tour = vec![0usize, 1, 2, 3];
         let mut pos = make_pos(&tour);
         let improved = lk_pass(&mut tour, &mut pos, &cands, &dm, 5);
-        assert!(!improved, "lk_pass must return false when tour is already optimal");
+        assert!(
+            !improved,
+            "lk_pass must return false when tour is already optimal"
+        );
     }
 
     #[test]
     fn lk_pass_returns_none_for_tiny_tour() {
         let pts: Vec<KDPoint> = (0..3)
-            .map(|i| KDPoint { id: i, coords: [i as f32, 0.0] })
+            .map(|i| KDPoint {
+                id: i,
+                coords: [i as f32, 0.0],
+            })
             .collect();
         let dm = distance_matrix::from_cities(&pts);
         let cands = build_candidates(&pts, &dm, 2);
@@ -830,7 +928,10 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         let tour: Vec<usize> = (0..7).collect();
         let result = double_bridge(&tour, &mut rng);
-        assert_eq!(result, tour, "tours with < 8 cities must be returned unchanged");
+        assert_eq!(
+            result, tour,
+            "tours with < 8 cities must be returned unchanged"
+        );
     }
 
     // ── solve on berlin52 ─────────────────────────────────────────────────────

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -2,16 +2,16 @@ pub mod bellman_karp;
 pub mod branch_bound;
 pub mod christofides;
 pub mod comparison;
-pub use comparison::{compare_tours, tour_cost, ComparisonStats};
+pub use comparison::{ComparisonStats, compare_tours, tour_cost};
 pub mod convert;
 pub mod cuckoo_search;
 pub mod distance_matrix;
 pub mod flower_pollination;
 pub mod fourier;
-pub mod lin_kernighan;
 pub mod genetic_algorithm;
 pub mod gravitational_search;
 pub mod kdtree;
+pub mod lin_kernighan;
 pub mod nearest_neighbor;
 pub mod opt_tour;
 pub mod or_opt;
@@ -200,15 +200,39 @@ impl SolverMeta {
 impl Solvers {
     pub fn all_meta() -> &'static [SolverMeta] {
         &[
-            SolverMeta { name: "bellman_karp", alias: Some("bhk"), kind: SolverKind::Exact },
-            SolverMeta { name: "branch_bound", alias: None, kind: SolverKind::Exact },
+            SolverMeta {
+                name: "bellman_karp",
+                alias: Some("bhk"),
+                kind: SolverKind::Exact,
+            },
+            SolverMeta {
+                name: "branch_bound",
+                alias: None,
+                kind: SolverKind::Exact,
+            },
             // SolverKind::Heuristic is the CLI-facing kind; the WASM-facing SolverInfo uses
             // category: "Approximation" to expose the distinction to the UI. The two registries
             // serve different audiences and intentionally diverge here.
-            SolverMeta { name: "christofides", alias: Some("chr"), kind: SolverKind::Heuristic },
-            SolverMeta { name: "nearest_neighbor", alias: Some("nn"), kind: SolverKind::Heuristic },
-            SolverMeta { name: "two_opt", alias: Some("2opt"), kind: SolverKind::Heuristic },
-            SolverMeta { name: "three_opt", alias: Some("3opt"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "christofides",
+                alias: Some("chr"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "nearest_neighbor",
+                alias: Some("nn"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "two_opt",
+                alias: Some("2opt"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "three_opt",
+                alias: Some("3opt"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "simulated_annealing",
                 alias: Some("sa"),
@@ -224,27 +248,51 @@ impl Solvers {
                 alias: Some("gsa"),
                 kind: SolverKind::Heuristic,
             },
-            SolverMeta { name: "tabu_search", alias: Some("tabu"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "tabu_search",
+                alias: Some("tabu"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "particle_swarm",
                 alias: Some("pso"),
                 kind: SolverKind::Heuristic,
             },
-            SolverMeta { name: "cuckoo_search", alias: Some("cs"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "cuckoo_search",
+                alias: Some("cs"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "flower_pollination",
                 alias: Some("fpa"),
                 kind: SolverKind::Heuristic,
             },
-            SolverMeta { name: "fourier", alias: Some("fourier"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "fourier",
+                alias: Some("fourier"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "lin_kernighan",
                 alias: Some("lk"),
                 kind: SolverKind::Heuristic,
             },
-            SolverMeta { name: "or_opt", alias: Some("or-opt"), kind: SolverKind::Heuristic },
-            SolverMeta { name: "stochastic_hill", alias: None, kind: SolverKind::Heuristic },
-            SolverMeta { name: "kohonen_som", alias: Some("som"), kind: SolverKind::Heuristic },
+            SolverMeta {
+                name: "or_opt",
+                alias: Some("or-opt"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "stochastic_hill",
+                alias: None,
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
+                name: "kohonen_som",
+                alias: Some("som"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "random_shuffle",
                 alias: Some("shuffle"),
@@ -259,73 +307,187 @@ impl Solvers {
 // ---------------------------------------------------------------------------
 
 pub struct SolverInfo {
-    pub name:        &'static str,
-    pub alias:       &'static str,
-    pub category:    &'static str,
-    pub desc:        &'static str,
-    pub complexity:  &'static str,
+    pub name: &'static str,
+    pub alias: &'static str,
+    pub category: &'static str,
+    pub desc: &'static str,
+    pub complexity: &'static str,
     pub has_options: bool,
-    pub exact:       bool,
+    pub exact: bool,
 }
 
 static SOLVER_LIST: [SolverInfo; 19] = [
-    SolverInfo { name: "Bellman-Held-Karp",     alias: "bhk",             category: "Exact",
-                 desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
-                 complexity: "O(n\u{00b2} \u{00b7} 2\u{207f})", has_options: false, exact: true },
-    SolverInfo { name: "Branch & Bound",        alias: "branch_bound",    category: "Exact",
-                 desc: "Exact branch-and-bound with lower-bound pruning.",
-                 complexity: "O(n!)", has_options: false, exact: true },
-    SolverInfo { name: "Christofides",          alias: "christofides",    category: "Approximation",
-                 desc: "\u{2264}1.5\u{00d7} approximation via MST + greedy matching + Eulerian shortcut (EUC_2D only).",
-                 complexity: "O(n\u{00b2})", has_options: false, exact: false },
-    SolverInfo { name: "Fourier",               alias: "fourier",         category: "Constructive",
-                 desc: "Closed-curve Fourier-basis gradient descent with argsort decode.",
-                 complexity: "O(K\u{00b7}epochs\u{00b7}n\u{00b7}M)", has_options: true, exact: false },
-    SolverInfo { name: "Nearest Neighbor",      alias: "nn",              category: "Constructive",
-                 desc: "Greedy heuristic: always visit the nearest unvisited city.",
-                 complexity: "O(n\u{00b2})", has_options: false, exact: false },
-    SolverInfo { name: "2-opt",                 alias: "2opt",            category: "Local Search",
-                 desc: "Iteratively reverses sub-tours to remove crossing edges.",
-                 complexity: "O(n\u{00b2}) / pass", has_options: false, exact: false },
-    SolverInfo { name: "3-opt",                 alias: "3opt",            category: "Local Search",
-                 desc: "Extends 2-opt by considering triple-edge reconnections.",
-                 complexity: "O(n\u{00b3}) / pass", has_options: false, exact: false },
-    SolverInfo { name: "Simulated Annealing",   alias: "sa",              category: "Metaheuristic",
-                 desc: "Accepts worse moves with decreasing probability to escape local optima.",
-                 complexity: "O(epochs \u{00b7} n)", has_options: true, exact: false },
-    SolverInfo { name: "Genetic Algorithm",     alias: "ga",              category: "Metaheuristic",
-                 desc: "Evolves a population of tours via crossover and mutation operators.",
-                 complexity: "O(epochs \u{00b7} pop \u{00b7} n)", has_options: true, exact: false },
-    SolverInfo { name: "Gravitational Search",  alias: "gsa",             category: "Metaheuristic",
-                 desc: "Agents (tours) attract each other by mass (fitness); heavier agents pull lighter ones via swap-list velocity.",
-                 complexity: "O(epochs \u{00b7} pop\u{00b2})", has_options: true, exact: false },
-    SolverInfo { name: "Particle Swarm",        alias: "pso",             category: "Metaheuristic",
-                 desc: "Discrete PSO with velocity-capped particles guided by a global best.",
-                 complexity: "O(epochs \u{00b7} swarm \u{00b7} n)", has_options: true, exact: false },
-    SolverInfo { name: "Cuckoo Search",         alias: "cs",              category: "Metaheuristic",
-                 desc: "L\u{00e9}vy-flight search with probabilistic nest abandonment.",
-                 complexity: "O(epochs \u{00b7} nests \u{00b7} n)", has_options: true, exact: false },
-    SolverInfo { name: "Flower Pollination",    alias: "fpa",             category: "Metaheuristic",
-                 desc: "Global L\u{00e9}vy-flight toward best tour; local \u{03b5}-scaled cross-pollination.",
-                 complexity: "O(epochs \u{00b7} pop \u{00b7} n)", has_options: true, exact: false },
-    SolverInfo { name: "Lin-Kernighan",         alias: "lk",              category: "Local Search",
-                 desc: "Lin-Kernighan style ILS: 2-opt with candidate lists + double-bridge kicks.",
-                 complexity: "O(epochs \u{00b7} n\u{00b2})", has_options: true, exact: false },
-    SolverInfo { name: "Or-opt",                alias: "or_opt",          category: "Local Search",
-                 desc: "Relocates segments of 1\u{2013}3 cities to better positions (best-improvement).",
-                 complexity: "O(n\u{00b2}) / pass", has_options: false, exact: false },
-    SolverInfo { name: "Stochastic Hill Climb", alias: "stochastic_hill", category: "Metaheuristic",
-                 desc: "Random-restart hill climbing to escape local optima.",
-                 complexity: "O(epochs \u{00b7} n)", has_options: false, exact: false },
-    SolverInfo { name: "Tabu Search",           alias: "tabu_search",     category: "Metaheuristic",
-                 desc: "Local search with a memory structure to avoid revisiting solutions.",
-                 complexity: "O(epochs \u{00b7} n)", has_options: false, exact: false },
-    SolverInfo { name: "Kohonen SOM",            alias: "som",             category: "Constructive",
-                 desc: "Elastic ring of neurons wrapping around cities via Hebbian learning; topology-preserving tour extraction.",
-                 complexity: "O(epochs\u{00b7}N\u{00b7}n)", has_options: true, exact: false },
-    SolverInfo { name: "Random Shuffle",        alias: "shuffle",         category: "Utility",
-                 desc: "Baseline random tour. Useful as a warm-start seed for pipelines.",
-                 complexity: "O(n)", has_options: false, exact: false },
+    SolverInfo {
+        name: "Bellman-Held-Karp",
+        alias: "bhk",
+        category: "Exact",
+        desc: "Exact dynamic-programming solution. Optimal tour guaranteed.",
+        complexity: "O(n\u{00b2} \u{00b7} 2\u{207f})",
+        has_options: false,
+        exact: true,
+    },
+    SolverInfo {
+        name: "Branch & Bound",
+        alias: "branch_bound",
+        category: "Exact",
+        desc: "Exact branch-and-bound with lower-bound pruning.",
+        complexity: "O(n!)",
+        has_options: false,
+        exact: true,
+    },
+    SolverInfo {
+        name: "Christofides",
+        alias: "christofides",
+        category: "Approximation",
+        desc: "\u{2264}1.5\u{00d7} approximation via MST + greedy matching + Eulerian shortcut (EUC_2D only).",
+        complexity: "O(n\u{00b2})",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Fourier",
+        alias: "fourier",
+        category: "Constructive",
+        desc: "Closed-curve Fourier-basis gradient descent with argsort decode.",
+        complexity: "O(K\u{00b7}epochs\u{00b7}n\u{00b7}M)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Nearest Neighbor",
+        alias: "nn",
+        category: "Constructive",
+        desc: "Greedy heuristic: always visit the nearest unvisited city.",
+        complexity: "O(n\u{00b2})",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "2-opt",
+        alias: "2opt",
+        category: "Local Search",
+        desc: "Iteratively reverses sub-tours to remove crossing edges.",
+        complexity: "O(n\u{00b2}) / pass",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "3-opt",
+        alias: "3opt",
+        category: "Local Search",
+        desc: "Extends 2-opt by considering triple-edge reconnections.",
+        complexity: "O(n\u{00b3}) / pass",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Simulated Annealing",
+        alias: "sa",
+        category: "Metaheuristic",
+        desc: "Accepts worse moves with decreasing probability to escape local optima.",
+        complexity: "O(epochs \u{00b7} n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Genetic Algorithm",
+        alias: "ga",
+        category: "Metaheuristic",
+        desc: "Evolves a population of tours via crossover and mutation operators.",
+        complexity: "O(epochs \u{00b7} pop \u{00b7} n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Gravitational Search",
+        alias: "gsa",
+        category: "Metaheuristic",
+        desc: "Agents (tours) attract each other by mass (fitness); heavier agents pull lighter ones via swap-list velocity.",
+        complexity: "O(epochs \u{00b7} pop\u{00b2})",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Particle Swarm",
+        alias: "pso",
+        category: "Metaheuristic",
+        desc: "Discrete PSO with velocity-capped particles guided by a global best.",
+        complexity: "O(epochs \u{00b7} swarm \u{00b7} n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Cuckoo Search",
+        alias: "cs",
+        category: "Metaheuristic",
+        desc: "L\u{00e9}vy-flight search with probabilistic nest abandonment.",
+        complexity: "O(epochs \u{00b7} nests \u{00b7} n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Flower Pollination",
+        alias: "fpa",
+        category: "Metaheuristic",
+        desc: "Global L\u{00e9}vy-flight toward best tour; local \u{03b5}-scaled cross-pollination.",
+        complexity: "O(epochs \u{00b7} pop \u{00b7} n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Lin-Kernighan",
+        alias: "lk",
+        category: "Local Search",
+        desc: "Lin-Kernighan style ILS: 2-opt with candidate lists + double-bridge kicks.",
+        complexity: "O(epochs \u{00b7} n\u{00b2})",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Or-opt",
+        alias: "or_opt",
+        category: "Local Search",
+        desc: "Relocates segments of 1\u{2013}3 cities to better positions (best-improvement).",
+        complexity: "O(n\u{00b2}) / pass",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Stochastic Hill Climb",
+        alias: "stochastic_hill",
+        category: "Metaheuristic",
+        desc: "Random-restart hill climbing to escape local optima.",
+        complexity: "O(epochs \u{00b7} n)",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Tabu Search",
+        alias: "tabu_search",
+        category: "Metaheuristic",
+        desc: "Local search with a memory structure to avoid revisiting solutions.",
+        complexity: "O(epochs \u{00b7} n)",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Kohonen SOM",
+        alias: "som",
+        category: "Constructive",
+        desc: "Elastic ring of neurons wrapping around cities via Hebbian learning; topology-preserving tour extraction.",
+        complexity: "O(epochs\u{00b7}N\u{00b7}n)",
+        has_options: true,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Random Shuffle",
+        alias: "shuffle",
+        category: "Utility",
+        desc: "Baseline random tour. Useful as a warm-start seed for pipelines.",
+        complexity: "O(n)",
+        has_options: false,
+        exact: false,
+    },
 ];
 
 pub fn list_solvers() -> &'static [SolverInfo] {
@@ -936,12 +1098,12 @@ impl LKOptions {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FourierOptions {
-    pub k_max: usize,       // max Fourier mode, default 4
-    pub m: usize,           // curve sampling resolution, default 200
-    pub lambda: f64,        // initial tension weight, default 0.05
-    pub lambda_decay: f64,  // tension decay multiplier per k_active stage, default 0.5
-    pub lr: f64,            // gradient learning rate, default 0.05
-    pub epochs: usize,      // gradient steps per k_active stage, default 400
+    pub k_max: usize,      // max Fourier mode, default 4
+    pub m: usize,          // curve sampling resolution, default 200
+    pub lambda: f64,       // initial tension weight, default 0.05
+    pub lambda_decay: f64, // tension decay multiplier per k_active stage, default 0.5
+    pub lr: f64,           // gradient learning rate, default 0.05
+    pub epochs: usize,     // gradient steps per k_active stage, default 400
 }
 
 impl Default for FourierOptions {
@@ -985,32 +1147,40 @@ impl FourierOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "k_max" => {
-                    f.k_max = v.as_integer()
+                    f.k_max = v
+                        .as_integer()
                         .ok_or_else(|| format!("config: `k_max` must be an integer, got {v}"))?
                         as usize;
                 }
                 "m" => {
-                    f.m = v.as_integer()
+                    f.m = v
+                        .as_integer()
                         .ok_or_else(|| format!("config: `m` must be an integer, got {v}"))?
                         as usize;
                 }
                 "lambda" => {
-                    f.lambda = v.as_float()
+                    f.lambda = v
+                        .as_float()
                         .or_else(|| v.as_integer().map(|i| i as f64))
                         .ok_or_else(|| format!("config: `lambda` must be a float, got {v}"))?;
                 }
                 "lambda_decay" => {
-                    f.lambda_decay = v.as_float()
+                    f.lambda_decay = v
+                        .as_float()
                         .or_else(|| v.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| format!("config: `lambda_decay` must be a float, got {v}"))?;
+                        .ok_or_else(|| {
+                            format!("config: `lambda_decay` must be a float, got {v}")
+                        })?;
                 }
                 "lr" => {
-                    f.lr = v.as_float()
+                    f.lr = v
+                        .as_float()
                         .or_else(|| v.as_integer().map(|i| i as f64))
                         .ok_or_else(|| format!("config: `lr` must be a float, got {v}"))?;
                 }
                 "epochs" => {
-                    f.epochs = v.as_integer()
+                    f.epochs = v
+                        .as_integer()
                         .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
                         as usize;
                 }
@@ -1028,7 +1198,8 @@ impl FourierOptions {
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
         let mut f = FourierOptions::default();
         if let Some(v) = args.get_one::<String>("epochs") {
-            f.epochs = v.parse::<usize>()
+            f.epochs = v
+                .parse::<usize>()
                 .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
         }
         f.validate()?;
@@ -1081,7 +1252,8 @@ impl SOMOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    let raw = v.as_integer()
+                    let raw = v
+                        .as_integer()
                         .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?;
                     if raw < 1 {
                         return Err(format!("config: `epochs` must be >= 1, got {raw}"));
@@ -1089,20 +1261,29 @@ impl SOMOptions {
                     s.epochs = raw as usize;
                 }
                 "learning_rate" => {
-                    s.learning_rate = v.as_float()
+                    s.learning_rate = v
+                        .as_float()
                         .or_else(|| v.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| format!("config: `learning_rate` must be a float, got {v}"))?;
+                        .ok_or_else(|| {
+                            format!("config: `learning_rate` must be a float, got {v}")
+                        })?;
                 }
                 "radius_fraction" => {
-                    s.radius_fraction = v.as_float()
+                    s.radius_fraction = v
+                        .as_float()
                         .or_else(|| v.as_integer().map(|i| i as f64))
-                        .ok_or_else(|| format!("config: `radius_fraction` must be a float, got {v}"))?;
+                        .ok_or_else(|| {
+                        format!("config: `radius_fraction` must be a float, got {v}")
+                    })?;
                 }
                 "neuron_multiplier" => {
-                    let raw = v.as_integer()
-                        .ok_or_else(|| format!("config: `neuron_multiplier` must be an integer, got {v}"))?;
+                    let raw = v.as_integer().ok_or_else(|| {
+                        format!("config: `neuron_multiplier` must be an integer, got {v}")
+                    })?;
                     if raw < 1 {
-                        return Err(format!("config: `neuron_multiplier` must be >= 1, got {raw}"));
+                        return Err(format!(
+                            "config: `neuron_multiplier` must be >= 1, got {raw}"
+                        ));
                     }
                     s.neuron_multiplier = raw as usize;
                 }
@@ -1120,19 +1301,23 @@ impl SOMOptions {
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
         let mut s = SOMOptions::default();
         if let Some(v) = args.get_one::<String>("epochs") {
-            s.epochs = v.parse::<usize>()
+            s.epochs = v
+                .parse::<usize>()
                 .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("learning_rate") {
-            s.learning_rate = v.parse::<f64>()
+            s.learning_rate = v
+                .parse::<f64>()
                 .map_err(|_| format!("--learning_rate: invalid float `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("radius_fraction") {
-            s.radius_fraction = v.parse::<f64>()
+            s.radius_fraction = v
+                .parse::<f64>()
                 .map_err(|_| format!("--radius_fraction: invalid float `{v}`"))?;
         }
         if let Some(v) = args.get_one::<String>("neuron_multiplier") {
-            s.neuron_multiplier = v.parse::<usize>()
+            s.neuron_multiplier = v
+                .parse::<usize>()
                 .map_err(|_| format!("--neuron_multiplier: invalid integer `{v}`"))?;
         }
         s.validate()?;
@@ -1731,13 +1916,18 @@ mod tests {
 
     #[test]
     fn lk_options_default_is_valid() {
-        LKOptions::default().validate().expect("default LKOptions must be valid");
+        LKOptions::default()
+            .validate()
+            .expect("default LKOptions must be valid");
     }
 
     #[test]
     fn lk_options_validate_rejects_zero_n_nearest() {
         let opts = LKOptions {
-            heuristic: HeuristicOptions { n_nearest: 0, ..HeuristicOptions::default() },
+            heuristic: HeuristicOptions {
+                n_nearest: 0,
+                ..HeuristicOptions::default()
+            },
             max_depth: 5,
         };
         assert!(opts.validate().is_err(), "n_nearest=0 must be rejected");
@@ -1745,14 +1935,16 @@ mod tests {
 
     #[test]
     fn lk_options_validate_rejects_zero_max_depth() {
-        let opts = LKOptions { max_depth: 0, ..LKOptions::default() };
+        let opts = LKOptions {
+            max_depth: 0,
+            ..LKOptions::default()
+        };
         assert!(opts.validate().is_err(), "max_depth=0 must be rejected");
     }
 
     #[test]
     fn lk_options_from_toml_parses_all_fields() {
-        let t: toml::Table =
-            toml::from_str("epochs=50\nn_nearest=7\nmax_depth=3").unwrap();
+        let t: toml::Table = toml::from_str("epochs=50\nn_nearest=7\nmax_depth=3").unwrap();
         let opts = LKOptions::from_toml(&t).unwrap();
         assert_eq!(opts.heuristic.epochs, 50);
         assert_eq!(opts.heuristic.n_nearest, 7);
@@ -1764,11 +1956,27 @@ mod tests {
         use clap::{Arg, ArgAction, Command};
         let cmd = Command::new("t")
             .arg(Arg::new("epochs").long("epochs").action(ArgAction::Set))
-            .arg(Arg::new("platoo_epochs").long("platoo_epochs").action(ArgAction::Set))
-            .arg(Arg::new("n_nearest").long("n_nearest").action(ArgAction::Set))
-            .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue))
-            .arg(Arg::new("max_depth").long("max-depth").action(ArgAction::Set));  // hyphen matches production CLI
-        let args = cmd.get_matches_from(["t", "--max-depth", "3"]);  // hyphen matches production CLI
+            .arg(
+                Arg::new("platoo_epochs")
+                    .long("platoo_epochs")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("n_nearest")
+                    .long("n_nearest")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("max_depth")
+                    .long("max-depth")
+                    .action(ArgAction::Set),
+            ); // hyphen matches production CLI
+        let args = cmd.get_matches_from(["t", "--max-depth", "3"]); // hyphen matches production CLI
         let opts = LKOptions::from_cli(&args).unwrap();
         assert_eq!(opts.max_depth, 3);
     }

--- a/src/tsp/or_opt.rs
+++ b/src/tsp/or_opt.rs
@@ -248,29 +248,21 @@ mod tests {
         // Tour: 0→1→2→3→4 (closed cycle). City 2 is a detour.
         // Layout: 0=(0,0), 1=(1,0), 2=(5,5) [far detour], 3=(2,0), 4=(3,0)
         // Moving city 2 elsewhere should be profitable.
-        let problem = make_problem(&[
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [5.0, 5.0],
-            [2.0, 0.0],
-            [3.0, 0.0],
-        ]);
+        let problem = make_problem(&[[0.0, 0.0], [1.0, 0.0], [5.0, 5.0], [2.0, 0.0], [3.0, 0.0]]);
         let path: Vec<usize> = problem.cities.iter().map(|c| c.id).collect();
         let result = find_best_move(&path, &problem.distances);
         assert!(result.is_some(), "expected an improving move");
         let (delta, _, _, _, _) = result.unwrap();
-        assert!(delta < 0.0, "delta should be negative (improvement), got {delta}");
+        assert!(
+            delta < 0.0,
+            "delta should be negative (improvement), got {delta}"
+        );
     }
 
     #[test]
     fn find_best_move_returns_none_for_optimal_tour() {
         // Square: [0,1,2,3] is already optimal (perimeter tour).
-        let problem = make_problem(&[
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [1.0, 1.0],
-            [0.0, 1.0],
-        ]);
+        let problem = make_problem(&[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]);
         let path = vec![0, 1, 2, 3];
         let result = find_best_move(&path, &problem.distances);
         assert!(
@@ -286,13 +278,7 @@ mod tests {
     #[test]
     fn or_opt_improves_detour_tour() {
         // City 2 is a far detour; Or-opt should relocate it.
-        let problem = make_problem(&[
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [5.0, 5.0],
-            [2.0, 0.0],
-            [3.0, 0.0],
-        ]);
+        let problem = make_problem(&[[0.0, 0.0], [1.0, 0.0], [5.0, 5.0], [2.0, 0.0], [3.0, 0.0]]);
         let detour_tour: Vec<usize> = problem.cities.iter().map(|c| c.id).collect();
         let detour_cost = problem.distances.tour_length(&detour_tour);
         let sol = solve(
@@ -312,19 +298,9 @@ mod tests {
     #[test]
     fn or_opt_preserves_optimal_tour() {
         // Already-optimal 4-city square; Or-opt must not worsen it.
-        let problem = make_problem(&[
-            [0.0, 0.0],
-            [1.0, 0.0],
-            [1.0, 1.0],
-            [0.0, 1.0],
-        ]);
+        let problem = make_problem(&[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]);
         let optimal = vec![0, 1, 2, 3];
-        let sol = solve(
-            &problem,
-            &HeuristicOptions::default(),
-            None,
-            Some(&optimal),
-        );
+        let sol = solve(&problem, &HeuristicOptions::default(), None, Some(&optimal));
         assert!(
             (sol.total - 4.0).abs() < 1e-2,
             "tour cost changed from optimal: {}",

--- a/src/tsp/som.rs
+++ b/src/tsp/som.rs
@@ -1,8 +1,8 @@
-use crate::tsp::{SOMOptions, Solution, TspProblem};
 use crate::tsp::progress::ProgressMessage;
 use crate::tsp::route::Route;
-use std::sync::mpsc;
+use crate::tsp::{SOMOptions, Solution, TspProblem};
 use rand::RngExt;
+use std::sync::mpsc;
 
 #[inline]
 fn sq_dist(a: &[f64; 2], b: &[f64; 2]) -> f64 {
@@ -90,7 +90,9 @@ pub fn solve(
             .iter()
             .enumerate()
             .min_by(|&(_, a), &(_, b)| {
-                sq_dist(a, &city).partial_cmp(&sq_dist(b, &city)).unwrap_or(std::cmp::Ordering::Equal)
+                sq_dist(a, &city)
+                    .partial_cmp(&sq_dist(b, &city))
+                    .unwrap_or(std::cmp::Ordering::Equal)
             })
             .map(|(i, _)| i)
             .expect("neurons is always non-empty: n >= 2 and neuron_multiplier >= 1");
@@ -113,7 +115,13 @@ pub fn solve(
 
         // Send progress at each 10% milestone
         if t % checkpoint == 0 {
-            tracing::debug!(epoch = t, pct = t * 100 / epochs, eta, sigma, "SOM: checkpoint");
+            tracing::debug!(
+                epoch = t,
+                pct = t * 100 / epochs,
+                eta,
+                sigma,
+                "SOM: checkpoint"
+            );
             if let Some(tx) = progress_tx {
                 let snapshot = extract_tour(&norm_cities, &neurons, cities);
                 let cost = problem.distances.tour_length(&snapshot);
@@ -166,7 +174,11 @@ fn extract_tour(
         let (bmu_b, dist_b) = city_bmu[b];
         bmu_a
             .cmp(&bmu_b)
-            .then_with(|| dist_a.partial_cmp(&dist_b).unwrap_or(std::cmp::Ordering::Equal))
+            .then_with(|| {
+                dist_a
+                    .partial_cmp(&dist_b)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
             .then_with(|| a.cmp(&b))
     });
 
@@ -176,8 +188,8 @@ fn extract_tour(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tsp::{TspProblem, distance_matrix, kdtree::KDPoint};
     use std::f32::consts::PI;
-    use crate::tsp::{distance_matrix, kdtree::KDPoint, TspProblem};
 
     fn circle_cities(n: usize) -> Vec<KDPoint> {
         (0..n)
@@ -217,7 +229,10 @@ mod tests {
         let problem = make_problem(cities.clone());
         let sol = solve(&problem, &fast_opts(), None, None);
         assert_eq!(sol.route().len(), 3, "tour must visit all 3 cities");
-        assert!(is_valid_tour(sol.route(), &cities), "tour must be a valid permutation");
+        assert!(
+            is_valid_tour(sol.route(), &cities),
+            "tour must be a valid permutation"
+        );
         assert!(sol.total > 0.0, "tour distance must be positive");
     }
 
@@ -227,7 +242,10 @@ mod tests {
         let problem = make_problem(cities.clone());
         let sol = solve(&problem, &fast_opts(), None, None);
         assert_eq!(sol.route().len(), 10, "tour must visit all 10 cities");
-        assert!(is_valid_tour(sol.route(), &cities), "tour must be a valid permutation");
+        assert!(
+            is_valid_tour(sol.route(), &cities),
+            "tour must be a valid permutation"
+        );
     }
 
     #[test]
@@ -257,8 +275,14 @@ mod tests {
     #[test]
     fn test_som_two_cities() {
         let cities = vec![
-            KDPoint { id: 0, coords: [0.0, 0.0] },
-            KDPoint { id: 1, coords: [1.0, 0.0] },
+            KDPoint {
+                id: 0,
+                coords: [0.0, 0.0],
+            },
+            KDPoint {
+                id: 1,
+                coords: [1.0, 0.0],
+            },
         ];
         let problem = make_problem(cities.clone());
         let sol = solve(&problem, &fast_opts(), None, None);

--- a/src/tsp/tsplib.rs
+++ b/src/tsp/tsplib.rs
@@ -652,7 +652,8 @@ mod tests {
     #[cfg(feature = "json")]
     #[test]
     fn test_parse_json_cities_valid() {
-        let json = r#"[{"id":0,"x":1.0,"y":2.0},{"id":1,"x":3.0,"y":4.0},{"id":2,"x":5.0,"y":6.0}]"#;
+        let json =
+            r#"[{"id":0,"x":1.0,"y":2.0},{"id":1,"x":3.0,"y":4.0},{"id":2,"x":5.0,"y":6.0}]"#;
         let cities = parse_json_cities(json).unwrap();
         assert_eq!(3, cities.len());
         assert_eq!(0, cities[0].id);
@@ -700,8 +701,8 @@ mod tests {
 
     #[test]
     fn test_read_from_str_burma14() {
-        let input = std::fs::read_to_string("tests/fixtures/burma14.tsp")
-            .expect("burma14.tsp missing");
+        let input =
+            std::fs::read_to_string("tests/fixtures/burma14.tsp").expect("burma14.tsp missing");
         let dt = read_from_str(&input).unwrap();
         assert_eq!(14, dt.len());
         assert_eq!("burma14", dt.name);
@@ -709,8 +710,8 @@ mod tests {
 
     #[test]
     fn test_read_from_str_berlin52() {
-        let input = std::fs::read_to_string("tests/fixtures/berlin52.tsp")
-            .expect("berlin52.tsp missing");
+        let input =
+            std::fs::read_to_string("tests/fixtures/berlin52.tsp").expect("berlin52.tsp missing");
         let dt = read_from_str(&input).unwrap();
         assert_eq!(52, dt.len());
     }

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -3,19 +3,19 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::thread;
 
+use serde_json::json;
+use teeline::DistanceType;
 use teeline::config::{
     AppOptionsProvider, IdentityProvider, PipelineSource, resolve_config_file,
     select_pipeline_source,
 };
 use teeline::tsp::{
-    self, AppOptions, Solution, SolverKind, Solvers, SOMOptions, TspProblem, distance_matrix,
+    self, AppOptions, SOMOptions, Solution, SolverKind, Solvers, TspProblem, distance_matrix,
     list_solvers,
     pipeline::{PipelineStage, run_pipeline},
     tsplib,
 };
-use teeline::DistanceType;
 use tracing_subscriber::EnvFilter;
-use serde_json::json;
 
 // ---------------------------------------------------------------------------
 // CliArgsProvider — applies CLI tuning flags to a base AppOptions.
@@ -35,7 +35,9 @@ impl<'a> CliArgsProvider<'a> {
 
 impl AppOptionsProvider for CliArgsProvider<'_> {
     fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
-        use teeline::tsp::{CSOptions, FPAOptions, GAOptions, HeuristicOptions, LKOptions, SAOptions};
+        use teeline::tsp::{
+            CSOptions, FPAOptions, GAOptions, HeuristicOptions, LKOptions, SAOptions,
+        };
         match self.solver {
             Solvers::SimulatedAnnealing => {
                 base.sa = Some(SAOptions::from_cli(self.args)?);
@@ -365,7 +367,11 @@ fn run_as_pipeline(steps: &[Solvers], args: &ArgMatches, json_mode: bool) {
     run_as_pipeline_stages(stage_configs, args, json_mode);
 }
 
-fn run_as_pipeline_stages(stage_configs: Vec<(Solvers, AppOptions)>, args: &ArgMatches, json_mode: bool) {
+fn run_as_pipeline_stages(
+    stage_configs: Vec<(Solvers, AppOptions)>,
+    args: &ArgMatches,
+    json_mode: bool,
+) {
     let verbose = args.get_flag("verbose");
     let default_level = if verbose { "debug" } else { "info" };
     let _ = tracing_subscriber::fmt()
@@ -513,20 +519,35 @@ fn run_solvers(args: &ArgMatches) {
 // ---------------------------------------------------------------------------
 
 fn solver_meta_matches(m: &tsp::SolverMeta, only_heuristic: bool, only_exact: bool) -> bool {
-    if only_heuristic { m.kind == SolverKind::Heuristic }
-    else if only_exact { m.kind == SolverKind::Exact }
-    else { true }
+    if only_heuristic {
+        m.kind == SolverKind::Heuristic
+    } else if only_exact {
+        m.kind == SolverKind::Exact
+    } else {
+        true
+    }
 }
 
 fn print_solvers_table(only_heuristic: bool, only_exact: bool) {
     println!("{:<22} {:<8} TYPE", "NAME", "ALIAS");
-    for m in Solvers::all_meta().iter().filter(|m| solver_meta_matches(m, only_heuristic, only_exact)) {
-        println!("{:<22} {:<8} {}", m.name, m.alias.unwrap_or("—"), m.kind.as_str());
+    for m in Solvers::all_meta()
+        .iter()
+        .filter(|m| solver_meta_matches(m, only_heuristic, only_exact))
+    {
+        println!(
+            "{:<22} {:<8} {}",
+            m.name,
+            m.alias.unwrap_or("—"),
+            m.kind.as_str()
+        );
     }
 }
 
 fn print_solvers_short(only_heuristic: bool, only_exact: bool) {
-    for m in Solvers::all_meta().iter().filter(|m| solver_meta_matches(m, only_heuristic, only_exact)) {
+    for m in Solvers::all_meta()
+        .iter()
+        .filter(|m| solver_meta_matches(m, only_heuristic, only_exact))
+    {
         println!("{}", m.short());
     }
 }
@@ -535,18 +556,24 @@ fn print_solvers_json(only_heuristic: bool, only_exact: bool) {
     let arr: Vec<_> = list_solvers()
         .iter()
         .filter(|s| {
-            if only_heuristic { !s.exact && s.category != "Utility" }
-            else if only_exact { s.exact }
-            else { true }
+            if only_heuristic {
+                !s.exact && s.category != "Utility"
+            } else if only_exact {
+                s.exact
+            } else {
+                true
+            }
         })
-        .map(|s| json!({
-            "name": s.name,
-            "alias": s.alias,
-            "category": s.category,
-            "complexity": s.complexity,
-            "has_options": s.has_options,
-            "exact": s.exact,
-        }))
+        .map(|s| {
+            json!({
+                "name": s.name,
+                "alias": s.alias,
+                "category": s.category,
+                "complexity": s.complexity,
+                "has_options": s.has_options,
+                "exact": s.exact,
+            })
+        })
         .collect();
     println!("{}", serde_json::to_string(&arr).unwrap());
 }
@@ -585,12 +612,19 @@ fn compute_optimal_comparison(
     } else {
         0.0
     };
-    Some(OptimalComparison { optimal_cost, gap_pct, opt_name: opt_tour.name.clone() })
+    Some(OptimalComparison {
+        optimal_cost,
+        gap_pct,
+        opt_name: opt_tour.name.clone(),
+    })
 }
 
 fn print_optimal_comparison(solver_cost: f32, cmp: &OptimalComparison) {
     eprintln!("--- Comparison ---");
-    eprintln!("Optimal  : {:.5}  (from {})", cmp.optimal_cost, cmp.opt_name);
+    eprintln!(
+        "Optimal  : {:.5}  (from {})",
+        cmp.optimal_cost, cmp.opt_name
+    );
     eprintln!("Solver   : {:.5}", solver_cost);
     if cmp.gap_pct.abs() < 0.001 {
         eprintln!("Gap      : 0.00 % (matches optimal)");

--- a/teeline-wasm/js-bindings/teeline_wasm.js
+++ b/teeline-wasm/js-bindings/teeline_wasm.js
@@ -1,9 +1,8 @@
 "use components";
-import { environment, exit as exit$1, stderr, stdin, stdout } from '@bytecodealliance/preview2-shim/cli';
+import { environment, exit as exit$1, stderr, stdin, stdout, terminalInput, terminalOutput, terminalStderr, terminalStdin, terminalStdout } from '@bytecodealliance/preview2-shim/cli';
 import { monotonicClock, wallClock } from '@bytecodealliance/preview2-shim/clocks';
-import { preopens, types } from '@bytecodealliance/preview2-shim/filesystem';
-import { error, streams } from '@bytecodealliance/preview2-shim/io';
-import { random } from '@bytecodealliance/preview2-shim/random';
+import { error, poll, streams } from '@bytecodealliance/preview2-shim/io';
+import { insecureSeed as insecureSeed$1, random } from '@bytecodealliance/preview2-shim/random';
 const { getEnvironment } = environment;
 
 if (getEnvironment=== undefined) {
@@ -44,6 +43,46 @@ if (getStdout=== undefined) {
   throw err;
 }
 
+const { TerminalInput } = terminalInput;
+
+if (TerminalInput=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'TerminalInput', was 'TerminalInput' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { TerminalOutput } = terminalOutput;
+
+if (TerminalOutput=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'TerminalOutput', was 'TerminalOutput' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStderr } = terminalStderr;
+
+if (getTerminalStderr=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStderr', was 'getTerminalStderr' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStdin } = terminalStdin;
+
+if (getTerminalStdin=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStdin', was 'getTerminalStdin' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStdout } = terminalStdout;
+
+if (getTerminalStdout=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStdout', was 'getTerminalStdout' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
 const { now } = monotonicClock;
 
 if (now=== undefined) {
@@ -60,34 +99,18 @@ if (now$1=== undefined) {
   throw err;
 }
 
-const { getDirectories } = preopens;
-
-if (getDirectories=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'getDirectories', was 'getDirectories' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
-const { Descriptor,
-  filesystemErrorCode } = types;
-
-if (Descriptor=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'Descriptor', was 'Descriptor' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
-
-if (filesystemErrorCode=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'filesystemErrorCode', was 'filesystemErrorCode' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
 const { Error: Error$1 } = error;
 
 if (Error$1=== undefined) {
   const err = new Error("unexpectedly undefined local import 'Error$1', was 'Error' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { Pollable } = poll;
+
+if (Pollable=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'Pollable', was 'Pollable' available at instantiation?");
   console.error("ERROR:", err.toString());
   throw err;
 }
@@ -108,10 +131,18 @@ if (OutputStream=== undefined) {
   throw err;
 }
 
-const { getRandomBytes } = random;
+const { insecureSeed } = insecureSeed$1;
 
-if (getRandomBytes=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'getRandomBytes', was 'getRandomBytes' available at instantiation?");
+if (insecureSeed=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'insecureSeed', was 'insecureSeed' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getRandomU64 } = random;
+
+if (getRandomU64=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getRandomU64', was 'getRandomU64' available at instantiation?");
   console.error("ERROR:", err.toString());
   throw err;
 }
@@ -2357,30 +2388,6 @@ function _lowerImportBackwardsCompat(args) {
   }
   
   
-  function _liftFlatU64(ctx) {
-    _debugLog('[_liftFlatU64()] args', { ctx });
-    let val;
-    
-    if (ctx.useDirectParams) {
-      if (ctx.params.length === 0) { throw new Error('expected at least one single i64 argument'); }
-      if (typeof ctx.params[0] !== 'bigint') { throw new Error('expected bigint'); }
-      val = ctx.params[0];
-      ctx.params = ctx.params.slice(1);
-      return [val, ctx];
-    }
-    
-    if (ctx.storageLen !== undefined && ctx.storageLen < 8) {
-      throw new Error(`insufficient storage ([${ctx.storageLen}] bytes) for lift (u64 requires 8 bytes)`);
-    }
-    
-    val = new DataView(ctx.memory.buffer).getBigUint64(ctx.storagePtr, true);
-    ctx.storagePtr += 8;
-    if (ctx.storageLen !== undefined) { ctx.storageLen -= 8; }
-    
-    return [val, ctx];
-  }
-  
-  
   function _liftFlatVariant(casesAndLiftFns) {
     return function _liftFlatVariantInner(ctx) {
       _debugLog('[_liftFlatVariant()] args', { ctx });
@@ -2878,22 +2885,6 @@ function _lowerFlatTuple(meta) {
     if (rem !== 0) {
       ctx.storagePtr += tupleAlign32 - rem;
     }
-  }
-}
-
-function _lowerFlatEnum(lowerMetas) {
-  return function _lowerFlatEnumInner(ctx) {
-    _debugLog('[_lowerFlatEnum()] args', { ctx });
-    
-    const v = ctx.vals[0];
-    const isNotEnumObject = typeof v !== 'object'
-    || Object.keys(v).length !== 2
-    || !('tag' in v);
-    if (isNotEnumObject) {
-      ctx.vals[0] = { tag: v };
-    }
-    
-    _lowerFlatVariant(lowerMetas)(ctx);
   }
 }
 
@@ -3704,10 +3695,9 @@ const instantiateCore = WebAssembly.instantiate;
 
 
 let exports0;
-let exports1;
 
 const _trampoline0 = function() {
-  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.3", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+  _debugLog('[iface="wasi:random/random@0.2.12", function="get-random-u64"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3718,7 +3708,7 @@ const _trampoline0 = function() {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'now',
+      entryFnName: 'getRandomU64',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -3757,7 +3747,7 @@ const _trampoline0 = function() {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => now(),
+      fn: () => getRandomU64(),
     })
     ;
   } catch (err) {
@@ -3769,8 +3759,8 @@ const _trampoline0 = function() {
     
   }
   
-  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.3", function="now"][Instruction::Return]', {
-    funcName: 'now',
+  _debugLog('[iface="wasi:random/random@0.2.12", function="get-random-u64"][Instruction::Return]', {
+    funcName: 'get-random-u64',
     paramCount: 1,
     async: false,
     postReturn: false
@@ -3779,14 +3769,30 @@ const _trampoline0 = function() {
   task.exit();
   return toUint64(ret);
 }
-_trampoline0.fnName = 'wasi:clocks/monotonic-clock@0.2.3#now';
-const handleTable1 = [T_FLAG, 0];
-const captureTable1= new Map();
-let captureCnt1 = 0;
-handleTables[1] = handleTable1;
+_trampoline0.fnName = 'wasi:random/random@0.2.12#getRandomU64';
 
-const _trampoline5 = function() {
-  _debugLog('[iface="wasi:cli/stderr@0.2.3", function="get-stderr"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline7 = function(arg0) {
+  let variant0;
+  switch (arg0) {
+    case 0: {
+      variant0= {
+        tag: 'ok',
+        val: undefined
+      };
+      break;
+    }
+    case 1: {
+      variant0= {
+        tag: 'err',
+        val: undefined
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  _debugLog('[iface="wasi:cli/exit@0.2.12", function="exit"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3797,7 +3803,189 @@ const _trampoline5 = function() {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'getStderr',
+      entryFnName: 'exit',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => exit(variant0),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  _debugLog('[iface="wasi:cli/exit@0.2.12", function="exit"][Instruction::Return]', {
+    funcName: 'exit',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline7.fnName = 'wasi:cli/exit@0.2.12#exit';
+const handleTable1 = [T_FLAG, 0];
+const captureTable1= new Map();
+let captureCnt1 = 0;
+handleTables[1] = handleTable1;
+
+const _trampoline8 = function(arg0) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable1.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(Pollable.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/poll@0.2.12", function="[method]pollable.block"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'block',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => rsc0.block(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  for (const rsc of curResourceBorrows) {
+    rsc[symbolRscHandle] = undefined;
+  }
+  curResourceBorrows = [];
+  _debugLog('[iface="wasi:io/poll@0.2.12", function="[method]pollable.block"][Instruction::Return]', {
+    funcName: '[method]pollable.block',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline8.fnName = 'wasi:io/poll@0.2.12#block';
+const handleTable3 = [T_FLAG, 0];
+const captureTable3= new Map();
+let captureCnt3 = 0;
+handleTables[3] = handleTable3;
+
+const _trampoline9 = function(arg0) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(OutputStream.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.subscribe"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'subscribe',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -3836,7 +4024,7 @@ const _trampoline5 = function() {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => getStderr(),
+      fn: () => rsc0.subscribe(),
     })
     ;
   } catch (err) {
@@ -3848,35 +4036,39 @@ const _trampoline5 = function() {
     
   }
   
-  
-  if (!(ret instanceof OutputStream)) {
-    throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+  for (const rsc of curResourceBorrows) {
+    rsc[symbolRscHandle] = undefined;
   }
-  var handle0 = ret[symbolRscHandle];
-  if (!handle0) {
+  curResourceBorrows = [];
+  
+  if (!(ret instanceof Pollable)) {
+    throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+  }
+  var handle3 = ret[symbolRscHandle];
+  if (!handle3) {
     const rep = ret[symbolRscRep] || ++captureCnt1;
     captureTable1.set(rep, ret);
-    handle0 = rscTableCreateOwn(handleTable1, rep);
+    handle3 = rscTableCreateOwn(handleTable1, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stderr@0.2.3", function="get-stderr"][Instruction::Return]', {
-    funcName: 'get-stderr',
+  _debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.subscribe"][Instruction::Return]', {
+    funcName: '[method]output-stream.subscribe',
     paramCount: 1,
     async: false,
     postReturn: false
   });
-  task.resolve([handle0]);
+  task.resolve([handle3]);
   task.exit();
-  return handle0;
+  return handle3;
 }
-_trampoline5.fnName = 'wasi:cli/stderr@0.2.3#getStderr';
+_trampoline9.fnName = 'wasi:io/streams@0.2.12#subscribe';
 const handleTable2 = [T_FLAG, 0];
 const captureTable2= new Map();
 let captureCnt2 = 0;
 handleTables[2] = handleTable2;
 
-const _trampoline6 = function() {
-  _debugLog('[iface="wasi:cli/stdin@0.2.3", function="get-stdin"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline10 = function() {
+  _debugLog('[iface="wasi:cli/stdin@0.2.12", function="get-stdin"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3949,7 +4141,7 @@ const _trampoline6 = function() {
     handle0 = rscTableCreateOwn(handleTable2, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stdin@0.2.3", function="get-stdin"][Instruction::Return]', {
+  _debugLog('[iface="wasi:cli/stdin@0.2.12", function="get-stdin"][Instruction::Return]', {
     funcName: 'get-stdin',
     paramCount: 1,
     async: false,
@@ -3959,10 +4151,10 @@ const _trampoline6 = function() {
   task.exit();
   return handle0;
 }
-_trampoline6.fnName = 'wasi:cli/stdin@0.2.3#getStdin';
+_trampoline10.fnName = 'wasi:cli/stdin@0.2.12#getStdin';
 
-const _trampoline7 = function() {
-  _debugLog('[iface="wasi:cli/stdout@0.2.3", function="get-stdout"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline11 = function() {
+  _debugLog('[iface="wasi:cli/stdout@0.2.12", function="get-stdout"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4030,12 +4222,12 @@ const _trampoline7 = function() {
   }
   var handle0 = ret[symbolRscHandle];
   if (!handle0) {
-    const rep = ret[symbolRscRep] || ++captureCnt1;
-    captureTable1.set(rep, ret);
-    handle0 = rscTableCreateOwn(handleTable1, rep);
+    const rep = ret[symbolRscRep] || ++captureCnt3;
+    captureTable3.set(rep, ret);
+    handle0 = rscTableCreateOwn(handleTable3, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stdout@0.2.3", function="get-stdout"][Instruction::Return]', {
+  _debugLog('[iface="wasi:cli/stdout@0.2.12", function="get-stdout"][Instruction::Return]', {
     funcName: 'get-stdout',
     paramCount: 1,
     async: false,
@@ -4045,30 +4237,10 @@ const _trampoline7 = function() {
   task.exit();
   return handle0;
 }
-_trampoline7.fnName = 'wasi:cli/stdout@0.2.3#getStdout';
+_trampoline11.fnName = 'wasi:cli/stdout@0.2.12#getStdout';
 
-const _trampoline8 = function(arg0) {
-  let variant0;
-  switch (arg0) {
-    case 0: {
-      variant0= {
-        tag: 'ok',
-        val: undefined
-      };
-      break;
-    }
-    case 1: {
-      variant0= {
-        tag: 'err',
-        val: undefined
-      };
-      break;
-    }
-    default: {
-      throw new TypeError('invalid variant discriminant for expected');
-    }
-  }
-  _debugLog('[iface="wasi:cli/exit@0.2.3", function="exit"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline12 = function() {
+  _debugLog('[iface="wasi:cli/stderr@0.2.12", function="get-stderr"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4079,7 +4251,7 @@ const _trampoline8 = function(arg0) {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'exit',
+      entryFnName: 'getStderr',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -4115,10 +4287,10 @@ const _trampoline8 = function(arg0) {
   let ret;
   
   try {
-    _withGlobalCurrentTaskMeta({
+    ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => exit(variant0),
+      fn: () => getStderr(),
     })
     ;
   } catch (err) {
@@ -4130,23 +4302,110 @@ const _trampoline8 = function(arg0) {
     
   }
   
-  _debugLog('[iface="wasi:cli/exit@0.2.3", function="exit"][Instruction::Return]', {
-    funcName: 'exit',
-    paramCount: 0,
+  
+  if (!(ret instanceof OutputStream)) {
+    throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+  }
+  var handle0 = ret[symbolRscHandle];
+  if (!handle0) {
+    const rep = ret[symbolRscRep] || ++captureCnt3;
+    captureTable3.set(rep, ret);
+    handle0 = rscTableCreateOwn(handleTable3, rep);
+  }
+  
+  _debugLog('[iface="wasi:cli/stderr@0.2.12", function="get-stderr"][Instruction::Return]', {
+    funcName: 'get-stderr',
+    paramCount: 1,
     async: false,
     postReturn: false
   });
-  task.resolve([ret]);
+  task.resolve([handle0]);
   task.exit();
+  return handle0;
 }
-_trampoline8.fnName = 'wasi:cli/exit@0.2.3#exit';
-let exports2;
+_trampoline12.fnName = 'wasi:cli/stderr@0.2.12#getStderr';
+
+const _trampoline13 = function() {
+  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.12", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'now',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => now(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.12", function="now"][Instruction::Return]', {
+    funcName: 'now',
+    paramCount: 1,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([toUint64(ret)]);
+  task.exit();
+  return toUint64(ret);
+}
+_trampoline13.fnName = 'wasi:clocks/monotonic-clock@0.2.12#now';
+let exports1;
 let memory0;
 let realloc0;
 let realloc0Async;
 
-const _trampoline9 = function(arg0) {
-  _debugLog('[iface="wasi:cli/environment@0.2.3", function="get-environment"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline14 = function(arg0) {
+  _debugLog('[iface="wasi:random/insecure-seed@0.2.12", function="insecure-seed"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4157,7 +4416,7 @@ const _trampoline9 = function(arg0) {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'getEnvironment',
+      entryFnName: 'insecureSeed',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -4196,7 +4455,7 @@ const _trampoline9 = function(arg0) {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => getEnvironment(),
+      fn: () => insecureSeed(),
     })
     ;
   } catch (err) {
@@ -4208,31 +4467,11 @@ const _trampoline9 = function(arg0) {
     
   }
   
-  var vec3 = ret;
-  var len3 = vec3.length;
-  var result3 = realloc0(0, 0, 4, len3 * 16);
-  for (let i = 0; i < vec3.length; i++) {
-    const e = vec3[i];
-    const base = result3 + i * 16;var [tuple0_0, tuple0_1] = e;
-    
-    var encodeRes = _utf8AllocateAndEncode(tuple0_0, realloc0, memory0);
-    var ptr1= encodeRes.ptr;
-    var len1 = encodeRes.len;
-    
-    dataView(memory0).setUint32(base + 4, len1, true);
-    dataView(memory0).setUint32(base + 0, ptr1, true);
-    
-    var encodeRes = _utf8AllocateAndEncode(tuple0_1, realloc0, memory0);
-    var ptr2= encodeRes.ptr;
-    var len2 = encodeRes.len;
-    
-    dataView(memory0).setUint32(base + 12, len2, true);
-    dataView(memory0).setUint32(base + 8, ptr2, true);
-  }
-  dataView(memory0).setUint32(arg0 + 4, len3, true);
-  dataView(memory0).setUint32(arg0 + 0, result3, true);
-  _debugLog('[iface="wasi:cli/environment@0.2.3", function="get-environment"][Instruction::Return]', {
-    funcName: 'get-environment',
+  var [tuple0_0, tuple0_1] = ret;
+  dataView(memory0).setBigInt64(arg0 + 0, toUint64(tuple0_0), true);
+  dataView(memory0).setBigInt64(arg0 + 8, toUint64(tuple0_1), true);
+  _debugLog('[iface="wasi:random/insecure-seed@0.2.12", function="insecure-seed"][Instruction::Return]', {
+    funcName: 'insecure-seed',
     paramCount: 0,
     async: false,
     postReturn: false
@@ -4240,1202 +4479,11 @@ const _trampoline9 = function(arg0) {
   task.resolve([ret]);
   task.exit();
 }
-_trampoline9.fnName = 'wasi:cli/environment@0.2.3#getEnvironment';
-
-const _trampoline10 = function(arg0) {
-  _debugLog('[iface="wasi:clocks/wall-clock@0.2.3", function="now"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'now$1',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => now$1(),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  var {seconds: v0_0, nanoseconds: v0_1 } = ret;
-  dataView(memory0).setBigInt64(arg0 + 0, toUint64(v0_0), true);
-  dataView(memory0).setInt32(arg0 + 8, toUint32(v0_1), true);
-  _debugLog('[iface="wasi:clocks/wall-clock@0.2.3", function="now"][Instruction::Return]', {
-    funcName: 'now',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline10.fnName = 'wasi:clocks/wall-clock@0.2.3#now$1';
+_trampoline14.fnName = 'wasi:random/insecure-seed@0.2.12#insecureSeed';
 const handleTable0 = [T_FLAG, 0];
 const captureTable0= new Map();
 let captureCnt0 = 0;
 handleTables[0] = handleTable0;
-
-const _trampoline11 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable0[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable0.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Error$1.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="filesystem-error-code"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'filesystemErrorCode',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => filesystemErrorCode(rsc0),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  for (const rsc of curResourceBorrows) {
-    rsc[symbolRscHandle] = undefined;
-  }
-  curResourceBorrows = [];
-  var variant4 = ret;
-  if (variant4 === null || variant4=== undefined) {
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-  } else {
-    const e = variant4;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val3 = e;
-    let enum3;
-    switch (val3) {
-      case 'access': {
-        enum3 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum3 = 1;
-        break;
-      }
-      case 'already': {
-        enum3 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum3 = 3;
-        break;
-      }
-      case 'busy': {
-        enum3 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum3 = 5;
-        break;
-      }
-      case 'quota': {
-        enum3 = 6;
-        break;
-      }
-      case 'exist': {
-        enum3 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum3 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum3 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum3 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum3 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum3 = 12;
-        break;
-      }
-      case 'io': {
-        enum3 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum3 = 14;
-        break;
-      }
-      case 'loop': {
-        enum3 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum3 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum3 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum3 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum3 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum3 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum3 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum3 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum3 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum3 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum3 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum3 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum3 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum3 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum3 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum3 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum3 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum3 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum3 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum3 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum3 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum3 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val3}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum3, true);
-  }
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="filesystem-error-code"][Instruction::Return]', {
-    funcName: 'filesystem-error-code',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline11.fnName = 'wasi:filesystem/types@0.2.3#filesystemErrorCode';
-const handleTable3 = [T_FLAG, 0];
-const captureTable3= new Map();
-let captureCnt3 = 0;
-handleTables[3] = handleTable3;
-
-const _trampoline12 = function(arg0, arg1, arg2) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.write-via-stream"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'writeViaStream',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.writeViaStream(BigInt.asUintN(64, BigInt(arg1))),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg2 + 0, 0, true);
-    
-    if (!(e instanceof OutputStream)) {
-      throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-    }
-    var handle3 = e[symbolRscHandle];
-    if (!handle3) {
-      const rep = e[symbolRscRep] || ++captureCnt1;
-      captureTable1.set(rep, e);
-      handle3 = rscTableCreateOwn(handleTable1, rep);
-    }
-    
-    dataView(memory0).setInt32(arg2 + 4, handle3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg2 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg2 + 4, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.write-via-stream"][Instruction::Return]', {
-  funcName: '[method]descriptor.write-via-stream',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline12.fnName = 'wasi:filesystem/types@0.2.3#writeViaStream';
-
-const _trampoline13 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.append-via-stream"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'appendViaStream',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.appendViaStream(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    
-    if (!(e instanceof OutputStream)) {
-      throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-    }
-    var handle3 = e[symbolRscHandle];
-    if (!handle3) {
-      const rep = e[symbolRscRep] || ++captureCnt1;
-      captureTable1.set(rep, e);
-      handle3 = rscTableCreateOwn(handleTable1, rep);
-    }
-    
-    dataView(memory0).setInt32(arg1 + 4, handle3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 4, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.append-via-stream"][Instruction::Return]', {
-  funcName: '[method]descriptor.append-via-stream',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline13.fnName = 'wasi:filesystem/types@0.2.3#appendViaStream';
-
-const _trampoline14 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.get-type"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getType',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.getType(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    var val3 = e;
-    let enum3;
-    switch (val3) {
-      case 'unknown': {
-        enum3 = 0;
-        break;
-      }
-      case 'block-device': {
-        enum3 = 1;
-        break;
-      }
-      case 'character-device': {
-        enum3 = 2;
-        break;
-      }
-      case 'directory': {
-        enum3 = 3;
-        break;
-      }
-      case 'fifo': {
-        enum3 = 4;
-        break;
-      }
-      case 'symbolic-link': {
-        enum3 = 5;
-        break;
-      }
-      case 'regular-file': {
-        enum3 = 6;
-        break;
-      }
-      case 'socket': {
-        enum3 = 7;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val3}" is not one of the cases of descriptor-type`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.get-type"][Instruction::Return]', {
-  funcName: '[method]descriptor.get-type',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline14.fnName = 'wasi:filesystem/types@0.2.3#getType';
 
 const _trampoline15 = function(arg0, arg1) {
   var handle1 = arg0;
@@ -5443,352 +4491,13 @@ const _trampoline15 = function(arg0, arg1) {
   var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
   var rsc0 = captureTable3.get(rep2);
   if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.stat"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'stat',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.stat(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant12 = ret;
-switch (variant12.tag) {
-  case 'ok': {
-    const e = variant12.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    var {type: v3_0, linkCount: v3_1, size: v3_2, dataAccessTimestamp: v3_3, dataModificationTimestamp: v3_4, statusChangeTimestamp: v3_5 } = e;
-    var val4 = v3_0;
-    let enum4;
-    switch (val4) {
-      case 'unknown': {
-        enum4 = 0;
-        break;
-      }
-      case 'block-device': {
-        enum4 = 1;
-        break;
-      }
-      case 'character-device': {
-        enum4 = 2;
-        break;
-      }
-      case 'directory': {
-        enum4 = 3;
-        break;
-      }
-      case 'fifo': {
-        enum4 = 4;
-        break;
-      }
-      case 'symbolic-link': {
-        enum4 = 5;
-        break;
-      }
-      case 'regular-file': {
-        enum4 = 6;
-        break;
-      }
-      case 'socket': {
-        enum4 = 7;
-        break;
-      }
-      default: {
-        if ((v3_0) instanceof Error) {
-          console.error(v3_0);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of descriptor-type`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 8, enum4, true);
-    dataView(memory0).setBigInt64(arg1 + 16, toUint64(v3_1), true);
-    dataView(memory0).setBigInt64(arg1 + 24, toUint64(v3_2), true);
-    var variant6 = v3_3;
-    if (variant6 === null || variant6=== undefined) {
-      dataView(memory0).setInt8(arg1 + 32, 0, true);
-    } else {
-      const e = variant6;
-      dataView(memory0).setInt8(arg1 + 32, 1, true);
-      var {seconds: v5_0, nanoseconds: v5_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 40, toUint64(v5_0), true);
-      dataView(memory0).setInt32(arg1 + 48, toUint32(v5_1), true);
-    }
-    var variant8 = v3_4;
-    if (variant8 === null || variant8=== undefined) {
-      dataView(memory0).setInt8(arg1 + 56, 0, true);
-    } else {
-      const e = variant8;
-      dataView(memory0).setInt8(arg1 + 56, 1, true);
-      var {seconds: v7_0, nanoseconds: v7_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 64, toUint64(v7_0), true);
-      dataView(memory0).setInt32(arg1 + 72, toUint32(v7_1), true);
-    }
-    var variant10 = v3_5;
-    if (variant10 === null || variant10=== undefined) {
-      dataView(memory0).setInt8(arg1 + 80, 0, true);
-    } else {
-      const e = variant10;
-      dataView(memory0).setInt8(arg1 + 80, 1, true);
-      var {seconds: v9_0, nanoseconds: v9_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 88, toUint64(v9_0), true);
-      dataView(memory0).setInt32(arg1 + 96, toUint32(v9_1), true);
-    }
-    
-    break;
-  }
-  case 'err': {
-    const e = variant12.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val11 = e;
-    let enum11;
-    switch (val11) {
-      case 'access': {
-        enum11 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum11 = 1;
-        break;
-      }
-      case 'already': {
-        enum11 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum11 = 3;
-        break;
-      }
-      case 'busy': {
-        enum11 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum11 = 5;
-        break;
-      }
-      case 'quota': {
-        enum11 = 6;
-        break;
-      }
-      case 'exist': {
-        enum11 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum11 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum11 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum11 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum11 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum11 = 12;
-        break;
-      }
-      case 'io': {
-        enum11 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum11 = 14;
-        break;
-      }
-      case 'loop': {
-        enum11 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum11 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum11 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum11 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum11 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum11 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum11 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum11 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum11 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum11 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum11 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum11 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum11 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum11 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum11 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum11 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum11 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum11 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum11 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum11 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum11 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum11 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val11}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 8, enum11, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant12, valueType: typeof variant12});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.stat"][Instruction::Return]', {
-  funcName: '[method]descriptor.stat',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline15.fnName = 'wasi:filesystem/types@0.2.3#stat';
-
-const _trampoline16 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
     rsc0 = Object.create(OutputStream.prototype);
     Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
     Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
   }
   
   curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.check-write"] [Instruction::CallInterface] (sync, @ enter)');
+  _debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.check-write"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -5895,7 +4604,7 @@ switch (variant5.tag) {
     throw new TypeError('invalid variant specified for result');
   }
 }
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.check-write"][Instruction::Return]', {
+_debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.check-write"][Instruction::Return]', {
   funcName: '[method]output-stream.check-write',
   paramCount: 0,
   async: false,
@@ -5904,13 +4613,13 @@ _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.check
 task.resolve([ret]);
 task.exit();
 }
-_trampoline16.fnName = 'wasi:io/streams@0.2.3#checkWrite';
+_trampoline15.fnName = 'wasi:io/streams@0.2.12#checkWrite';
 
-const _trampoline17 = function(arg0, arg1, arg2, arg3) {
+const _trampoline16 = function(arg0, arg1, arg2, arg3) {
   var handle1 = arg0;
   
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
   if (!rsc0) {
     rsc0 = Object.create(OutputStream.prototype);
     Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
@@ -5921,7 +4630,7 @@ const _trampoline17 = function(arg0, arg1, arg2, arg3) {
   var ptr3 = arg1;
   var len3 = arg2;
   var result3 = new Uint8Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 1));
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.write"] [Instruction::CallInterface] (sync, @ enter)');
+  _debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.write"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -6027,7 +4736,7 @@ switch (variant6.tag) {
     throw new TypeError('invalid variant specified for result');
   }
 }
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.write"][Instruction::Return]', {
+_debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.write"][Instruction::Return]', {
   funcName: '[method]output-stream.write',
   paramCount: 0,
   async: false,
@@ -6036,13 +4745,13 @@ _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.write
 task.resolve([ret]);
 task.exit();
 }
-_trampoline17.fnName = 'wasi:io/streams@0.2.3#write';
+_trampoline16.fnName = 'wasi:io/streams@0.2.12#write';
 
-const _trampoline18 = function(arg0, arg1) {
+const _trampoline17 = function(arg0, arg1) {
   var handle1 = arg0;
   
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
   if (!rsc0) {
     rsc0 = Object.create(OutputStream.prototype);
     Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
@@ -6050,7 +4759,7 @@ const _trampoline18 = function(arg0, arg1) {
   }
   
   curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-flush"] [Instruction::CallInterface] (sync, @ enter)');
+  _debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.blocking-flush"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -6156,7 +4865,7 @@ switch (variant5.tag) {
     throw new TypeError('invalid variant specified for result');
   }
 }
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-flush"][Instruction::Return]', {
+_debugLog('[iface="wasi:io/streams@0.2.12", function="[method]output-stream.blocking-flush"][Instruction::Return]', {
   funcName: '[method]output-stream.blocking-flush',
   paramCount: 0,
   async: false,
@@ -6165,24 +4874,10 @@ _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.block
 task.resolve([ret]);
 task.exit();
 }
-_trampoline18.fnName = 'wasi:io/streams@0.2.3#blockingFlush';
+_trampoline17.fnName = 'wasi:io/streams@0.2.12#blockingFlush';
 
-const _trampoline19 = function(arg0, arg1, arg2, arg3) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(OutputStream.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  var ptr3 = arg1;
-  var len3 = arg2;
-  var result3 = new Uint8Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 1));
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-write-and-flush"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline18 = function(arg0) {
+  _debugLog('[iface="wasi:cli/environment@0.2.12", function="get-environment"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -6193,125 +4888,7 @@ const _trampoline19 = function(arg0, arg1, arg2, arg3) {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'blockingWriteAndFlush',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.blockingWriteAndFlush(result3),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant6 = ret;
-switch (variant6.tag) {
-  case 'ok': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 0, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 1, true);
-    var variant5 = e;
-    switch (variant5.tag) {
-      case 'last-operation-failed': {
-        const e = variant5.val;
-        dataView(memory0).setInt8(arg3 + 4, 0, true);
-        
-        if (!(e instanceof Error$1)) {
-          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
-        }
-        var handle4 = e[symbolRscHandle];
-        if (!handle4) {
-          const rep = e[symbolRscRep] || ++captureCnt0;
-          captureTable0.set(rep, e);
-          handle4 = rscTableCreateOwn(handleTable0, rep);
-        }
-        
-        dataView(memory0).setInt32(arg3 + 8, handle4, true);
-        break;
-      }
-      case 'closed': {
-        dataView(memory0).setInt8(arg3 + 4, 1, true);
-        break;
-      }
-      default: {
-        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant5.tag)}\` (received \`${variant5}\`) specified for \`StreamError\``);
-      }
-    }
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant6, valueType: typeof variant6});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-write-and-flush"][Instruction::Return]', {
-  funcName: '[method]output-stream.blocking-write-and-flush',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline19.fnName = 'wasi:io/streams@0.2.3#blockingWriteAndFlush';
-
-const _trampoline20 = function(arg0, arg1) {
-  _debugLog('[iface="wasi:random/random@0.2.3", function="get-random-bytes"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getRandomBytes',
+      entryFnName: 'getEnvironment',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -6350,105 +4927,7 @@ const _trampoline20 = function(arg0, arg1) {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => getRandomBytes(BigInt.asUintN(64, BigInt(arg0))),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  var val0 = ret;
-  var len0 = Array.isArray(val0) ? val0.length : val0.byteLength;
-  var ptr0 = realloc0(0, 0, 1, len0 * 1);
-  
-  let valData0;
-  const valLenBytes0 = len0 * 1;
-  if (Array.isArray(val0)) {
-    // Regular array likely containing numbers, write values to memory
-    let offset = 0;
-    const dv0 = new DataView(memory0.buffer);
-    for (const v of val0) {
-      _requireValidNumericPrimitive.bind(null, 'u8')(v);
-      dv0.setUint8(ptr0+ offset, v, true);
-      offset += 1;
-    }
-  } else {
-    // TypedArray / ArrayBuffer-like, direct copy
-    valData0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, valLenBytes0);
-    const out0 = new Uint8Array(memory0.buffer, ptr0, valLenBytes0);
-    out0.set(valData0);
-  }
-  
-  dataView(memory0).setUint32(arg1 + 4, len0, true);
-  dataView(memory0).setUint32(arg1 + 0, ptr0, true);
-  _debugLog('[iface="wasi:random/random@0.2.3", function="get-random-bytes"][Instruction::Return]', {
-    funcName: 'get-random-bytes',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline20.fnName = 'wasi:random/random@0.2.3#getRandomBytes';
-
-const _trampoline21 = function(arg0) {
-  _debugLog('[iface="wasi:filesystem/preopens@0.2.3", function="get-directories"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getDirectories',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => getDirectories(),
+      fn: () => getEnvironment(),
     })
     ;
   } catch (err) {
@@ -6462,34 +4941,29 @@ const _trampoline21 = function(arg0) {
   
   var vec3 = ret;
   var len3 = vec3.length;
-  var result3 = realloc0(0, 0, 4, len3 * 12);
+  var result3 = realloc0(0, 0, 4, len3 * 16);
   for (let i = 0; i < vec3.length; i++) {
     const e = vec3[i];
-    const base = result3 + i * 12;var [tuple0_0, tuple0_1] = e;
+    const base = result3 + i * 16;var [tuple0_0, tuple0_1] = e;
     
-    if (!(tuple0_0 instanceof Descriptor)) {
-      throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-    }
-    var handle1 = tuple0_0[symbolRscHandle];
-    if (!handle1) {
-      const rep = tuple0_0[symbolRscRep] || ++captureCnt3;
-      captureTable3.set(rep, tuple0_0);
-      handle1 = rscTableCreateOwn(handleTable3, rep);
-    }
+    var encodeRes = _utf8AllocateAndEncode(tuple0_0, realloc0, memory0);
+    var ptr1= encodeRes.ptr;
+    var len1 = encodeRes.len;
     
-    dataView(memory0).setInt32(base + 0, handle1, true);
+    dataView(memory0).setUint32(base + 4, len1, true);
+    dataView(memory0).setUint32(base + 0, ptr1, true);
     
     var encodeRes = _utf8AllocateAndEncode(tuple0_1, realloc0, memory0);
     var ptr2= encodeRes.ptr;
     var len2 = encodeRes.len;
     
-    dataView(memory0).setUint32(base + 8, len2, true);
-    dataView(memory0).setUint32(base + 4, ptr2, true);
+    dataView(memory0).setUint32(base + 12, len2, true);
+    dataView(memory0).setUint32(base + 8, ptr2, true);
   }
   dataView(memory0).setUint32(arg0 + 4, len3, true);
   dataView(memory0).setUint32(arg0 + 0, result3, true);
-  _debugLog('[iface="wasi:filesystem/preopens@0.2.3", function="get-directories"][Instruction::Return]', {
-    funcName: 'get-directories',
+  _debugLog('[iface="wasi:cli/environment@0.2.12", function="get-environment"][Instruction::Return]', {
+    funcName: 'get-environment',
     paramCount: 0,
     async: false,
     postReturn: false
@@ -6497,10 +4971,372 @@ const _trampoline21 = function(arg0) {
   task.resolve([ret]);
   task.exit();
 }
-_trampoline21.fnName = 'wasi:filesystem/preopens@0.2.3#getDirectories';
-let exports3;
-let realloc1;
-let realloc1Async;
+_trampoline18.fnName = 'wasi:cli/environment@0.2.12#getEnvironment';
+const handleTable4 = [T_FLAG, 0];
+const captureTable4= new Map();
+let captureCnt4 = 0;
+handleTables[4] = handleTable4;
+
+const _trampoline19 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stdin@0.2.12", function="get-terminal-stdin"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStdin',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStdin(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalInput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt4;
+      captureTable4.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable4, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stdin@0.2.12", function="get-terminal-stdin"][Instruction::Return]', {
+    funcName: 'get-terminal-stdin',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline19.fnName = 'wasi:cli/terminal-stdin@0.2.12#getTerminalStdin';
+const handleTable5 = [T_FLAG, 0];
+const captureTable5= new Map();
+let captureCnt5 = 0;
+handleTables[5] = handleTable5;
+
+const _trampoline20 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stdout@0.2.12", function="get-terminal-stdout"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStdout',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStdout(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalOutput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt5;
+      captureTable5.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable5, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stdout@0.2.12", function="get-terminal-stdout"][Instruction::Return]', {
+    funcName: 'get-terminal-stdout',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline20.fnName = 'wasi:cli/terminal-stdout@0.2.12#getTerminalStdout';
+
+const _trampoline21 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stderr@0.2.12", function="get-terminal-stderr"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStderr',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStderr(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalOutput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt5;
+      captureTable5.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable5, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stderr@0.2.12", function="get-terminal-stderr"][Instruction::Return]', {
+    funcName: 'get-terminal-stderr',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline21.fnName = 'wasi:cli/terminal-stderr@0.2.12#getTerminalStderr';
+
+const _trampoline22 = function(arg0) {
+  _debugLog('[iface="wasi:clocks/wall-clock@0.2.12", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'now$1',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => now$1(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var {seconds: v0_0, nanoseconds: v0_1 } = ret;
+  dataView(memory0).setBigInt64(arg0 + 0, toUint64(v0_0), true);
+  dataView(memory0).setInt32(arg0 + 8, toUint32(v0_1), true);
+  _debugLog('[iface="wasi:clocks/wall-clock@0.2.12", function="now"][Instruction::Return]', {
+    funcName: 'now',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline22.fnName = 'wasi:clocks/wall-clock@0.2.12#now$1';
+let exports2;
 let postReturn0;
 let postReturn0Async;
 let postReturn1;
@@ -6513,17 +5349,19 @@ let postReturn4;
 let postReturn4Async;
 let postReturn5;
 let postReturn5Async;
+let postReturn6;
+let postReturn6Async;
 let exports1Solve;
 
 function solve(arg0, arg1, arg2) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
   var vec2 = arg1;
   var len2 = vec2.length;
-  var result2 = realloc1(0, 0, 4, len2 * 12);
+  var result2 = realloc0(0, 0, 4, len2 * 12);
   for (let i = 0; i < vec2.length; i++) {
     const e = vec2[i];
     const base = result2 + i * 12;var {id: v1_0, x: v1_1, y: v1_2 } = e;
@@ -6633,12 +5471,12 @@ let exports1ParseAndSolve;
 
 function parseAndSolve(arg0, arg1, arg2) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
   
-  var encodeRes = _utf8AllocateAndEncode(arg1, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg1, realloc0, memory0);
   var ptr1= encodeRes.ptr;
   var len1 = encodeRes.len;
   
@@ -6744,7 +5582,7 @@ let exports1Parse;
 
 function parse(arg0) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
@@ -7097,11 +5935,11 @@ let exports1Compare;
 function compare(arg0, arg1, arg2) {
   var vec1 = arg0;
   var len1 = vec1.length;
-  var result1 = realloc1(0, 0, 4, len1 * 8);
+  var result1 = realloc0(0, 0, 4, len1 * 8);
   for (let i = 0; i < vec1.length; i++) {
     const e = vec1[i];
     const base = result1 + i * 8;
-    var encodeRes = _utf8AllocateAndEncode(e, realloc1, memory0);
+    var encodeRes = _utf8AllocateAndEncode(e, realloc0, memory0);
     var ptr0= encodeRes.ptr;
     var len0 = encodeRes.len;
     
@@ -7109,7 +5947,7 @@ function compare(arg0, arg1, arg2) {
     dataView(memory0).setUint32(base + 0, ptr0, true);
   }
   
-  var encodeRes = _utf8AllocateAndEncode(arg1, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg1, realloc0, memory0);
   var ptr2= encodeRes.ptr;
   var len2 = encodeRes.len;
   
@@ -7218,6 +6056,160 @@ function compare(arg0, arg1, arg2) {
   return retCopy;
   
 }
+let exports1CompareTours;
+
+function compareTours(arg0, arg1, arg2) {
+  var val0 = arg0;
+  var len0 = val0.length;
+  var ptr0 = realloc0(0, 0, 4, len0 * 4);
+  
+  let valData0;
+  const valLenBytes0 = len0 * 4;
+  if (Array.isArray(val0)) {
+    // Regular array likely containing numbers, write values to memory
+    let offset = 0;
+    const dv0 = new DataView(memory0.buffer);
+    for (const v of val0) {
+      _requireValidNumericPrimitive.bind(null, 'u32')(v);
+      dv0.setUint32(ptr0+ offset, v, true);
+      offset += 4;
+    }
+  } else {
+    // TypedArray / ArrayBuffer-like, direct copy
+    valData0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, valLenBytes0);
+    const out0 = new Uint8Array(memory0.buffer, ptr0, valLenBytes0);
+    out0.set(valData0);
+  }
+  
+  var val1 = arg1;
+  var len1 = val1.length;
+  var ptr1 = realloc0(0, 0, 4, len1 * 4);
+  
+  let valData1;
+  const valLenBytes1 = len1 * 4;
+  if (Array.isArray(val1)) {
+    // Regular array likely containing numbers, write values to memory
+    let offset = 0;
+    const dv1 = new DataView(memory0.buffer);
+    for (const v of val1) {
+      _requireValidNumericPrimitive.bind(null, 'u32')(v);
+      dv1.setUint32(ptr1+ offset, v, true);
+      offset += 4;
+    }
+  } else {
+    // TypedArray / ArrayBuffer-like, direct copy
+    valData1 = new Uint8Array(val1.buffer || val1, val1.byteOffset, valLenBytes1);
+    const out1 = new Uint8Array(memory0.buffer, ptr1, valLenBytes1);
+    out1.set(valData1);
+  }
+  
+  var vec3 = arg2;
+  var len3 = vec3.length;
+  var result3 = realloc0(0, 0, 4, len3 * 12);
+  for (let i = 0; i < vec3.length; i++) {
+    const e = vec3[i];
+    const base = result3 + i * 12;var {id: v2_0, x: v2_1, y: v2_2 } = e;
+    dataView(memory0).setInt32(base + 0, toUint32(v2_0), true);
+    dataView(memory0).setFloat32(base + 4, +v2_1, true);
+    dataView(memory0).setFloat32(base + 8, +v2_2, true);
+  }
+  _debugLog('[iface="compare-tours", function="compare-tours"][Instruction::CallWasm] enter', {
+    funcName: 'compare-tours',
+    paramCount: 6,
+    async: false,
+    postReturn: true,
+  });
+  const hostProvided = false;
+  
+  const [task, _wasm_call_currentTaskID] = createNewCurrentTask({
+    componentIdx: 0,
+    isAsync: false,
+    isManualAsync: false,
+    entryFnName: 'exports1CompareTours',
+    getCallbackFn: () => null,
+    callbackFnName: null,
+    errHandling: 'throw-result-err',
+    callingWasmExport: true,
+  });
+  
+  const started = task.enterSync();
+  
+  if (0!== null) {
+    task.setReturnMemoryIdx(0);
+    task.setReturnMemory(() => memory0());
+  }
+  
+  
+  let ret;
+  
+  try {
+    ret =   _withGlobalCurrentTaskMeta({
+      taskID: task.id(),
+      componentIdx: task.componentIdx(),
+      fn: () => exports1CompareTours(ptr0, len0, ptr1, len1, result3, len3),
+    });
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  let variant5;
+  switch (dataView(memory0).getUint8(ret + 0, true)) {
+    case 0: {
+      variant5= {
+        tag: 'ok',
+        val: {
+          optimalCost: dataView(memory0).getFloat32(ret + 4, true),
+          solverCost: dataView(memory0).getFloat32(ret + 8, true),
+          gapPct: dataView(memory0).getFloat32(ret + 12, true),
+          sharedEdges: dataView(memory0).getInt32(ret + 16, true) >>> 0,
+          solverOnlyEdges: dataView(memory0).getInt32(ret + 20, true) >>> 0,
+          optimalOnlyEdges: dataView(memory0).getInt32(ret + 24, true) >>> 0,
+        }
+      };
+      break;
+    }
+    case 1: {
+      var ptr4 = dataView(memory0).getUint32(ret + 4, true);
+      var len4 = dataView(memory0).getUint32(ret + 8, true);
+      var result4 = TEXT_DECODER_UTF8.decode(new Uint8Array(memory0.buffer, ptr4, len4));
+      variant5= {
+        tag: 'err',
+        val: result4
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  _debugLog('[iface="compare-tours", function="compare-tours"][Instruction::Return]', {
+    funcName: 'compare-tours',
+    paramCount: 1,
+    async: false,
+    postReturn: true
+  });
+  const retCopy = variant5;
+  task.resolve([retCopy.val]);
+  
+  let cstate = getOrCreateAsyncState(0);
+  cstate.mayLeave = false;
+  postReturn6(ret);
+  cstate.mayLeave = true;
+  task.exit();
+  
+  
+  
+  if (typeof retCopy === 'object' && retCopy.tag === 'err') {
+    throw new ComponentError(retCopy.val);
+  }
+  return retCopy.val;
+  
+}
 let trampoline0 = _trampoline0.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
 null,
 {
@@ -7260,32 +6252,6 @@ null,
 },
 );
 function trampoline1(handle) {
-  const handleEntry = rscTableRemove(handleTable3, handle);
-  if (handleEntry.own) {
-    
-    const rsc = captureTable3.get(handleEntry.rep);
-    if (rsc) {
-      if (rsc[symbolDispose]) rsc[symbolDispose]();
-      captureTable3.delete(handleEntry.rep);
-    } else if (Descriptor[symbolCabiDispose]) {
-      Descriptor[symbolCabiDispose](handleEntry.rep);
-    }
-  }
-}
-function trampoline2(handle) {
-  const handleEntry = rscTableRemove(handleTable1, handle);
-  if (handleEntry.own) {
-    
-    const rsc = captureTable1.get(handleEntry.rep);
-    if (rsc) {
-      if (rsc[symbolDispose]) rsc[symbolDispose]();
-      captureTable1.delete(handleEntry.rep);
-    } else if (OutputStream[symbolCabiDispose]) {
-      OutputStream[symbolCabiDispose](handleEntry.rep);
-    }
-  }
-}
-function trampoline3(handle) {
   const handleEntry = rscTableRemove(handleTable0, handle);
   if (handleEntry.own) {
     
@@ -7298,7 +6264,20 @@ function trampoline3(handle) {
     }
   }
 }
-function trampoline4(handle) {
+function trampoline2(handle) {
+  const handleEntry = rscTableRemove(handleTable1, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable1.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable1.delete(handleEntry.rep);
+    } else if (Pollable[symbolCabiDispose]) {
+      Pollable[symbolCabiDispose](handleEntry.rep);
+    }
+  }
+}
+function trampoline3(handle) {
   const handleEntry = rscTableRemove(handleTable2, handle);
   if (handleEntry.own) {
     
@@ -7311,152 +6290,45 @@ function trampoline4(handle) {
     }
   }
 }
-let trampoline5 = _trampoline5.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 5,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline5.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
+function trampoline4(handle) {
+  const handleEntry = rscTableRemove(handleTable3, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable3.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable3.delete(handleEntry.rep);
+    } else if (OutputStream[symbolCabiDispose]) {
+      OutputStream[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline5,
-},
-)) : _lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 5,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline5.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
+  }
+}
+function trampoline5(handle) {
+  const handleEntry = rscTableRemove(handleTable4, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable4.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable4.delete(handleEntry.rep);
+    } else if (TerminalInput[symbolCabiDispose]) {
+      TerminalInput[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline5,
-},
-);
-let trampoline6 = _trampoline6.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 6,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline6.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_InputStream(obj) {
-      if (!(obj instanceof InputStream)) {
-        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt2;
-        captureTable2.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable2, rep);
-      }
-      return handle;
+  }
+}
+function trampoline6(handle) {
+  const handleEntry = rscTableRemove(handleTable5, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable5.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable5.delete(handleEntry.rep);
+    } else if (TerminalOutput[symbolCabiDispose]) {
+      TerminalOutput[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline6,
-},
-)) : _lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 6,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline6.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_InputStream(obj) {
-      if (!(obj instanceof InputStream)) {
-        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt2;
-        captureTable2.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable2, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline6,
-},
-);
+  }
+}
 let trampoline7 = _trampoline7.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
 null,
 {
@@ -7464,24 +6336,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline7.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
+  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7500,24 +6356,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline7.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
+  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7537,7 +6377,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline8.manuallyAsync,
-  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
   resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
@@ -7557,7 +6397,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline8.manuallyAsync,
-  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
   resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
@@ -7578,21 +6418,33 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline9.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
-    elemSize32: 16,
-    elemAlign32: 4,
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Pollable(obj) {
+      if (!(obj instanceof Pollable)) {
+        throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
+      }
+      return handle;
+    }
+    ,
   })],
-  hasResultPointer: true,
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getMemoryFn: () => null,
+  getReallocFn: undefined,
   importFn: _trampoline9,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -7602,21 +6454,33 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline9.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
-    elemSize32: 16,
-    elemAlign32: 4,
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Pollable(obj) {
+      if (!(obj instanceof Pollable)) {
+        throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
+      }
+      return handle;
+    }
+    ,
   })],
-  hasResultPointer: true,
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getMemoryFn: () => null,
+  getReallocFn: undefined,
   importFn: _trampoline9,
 },
 );
@@ -7628,15 +6492,31 @@ null,
   isAsync: false,
   isManualAsync: _trampoline10.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
-  hasResultPointer: true,
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_InputStream(obj) {
+      if (!(obj instanceof InputStream)) {
+        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt2;
+        captureTable2.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable2, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline10,
 },
@@ -7648,15 +6528,31 @@ null,
   isAsync: false,
   isManualAsync: _trampoline10.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
-  hasResultPointer: true,
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_InputStream(obj) {
+      if (!(obj instanceof InputStream)) {
+        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt2;
+        captureTable2.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable2, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline10,
 },
@@ -7668,20 +6564,32 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline11.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
-  resultLowerFns: [_lowerFlatOption([
-  [ 'none', null, 2, 1, 1 ],
-  [ 'some', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_OutputStream(obj) {
+      if (!(obj instanceof OutputStream)) {
+        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline11,
 },
@@ -7692,20 +6600,32 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline11.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
-  resultLowerFns: [_lowerFlatOption([
-  [ 'none', null, 2, 1, 1 ],
-  [ 'some', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_OutputStream(obj) {
+      if (!(obj instanceof OutputStream)) {
+        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline11,
 },
@@ -7717,9 +6637,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline12.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatU64],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
     function lowerImportedOwnedHost_OutputStream(obj) {
@@ -7728,25 +6647,22 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline12,
 },
@@ -7757,9 +6673,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline12.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatU64],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
     function lowerImportedOwnedHost_OutputStream(obj) {
@@ -7768,25 +6683,22 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline12,
 },
@@ -7798,36 +6710,16 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline13.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatU64],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline13,
 },
@@ -7838,36 +6730,16 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline13.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatU64],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline13,
 },
@@ -7879,12 +6751,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline14.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 2, 1, 1 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatTuple({ elemLowerMetas: [[_lowerFlatU64, 8, 8],[_lowerFlatU64, 8, 8],], size32: 16, align32: 8 })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7903,12 +6771,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline14.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 2, 1, 1 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatTuple({ elemLowerMetas: [[_lowerFlatU64, 8, 8],[_lowerFlatU64, 8, 8],], size32: 16, align32: 8 })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7930,20 +6794,24 @@ null,
   isManualAsync: _trampoline15.manuallyAsync,
   paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatRecord({ fieldMetas: [['type', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 1, 1 ],['linkCount', _lowerFlatU64, 8, 8 ],['size', _lowerFlatU64, 8, 8 ],['dataAccessTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['dataModificationTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['statusChangeTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],], size32: 96, align32: 8 }), 104, 8, 8 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 104, 8, 8 ],
+  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Error$1(obj) {
+      if (!(obj instanceof Error$1)) {
+        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt0;
+        captureTable0.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable0, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
   ])
   ],
   hasResultPointer: true,
@@ -7966,20 +6834,24 @@ null,
   isManualAsync: _trampoline15.manuallyAsync,
   paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatRecord({ fieldMetas: [['type', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 1, 1 ],['linkCount', _lowerFlatU64, 8, 8 ],['size', _lowerFlatU64, 8, 8 ],['dataAccessTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['dataModificationTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['statusChangeTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],], size32: 96, align32: 8 }), 104, 8, 8 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 104, 8, 8 ],
+  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Error$1(obj) {
+      if (!(obj instanceof Error$1)) {
+        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt0;
+        captureTable0.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable0, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
   ])
   ],
   hasResultPointer: true,
@@ -8001,9 +6873,14 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline16.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatList({
+    elemLiftFn: _liftFlatU8,
+    elemAlign32: 1,
+    elemSize32: 1,
+    typedArray: Uint8Array,
+  })],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
@@ -8020,7 +6897,7 @@ null,
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8041,9 +6918,14 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline16.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatList({
+    elemLiftFn: _liftFlatU8,
+    elemAlign32: 1,
+    elemSize32: 1,
+    typedArray: Uint8Array,
+  })],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
@@ -8060,7 +6942,7 @@ null,
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8082,12 +6964,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline17.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
   [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
@@ -8127,12 +7004,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline17.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
   [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
@@ -8173,28 +7045,12 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline18.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatList({
+    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
+    elemSize32: 16,
+    elemAlign32: 4,
+  })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8203,7 +7059,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: undefined,
+  getReallocFn: () => realloc0,
   importFn: _trampoline18,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8213,28 +7069,12 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline18.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatList({
+    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
+    elemSize32: 16,
+    elemAlign32: 4,
+  })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8243,7 +7083,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: undefined,
+  getReallocFn: () => realloc0,
   importFn: _trampoline18,
 },
 );
@@ -8254,31 +7094,26 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline19.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+    function lowerImportedOwnedHost_TerminalInput(obj) {
+      if (!(obj instanceof TerminalInput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt4;
+        captureTable4.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable4, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
+  }), 8, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8299,31 +7134,26 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline19.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+    function lowerImportedOwnedHost_TerminalInput(obj) {
+      if (!(obj instanceof TerminalInput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt4;
+        captureTable4.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable4, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
+  }), 8, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8345,12 +7175,28 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline20.manuallyAsync,
-  paramLiftFns: [_liftFlatU64],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatU8,
-    elemSize32: 1,
-    elemAlign32: 1,
-  })],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8359,7 +7205,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline20,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8369,12 +7215,28 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline20.manuallyAsync,
-  paramLiftFns: [_liftFlatU64],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatU8,
-    elemSize32: 1,
-    elemAlign32: 1,
-  })],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8383,7 +7245,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline20,
 },
 );
@@ -8395,27 +7257,27 @@ null,
   isAsync: false,
   isManualAsync: _trampoline21.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatOwn({
-      componentIdx: 0,
-      lowerFn: 
-      function lowerImportedOwnedHost_Descriptor(obj) {
-        if (!(obj instanceof Descriptor)) {
-          throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-        }
-        let handle = obj[symbolRscHandle];
-        if (!handle) {
-          const rep = obj[symbolRscRep] || ++captureCnt3;
-          captureTable3.set(rep, obj);
-          handle = rscTableCreateOwn(handleTable3, rep);
-        }
-        return handle;
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
       }
-      ,
-    }), 4, 4],[_lowerFlatStringAny, 8, 4],], size32: 12, align32: 4 }),
-    elemSize32: 12,
-    elemAlign32: 4,
-  })],
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8424,7 +7286,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline21,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8435,27 +7297,27 @@ null,
   isAsync: false,
   isManualAsync: _trampoline21.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatOwn({
-      componentIdx: 0,
-      lowerFn: 
-      function lowerImportedOwnedHost_Descriptor(obj) {
-        if (!(obj instanceof Descriptor)) {
-          throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-        }
-        let handle = obj[symbolRscHandle];
-        if (!handle) {
-          const rep = obj[symbolRscRep] || ++captureCnt3;
-          captureTable3.set(rep, obj);
-          handle = rscTableCreateOwn(handleTable3, rep);
-        }
-        return handle;
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
       }
-      ,
-    }), 4, 4],[_lowerFlatStringAny, 8, 4],], size32: 12, align32: 4 }),
-    elemSize32: 12,
-    elemAlign32: 4,
-  })],
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8464,125 +7326,140 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline21,
+},
+);
+let trampoline22 = _trampoline22.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
+null,
+{
+  trampolineIdx: 22,
+  componentIdx: 0,
+  isAsync: false,
+  isManualAsync: _trampoline22.manuallyAsync,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
+  hasResultPointer: true,
+  funcTypeIsAsync: false,
+  getCallbackFn: () => null,
+  getPostReturnFn: () => null,
+  isCancellable: false,
+  memoryIdx: 0,
+  stringEncoding: 'utf8',
+  getMemoryFn: () => memory0,
+  getReallocFn: undefined,
+  importFn: _trampoline22,
+},
+)) : _lowerImportBackwardsCompat.bind(
+null,
+{
+  trampolineIdx: 22,
+  componentIdx: 0,
+  isAsync: false,
+  isManualAsync: _trampoline22.manuallyAsync,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
+  hasResultPointer: true,
+  funcTypeIsAsync: false,
+  getCallbackFn: () => null,
+  getPostReturnFn: () => null,
+  isCancellable: false,
+  memoryIdx: 0,
+  stringEncoding: 'utf8',
+  getMemoryFn: () => memory0,
+  getReallocFn: undefined,
+  importFn: _trampoline22,
 },
 );
 
 const $init = (() => {
   let gen = (function* _initGenerator () {
     const module0 = fetchCompile(new URL('./teeline_wasm.core.wasm', import.meta.url));
-    const module1 = fetchCompile(new URL('./teeline_wasm.core2.wasm', import.meta.url));
-    const module2 = base64Compile('AGFzbQEAAAABOQpgAn9/AX9gA39+fwF/YAR/f39/AX9gAX8AYAABf2ABfwBgAn9/AGADf35/AGAEf39/fwBgAn5/AAMVFAAAAAECAwQFBQYHBgYGBggGCAkFBAUBcAEUFAdmFQEwAAABMQABATIAAgEzAAMBNAAEATUABQE2AAYBNwAHATgACAE5AAkCMTAACgIxMQALAjEyAAwCMTMADQIxNAAOAjE1AA8CMTYAEAIxNwARAjE4ABICMTkAEwgkaW1wb3J0cwEACvUBFAsAIAAgAUEAEQAACwsAIAAgAUEBEQAACwsAIAAgAUECEQAACw0AIAAgASACQQMRAQALDwAgACABIAIgA0EEEQIACwkAIABBBREDAAsHAEEGEQQACwkAIABBBxEFAAsJACAAQQgRBQALCwAgACABQQkRBgALDQAgACABIAJBChEHAAsLACAAIAFBCxEGAAsLACAAIAFBDBEGAAsLACAAIAFBDREGAAsLACAAIAFBDhEGAAsPACAAIAEgAiADQQ8RCAALCwAgACABQRARBgALDwAgACABIAIgA0EREQgACwsAIAAgAUESEQkACwkAIABBExEFAAsALwlwcm9kdWNlcnMBDHByb2Nlc3NlZC1ieQENd2l0LWNvbXBvbmVudAcwLjIyNy4xAPcIBG5hbWUAExJ3aXQtY29tcG9uZW50OnNoaW0B2ggUACdhZGFwdC13YXNpX3NuYXBzaG90X3ByZXZpZXcxLXJhbmRvbV9nZXQBKGFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZW52aXJvbl9nZXQCLmFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZW52aXJvbl9zaXplc19nZXQDK2FkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtY2xvY2tfdGltZV9nZXQEJWFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZmRfd3JpdGUFJmFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtcHJvY19leGl0BihhZGFwdC13YXNpX3NuYXBzaG90X3ByZXZpZXcxLXNjaGVkX3lpZWxkBzNpbmRpcmVjdC13YXNpOmNsaS9lbnZpcm9ubWVudEAwLjIuMy1nZXQtZW52aXJvbm1lbnQIKWluZGlyZWN0LXdhc2k6Y2xvY2tzL3dhbGwtY2xvY2tAMC4yLjMtbm93CTppbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vdHlwZXNAMC4yLjMtZmlsZXN5c3RlbS1lcnJvci1jb2RlCkhpbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vdHlwZXNAMC4yLjMtW21ldGhvZF1kZXNjcmlwdG9yLndyaXRlLXZpYS1zdHJlYW0LSWluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3IuYXBwZW5kLXZpYS1zdHJlYW0MQGluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3IuZ2V0LXR5cGUNPGluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3Iuc3RhdA5AaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5jaGVjay13cml0ZQ86aW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS53cml0ZRBDaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5ibG9ja2luZy1mbHVzaBFNaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5ibG9ja2luZy13cml0ZS1hbmQtZmx1c2gSMmluZGlyZWN0LXdhc2k6cmFuZG9tL3JhbmRvbUAwLjIuMy1nZXQtcmFuZG9tLWJ5dGVzEzdpbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vcHJlb3BlbnNAMC4yLjItZ2V0LWRpcmVjdG9yaWVz');
-    const module3 = base64Compile('AGFzbQEAAAABOQpgAn9/AX9gA39+fwF/YAR/f39/AX9gAX8AYAABf2ABfwBgAn9/AGADf35/AGAEf39/fwBgAn5/AAJ+FQABMAAAAAExAAAAATIAAAABMwABAAE0AAIAATUAAwABNgAEAAE3AAUAATgABQABOQAGAAIxMAAHAAIxMQAGAAIxMgAGAAIxMwAGAAIxNAAGAAIxNQAIAAIxNgAGAAIxNwAIAAIxOAAJAAIxOQAFAAgkaW1wb3J0cwFwARQUCRoBAEEACxQAAQIDBAUGBwgJCgsMDQ4PEBESEwAvCXByb2R1Y2VycwEMcHJvY2Vzc2VkLWJ5AQ13aXQtY29tcG9uZW50BzAuMjI3LjEAHARuYW1lABUUd2l0LWNvbXBvbmVudDpmaXh1cHM');
-    ({ exports: exports0 } = yield instantiateCore(yield module2));
+    const module1 = base64Compile('AGFzbQEAAAABEQNgAX8AYAJ/fwBgBH9/f38AAwoJAAECAQAAAAAABAUBcAEJCQcwCgEwAAABMQABATIAAgEzAAMBNAAEATUABQE2AAYBNwAHATgACAgkaW1wb3J0cwEACmUJCQAgAEEAEQAACwsAIAAgAUEBEQEACw8AIAAgASACIANBAhECAAsLACAAIAFBAxEBAAsJACAAQQQRAAALCQAgAEEFEQAACwkAIABBBhEAAAsJACAAQQcRAAALCQAgAEEIEQAACwAvCXByb2R1Y2VycwEMcHJvY2Vzc2VkLWJ5AQ13aXQtY29tcG9uZW50BzAuMjQ2LjI');
+    const module2 = base64Compile('AGFzbQEAAAABEQNgAX8AYAJ/fwBgBH9/f38AAj0KAAEwAAAAATEAAQABMgACAAEzAAEAATQAAAABNQAAAAE2AAAAATcAAAABOAAAAAgkaW1wb3J0cwFwAQkJCQ8BAEEACwkAAQIDBAUGBwgALwlwcm9kdWNlcnMBDHByb2Nlc3NlZC1ieQENd2l0LWNvbXBvbmVudAcwLjI0Ni4y');
+    ({ exports: exports0 } = yield instantiateCore(yield module1));
     ({ exports: exports1 } = yield instantiateCore(yield module0, {
-      wasi_snapshot_preview1: {
-        clock_time_get: exports0['3'],
-        environ_get: exports0['1'],
-        environ_sizes_get: exports0['2'],
-        fd_write: exports0['4'],
-        proc_exit: exports0['5'],
-        random_get: exports0['0'],
-        sched_yield: exports0['6'],
+      'wasi:cli/environment@0.2.0': {
+        'get-environment': exports0['4'],
       },
-    }));
-    ({ exports: exports2 } = yield instantiateCore(yield module1, {
-      __main_module__: {
-        cabi_realloc: exports1.cabi_realloc,
+      'wasi:cli/exit@0.2.0': {
+        exit: trampoline7,
       },
-      env: {
-        memory: exports1.memory,
+      'wasi:cli/stderr@0.2.0': {
+        'get-stderr': trampoline12,
       },
-      'wasi:cli/environment@0.2.3': {
-        'get-environment': exports0['7'],
+      'wasi:cli/stdin@0.2.0': {
+        'get-stdin': trampoline10,
       },
-      'wasi:cli/exit@0.2.3': {
-        exit: trampoline8,
+      'wasi:cli/stdout@0.2.0': {
+        'get-stdout': trampoline11,
       },
-      'wasi:cli/stderr@0.2.3': {
-        'get-stderr': trampoline5,
+      'wasi:cli/terminal-input@0.2.0': {
+        '[resource-drop]terminal-input': trampoline5,
       },
-      'wasi:cli/stdin@0.2.3': {
-        'get-stdin': trampoline6,
+      'wasi:cli/terminal-output@0.2.0': {
+        '[resource-drop]terminal-output': trampoline6,
       },
-      'wasi:cli/stdout@0.2.3': {
-        'get-stdout': trampoline7,
+      'wasi:cli/terminal-stderr@0.2.0': {
+        'get-terminal-stderr': exports0['7'],
       },
-      'wasi:clocks/monotonic-clock@0.2.3': {
-        now: trampoline0,
+      'wasi:cli/terminal-stdin@0.2.0': {
+        'get-terminal-stdin': exports0['5'],
       },
-      'wasi:clocks/wall-clock@0.2.3': {
+      'wasi:cli/terminal-stdout@0.2.0': {
+        'get-terminal-stdout': exports0['6'],
+      },
+      'wasi:clocks/monotonic-clock@0.2.0': {
+        now: trampoline13,
+      },
+      'wasi:clocks/wall-clock@0.2.0': {
         now: exports0['8'],
       },
-      'wasi:filesystem/preopens@0.2.2': {
-        'get-directories': exports0['19'],
+      'wasi:io/error@0.2.0': {
+        '[resource-drop]error': trampoline1,
       },
-      'wasi:filesystem/types@0.2.3': {
-        '[method]descriptor.append-via-stream': exports0['11'],
-        '[method]descriptor.get-type': exports0['12'],
-        '[method]descriptor.stat': exports0['13'],
-        '[method]descriptor.write-via-stream': exports0['10'],
-        '[resource-drop]descriptor': trampoline1,
-        'filesystem-error-code': exports0['9'],
+      'wasi:io/poll@0.2.0': {
+        '[method]pollable.block': trampoline8,
+        '[resource-drop]pollable': trampoline2,
       },
-      'wasi:io/error@0.2.3': {
-        '[resource-drop]error': trampoline3,
+      'wasi:io/streams@0.2.0': {
+        '[method]output-stream.blocking-flush': exports0['3'],
+        '[method]output-stream.check-write': exports0['1'],
+        '[method]output-stream.subscribe': trampoline9,
+        '[method]output-stream.write': exports0['2'],
+        '[resource-drop]input-stream': trampoline3,
+        '[resource-drop]output-stream': trampoline4,
       },
-      'wasi:io/streams@0.2.3': {
-        '[method]output-stream.blocking-flush': exports0['16'],
-        '[method]output-stream.blocking-write-and-flush': exports0['17'],
-        '[method]output-stream.check-write': exports0['14'],
-        '[method]output-stream.write': exports0['15'],
-        '[resource-drop]input-stream': trampoline4,
-        '[resource-drop]output-stream': trampoline2,
+      'wasi:random/insecure-seed@0.2.4': {
+        'insecure-seed': exports0['0'],
       },
-      'wasi:random/random@0.2.3': {
-        'get-random-bytes': exports0['18'],
+      'wasi:random/random@0.2.12': {
+        'get-random-u64': trampoline0,
       },
     }));
     memory0 = exports1.memory;
-    realloc0 = exports2.cabi_import_realloc;
+    realloc0 = exports1.cabi_realloc;
     
     try {
-      realloc0Async = WebAssembly.promising(exports2.cabi_import_realloc);
+      realloc0Async = WebAssembly.promising(exports1.cabi_realloc);
     } catch(err) {
-      realloc0Async = exports2.cabi_import_realloc;
+      realloc0Async = exports1.cabi_realloc;
     }
     
-    ({ exports: exports3 } = yield instantiateCore(yield module3, {
+    ({ exports: exports2 } = yield instantiateCore(yield module2, {
       '': {
         $imports: exports0.$imports,
-        '0': exports2.random_get,
-        '1': exports2.environ_get,
-        '10': trampoline12,
-        '11': trampoline13,
-        '12': trampoline14,
-        '13': trampoline15,
-        '14': trampoline16,
-        '15': trampoline17,
-        '16': trampoline18,
-        '17': trampoline19,
-        '18': trampoline20,
-        '19': trampoline21,
-        '2': exports2.environ_sizes_get,
-        '3': exports2.clock_time_get,
-        '4': exports2.fd_write,
-        '5': exports2.proc_exit,
-        '6': exports2.sched_yield,
-        '7': trampoline9,
-        '8': trampoline10,
-        '9': trampoline11,
+        '0': trampoline14,
+        '1': trampoline15,
+        '2': trampoline16,
+        '3': trampoline17,
+        '4': trampoline18,
+        '5': trampoline19,
+        '6': trampoline20,
+        '7': trampoline21,
+        '8': trampoline22,
       },
     }));
-    realloc1 = exports1.cabi_realloc;
-    
-    try {
-      realloc1Async = WebAssembly.promising(exports1.cabi_realloc);
-    } catch(err) {
-      realloc1Async = exports1.cabi_realloc;
-    }
-    
     postReturn0 = exports1.cabi_post_solve;
     
     try {
@@ -8631,12 +7508,21 @@ const $init = (() => {
       postReturn5Async = exports1.cabi_post_compare;
     }
     
+    postReturn6 = exports1['cabi_post_compare-tours'];
+    
+    try {
+      postReturn6Async = WebAssembly.promising(exports1['cabi_post_compare-tours']);
+    } catch(err) {
+      postReturn6Async = exports1['cabi_post_compare-tours'];
+    }
+    
     exports1Solve = exports1.solve;
     exports1ParseAndSolve = exports1['parse-and-solve'];
     exports1Parse = exports1.parse;
     exports1ListAlgorithms = exports1['list-algorithms'];
     exports1GetVersion = exports1['get-version'];
     exports1Compare = exports1.compare;
+    exports1CompareTours = exports1['compare-tours'];
   })();
   let promise, resolve, reject;
   function runNext (value) {
@@ -8663,4 +7549,4 @@ const $init = (() => {
 
 await $init;
 
-export { compare, getVersion, listAlgorithms, parse, parseAndSolve, solve,  }
+export { compare, compareTours, getVersion, listAlgorithms, parse, parseAndSolve, solve,  }

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -3,8 +3,10 @@ mod bindings;
 
 use bindings::Guest;
 use bindings::teeline::solver::types::{
-    AlgorithmInfo, City, CompareResult, ParamSpec, ParsedProblem, Solution, SolveOptions,
+    AlgorithmInfo, City, CompareResult, ComparisonStats, ParamSpec, ParsedProblem, Solution,
+    SolveOptions,
 };
+use teeline::tsp::comparison;
 use teeline::tsp::{
     AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, SAOptions,
     Solvers, TspProblem, distance_matrix::DistanceMatrix, kdtree::KDPoint,
@@ -73,7 +75,11 @@ fn build_opts(solver: Solvers, o: &SolveOptions) -> AppOptions {
 }
 
 fn kd_to_city(c: &KDPoint) -> City {
-    City { id: c.id as u32, x: c.x(), y: c.y() }
+    City {
+        id: c.id as u32,
+        x: c.x(),
+        y: c.y(),
+    }
 }
 
 fn parse_input_to_kd(input: &str) -> Result<Vec<KDPoint>, String> {
@@ -112,11 +118,14 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
 
 fn kind_for(solver: Solvers) -> String {
     match solver {
-        Solvers::BellmanKarp | Solvers::BranchBound       => "exact",
-        Solvers::NearestNeighbor | Solvers::Christofides | Solvers::Fourier | Solvers::KohonenSom => "constructive",
-        Solvers::TwoOpt | Solvers::ThreeOpt                => "local-search",
-        Solvers::RandomShuffle                             => "utility",
-        _                                                  => "metaheuristic",
+        Solvers::BellmanKarp | Solvers::BranchBound => "exact",
+        Solvers::NearestNeighbor
+        | Solvers::Christofides
+        | Solvers::Fourier
+        | Solvers::KohonenSom => "constructive",
+        Solvers::TwoOpt | Solvers::ThreeOpt => "local-search",
+        Solvers::RandomShuffle => "utility",
+        _ => "metaheuristic",
     }
     .to_string()
 }
@@ -159,23 +168,29 @@ fn pi(key: &str, label: &str, min: f32) -> ParamSpec {
 
 fn shared_heuristic_params() -> Vec<ParamSpec> {
     vec![
-        pi("epochs",       "Epochs",              1.0),
-        pi("platooEpochs", "Plateau epochs",       0.0),
-        pi("nNearest",     "Nearest neighbours",   1.0),
+        pi("epochs", "Epochs", 1.0),
+        pi("platooEpochs", "Plateau epochs", 0.0),
+        pi("nNearest", "Nearest neighbours", 1.0),
     ]
 }
 
 fn mutation_param() -> ParamSpec {
-    pf("mutationProbability", "Mutation probability", 0.0, 1.0, 0.001)
+    pf(
+        "mutationProbability",
+        "Mutation probability",
+        0.0,
+        1.0,
+        0.001,
+    )
 }
 
 fn params_for_solver(solver: Solvers) -> Vec<ParamSpec> {
     match solver {
         Solvers::SimulatedAnnealing => {
             let mut v = shared_heuristic_params();
-            v.push(pf("coolingRate",    "Cooling rate",    0.00001, 0.9999, 0.00001));
-            v.push(pf_min("maxTemperature", "Max temperature", 0.01,  1.0));
-            v.push(pf_min("minTemperature", "Min temperature", 0.0,   0.001));
+            v.push(pf("coolingRate", "Cooling rate", 0.00001, 0.9999, 0.00001));
+            v.push(pf_min("maxTemperature", "Max temperature", 0.01, 1.0));
+            v.push(pf_min("minTemperature", "Min temperature", 0.0, 0.001));
             v
         }
         Solvers::GeneticAlgorithm => {
@@ -320,6 +335,52 @@ impl Guest for Component {
                 }
             })
             .collect()
+    }
+
+    fn compare_tours(
+        solver_route: Vec<u32>,
+        opt_route: Vec<u32>,
+        cities: Vec<City>,
+    ) -> Result<ComparisonStats, String> {
+        // Length validation
+        if solver_route.len() != opt_route.len() || opt_route.len() != cities.len() {
+            return Err(format!(
+                "dimension mismatch: solver={} opt={} cities={}",
+                solver_route.len(),
+                opt_route.len(),
+                cities.len()
+            ));
+        }
+
+        // Convert WIT City -> KDPoint
+        let kd_cities: Vec<KDPoint> = cities
+            .iter()
+            .map(|c| KDPoint::new_with_id(c.id as usize, &[c.x, c.y]))
+            .collect();
+
+        // Build city ID set for membership validation
+        let city_ids: std::collections::HashSet<usize> = kd_cities.iter().map(|c| c.id).collect();
+
+        // Validate that every route ID exists in the cities list
+        for &id in solver_route.iter().chain(opt_route.iter()) {
+            if !city_ids.contains(&(id as usize)) {
+                return Err(format!("unknown city id {} in route", id));
+            }
+        }
+
+        // Convert route IDs
+        let solver: Vec<usize> = solver_route.iter().map(|&x| x as usize).collect();
+        let opt: Vec<usize> = opt_route.iter().map(|&x| x as usize).collect();
+
+        let stats = comparison::compare_tours(&solver, &opt, &kd_cities);
+        Ok(ComparisonStats {
+            optimal_cost: stats.optimal_cost,
+            solver_cost: stats.solver_cost,
+            gap_pct: stats.gap_pct,
+            shared_edges: stats.shared_edges as u32,
+            solver_only_edges: stats.solver_only_edges as u32,
+            optimal_only_edges: stats.optimal_only_edges as u32,
+        })
     }
 }
 

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -85,11 +85,31 @@ fn make_instance() -> (Store<HostState>, Solver) {
 fn five_cities() -> Vec<crate::teeline::solver::types::City> {
     use crate::teeline::solver::types::City;
     vec![
-        City { id: 0, x: 565.0, y: 575.0 },
-        City { id: 1, x: 25.0,  y: 185.0 },
-        City { id: 2, x: 345.0, y: 750.0 },
-        City { id: 3, x: 945.0, y: 685.0 },
-        City { id: 4, x: 845.0, y: 655.0 },
+        City {
+            id: 0,
+            x: 565.0,
+            y: 575.0,
+        },
+        City {
+            id: 1,
+            x: 25.0,
+            y: 185.0,
+        },
+        City {
+            id: 2,
+            x: 345.0,
+            y: 750.0,
+        },
+        City {
+            id: 3,
+            x: 945.0,
+            y: 685.0,
+        },
+        City {
+            id: 4,
+            x: 845.0,
+            y: 655.0,
+        },
     ]
 }
 
@@ -112,7 +132,11 @@ fn assert_valid_tour(solution: &crate::teeline::solver::types::Solution, n_citie
     let mut sorted: Vec<u32> = solution.route.clone();
     sorted.sort_unstable();
     sorted.dedup();
-    assert_eq!(sorted.len(), n_cities, "each city must be visited exactly once");
+    assert_eq!(
+        sorted.len(),
+        n_cities,
+        "each city must be visited exactly once"
+    );
 }
 
 // ── Per-call helpers (use shared runtime) ────────────────────────────────────
@@ -166,47 +190,88 @@ fn run_get_version() -> String {
 // ── solve tests ───────────────────────────────────────────────────────────────
 
 #[test]
-fn test_sa() { run_solver("sa") }
+fn test_sa() {
+    run_solver("sa")
+}
 #[test]
-fn test_two_opt() { run_solver("two_opt") }
+fn test_two_opt() {
+    run_solver("two_opt")
+}
 #[test]
-fn test_nearest_neighbor() { run_solver("nn") }
+fn test_nearest_neighbor() {
+    run_solver("nn")
+}
 #[test]
-fn test_genetic_algorithm() { run_solver("ga") }
+fn test_genetic_algorithm() {
+    run_solver("ga")
+}
 #[test]
-fn test_particle_swarm() { run_solver("pso") }
+fn test_particle_swarm() {
+    run_solver("pso")
+}
 #[test]
-fn test_cuckoo_search() { run_solver("cs") }
+fn test_cuckoo_search() {
+    run_solver("cs")
+}
 #[test]
-fn test_flower_pollination() { run_solver("fpa") }
+fn test_flower_pollination() {
+    run_solver("fpa")
+}
 #[test]
-fn test_lin_kernighan() { run_solver("lk") }
+fn test_lin_kernighan() {
+    run_solver("lk")
+}
 #[test]
-fn test_tabu_search() { run_solver("tabu_search") }
+fn test_tabu_search() {
+    run_solver("tabu_search")
+}
 #[test]
-fn test_stochastic_hill() { run_solver("stochastic_hill") }
+fn test_stochastic_hill() {
+    run_solver("stochastic_hill")
+}
 #[test]
-fn test_bellman_karp() { run_solver("bhk") }
+fn test_bellman_karp() {
+    run_solver("bhk")
+}
 #[test]
-fn test_branch_bound() { run_solver("branch_bound") }
+fn test_branch_bound() {
+    run_solver("branch_bound")
+}
 #[test]
-fn test_three_opt() { run_solver("3opt") }
+fn test_three_opt() {
+    run_solver("3opt")
+}
 #[test]
-fn test_or_opt() { run_solver("or_opt") }
+fn test_or_opt() {
+    run_solver("or_opt")
+}
 #[test]
-fn test_shuffle() { run_solver("shuffle") }
+fn test_shuffle() {
+    run_solver("shuffle")
+}
 #[test]
-fn test_christofides() { run_solver("christofides") }
+fn test_christofides() {
+    run_solver("christofides")
+}
 #[test]
-fn test_gravitational_search() { run_solver("gsa") }
+fn test_gravitational_search() {
+    run_solver("gsa")
+}
 #[test]
-fn test_fourier() { run_solver("fourier") }
+fn test_fourier() {
+    run_solver("fourier")
+}
 
 #[test]
 fn unknown_solver_returns_err() {
     let (mut store, instance) = make_instance();
     let result = instance
-        .call_solve(&mut store, "does_not_exist", &five_cities(), default_options())
+        .call_solve(
+            &mut store,
+            "does_not_exist",
+            &five_cities(),
+            default_options(),
+        )
         .unwrap();
     assert!(
         result.is_err(),
@@ -245,7 +310,12 @@ fn test_parse_and_solve_json_leading_whitespace() {
 fn test_parse_and_solve_one_city_json_returns_err() {
     let (mut store, instance) = make_instance();
     let result = instance
-        .call_parse_and_solve(&mut store, "nn", r#"[{"id":0,"x":1.0,"y":2.0}]"#, default_options())
+        .call_parse_and_solve(
+            &mut store,
+            "nn",
+            r#"[{"id":0,"x":1.0,"y":2.0}]"#,
+            default_options(),
+        )
         .unwrap();
     assert!(result.is_err(), "single city must return Err");
 }
@@ -308,11 +378,31 @@ fn test_list_algorithms_returns_all_solvers() {
     assert_eq!(algorithms.len(), 19, "expected 19 solvers");
     let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
     for expected_id in &[
-        "nn", "2opt", "3opt", "sa", "ga", "gsa", "pso", "cs", "fpa",
-        "tabu_search", "stochastic_hill", "shuffle", "bhk", "branch_bound", "lk", "or_opt",
-        "christofides", "fourier", "som",
+        "nn",
+        "2opt",
+        "3opt",
+        "sa",
+        "ga",
+        "gsa",
+        "pso",
+        "cs",
+        "fpa",
+        "tabu_search",
+        "stochastic_hill",
+        "shuffle",
+        "bhk",
+        "branch_bound",
+        "lk",
+        "or_opt",
+        "christofides",
+        "fourier",
+        "som",
     ] {
-        assert!(ids.contains(expected_id), "missing algorithm id: {}", expected_id);
+        assert!(
+            ids.contains(expected_id),
+            "missing algorithm id: {}",
+            expected_id
+        );
     }
 }
 
@@ -320,10 +410,18 @@ fn test_list_algorithms_returns_all_solvers() {
 fn test_list_algorithms_fields_non_empty() {
     let algorithms = run_list_algorithms();
     for algo in &algorithms {
-        assert!(!algo.id.is_empty(),             "id empty for {:?}", algo.name);
-        assert!(!algo.name.is_empty(),           "name empty for {}", algo.id);
-        assert!(!algo.description.is_empty(),    "description empty for {}", algo.id);
-        assert!(!algo.recommendation.is_empty(), "recommendation empty for {}", algo.id);
+        assert!(!algo.id.is_empty(), "id empty for {:?}", algo.name);
+        assert!(!algo.name.is_empty(), "name empty for {}", algo.id);
+        assert!(
+            !algo.description.is_empty(),
+            "description empty for {}",
+            algo.id
+        );
+        assert!(
+            !algo.recommendation.is_empty(),
+            "recommendation empty for {}",
+            algo.id
+        );
     }
 }
 
@@ -354,16 +452,25 @@ fn test_compare_preserves_algorithm_order() {
 fn test_compare_unknown_algorithm_returns_error_entry() {
     let results = run_compare(&["nn", "does_not_exist"], FIVE_CITIES_TSPLIB);
     assert_eq!(results.len(), 2);
-    assert!(results[0].solution.is_ok(),  "nn should succeed");
-    assert!(results[1].solution.is_err(), "unknown solver should return error entry");
+    assert!(results[0].solution.is_ok(), "nn should succeed");
+    assert!(
+        results[1].solution.is_err(),
+        "unknown solver should return error entry"
+    );
 }
 
 #[test]
 fn test_compare_invalid_input_all_error_entries() {
     let results = run_compare(&["nn", "2opt"], "not valid tsplib or json");
     assert_eq!(results.len(), 2);
-    assert!(results[0].solution.is_err(), "should return parse error for nn");
-    assert!(results[1].solution.is_err(), "should return parse error for 2opt");
+    assert!(
+        results[0].solution.is_err(),
+        "should return parse error for nn"
+    );
+    assert!(
+        results[1].solution.is_err(),
+        "should return parse error for 2opt"
+    );
 }
 
 #[test]
@@ -371,7 +478,10 @@ fn test_compare_json_input() {
     let results = run_compare(&["nn", "2opt"], &five_cities_json());
     assert_eq!(results.len(), 2);
     for r in &results {
-        let sol = r.solution.as_ref().expect("solver should succeed with JSON input");
+        let sol = r
+            .solution
+            .as_ref()
+            .expect("solver should succeed with JSON input");
         assert_valid_tour(sol, 5);
     }
 }
@@ -432,12 +542,19 @@ fn test_get_version_returns_non_empty() {
 #[test]
 fn test_list_algorithms_kind_fields_present() {
     let algorithms = run_list_algorithms();
-    let valid_kinds = ["exact", "constructive", "local-search", "metaheuristic", "utility"];
+    let valid_kinds = [
+        "exact",
+        "constructive",
+        "local-search",
+        "metaheuristic",
+        "utility",
+    ];
     for algo in &algorithms {
         assert!(
             valid_kinds.contains(&algo.kind.as_str()),
             "unexpected kind '{}' for solver '{}'",
-            algo.kind, algo.id
+            algo.kind,
+            algo.id
         );
     }
 }
@@ -445,13 +562,25 @@ fn test_list_algorithms_kind_fields_present() {
 #[test]
 fn test_list_algorithms_sa_kind_and_params() {
     let algorithms = run_list_algorithms();
-    let sa = algorithms.iter().find(|a| a.id == "sa").expect("sa missing");
+    let sa = algorithms
+        .iter()
+        .find(|a| a.id == "sa")
+        .expect("sa missing");
     assert_eq!(sa.kind, "metaheuristic");
     let keys: Vec<&str> = sa.params.iter().map(|p| p.key.as_str()).collect();
-    assert!(keys.contains(&"coolingRate"),    "sa must have coolingRate param");
-    assert!(keys.contains(&"maxTemperature"), "sa must have maxTemperature param");
-    assert!(keys.contains(&"minTemperature"), "sa must have minTemperature param");
-    assert!(keys.contains(&"epochs"),         "sa must have epochs param");
+    assert!(
+        keys.contains(&"coolingRate"),
+        "sa must have coolingRate param"
+    );
+    assert!(
+        keys.contains(&"maxTemperature"),
+        "sa must have maxTemperature param"
+    );
+    assert!(
+        keys.contains(&"minTemperature"),
+        "sa must have minTemperature param"
+    );
+    assert!(keys.contains(&"epochs"), "sa must have epochs param");
     let cr = sa.params.iter().find(|p| p.key == "coolingRate").unwrap();
     assert_eq!(cr.value_type, "float", "coolingRate must be float type");
 }
@@ -459,7 +588,10 @@ fn test_list_algorithms_sa_kind_and_params() {
 #[test]
 fn test_list_algorithms_nn_kind_and_params() {
     let algorithms = run_list_algorithms();
-    let nn = algorithms.iter().find(|a| a.id == "nn").expect("nn missing");
+    let nn = algorithms
+        .iter()
+        .find(|a| a.id == "nn")
+        .expect("nn missing");
     assert_eq!(nn.kind, "constructive");
     assert!(nn.params.is_empty(), "nn must have no configurable params");
 }
@@ -467,29 +599,50 @@ fn test_list_algorithms_nn_kind_and_params() {
 #[test]
 fn test_list_algorithms_bhk_kind_and_params() {
     let algorithms = run_list_algorithms();
-    let bhk = algorithms.iter().find(|a| a.id == "bhk").expect("bhk missing");
+    let bhk = algorithms
+        .iter()
+        .find(|a| a.id == "bhk")
+        .expect("bhk missing");
     assert_eq!(bhk.kind, "exact");
-    assert!(bhk.params.is_empty(), "bhk must have no configurable params");
+    assert!(
+        bhk.params.is_empty(),
+        "bhk must have no configurable params"
+    );
 }
 
 #[test]
 fn test_list_algorithms_two_opt_kind() {
     let algorithms = run_list_algorithms();
-    let two_opt = algorithms.iter().find(|a| a.id == "2opt").expect("2opt missing");
+    let two_opt = algorithms
+        .iter()
+        .find(|a| a.id == "2opt")
+        .expect("2opt missing");
     assert_eq!(two_opt.kind, "local-search");
-    assert!(!two_opt.params.is_empty(), "2opt must have heuristic params");
+    assert!(
+        !two_opt.params.is_empty(),
+        "2opt must have heuristic params"
+    );
 }
 
 #[test]
 fn test_list_algorithms_shuffle_kind() {
     let algorithms = run_list_algorithms();
-    let shuffle = algorithms.iter().find(|a| a.id == "shuffle").expect("shuffle missing");
+    let shuffle = algorithms
+        .iter()
+        .find(|a| a.id == "shuffle")
+        .expect("shuffle missing");
     assert_eq!(shuffle.kind, "utility");
 }
 
 const VALID_SOLVE_OPTIONS_KEYS: &[&str] = &[
-    "epochs", "platooEpochs", "coolingRate", "maxTemperature",
-    "minTemperature", "mutationProbability", "nElite", "nNearest",
+    "epochs",
+    "platooEpochs",
+    "coolingRate",
+    "maxTemperature",
+    "minTemperature",
+    "mutationProbability",
+    "nElite",
+    "nNearest",
 ];
 
 #[test]
@@ -500,7 +653,8 @@ fn test_list_algorithms_all_param_keys_are_valid_solve_options_fields() {
             assert!(
                 VALID_SOLVE_OPTIONS_KEYS.contains(&param.key.as_str()),
                 "solver '{}' has unknown param key '{}' — must be a valid SolveOptions field",
-                algo.id, param.key
+                algo.id,
+                param.key
             );
         }
     }
@@ -509,8 +663,14 @@ fn test_list_algorithms_all_param_keys_are_valid_solve_options_fields() {
 #[test]
 fn test_list_algorithms_christofides_kind_and_recommendation() {
     let algorithms = run_list_algorithms();
-    let chr = algorithms.iter().find(|a| a.id == "christofides").expect("christofides missing");
-    assert_eq!(chr.kind, "constructive", "christofides must be 'constructive'");
+    let chr = algorithms
+        .iter()
+        .find(|a| a.id == "christofides")
+        .expect("christofides missing");
+    assert_eq!(
+        chr.kind, "constructive",
+        "christofides must be 'constructive'"
+    );
     assert!(
         chr.params.is_empty(),
         "christofides must have no configurable params"
@@ -529,9 +689,16 @@ fn test_list_algorithms_christofides_kind_and_recommendation() {
 #[test]
 fn test_list_algorithms_fourier_kind_and_params() {
     let algorithms = run_list_algorithms();
-    let f = algorithms.iter().find(|a| a.id == "fourier").expect("fourier missing");
+    let f = algorithms
+        .iter()
+        .find(|a| a.id == "fourier")
+        .expect("fourier missing");
     assert_eq!(f.kind, "constructive", "fourier must be 'constructive'");
-    assert_eq!(f.params.len(), 1, "fourier must have exactly 1 param (epochs)");
+    assert_eq!(
+        f.params.len(),
+        1,
+        "fourier must have exactly 1 param (epochs)"
+    );
     assert_eq!(f.params[0].key, "epochs", "fourier param must be 'epochs'");
     assert_eq!(f.params[0].value_type, "int", "epochs must be int type");
     assert!(
@@ -544,11 +711,17 @@ fn test_list_algorithms_fourier_kind_and_params() {
 #[test]
 fn test_list_algorithms_ga_params() {
     let algorithms = run_list_algorithms();
-    let ga = algorithms.iter().find(|a| a.id == "ga").expect("ga missing");
+    let ga = algorithms
+        .iter()
+        .find(|a| a.id == "ga")
+        .expect("ga missing");
     assert_eq!(ga.kind, "metaheuristic");
     let keys: Vec<&str> = ga.params.iter().map(|p| p.key.as_str()).collect();
-    assert!(keys.contains(&"mutationProbability"), "ga must have mutationProbability");
-    assert!(keys.contains(&"nElite"),             "ga must have nElite");
+    assert!(
+        keys.contains(&"mutationProbability"),
+        "ga must have mutationProbability"
+    );
+    assert!(keys.contains(&"nElite"), "ga must have nElite");
     let n_elite = ga.params.iter().find(|p| p.key == "nElite").unwrap();
     assert_eq!(n_elite.value_type, "int", "nElite must be int type");
 }

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -187,6 +187,17 @@ fn run_get_version() -> String {
     instance.call_get_version(&mut store).unwrap()
 }
 
+fn run_compare_tours(
+    solver_route: &[u32],
+    opt_route: &[u32],
+    cities: &[crate::teeline::solver::types::City],
+) -> Result<crate::teeline::solver::types::ComparisonStats, String> {
+    let (mut store, instance) = make_instance();
+    instance
+        .call_compare_tours(&mut store, solver_route, opt_route, cities)
+        .unwrap()
+}
+
 // ── solve tests ───────────────────────────────────────────────────────────────
 
 #[test]
@@ -484,6 +495,107 @@ fn test_compare_json_input() {
             .expect("solver should succeed with JSON input");
         assert_valid_tour(sol, 5);
     }
+}
+
+// ── compare_tours tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_compare_tours_identical_routes() {
+    let cities = five_cities();
+    let route: Vec<u32> = cities.iter().map(|c| c.id).collect();
+    let stats = run_compare_tours(&route, &route, &cities).expect("identical routes must succeed");
+    assert_eq!(stats.gap_pct, 0.0, "identical tour must have 0% gap");
+    assert_eq!(
+        stats.shared_edges,
+        route.len() as u32,
+        "all edges must be shared"
+    );
+    assert_eq!(stats.solver_only_edges, 0);
+    assert_eq!(stats.optimal_only_edges, 0);
+    assert!((stats.optimal_cost - stats.solver_cost).abs() < 0.001);
+}
+
+#[test]
+fn test_compare_tours_permuted_route_has_positive_gap() {
+    let cities = five_cities();
+    // five_cities() returns IDs 0..4; optimal: [0,1,2,3,4], solver: [0,2,1,3,4]
+    let optimal: Vec<u32> = cities.iter().map(|c| c.id).collect();
+    let mut solver = optimal.clone();
+    solver.swap(1, 2); // swap cities 1 and 2 to create a worse route
+    let stats =
+        run_compare_tours(&solver, &optimal, &cities).expect("valid permuted routes must succeed");
+    assert!(stats.gap_pct >= 0.0, "gap must be non-negative");
+    // Swapped route may or may not be worse depending on geometry; just verify the call works
+    // and stats are consistent
+    assert_eq!(
+        stats.shared_edges + stats.solver_only_edges,
+        optimal.len() as u32,
+        "shared + solver_only must equal tour length"
+    );
+}
+
+#[test]
+fn test_compare_tours_dimension_mismatch_returns_error() {
+    let cities = five_cities();
+    let route: Vec<u32> = cities.iter().map(|c| c.id).collect();
+    let short_route = vec![route[0], route[1]]; // only 2 cities
+    let result = run_compare_tours(&short_route, &route, &cities);
+    assert!(result.is_err(), "mismatched lengths must return Err");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("dimension mismatch"),
+        "error must mention 'dimension mismatch', got: {msg}"
+    );
+}
+
+#[test]
+fn test_compare_tours_unknown_city_id_returns_error() {
+    let cities = five_cities(); // IDs 0..4
+    let route: Vec<u32> = cities.iter().map(|c| c.id).collect();
+    let bad_route: Vec<u32> = route.iter().map(|&id| id + 100).collect(); // IDs 100..104 don't exist
+    let result = run_compare_tours(&bad_route, &route, &cities);
+    assert!(result.is_err(), "unknown city IDs must return Err");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("unknown city"),
+        "error must mention 'unknown city', got: {msg}"
+    );
+}
+
+#[test]
+fn test_compare_tours_berlin52_optimal_vs_itself() {
+    // Parse berlin52 cities from the TSP file (reuse existing run_parse helper)
+    let tsp_input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/berlin52.tsp",
+    ))
+    .expect("berlin52.tsp must exist");
+    let parsed = run_parse(&tsp_input);
+
+    // Parse the optimal tour (city IDs, 1-based as per TSPLIB)
+    let opt_text = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/berlin52.opt.tour",
+    ))
+    .expect("berlin52.opt.tour must exist");
+    let opt_route: Vec<u32> = opt_text
+        .lines()
+        .skip_while(|l| l.trim() != "TOUR_SECTION")
+        .skip(1)
+        .map(|l| l.trim().parse::<i32>().unwrap_or(-1))
+        .take_while(|&n| n > 0)
+        .map(|n| n as u32)
+        .collect();
+    assert_eq!(
+        opt_route.len(),
+        52,
+        "berlin52 optimal tour must have 52 cities"
+    );
+
+    let stats = run_compare_tours(&opt_route, &opt_route, &parsed.cities)
+        .expect("optimal vs itself must succeed");
+    assert_eq!(stats.gap_pct, 0.0, "optimal vs itself must have 0% gap");
+    assert_eq!(stats.shared_edges, 52, "all 52 edges must be shared");
 }
 
 // ── parse integration tests ────────────────────────────────────────────────────

--- a/teeline-wasm/wit/world.wit
+++ b/teeline-wasm/wit/world.wit
@@ -54,10 +54,19 @@ interface types {
         algorithm: string,
         solution: result<solution, string>,
     }
+
+    record comparison-stats {
+        optimal-cost:       f32,
+        solver-cost:        f32,
+        gap-pct:            f32,
+        shared-edges:       u32,
+        solver-only-edges:  u32,
+        optimal-only-edges: u32,
+    }
 }
 
 world solver {
-    use types.{city, solve-options, solution, parsed-problem, algorithm-info, compare-result};
+    use types.{city, solve-options, solution, parsed-problem, algorithm-info, compare-result, comparison-stats};
 
     export solve: func(
         solver: string,
@@ -84,4 +93,10 @@ world solver {
         input: string,
         options: solve-options,
     ) -> list<compare-result>;
+
+    export compare-tours: func(
+        solver-route: list<u32>,
+        opt-route:    list<u32>,
+        cities:       list<city>,
+    ) -> result<comparison-stats, string>;
 }

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -274,6 +274,8 @@
                 </tbody>
               </table>
 
+              <p id="comparison-error" class="comparison-error pico-color-red-500" hidden aria-live="polite"></p>
+
               <section aria-labelledby="run-history-heading">
                 <h3 id="run-history-heading">Run history</h3>
                 <ol

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -256,6 +256,9 @@
                   <tr>
                     <th>Tour length</th>
                     <th>Gap vs optimal</th>
+                    <th>Shared edges</th>
+                    <th>Solver-only</th>
+                    <th>Opt-only</th>
                     <th>Runtime</th>
                   </tr>
                 </thead>
@@ -263,6 +266,9 @@
                   <tr>
                     <td id="result-total">—</td>
                     <td id="result-gap">—</td>
+                    <td id="result-shared-edges">—</td>
+                    <td id="result-solver-only-edges">—</td>
+                    <td id="result-optimal-only-edges">—</td>
                     <td id="result-runtime">—</td>
                   </tr>
                 </tbody>

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -7,7 +7,7 @@ import { type SolveOptions } from './solver-options'
 import type { SolveResult, SolveError, ParseResult, AlgorithmsResult, VersionResult, WorkerReadyMessage } from './worker'
 import { initUpload, resetUpload } from './upload'
 import { initSolverConfig } from './solver-form'
-import { initResults, updateOptRoute, showRunning, showResult, computeRouteLength } from './results'
+import { initResults, updateOptRoute, showRunning, showResult } from './results'
 import { buildTourText, buildCsvText, buildJsonText, serializeSvg, triggerDownload } from './download'
 
 initTopbar()
@@ -140,10 +140,7 @@ worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMe
         runSolver(solver, parsedProblem.cities, options)
           .then((result) => {
             const runtime = Date.now() - start
-            const optTotal = optTourRoute
-              ? computeRouteLength(optTourRoute, parsedProblem!.cities)
-              : undefined
-            const record = { solver, total: result.total, optTotal, runtime, route: result.route }
+            const record = { solver, total: result.total, runtime, route: result.route }
             showResult(record)
             showDownloadButtons(record, parsedProblem!)
           })

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -4,10 +4,10 @@ import './docs.css'
 import { initTopbar } from './topbar'
 import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
-import type { SolveResult, SolveError, ParseResult, AlgorithmsResult, VersionResult, WorkerReadyMessage } from './worker'
+import type { SolveResult, SolveError, ParseResult, AlgorithmsResult, VersionResult, WorkerReadyMessage, CompareToursResult } from './worker'
 import { initUpload, resetUpload } from './upload'
 import { initSolverConfig } from './solver-form'
-import { initResults, updateOptRoute, showRunning, showResult } from './results'
+import { initResults, updateOptRoute, showRunning, showResult, patchComparison } from './results'
 import { buildTourText, buildCsvText, buildJsonText, serializeSvg, triggerDownload } from './download'
 
 initTopbar()
@@ -143,6 +143,29 @@ worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMe
             const record = { solver, total: result.total, runtime, route: result.route }
             showResult(record)
             showDownloadButtons(record, parsedProblem!)
+            clearCompareError()
+
+            if (optTourRoute) {
+              const compareId = crypto.randomUUID()
+              const compareHandler = (e: MessageEvent<CompareToursResult>) => {
+                if (e.data.type !== 'compare-tours-result') return
+                if (e.data.id !== compareId) return
+                worker.removeEventListener('message', compareHandler)
+                if (e.data.stats) {
+                  patchComparison(record, e.data.stats)
+                } else {
+                  showCompareError(e.data.error ?? 'Comparison failed')
+                }
+              }
+              worker.addEventListener('message', compareHandler)
+              worker.postMessage({
+                type: 'compare-tours',
+                id: compareId,
+                solverRoute: result.route,
+                optRoute: optTourRoute,
+                cities: parsedProblem!.cities,
+              })
+            }
           })
           .catch((err: Error) => {
             const overlay = document.getElementById('solving-overlay') as HTMLElement
@@ -176,6 +199,20 @@ worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMe
     worker.removeEventListener('message', onInit)
   }
 })
+
+// ---- Comparison error banner ----
+
+function showCompareError(msg: string): void {
+  const el = document.getElementById('comparison-error') as HTMLElement | null
+  if (!el) return
+  el.textContent = `Comparison unavailable: ${msg}`
+  el.hidden = false
+}
+
+function clearCompareError(): void {
+  const el = document.getElementById('comparison-error') as HTMLElement | null
+  if (el) { el.hidden = true; el.textContent = '' }
+}
 
 // ---- Reset / new dataset ----
 

--- a/teeline-web/src/results.test.ts
+++ b/teeline-web/src/results.test.ts
@@ -1,23 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { formatGap, formatRuntime, computeRouteLength } from './results'
-
-describe('formatGap', () => {
-  it('returns "—" when optimal is not provided', () => {
-    expect(formatGap(8000, undefined)).toBe('—')
-  })
-
-  it('returns "0.0%" when tour equals optimal', () => {
-    expect(formatGap(7542, 7542)).toBe('0.0%')
-  })
-
-  it('returns correct percentage with 1 decimal place', () => {
-    expect(formatGap(8296, 7542)).toBe('10.0%')
-  })
-
-  it('handles large gaps correctly', () => {
-    expect(formatGap(15084, 7542)).toBe('100.0%')
-  })
-})
+import { formatRuntime } from './results'
+import type { RunRecord } from './results'
+import type { ComparisonStats } from './worker'
 
 describe('formatRuntime', () => {
   it('formats sub-second as "<N>ms"', () => {
@@ -33,23 +17,31 @@ describe('formatRuntime', () => {
   })
 })
 
-describe('computeRouteLength', () => {
-  it('returns 0 for a single-city route', () => {
-    const cities = [{ id: 1, x: 0, y: 0 }]
-    expect(computeRouteLength([1], cities)).toBe(0)
+describe('RunRecord type', () => {
+  it('accepts comparison field with ComparisonStats', () => {
+    const stats: ComparisonStats = {
+      optimalCost: 7542,
+      solverCost: 8296,
+      gapPct: 10.0,
+      sharedEdges: 30,
+      solverOnlyEdges: 22,
+      optimalOnlyEdges: 22,
+    }
+    const record: RunRecord = {
+      solver: 'nn',
+      total: 8296,
+      comparison: stats,
+      runtime: 12,
+      route: [1, 2, 3],
+    }
+    expect(record.comparison?.gapPct).toBe(10.0)
+    expect(record.comparison?.sharedEdges).toBe(30)
+    expect(record.comparison?.solverOnlyEdges).toBe(22)
+    expect(record.comparison?.optimalOnlyEdges).toBe(22)
   })
 
-  it('computes Euclidean distances for a simple triangle', () => {
-    const cities = [
-      { id: 1, x: 0, y: 0 },
-      { id: 2, x: 3, y: 0 },
-      { id: 3, x: 0, y: 4 },
-    ]
-    // 1→2: 3, 2→3: 5, 3→1: 4 → total 12
-    expect(computeRouteLength([1, 2, 3], cities)).toBeCloseTo(12)
-  })
-
-  it('returns 0 for empty route', () => {
-    expect(computeRouteLength([], [])).toBe(0)
+  it('allows comparison to be absent', () => {
+    const record: RunRecord = { solver: 'nn', total: 8296, runtime: 12, route: [1, 2, 3] }
+    expect(record.comparison).toBeUndefined()
   })
 })

--- a/teeline-web/src/results.ts
+++ b/teeline-web/src/results.ts
@@ -1,43 +1,24 @@
 import type { City } from 'teeline-wasm'
 import { renderTour } from './canvas'
+import type { ComparisonStats } from './worker'
 
 export interface RunRecord {
   solver: string
   total: number
-  optTotal?: number
+  comparison?: ComparisonStats
   runtime: number
   route: number[]
 }
 
 // ---- Pure helpers ----
 
-export function formatGap(total: number, optimal: number | undefined): string {
-  if (optimal === undefined) return '—'
-  const pct = ((total - optimal) / optimal) * 100
-  return `${pct.toFixed(1)}%`
-}
-
 export function formatRuntime(ms: number): string {
   if (ms < 1000) return `${ms}ms`
   return `${(ms / 1000).toFixed(1)}s`
 }
 
-export function computeRouteLength(
-  route: number[],
-  cities: Array<{ id: number; x: number; y: number }>,
-): number {
-  if (route.length < 2) return 0
-  const byId = new Map(cities.map((c) => [c.id, c]))
-  let total = 0
-  for (let i = 0; i < route.length; i++) {
-    const a = byId.get(route[i])
-    const b = byId.get(route[(i + 1) % route.length])
-    if (!a || !b) continue
-    const dx = b.x - a.x
-    const dy = b.y - a.y
-    total += Math.sqrt(dx * dx + dy * dy)
-  }
-  return total
+function formatGapPct(c: ComparisonStats | undefined): string {
+  return c !== undefined ? `${c.gapPct.toFixed(1)}%` : '—'
 }
 
 // ---- DOM module ----
@@ -80,25 +61,37 @@ export function showResult(record: RunRecord): void {
   overlay.hidden = true
 
   const svgEl = document.getElementById('tour-svg') as unknown as SVGSVGElement
-  renderTour(svgEl, citiesRef, record.route, record.optTotal !== undefined ? optRouteRef : undefined)
+  renderTour(svgEl, citiesRef, record.route, record.comparison !== undefined ? optRouteRef : undefined)
 
-  const totalEl = document.getElementById('result-total')!
-  const gapEl = document.getElementById('result-gap')!
-  const runtimeEl = document.getElementById('result-runtime')!
-
-  totalEl.textContent = record.total.toFixed(1)
-  gapEl.textContent = formatGap(record.total, record.optTotal)
-  runtimeEl.textContent = formatRuntime(record.runtime)
+  document.getElementById('result-total')!.textContent = record.total.toFixed(1)
+  document.getElementById('result-gap')!.textContent = formatGapPct(record.comparison)
+  document.getElementById('result-runtime')!.textContent = formatRuntime(record.runtime)
+  applyComparisonCells(record.comparison)
 
   runHistory.unshift(record)
   renderHistoryRow(record)
+}
+
+export function patchComparison(record: RunRecord, stats: ComparisonStats): void {
+  record.comparison = stats
+  document.getElementById('result-gap')!.textContent = formatGapPct(stats)
+  applyComparisonCells(stats)
+  const svgEl = document.getElementById('tour-svg') as unknown as SVGSVGElement
+  renderTour(svgEl, citiesRef, record.route, optRouteRef)
+}
+
+function applyComparisonCells(c: ComparisonStats | undefined): void {
+  const dash = '—'
+  document.getElementById('result-shared-edges')!.textContent = c !== undefined ? String(c.sharedEdges) : dash
+  document.getElementById('result-solver-only-edges')!.textContent = c !== undefined ? String(c.solverOnlyEdges) : dash
+  document.getElementById('result-optimal-only-edges')!.textContent = c !== undefined ? String(c.optimalOnlyEdges) : dash
 }
 
 function renderHistoryRow(record: RunRecord): void {
   const list = document.getElementById('run-history-list')!
   const li = document.createElement('li')
   li.className = 'run-history-item'
-  li.textContent = `${record.solver} — ${record.total.toFixed(1)} ${formatGap(record.total, record.optTotal)} ${formatRuntime(record.runtime)}`
+  li.textContent = `${record.solver} — ${record.total.toFixed(1)} ${formatGapPct(record.comparison)} ${formatRuntime(record.runtime)}`
   li.setAttribute('role', 'button')
   li.setAttribute('tabindex', '0')
   li.addEventListener('click', () => replayRecord(record))
@@ -108,11 +101,12 @@ function renderHistoryRow(record: RunRecord): void {
 
 function replayRecord(record: RunRecord): void {
   const svgEl = document.getElementById('tour-svg') as unknown as SVGSVGElement
-  renderTour(svgEl, citiesRef, record.route, record.optTotal !== undefined ? optRouteRef : undefined)
+  renderTour(svgEl, citiesRef, record.route, record.comparison !== undefined ? optRouteRef : undefined)
 
   document.getElementById('result-total')!.textContent = record.total.toFixed(1)
-  document.getElementById('result-gap')!.textContent = formatGap(record.total, record.optTotal)
+  document.getElementById('result-gap')!.textContent = formatGapPct(record.comparison)
   document.getElementById('result-runtime')!.textContent = formatRuntime(record.runtime)
+  applyComparisonCells(record.comparison)
 }
 
 function resetStepperToStep2(): void {

--- a/teeline-web/src/teeline-wasm.d.ts
+++ b/teeline-web/src/teeline-wasm.d.ts
@@ -46,5 +46,14 @@ declare module 'teeline-wasm' {
   export function parse(input: string): ParsedProblem
   export function listAlgorithms(): Array<AlgorithmInfo>
   export function getVersion(): string
+  export interface ComparisonStats {
+    optimalCost: number
+    solverCost: number
+    gapPct: number
+    sharedEdges: number
+    solverOnlyEdges: number
+    optimalOnlyEdges: number
+  }
+  export function compareTours(solverRoute: Uint32Array, optRoute: Uint32Array, cities: Array<City>): ComparisonStats
   export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E }
 }

--- a/teeline-web/src/worker.test.ts
+++ b/teeline-web/src/worker.test.ts
@@ -6,9 +6,10 @@ vi.mock('teeline-wasm', () => ({
   parse: vi.fn(),
   listAlgorithms: vi.fn(),
   getVersion: vi.fn(),
+  compareTours: vi.fn(),
 }))
 
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion } from 'teeline-wasm'
+import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours } from 'teeline-wasm'
 import {
   handleMessage,
   type ParseAndSolveRequest,
@@ -16,6 +17,8 @@ import {
   type SolveRequest,
   type ListAlgorithmsRequest,
   type GetVersionRequest,
+  type CompareToursRequest,
+  type ComparisonStats,
 } from './worker'
 
 const mockSolution = { total: 42.0, route: new Uint32Array([0, 1, 2]) }
@@ -171,6 +174,79 @@ describe('handleMessage — get-version', () => {
     expect(res.type).toBe('error')
     if (res.type === 'error') {
       expect(res.message).toContain('version unavailable')
+    }
+  })
+})
+
+describe('handleMessage — compare-tours', () => {
+  const mockStats: ComparisonStats = {
+    optimalCost: 100.0,
+    solverCost: 110.0,
+    gapPct: 10.0,
+    sharedEdges: 3,
+    solverOnlyEdges: 1,
+    optimalOnlyEdges: 1,
+  }
+  const cities = [
+    { id: 1, x: 0.0, y: 0.0 },
+    { id: 2, x: 1.0, y: 0.0 },
+    { id: 3, x: 1.0, y: 1.0 },
+    { id: 4, x: 0.0, y: 1.0 },
+  ]
+  const solverRoute = [1, 2, 3, 4]
+  const optRoute    = [1, 2, 4, 3]
+
+  it('returns compare-tours-result with stats on success', () => {
+    vi.mocked(compareTours).mockReturnValue(mockStats)
+    const req: CompareToursRequest = {
+      type: 'compare-tours',
+      id: 'test-id-1',
+      solverRoute,
+      optRoute,
+      cities,
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('compare-tours-result')
+    if (res.type === 'compare-tours-result') {
+      expect(res.id).toBe('test-id-1')
+      expect(res.stats?.gapPct).toBe(10.0)
+      expect(res.stats?.sharedEdges).toBe(3)
+      expect(res.error).toBeUndefined()
+    }
+  })
+
+  it('echoes the request id in the response', () => {
+    vi.mocked(compareTours).mockReturnValue(mockStats)
+    const req: CompareToursRequest = {
+      type: 'compare-tours',
+      id: 'correlation-abc',
+      solverRoute,
+      optRoute,
+      cities,
+    }
+    const res = handleMessage(req)
+    if (res.type === 'compare-tours-result') {
+      expect(res.id).toBe('correlation-abc')
+    }
+  })
+
+  it('returns error in compare-tours-result when compareTours throws', () => {
+    vi.mocked(compareTours).mockImplementation(() => {
+      throw new Error('dimension mismatch: solver=3 opt=4 cities=4')
+    })
+    const req: CompareToursRequest = {
+      type: 'compare-tours',
+      id: 'test-id-err',
+      solverRoute: [1, 2, 3],
+      optRoute: [1, 2, 3, 4],
+      cities,
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('compare-tours-result')
+    if (res.type === 'compare-tours-result') {
+      expect(res.id).toBe('test-id-err')
+      expect(res.error).toContain('dimension mismatch')
+      expect(res.stats).toBeUndefined()
     }
   })
 })

--- a/teeline-web/src/worker.ts
+++ b/teeline-web/src/worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion, type ParsedProblem } from 'teeline-wasm'
+import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, type ParsedProblem } from 'teeline-wasm'
 import type { AlgorithmInfo } from 'teeline-wasm'
 import { defaultSolveOptions, type SolveOptions } from './solver-options'
 
@@ -60,8 +60,32 @@ export interface WorkerReadyMessage {
   type: 'worker-ready'
 }
 
-type WorkerRequest = SolveRequest | ParseAndSolveRequest | ParseRequest | ListAlgorithmsRequest | GetVersionRequest
-type WorkerResponse = SolveResult | ParseResult | AlgorithmsResult | VersionResult | SolveError | WorkerReadyMessage
+export interface ComparisonStats {
+  optimalCost: number
+  solverCost: number
+  gapPct: number
+  sharedEdges: number
+  solverOnlyEdges: number
+  optimalOnlyEdges: number
+}
+
+export interface CompareToursRequest {
+  type: 'compare-tours'
+  id: string
+  solverRoute: number[]
+  optRoute: number[]
+  cities: Array<{ id: number; x: number; y: number }>
+}
+
+export interface CompareToursResult {
+  type: 'compare-tours-result'
+  id: string
+  stats?: ComparisonStats
+  error?: string
+}
+
+type WorkerRequest = SolveRequest | ParseAndSolveRequest | ParseRequest | ListAlgorithmsRequest | GetVersionRequest | CompareToursRequest
+type WorkerResponse = SolveResult | ParseResult | AlgorithmsResult | VersionResult | SolveError | WorkerReadyMessage | CompareToursResult
 
 export function handleMessage(data: WorkerRequest): WorkerResponse {
   try {
@@ -74,6 +98,31 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
     }
     if (data.type === 'get-version') {
       return { type: 'version', version: getVersion() }
+    }
+    if (data.type === 'compare-tours') {
+      const req = data as CompareToursRequest
+      try {
+        // compareTours returns ComparisonStats directly (jco throws on WIT Err)
+        const s = compareTours(new Uint32Array(req.solverRoute), new Uint32Array(req.optRoute), req.cities)
+        return {
+          type: 'compare-tours-result',
+          id: req.id,
+          stats: {
+            optimalCost: s.optimalCost,
+            solverCost: s.solverCost,
+            gapPct: s.gapPct,
+            sharedEdges: s.sharedEdges,
+            solverOnlyEdges: s.solverOnlyEdges,
+            optimalOnlyEdges: s.optimalOnlyEdges,
+          },
+        }
+      } catch (err) {
+        return {
+          type: 'compare-tours-result',
+          id: req.id,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
     }
     const mergedOptions: SolveOptions = { ...defaultSolveOptions(), ...data.options }
     let solution: ReturnType<typeof solve>

--- a/tests/lin_kernighan_test.rs
+++ b/tests/lin_kernighan_test.rs
@@ -52,11 +52,7 @@ fn lk_solve_returns_valid_tour() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let problem = make_problem(cities.clone());
     let sol = lin_kernighan::solve(&problem, &lk_opts_fast(), None, None);
-    assert_eq!(
-        sol.route().len(),
-        52,
-        "tour must visit all 52 cities"
-    );
+    assert_eq!(sol.route().len(), 52, "tour must visit all 52 cities");
     assert!(
         is_valid_tour(sol.route(), &cities),
         "tour must contain every city exactly once"
@@ -90,7 +86,10 @@ fn lk_solve_reported_distance_matches_tour() {
     let route = sol.route();
     let n = route.len();
     let recomputed: f32 = (0..n)
-        .map(|i| dm.distance_between(route[i], route[(i + 1) % n]).unwrap_or(f32::MAX))
+        .map(|i| {
+            dm.distance_between(route[i], route[(i + 1) % n])
+                .unwrap_or(f32::MAX)
+        })
         .sum();
 
     assert!(

--- a/tests/or_opt_test.rs
+++ b/tests/or_opt_test.rs
@@ -73,7 +73,12 @@ fn or_opt_berlin52_improves_over_identity_tour() {
     let identity: Vec<usize> = cities.iter().map(|c| c.id).collect();
     let identity_cost = problem.distances.tour_length(&identity);
 
-    let sol = or_opt::solve(&problem, &HeuristicOptions::default(), None, Some(&identity));
+    let sol = or_opt::solve(
+        &problem,
+        &HeuristicOptions::default(),
+        None,
+        Some(&identity),
+    );
     assert!(
         sol.total < identity_cost,
         "or-opt ({:.1}) should improve over identity tour ({:.1})",

--- a/tests/solvers_integration.rs
+++ b/tests/solvers_integration.rs
@@ -219,12 +219,8 @@ fn particle_swarm_valid_tour_berlin52() {
 #[test]
 fn gravitational_search_valid_tour_berlin52() {
     let cities = load_berlin52();
-    let tour = gravitational_search::solve(
-        &make_problem(&cities),
-        &stochastic_options(200),
-        None,
-        None,
-    );
+    let tour =
+        gravitational_search::solve(&make_problem(&cities), &stochastic_options(200), None, None);
     assert!(
         is_valid_tour(tour.route(), &cities),
         "GSA tour is not valid on berlin52"
@@ -234,12 +230,8 @@ fn gravitational_search_valid_tour_berlin52() {
 #[test]
 fn gravitational_search_valid_tour_small() {
     let cities = tsp5_cities();
-    let tour = gravitational_search::solve(
-        &make_problem(&cities),
-        &stochastic_options(50),
-        None,
-        None,
-    );
+    let tour =
+        gravitational_search::solve(&make_problem(&cities), &stochastic_options(50), None, None);
     assert!(
         is_valid_tour(tour.route(), &cities),
         "GSA tour is not valid on 5-city instance"

--- a/tests/som_test.rs
+++ b/tests/som_test.rs
@@ -4,8 +4,8 @@
 /// The quality test is #[ignore] and requires: cargo test --test som_test -- --include-ignored
 use std::path::Path;
 use std::sync::mpsc;
-use teeline::tsp::{SOMOptions, TspProblem, distance_matrix, kdtree, tsplib};
 use teeline::tsp::progress::ProgressMessage;
+use teeline::tsp::{SOMOptions, TspProblem, distance_matrix, kdtree, tsplib};
 
 fn load_tsp(fixture: &str) -> tsplib::TspLibData {
     let path = Path::new("tests/fixtures").join(fixture);
@@ -73,18 +73,23 @@ fn som_sends_progress_messages() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let problem = make_problem(cities);
     // 100 epochs → checkpoint = 10, so we get 10 EpochUpdates and the last fires at t=100=epochs
-    let opts = SOMOptions { epochs: 100, ..SOMOptions::default() };
+    let opts = SOMOptions {
+        epochs: 100,
+        ..SOMOptions::default()
+    };
     let (tx, rx) = mpsc::channel();
     let _ = teeline::tsp::som::solve(&problem, &opts, Some(&tx), None);
     drop(tx);
 
     let msgs: Vec<_> = rx.try_iter().collect();
     assert!(
-        msgs.iter().any(|m| matches!(m, ProgressMessage::EpochUpdate(_))),
+        msgs.iter()
+            .any(|m| matches!(m, ProgressMessage::EpochUpdate(_))),
         "expected at least one EpochUpdate"
     );
     assert!(
-        msgs.iter().any(|m| matches!(m, ProgressMessage::PathUpdate(..))),
+        msgs.iter()
+            .any(|m| matches!(m, ProgressMessage::PathUpdate(..))),
         "expected at least one PathUpdate"
     );
     assert!(

--- a/tests/test_kdtree_and_distance_matrix.rs
+++ b/tests/test_kdtree_and_distance_matrix.rs
@@ -62,7 +62,10 @@ fn test_nearest_excludes_self() {
     let dm = distance_matrix::from_cities(&cities);
     let result = dm.nearest(&cities[0], 2);
     let ids: Vec<usize> = result.nearest().iter().map(|r| r.point.id).collect();
-    assert!(!ids.contains(&0), "self must not appear in nearest results: {ids:?}");
+    assert!(
+        !ids.contains(&0),
+        "self must not appear in nearest results: {ids:?}"
+    );
 }
 
 /// distance_by_pos must return Err (not panic) for an out-of-range position.
@@ -92,11 +95,7 @@ fn test_distance_between_unknown_city_returns_err() {
 /// nearest() must return an empty result (not panic) for an unknown target city ID.
 #[test]
 fn test_nearest_unknown_target_returns_empty() {
-    let cities = kdtree::build_points(&[
-        vec![0.0, 0.0],
-        vec![1.0, 0.0],
-        vec![2.0, 0.0],
-    ]);
+    let cities = kdtree::build_points(&[vec![0.0, 0.0], vec![1.0, 0.0], vec![2.0, 0.0]]);
     let dm = distance_matrix::from_cities(&cities);
     let unknown = KDPoint::new_with_id(99, &[0.0, 0.0]);
     let result = dm.nearest(&unknown, 2);
@@ -130,7 +129,9 @@ fn test_burma14_geo_distance_matrix() {
 
     // Cities 1=(16.47, 96.10) and 2=(16.47, 94.44) share the same latitude.
     // Euclidean distance would be ~1.66; GEO distance should be much larger (hundreds of km).
-    let geo_d = dm.distance_between(1, 2).expect("distance between city 1 and 2");
+    let geo_d = dm
+        .distance_between(1, 2)
+        .expect("distance between city 1 and 2");
     assert!(
         geo_d > 100.0,
         "GEO distance should be > 100 km, got {geo_d}"


### PR DESCRIPTION
## Summary

Closes #180.

Exposes `compare_tours` from the Rust library via a new WASM WIT export (`compare-tours`) and replaces the TypeScript gap calculation in `teeline-web` with WASM-computed `ComparisonStats`, adding shared/solver-only/optimal-only edge counts to the results table.

## Changes

**WASM layer (`teeline-wasm`)**
- `wit/world.wit`: new `comparison-stats` record and `compare-tours` export (returns `result<comparison-stats, string>`)
- `src/lib.rs`: `Guest::compare_tours` binding — dimension mismatch + city-ID membership validation before delegating to `comparison::compare_tours()`
- `tests/wasm_component.rs`: 5 wasmtime integration tests (identical routes, permuted route, dimension mismatch error, unknown city ID error, berlin52 self-comparison); 53/53 passing
- `js-bindings/teeline_wasm.js`: updated jco output (WASI 0.2.12, adds `compareTours`)

**Web layer (`teeline-web`)**
- `src/teeline-wasm.d.ts`: added `ComparisonStats` interface + `compareTours` signature to the ambient module declaration (this file is the tsc source of truth — shadows `node_modules`)
- `src/worker.ts`: `CompareToursRequest`/`CompareToursResult` types; handler calls `compareTours()` and echoes correlation `id` for race-free matching
- `src/results.ts`: `RunRecord.comparison?: ComparisonStats` (replaces `optTotal?: number`); removes `formatGap()` and `computeRouteLength()`; adds `patchComparison()` for async updates; new `applyComparisonCells()` populates Shared/Solver-only/Opt-only columns
- `src/main.ts`: after solve resolves with `optTourRoute` present — posts `compare-tours` with `crypto.randomUUID()` correlation ID; ignores stale responses; calls `patchComparison()` on success or shows `#comparison-error` banner on error
- `index.html`: 3 new columns (Shared edges, Solver-only, Opt-only) in results table; `#comparison-error` element with `aria-live="polite"`

## Test plan

- [x] WASM: `cargo test -p teeline-wasm --test wasm_component` — 53/53 passing
- [x] Web: `npm test` in `teeline-web/` — 104/104 passing
- [x] `tsc --noEmit` clean (pre-commit hook passes on all 6 commits)
- [x] Manual: berlin52 + NN → gap 19.0%, shared 33, solver-only 19, opt-only 19 ✓
- [x] Manual: both tour overlays render on the canvas (solid = solver, dashed = optimal)
- [x] Error banner: upload opt.tour from a different problem → "Comparison unavailable: dimension mismatch" banner appears

## Notes

- `teeline-web/src/teeline-wasm.d.ts` is an ambient module declaration that TypeScript uses as the sole source of truth for `'teeline-wasm'` imports — it completely shadows `node_modules/teeline-wasm/teeline_wasm.d.ts`. Any future WIT export must be added here too (documented in CLAUDE.md).
- Run history entries show gap as `—` (comparison is async and arrives after the row is rendered). Follow-up: update history rows when `patchComparison` is called.