### PR TITLE
feat(web): add interactive FPA explainer (#239)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,12 @@
 name: Rust
 
-on:
+"on":
   push:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
       - 'teeline-web/**'
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
       - 'teeline-web/**'
 
@@ -15,66 +15,65 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - name: Build
-      run: cargo build -p teeline -p teeline-cli --verbose
-    - name: Run tests
-      run: cargo test -p teeline -p teeline-cli --verbose
-    - name: Run e2e tests (BATS)
-      run: ./tests/bats/bin/bats tests/e2e/
-    - name: Clippy
-      run: cargo clippy -p teeline -p teeline-cli -- -D warnings
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
-    - name: Coverage
-      run: cargo llvm-cov -p teeline -p teeline-cli --lcov --output-path lcov.info
-    - name: Upload coverage
-      uses: codecov/codecov-action@v7
-      with:
-        files: lcov.info
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Build
+        run: cargo build -p teeline -p teeline-cli --verbose
+      - name: Run tests
+        run: cargo test -p teeline -p teeline-cli --verbose
+      - name: Run e2e tests (BATS)
+        run: ./tests/bats/bin/bats tests/e2e/
+      - name: Clippy
+        run: cargo clippy -p teeline -p teeline-cli -- -D warnings
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Coverage
+        run: cargo llvm-cov -p teeline -p teeline-cli --lcov --output-path lcov.info
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - name: Install cargo-component
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-component
-    - name: Add wasm32-wasip2 target
-      run: rustup target add wasm32-wasip2
-    - name: Build WASM component
-      run: cd teeline-wasm && cargo component build --target wasm32-wasip2
-    - name: Upload WASM artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: teeline-wasm-debug
-        path: target/wasm32-wasip2/debug/teeline_wasm.wasm
-    - name: Run wasm_component integration tests
-      run: cargo test -p teeline-wasm --test wasm_component --target x86_64-unknown-linux-gnu
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install cargo-component
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-component
+      - name: Add wasm32-wasip2 target
+        run: rustup target add wasm32-wasip2
+      - name: Build WASM component
+        run: cd teeline-wasm && cargo component build --target wasm32-wasip2
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: teeline-wasm-debug
+          path: teeline-wasm/target/wasm32-wasip2/debug/teeline_wasm.wasm
+      - name: Run wasm_component integration tests
+        run: cd teeline-wasm && cargo test --test wasm_component --target x86_64-unknown-linux-gnu
 
   build-qt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - name: Install build dependencies
-      run: sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev
-    - name: Install Qt 6
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.11.*'
-        cache: true
-    - name: Build teeline-qt
-      run: cargo build --manifest-path teeline-qt/Cargo.toml 2>&1
-      env:
-        RUST_LOG: debug
+      - uses: actions/checkout@v6
+      - name: Install build dependencies
+        run: sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev
+      - name: Install Qt 6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.*'
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --manifest-path teeline-qt/Cargo.toml 2>&1
+        env:
+          RUST_LOG: debug

--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -1,12 +1,12 @@
 name: teeline-web
 
-on:
+"on":
   push:
-    branches: [ master ]
-    paths: [ 'teeline-web/**' ]
+    branches: [master]
+    paths: ['teeline-web/**']
   pull_request:
-    branches: [ master ]
-    paths: [ 'teeline-web/**' ]
+    branches: [master]
+    paths: ['teeline-web/**']
 
 defaults:
   run:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Transpile WASM to JS bindings (jco)
         working-directory: teeline-web
-        run: npx --yes @bytecodealliance/jco@1.20.0 transpile ../target/wasm32-wasip1/debug/teeline_wasm.wasm --name teeline_wasm -o ../teeline-wasm/js-bindings
+        run: npx --yes @bytecodealliance/jco@1.20.0 transpile ../teeline-wasm/target/wasm32-wasip1/debug/teeline_wasm.wasm --name teeline_wasm -o ../teeline-wasm/js-bindings
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -3,10 +3,14 @@ name: teeline-web
 "on":
   push:
     branches: [master]
-    paths: ['teeline-web/**']
+    paths:
+      - 'teeline-web/**'
+      - '.github/workflows/teeline-web.yml'
   pull_request:
     branches: [master]
-    paths: ['teeline-web/**']
+    paths:
+      - 'teeline-web/**'
+      - '.github/workflows/teeline-web.yml'
 
 defaults:
   run:

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -49,7 +49,7 @@ fn shared_component() -> &'static Component {
     COMPONENT.get_or_init(|| {
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/../target/wasm32-wasip2/debug/teeline_wasm.wasm"
+            "/target/wasm32-wasip2/debug/teeline_wasm.wasm"
         );
         Component::from_file(shared_engine(), path).expect(
             "WASM component not found — run: cargo component build --manifest-path teeline-wasm/Cargo.toml --target wasm32-wasip2",

--- a/teeline-web/algorithms/fpa/explainer/index.html
+++ b/teeline-web/algorithms/fpa/explainer/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flower Pollination — Interactive Explainer — Teeline</title>
+    <meta name="description" content="Interactive walkthrough of the Flower Pollination Algorithm: watch a population of tours evolve via Lévy-flight global pollination and ε-scaled local cross-pollination." />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/algorithms/fpa/">← Back to FPA docs</a>
+      </p>
+      <div id="app"></div>
+    </main>
+    <script type="module" src="/src/explainers/fpa-page.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/fpa/index.html
+++ b/teeline-web/algorithms/fpa/index.html
@@ -28,7 +28,8 @@
         </nav>
 
                 <p class="docs-type-badge">Heuristic — nature-inspired metaheuristic</p>
-                        <h1>Flower Pollination Algorithm</h1>
+                        <a class="docs-explainer-cta" href="/algorithms/fpa/explainer/">▶ Open interactive explainer →</a>
+                <h1>Flower Pollination Algorithm</h1>
 <table class="docs-meta-table">
   <thead><tr><th></th><th></th></tr></thead>
   <tbody>

--- a/teeline-web/public/sitemap.xml
+++ b/teeline-web/public/sitemap.xml
@@ -19,5 +19,6 @@
   <url><loc>https://tspsolver.com/algorithms/lk/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/som/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/fourier/explainer/</loc></url>
+  <url><loc>https://tspsolver.com/algorithms/fpa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/lk/explainer/</loc></url>
 </urlset>

--- a/teeline-web/src/explainers/fpa-page.ts
+++ b/teeline-web/src/explainers/fpa-page.ts
@@ -1,0 +1,11 @@
+import '@picocss/pico/css/pico.min.css'
+import '../docs.css'
+import { initTopbar } from '../topbar'
+import { render, h } from 'preact'
+import FPAExplainer from './fpa'
+
+initTopbar()
+const appEl = document.getElementById('app')
+if (appEl) {
+  render(h(FPAExplainer, null), appEl)
+}

--- a/teeline-web/src/explainers/fpa.tsx
+++ b/teeline-web/src/explainers/fpa.tsx
@@ -1,0 +1,666 @@
+import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+
+// ---------------------------------------------------------------
+// Fixed demo instance: 18 cities on a 300×300 canvas.
+// ---------------------------------------------------------------
+const CITIES: [number, number][] = [
+  [50, 50], [150, 20], [260, 60], [290, 160], [240, 260], [140, 280],
+  [40, 250], [20, 140], [100, 110], [200, 90], [250, 170], [190, 230],
+  [110, 210], [60, 170], [150, 140], [220, 140], [130, 80], [175, 195],
+]
+const N_CITIES = CITIES.length
+
+// ---------------------------------------------------------------
+// Algorithm helpers
+// ---------------------------------------------------------------
+function randNorm(): number {
+  const u1 = Math.max(Math.random(), 1e-12)
+  const u2 = Math.random()
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+}
+
+// Mantegna's algorithm for Lévy step, β = 1.5
+// σ precomputed: (Γ(2.5)·sin(3π/4)) / (Γ(1.25)·1.5·2^0.25))^(2/3) ≈ 0.7213
+const LEVY_SIGMA = 0.7213
+function levyStep(): number {
+  const u = randNorm() * LEVY_SIGMA
+  const v = Math.abs(randNorm())
+  if (v < 1e-12) return 1.0
+  return Math.abs(u / Math.pow(v, 2 / 3))
+}
+
+function tourLength(tour: number[]): number {
+  let total = 0
+  for (let i = 0; i < tour.length; i++) {
+    const [x1, y1] = CITIES[tour[i]]
+    const [x2, y2] = CITIES[tour[(i + 1) % tour.length]]
+    total += Math.hypot(x2 - x1, y2 - y1)
+  }
+  return total
+}
+
+// Returns the sequence of adjacent transpositions that transforms a into b.
+function swapSequence(a: number[], b: number[]): [number, number][] {
+  const arr = a.slice()
+  const swaps: [number, number][] = []
+  for (let i = 0; i < b.length; i++) {
+    const j = arr.indexOf(b[i], i)
+    if (j === i) continue
+    for (let k = j; k > i; k--) {
+      swaps.push([k - 1, k])
+      ;[arr[k - 1], arr[k]] = [arr[k], arr[k - 1]]
+    }
+  }
+  return swaps
+}
+
+function applySwaps(tour: number[], swaps: [number, number][], n: number): number[] {
+  const t = tour.slice()
+  const lim = Math.min(n, swaps.length)
+  for (let i = 0; i < lim; i++) {
+    const [a, b] = swaps[i]
+    ;[t[a], t[b]] = [t[b], t[a]]
+  }
+  return t
+}
+
+function shuffle(n: number): number[] {
+  const t = Array.from({ length: n }, (_, i) => i)
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[t[i], t[j]] = [t[j], t[i]]
+  }
+  return t
+}
+
+function centroid(tour: number[]): [number, number] {
+  let x = 0, y = 0
+  for (const idx of tour) {
+    x += CITIES[idx][0]
+    y += CITIES[idx][1]
+  }
+  return [x / tour.length, y / tour.length]
+}
+
+// ---------------------------------------------------------------
+// Simulation state
+// ---------------------------------------------------------------
+type SimState = {
+  flowers: number[][]
+  costs: number[]
+  gbest: number[]
+  gbestCost: number
+  iter: number
+  globalCount: number
+  localCount: number
+}
+
+function makeInitState(nFlowers: number): SimState {
+  const flowers = Array.from({ length: nFlowers }, () => shuffle(N_CITIES))
+  const costs = flowers.map(tourLength)
+  const bestIdx = costs.indexOf(Math.min(...costs))
+  return {
+    flowers,
+    costs,
+    gbest: flowers[bestIdx].slice(),
+    gbestCost: costs[bestIdx],
+    iter: 0,
+    globalCount: 0,
+    localCount: 0,
+  }
+}
+
+// ---------------------------------------------------------------
+// SVG helper
+// ---------------------------------------------------------------
+function polyPts(tour: number[]): string {
+  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  return tour.length > 0 ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}` : pts
+}
+
+// ---------------------------------------------------------------
+// TourSVG
+// ---------------------------------------------------------------
+interface TourSVGProps {
+  flowers: number[][]
+  gbest: number[]
+  activeIdx: number
+}
+
+function TourSVG({ flowers, gbest, activeIdx }: TourSVGProps) {
+  const ghosts = flowers.filter((_, i) => i !== activeIdx).slice(0, 5)
+  const active = flowers[activeIdx]
+  return (
+    <svg viewBox="0 0 300 300" className="fp-canvas" role="img" aria-label="FPA tour population">
+      <rect x={0} y={0} width={300} height={300} className="fp-bg" />
+      {ghosts.map((tour, i) => (
+        <polyline key={i} className="fp-ghost" points={polyPts(tour)} />
+      ))}
+      {active && <polyline className="fp-active" points={polyPts(active)} />}
+      {gbest.length > 0 && <polyline className="fp-gbest" points={polyPts(gbest)} />}
+      {CITIES.map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r={4} className="fp-city" />
+      ))}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Lévy sparkline: bar chart of last 30 step sizes
+// ---------------------------------------------------------------
+type SparkEntry = { value: number; mode: "global" | "local" }
+
+function LevySparkline({ history }: { history: SparkEntry[] }) {
+  const W = 180, H = 54
+  const visible = history.slice(-30)
+  if (!visible.length) {
+    return <svg viewBox={`0 0 ${W} ${H}`} className="fp-spark" />
+  }
+  const maxVal = Math.min(Math.max(...visible.map(h => h.value), 0.5), 4)
+  const slotW = W / 30
+  const barW = Math.max(1, slotW - 1)
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="fp-spark">
+      {visible.map((h, i) => {
+        const bh = Math.max(2, (Math.min(h.value, maxVal) / maxVal) * (H - 4))
+        return (
+          <rect
+            key={i}
+            x={i * slotW}
+            y={H - bh - 2}
+            width={barW}
+            height={bh}
+            fill={h.mode === "global" ? "#3b82f6" : "#d97706"}
+            opacity={0.85}
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------
+export default function FPAExplainer() {
+  // Config state (for slider display)
+  const [switchProb, setSwitchProb] = useState(0.8)
+  const [nFlowers, setNFlowers] = useState(8)
+  const [speed, setSpeed] = useState(5)
+
+  // Refs for values read inside the stable step callback
+  const switchProbRef = useRef(0.8)
+  const simRef = useRef<SimState>(makeInitState(8))
+
+  // Display state — mirrors simRef for rendering
+  const [flowers, setFlowers] = useState<number[][]>(() => simRef.current.flowers)
+  const [gbest, setGbest] = useState<number[]>(() => simRef.current.gbest)
+  const [gbestCost, setGbestCost] = useState(() => simRef.current.gbestCost)
+  const [iter, setIter] = useState(0)
+  const [globalCount, setGlobalCount] = useState(0)
+  const [localCount, setLocalCount] = useState(0)
+
+  // Per-step annotation state
+  const [mode, setMode] = useState<"global" | "local" | null>(null)
+  const [activeIdx, setActiveIdx] = useState(0)
+  const [levyHistory, setLevyHistory] = useState<SparkEntry[]>([])
+  const [lastLevy, setLastLevy] = useState<number | null>(null)
+  const [iconPos, setIconPos] = useState<{ icon: string; x: number; y: number } | null>(null)
+
+  const [running, setRunning] = useState(false)
+
+  // Reinitialize simulation — stable callback (no deps)
+  const reinit = useCallback((n: number) => {
+    const s = makeInitState(n)
+    simRef.current = s
+    setFlowers(s.flowers.slice())
+    setGbest(s.gbest.slice())
+    setGbestCost(s.gbestCost)
+    setIter(0)
+    setGlobalCount(0)
+    setLocalCount(0)
+    setMode(null)
+    setActiveIdx(0)
+    setLevyHistory([])
+    setLastLevy(null)
+    setIconPos(null)
+    setRunning(false)
+  }, [])
+
+  // Advance one pollination event — stable callback, reads via refs
+  const stepOnce = useCallback(() => {
+    const sim = simRef.current
+    const sp = switchProbRef.current
+    const n = sim.flowers.length
+    if (n === 0) return
+
+    const i = Math.floor(Math.random() * n)
+    let newTour: number[]
+    let stepMode: "global" | "local"
+    let stepLevy: number
+    let localJ = -1
+    let localK = -1
+
+    if (Math.random() < sp) {
+      // Global pollination: Lévy-flight toward gbest
+      stepMode = "global"
+      const lv = levyStep()
+      stepLevy = lv
+      const seq = swapSequence(sim.flowers[i], sim.gbest)
+      if (seq.length === 0) {
+        newTour = sim.flowers[i].slice()
+      } else {
+        // * 0.5 matches the Rust implementation: never jump more than halfway to gbest
+        const nSwaps = Math.min(seq.length, Math.max(1, Math.ceil(lv * seq.length * 0.5)))
+        newTour = applySwaps(sim.flowers[i], seq, nSwaps)
+      }
+    } else {
+      // Local pollination: ε-scaled cross-pollination between two random flowers
+      stepMode = "local"
+      if (n < 3) {
+        newTour = sim.flowers[i].slice()
+        stepLevy = 0
+      } else {
+        do { localJ = Math.floor(Math.random() * n) } while (localJ === i)
+        do { localK = Math.floor(Math.random() * n) } while (localK === i || localK === localJ)
+        const epsilon = Math.random()
+        stepLevy = epsilon
+        const seq = swapSequence(sim.flowers[localJ], sim.flowers[localK])
+        if (seq.length === 0) {
+          newTour = sim.flowers[i].slice()
+        } else {
+          const nSwaps = Math.min(seq.length, Math.max(1, Math.ceil(epsilon * seq.length)))
+          newTour = applySwaps(sim.flowers[i], seq, nSwaps)
+        }
+      }
+    }
+
+    const newCost = tourLength(newTour)
+    const improved = newCost < sim.costs[i]
+
+    const newFlowers = sim.flowers.slice()
+    const newCosts = sim.costs.slice()
+    if (improved) {
+      newFlowers[i] = newTour
+      newCosts[i] = newCost
+    }
+
+    let newGbest = sim.gbest
+    let newGbestCost = sim.gbestCost
+    if (improved && newCost < sim.gbestCost) {
+      newGbest = newTour.slice()
+      newGbestCost = newCost
+    }
+
+    const newGlobalCount = sim.globalCount + (stepMode === "global" ? 1 : 0)
+    const newLocalCount = sim.localCount + (stepMode === "local" ? 1 : 0)
+    const newIter = sim.iter + 1
+
+    simRef.current = {
+      flowers: newFlowers,
+      costs: newCosts,
+      gbest: newGbest,
+      gbestCost: newGbestCost,
+      iter: newIter,
+      globalCount: newGlobalCount,
+      localCount: newLocalCount,
+    }
+
+    setFlowers(newFlowers)
+    setGbest(newGbest)
+    setGbestCost(newGbestCost)
+    setIter(newIter)
+    setGlobalCount(newGlobalCount)
+    setLocalCount(newLocalCount)
+    setMode(stepMode)
+    setActiveIdx(i)
+    setLastLevy(stepLevy)
+    setLevyHistory(h => [...h.slice(-99), { value: stepLevy, mode: stepMode }])
+
+    // Position the icon at the midpoint of the relevant move
+    if (stepMode === "global") {
+      const [ax, ay] = centroid(sim.flowers[i])
+      const [gx, gy] = centroid(sim.gbest)
+      setIconPos({ icon: "🐝", x: ((ax + gx) / 2 / 300) * 100, y: ((ay + gy) / 2 / 300) * 100 })
+    } else if (localJ !== -1 && localK !== -1) {
+      const [jx, jy] = centroid(sim.flowers[localJ])
+      const [kx, ky] = centroid(sim.flowers[localK])
+      setIconPos({ icon: "🌬️", x: ((jx + kx) / 2 / 300) * 100, y: ((jy + ky) / 2 / 300) * 100 })
+    }
+  }, [])
+
+  // Animation loop
+  const delay = Math.max(50, 660 - speed * 66)
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepOnce, delay)
+    return () => clearInterval(id)
+  }, [running, stepOnce, delay])
+
+  const modeLabel =
+    mode === "global"
+      ? "🌍 Global pollination — Lévy flight toward gbest"
+      : mode === "local"
+        ? "🌸 Local pollination — ε cross-pollination"
+        : "Press Step or Run to begin"
+
+  return (
+    <div className="fp-root">
+      <style>{CSS}</style>
+
+      <header className="fp-header">
+        <div className="fp-eyebrow">teeline · algorithms/fpa</div>
+        <h2 className="fp-title">Flower Pollination Algorithm</h2>
+        <p className="fp-sub">
+          A population of candidate tours (flowers) evolves each step: with probability{" "}
+          <code>p</code> a flower makes a long-range <strong>Lévy flight</strong> toward the
+          global best; otherwise it <strong>cross-pollinates</strong> with two random flowers
+          nearby. Drag the sliders to see how <code>p</code> and population size shape search.
+        </p>
+      </header>
+
+      {/* Tour canvas + emoji icon overlay */}
+      <div className="fp-canvas-wrap">
+        <TourSVG flowers={flowers} gbest={gbest} activeIdx={activeIdx} />
+        {iconPos && (
+          <span className="fp-icon" style={{ left: `${iconPos.x}%`, top: `${iconPos.y}%` }}>
+            {iconPos.icon}
+          </span>
+        )}
+      </div>
+
+      {/* Canvas legend */}
+      <div className="fp-legend">
+        <span><span className="fp-dot fp-dot-gbest">●</span> gbest</span>
+        <span><span className="fp-dot fp-dot-active">●</span> active flower</span>
+        <span><span className="fp-dot fp-dot-ghost">●</span> population</span>
+        <span><span className="fp-dot fp-dot-city">●</span> city</span>
+      </div>
+
+      {/* Mode chip */}
+      <div className={`fp-mode fp-mode-${mode ?? "idle"}`}>{modeLabel}</div>
+
+      {/* Lévy sparkline + step size */}
+      <div className="fp-spark-row">
+        <div className="fp-spark-wrap">
+          <LevySparkline history={levyHistory} />
+          <div className="fp-spark-caption">
+            <span className="fp-swatch fp-swatch-global">■</span> global Lévy step &nbsp;
+            <span className="fp-swatch fp-swatch-local">■</span> local ε step
+          </div>
+        </div>
+        <div className="fp-stepval-wrap">
+          <div className="fp-statlabel">step size</div>
+          <div className="fp-mono fp-stepval">
+            {lastLevy !== null ? lastLevy.toFixed(3) : "—"}
+          </div>
+          <div className="fp-statlabel" style={{ marginTop: "4px" }}>
+            {mode === "global"
+              ? "Lévy draw"
+              : mode === "local"
+                ? "ε (uniform)"
+                : ""}
+          </div>
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="fp-statgrid">
+        <div>
+          <div className="fp-statlabel">iteration</div>
+          <div className="fp-mono">{iter}</div>
+        </div>
+        <div>
+          <div className="fp-statlabel">gbest distance</div>
+          <div className="fp-mono">{gbestCost.toFixed(1)}</div>
+        </div>
+        <div>
+          <div className="fp-statlabel">global steps</div>
+          <div className="fp-mono fp-global-val">{globalCount}</div>
+        </div>
+        <div>
+          <div className="fp-statlabel">local steps</div>
+          <div className="fp-mono fp-local-val">{localCount}</div>
+        </div>
+      </div>
+
+      {/* Config sliders */}
+      <div className="fp-config">
+        <div className="fp-config-row">
+          <label className="fp-config-label">
+            Switch prob <code>p</code> = <strong>{switchProb.toFixed(2)}</strong>
+          </label>
+          <input
+            type="range" min={0} max={1} step={0.05}
+            value={switchProb}
+            className="fp-slider"
+            onInput={(e) => {
+              const v = Number((e.target as HTMLInputElement).value)
+              setSwitchProb(v)
+              switchProbRef.current = v
+            }}
+          />
+          <div className="fp-hint">
+            {switchProb >= 0.9
+              ? "Mostly global — fast but risks premature convergence"
+              : switchProb <= 0.1
+                ? "Mostly local — slow diffuse search, global rarely fires"
+                : `~${Math.round(switchProb * 100)}% global / ${Math.round((1 - switchProb) * 100)}% local`}
+          </div>
+        </div>
+
+        <div className="fp-config-row">
+          <label className="fp-config-label">
+            Flowers (population) = <strong>{nFlowers}</strong>
+          </label>
+          <input
+            type="range" min={3} max={15} step={1}
+            value={nFlowers}
+            className="fp-slider"
+            onInput={(e) => {
+              const n = Number((e.target as HTMLInputElement).value)
+              setNFlowers(n)
+              reinit(n)
+            }}
+          />
+          <div className="fp-hint">
+            {nFlowers <= 4
+              ? "Small swarm: fast per-step but low diversity"
+              : nFlowers >= 12
+                ? "Large swarm: more diversity, slower per step"
+                : "Balanced population size"}
+          </div>
+        </div>
+
+        <div className="fp-config-row">
+          <label className="fp-config-label">Speed</label>
+          <input
+            type="range" min={1} max={10} step={1}
+            value={speed}
+            className="fp-slider"
+            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+          />
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="fp-controls">
+        <button className="fp-btn" onClick={stepOnce} disabled={running}>
+          ◀ Step
+        </button>
+        <button
+          className={`fp-btn ${!running ? "fp-btn-primary" : ""}`}
+          onClick={() => setRunning(r => !r)}
+        >
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="fp-btn" onClick={() => reinit(nFlowers)}>
+          ↺ Reset
+        </button>
+      </div>
+
+      <footer className="fp-footer">
+        <span className="fp-mono">cities: {N_CITIES}</span>
+        <span className="fp-mono">flowers: {nFlowers}</span>
+        <span className="fp-mono">p: {switchProb.toFixed(2)}</span>
+        <span className="fp-mono">β (Lévy): 1.5</span>
+      </footer>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// Styles — self-contained, scoped via fp- prefix
+// ---------------------------------------------------------------
+const CSS = `
+.fp-root {
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --global: #3b82f6;
+  --local: #d97706;
+  --gbest: #16a34a;
+  --active: #3b82f6;
+  --ghost: #9ca3af;
+  --city: #f2a154;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.fp-root * { box-sizing: border-box; }
+.fp-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* Header */
+.fp-header { margin-bottom: 2px; }
+.fp-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--gbest); margin-bottom: 6px;
+}
+.fp-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.fp-sub {
+  margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55;
+}
+.fp-sub code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em; background: rgba(22,163,74,0.08);
+  padding: 1px 4px; border-radius: 4px;
+}
+
+/* Canvas */
+.fp-canvas-wrap { position: relative; display: inline-block; width: 100%; max-width: 340px; }
+.fp-canvas {
+  width: 100%; max-width: 340px; display: block;
+  border-radius: 8px; border: 1px solid var(--line);
+}
+.fp-bg { fill: var(--panel); }
+.fp-ghost { fill: none; stroke: var(--ghost); stroke-width: 1; stroke-opacity: 0.22; stroke-linejoin: round; }
+.fp-active { fill: none; stroke: var(--active); stroke-width: 1.8; stroke-linejoin: round; }
+.fp-gbest { fill: none; stroke: var(--gbest); stroke-width: 2.5; stroke-linejoin: round; }
+.fp-city { fill: var(--city); stroke: var(--bg); stroke-width: 1.5; }
+
+/* Icon overlay */
+.fp-icon {
+  position: absolute;
+  font-size: 18px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  transition: left 0.35s ease, top 0.35s ease;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.3));
+}
+
+/* Legend */
+.fp-legend {
+  display: flex; gap: 14px; flex-wrap: wrap;
+  font-size: 0.8rem; color: var(--muted);
+}
+.fp-dot { font-size: 1em; }
+.fp-dot-gbest { color: var(--gbest); }
+.fp-dot-active { color: var(--active); }
+.fp-dot-ghost { color: var(--ghost); }
+.fp-dot-city { color: var(--city); }
+
+/* Mode chip */
+.fp-mode {
+  font-size: 0.95rem; font-weight: 600;
+  padding: 8px 14px; border-radius: 8px;
+  border: 1px solid transparent;
+}
+.fp-mode-idle { background: var(--panel); color: var(--muted); border-color: var(--line); }
+.fp-mode-global { background: rgba(59,130,246,0.1); color: #1d4ed8; border-color: rgba(59,130,246,0.3); }
+.fp-mode-local { background: rgba(217,119,6,0.1); color: #92400e; border-color: rgba(217,119,6,0.3); }
+
+/* Sparkline row */
+.fp-spark-row { display: flex; gap: 16px; align-items: flex-start; }
+.fp-spark-wrap { display: flex; flex-direction: column; gap: 4px; }
+.fp-spark {
+  width: 180px; height: 54px;
+  border: 1px solid var(--line); border-radius: 6px;
+  background: var(--panel); display: block;
+}
+.fp-spark-caption {
+  font-size: 0.72rem; color: var(--muted);
+}
+.fp-swatch { font-size: 0.9em; }
+.fp-swatch-global { color: var(--global); }
+.fp-swatch-local { color: var(--local); }
+.fp-stepval-wrap { display: flex; flex-direction: column; }
+.fp-stepval { font-size: 1.3rem; font-weight: 600; color: var(--text); }
+
+/* Stats grid */
+.fp-statgrid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
+}
+@media (max-width: 480px) {
+  .fp-statgrid { grid-template-columns: repeat(2, 1fr); }
+}
+.fp-statlabel {
+  font-size: 0.7rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+}
+.fp-global-val { color: var(--global); }
+.fp-local-val { color: var(--local); }
+
+/* Config sliders */
+.fp-config { display: flex; flex-direction: column; gap: 10px; }
+.fp-config-row { display: flex; flex-direction: column; gap: 4px; }
+.fp-config-label { font-size: 0.88rem; }
+.fp-config-label code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+.fp-slider { width: 100%; accent-color: var(--gbest); cursor: pointer; }
+.fp-hint { font-size: 0.78rem; color: var(--muted); }
+
+/* Controls */
+.fp-controls { display: flex; gap: 8px; }
+.fp-btn {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--line); border-radius: 6px;
+  padding: 6px 16px; font-size: 0.88rem; cursor: pointer;
+  font-family: inherit;
+}
+.fp-btn:hover:not(:disabled) { border-color: var(--gbest); }
+.fp-btn:disabled { opacity: 0.45; cursor: default; }
+.fp-btn-primary { color: var(--gbest); border-color: var(--gbest); }
+
+/* Footer */
+.fp-footer {
+  display: flex; flex-wrap: wrap; gap: 14px;
+  padding-top: 10px; border-top: 1px solid var(--line);
+  color: var(--muted);
+}
+`


### PR DESCRIPTION
## Summary

- Adds an interactive explainer at `/algorithms/fpa/explainer/` for the Flower Pollination Algorithm
- Single-panel Preact component (no tabs) with live step-through of the algorithm
- JS port of `flower_pollination.rs` using Mantegna's Lévy distribution (β=1.5)

## What students see

- **Tour canvas** — ghost population (grey), active flower (blue), gbest (green); 🐝 overlaid on global steps, 🌬️ on local steps
- **Mode chip** — large label updates each step: "🌍 Global pollination — Lévy flight toward gbest" vs "🌸 Local pollination — ε cross-pollination"
- **Lévy sparkline** — last 30 step sizes (blue = global Lévy draw, amber = local ε); heavy tail becomes visible after ~20 steps
- **Config sliders** — switch prob `p`, population size, speed; dragging `p` to 0/1 makes the global/local counters demonstrate the boundary behaviour live

## Files changed

| File | Change |
|------|--------|
| `teeline-web/algorithms/fpa/explainer/index.html` | New HTML shell |
| `teeline-web/src/explainers/fpa-page.ts` | New entry point |
| `teeline-web/src/explainers/fpa.tsx` | New Preact component (~440 lines) |
| `teeline-web/algorithms/fpa/index.html` | CTA auto-wired by build-docs (existsSync check) |
| `teeline-web/public/sitemap.xml` | New explainer URL added |

## Test plan

- [x] Navigate to `/algorithms/fpa/explainer/` — canvas renders with ghost tours, active, gbest
- [x] Click **Step** — mode chip updates, icon appears on canvas, sparkline gets first bar
- [x] Click **Run** — animation runs, gbest distance decreases over time
- [x] Drag `p` to 0 — only amber bars in sparkline, GLOBAL STEPS stays 0
- [x] Drag `p` to 1 — only blue bars, LOCAL STEPS stays 0
- [x] Drag **Flowers** slider — simulation reinitialises, stats reset
- [x] Click **Reset** — all state clears
- [x] Navigate to `/algorithms/fpa/` — "▶ Open interactive explainer →" CTA is present
- [ ] `npm run build` completes without errors