### PR TITLE
feat(web): add PSO interactive explainer (#237)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,18 +10,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "ambient-authority"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -98,33 +77,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -156,83 +112,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cap-fs-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix",
- "smallvec",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "rustix",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix",
- "winx",
-]
 
 [[package]]
 name = "cc"
@@ -241,8 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -343,15 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,15 +230,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpp_demangle"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -388,157 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
-dependencies = [
- "cranelift-entity",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
-dependencies = [
- "serde",
- "serde_derive",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
- "hashbrown 0.17.1",
- "libm",
- "log",
- "pulley-interpreter",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
- "heck",
- "pulley-interpreter",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
-
-[[package]]
-name = "cranelift-control"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
-dependencies = [
- "cranelift-bitset",
- "serde",
- "serde_derive",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
-
-[[package]]
-name = "cranelift-native"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -577,15 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "uuid",
-]
-
-[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,38 +298,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "directories-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -652,27 +319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,12 +333,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -711,90 +351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "fs-set-times"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
-dependencies = [
- "io-lifetimes",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -808,28 +374,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxprof-processed-profile"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
-dependencies = [
- "bitflags",
- "debugid",
- "rustc-hash",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -855,18 +403,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -874,23 +410,11 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gimli"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
-dependencies = [
- "fnv",
- "hashbrown 0.16.1",
- "indexmap",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -923,25 +447,14 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "heck"
@@ -995,113 +508,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "ignore"
@@ -1132,28 +542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,36 +561,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "ittapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
-dependencies = [
- "anyhow",
- "ittapi-sys",
- "log",
-]
-
-[[package]]
-name = "ittapi-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1234,12 +592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,40 +610,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "matchers"
@@ -1303,25 +625,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memfd"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
-dependencies = [
- "rustix",
-]
 
 [[package]]
 name = "miette"
@@ -1331,7 +638,7 @@ checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "miette-derive",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1343,17 +650,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "mio"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1402,18 +698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
-dependencies = [
- "crc32fast",
- "hashbrown 0.17.1",
- "indexmap",
- "memchr",
 ]
 
 [[package]]
@@ -1497,16 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,33 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,29 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6ccdd6fc70f6c33eb21cb8fe05a71a5f7ee4cbef7a093a8a87dd8a908697cd"
-dependencies = [
- "cranelift-bitset",
- "log",
- "pulley-macros",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00101fdb6fcaf9ea98a1994be11861d7e0c910c718c41bae373c44179e3160c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,12 +860,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1697,51 +915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.17.1",
- "log",
- "rustc-hash",
- "smallvec",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,41 +950,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustix-linux-procfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
-dependencies = [
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,10 +969,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -1995,25 +1129,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -2054,25 +1169,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
 name = "teeline"
-version = "1.0.1"
+version = "1.0.10"
 dependencies = [
  "clap",
  "num-complex",
@@ -2080,14 +1178,14 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "teeline-cli"
-version = "1.0.1"
+version = "1.0.10"
 dependencies = [
  "clap",
  "serde_json",
@@ -2095,29 +1193,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "usage-lib",
-]
-
-[[package]]
-name = "teeline-wasm"
-version = "0.1.0"
-dependencies = [
- "teeline",
- "wasmtime",
- "wasmtime-wasi",
- "wit-bindgen-rt",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2143,41 +1218,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2201,45 +1247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,19 +1255,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -2379,28 +1377,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
 
 [[package]]
 name = "usage-lib"
@@ -2421,32 +1401,16 @@ dependencies = [
  "shell-words",
  "strum",
  "tera",
- "thiserror 2.0.18",
+ "thiserror",
  "versions",
  "xx",
 ]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"
@@ -2550,50 +1514,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-compose"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "log",
- "petgraph",
- "smallvec",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wat",
-]
-
-[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2604,8 +1531,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2621,432 +1548,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
-dependencies = [
- "bitflags",
- "hashbrown 0.17.1",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c191891081c3bf9f10cb579819b32b0e81695641dc639eef34b57cf10c59ad81"
-dependencies = [
- "addr2line",
- "async-trait",
- "bitflags",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "futures",
- "fxprof-processed-profile",
- "gimli",
- "ittapi",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object",
- "once_cell",
- "postcard",
- "pulley-interpreter",
- "rayon",
- "rustix",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "smallvec",
- "target-lexicon",
- "tempfile",
- "wasm-compose",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cache",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "wat",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f337d68a62d868f3c297517b46d20dc7e293f0da36bbee2f6ec3c30eab938bd"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "hashbrown 0.17.1",
- "indexmap",
- "log",
- "object",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "sha2",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter",
- "wasmtime-internal-component-util",
- "wasmtime-internal-core",
-]
-
-[[package]]
-name = "wasmtime-internal-cache"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f45a4fb2a6a269100b845404f2210d874eaee9ecd9efb6fc6c1e80896fab40f"
-dependencies = [
- "base64",
- "directories-next",
- "log",
- "postcard",
- "rustix",
- "serde",
- "serde_derive",
- "sha2",
- "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ",
- "windows-sys 0.61.2",
- "zstd",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1cc8df1940657960571d7bc9bc0eadf869c0eb95cff831a6554409f89b25b0"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
- "wit-parser 0.248.0",
-]
-
-[[package]]
-name = "wasmtime-internal-component-util"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73ccd2e0e6bd91fb0161a17ee5e2d7badbeba6eb7461d0e0e3991492bd3835d"
-
-[[package]]
-name = "wasmtime-internal-core"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110bf85122cd451d3b9ff67f8911d428ec9b729208abe950a0333c3244660e88"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "libm",
- "serde",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0236a21553c5b30ee953f413a8dc99729548b747219eef7e70f8288ed313ebe"
-dependencies = [
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools",
- "log",
- "object",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccd50931b61ad593ae91e62d41a96b997b26c9308305cae4523cfef9301d9e8"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "rustix",
- "wasmtime-environ",
- "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a52ca7429272234b44f81fdf80d4793593e5c368b0f960d41fd401b1117bec"
-dependencies = [
- "cc",
- "object",
- "rustix",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6818a4864719772680694f4e4649a8600bb5efcf71111ebaf7419b266463e8"
-dependencies = [
- "cfg-if",
- "libc",
- "wasmtime-internal-core",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdc6a69c42fbbf13104ccbf0d3c096d0392f00102e2c70b542d9fca402eb162"
-dependencies = [
- "cfg-if",
- "cranelift-codegen",
- "log",
- "object",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0bd1cd696ec4b7e6f46357c0479e7739c3858e54afb69a15765402bbc1f9dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2ca01234ef55acd10c0fa5a2f96c3fd422eba03b221e2e9572944d19a476a7"
-dependencies = [
- "cranelift-codegen",
- "gimli",
- "log",
- "object",
- "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b3d8cfaad2d33a92ec4ed93d69e9836c04f7eb5b8dfe1dde9df47c41f20b7"
-dependencies = [
- "anyhow",
- "bitflags",
- "heck",
- "indexmap",
- "wit-parser 0.248.0",
-]
-
-[[package]]
-name = "wasmtime-wasi"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d0c0121dcc5152390d099fb853b9a0d79e7e0a172c12cc668ea8c5d8f883c2"
-dependencies = [
- "async-trait",
- "bitflags",
- "bytes",
- "cap-fs-ext",
- "cap-net-ext",
- "cap-std",
- "cap-time-ext",
- "cfg-if",
- "fs-set-times",
- "futures",
- "io-extras",
- "io-lifetimes",
- "rand 0.10.1",
- "rustix",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "wasmtime",
- "wasmtime-wasi-io",
- "wiggle",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-wasi-io"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ca2fd53dbd62f5f95b470b43ff1e711933e8f30ebc89d9050351a72f6e5c28"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "tracing",
- "wasmtime",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
-version = "252.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width 0.2.2",
- "wasm-encoder 0.252.0",
-]
-
-[[package]]
-name = "wat"
-version = "1.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
-dependencies = [
- "wast 252.0.0",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "wiggle"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cd8015611a3bc95e449ad198dfd133b7488759b0dc49b515052101eb954587"
-dependencies = [
- "bitflags",
- "thiserror 2.0.18",
- "tracing",
- "wasmtime",
- "wasmtime-environ",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0f655ec3eba7df68408018796911a6acdda3a41e67d6551a3766563495e333"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
- "wasmtime-environ",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a22f38e7b0f2a3b58bae4dd655dcedd65d56f257916a5eda5f08c40910ee9d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wiggle-generate",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -3055,31 +1560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fdfab04a4d446c558a9ea994ded662d35580a17b15385b862002703aa43245"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
 ]
 
 [[package]]
@@ -3223,20 +1703,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3250,35 +1721,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3292,21 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3316,21 +1759,9 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -3340,21 +1771,9 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3364,21 +1783,9 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3400,16 +1807,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-
-[[package]]
-name = "winx"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
-dependencies = [
- "bitflags",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -3434,16 +1831,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653c85dd7aee6fe6f4bded0d242406deadae9819029ce6f7d258c920c384358a"
-dependencies = [
- "bitflags",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3490,10 +1878,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.244.0",
+ "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3511,45 +1899,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
-
-[[package]]
-name = "wit-parser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
-dependencies = [
- "anyhow",
- "log",
- "thiserror 1.0.69",
- "wast 35.0.2",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xx"
@@ -3566,30 +1917,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "strsim",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "thiserror",
 ]
 
 [[package]]
@@ -3613,89 +1941,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/teeline-web/algorithms/ga/index.html
+++ b/teeline-web/algorithms/ga/index.html
@@ -28,7 +28,8 @@
         </nav>
 
                 <p class="docs-type-badge">Heuristic — evolutionary metaheuristic</p>
-                        <h1>Genetic Algorithm</h1>
+                        <a class="docs-explainer-cta" href="/algorithms/ga/explainer/">▶ Open interactive explainer →</a>
+                <h1>Genetic Algorithm</h1>
 <table class="docs-meta-table">
   <thead><tr><th></th><th></th></tr></thead>
   <tbody>

--- a/teeline-web/algorithms/pso/explainer/index.html
+++ b/teeline-web/algorithms/pso/explainer/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Particle Swarm Optimisation — Interactive Explainer — Teeline</title>
+    <meta name="description" content="Interactive walkthrough of Particle Swarm Optimisation: watch a swarm of tours evolve via velocity-capped swap sequences with decaying inertia." />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/algorithms/pso/">← Back to PSO docs</a>
+      </p>
+      <div id="app"></div>
+    </main>
+    <script type="module" src="/src/explainers/pso-page.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/pso/index.html
+++ b/teeline-web/algorithms/pso/index.html
@@ -28,7 +28,8 @@
         </nav>
 
                 <p class="docs-type-badge">Heuristic — swarm metaheuristic</p>
-                        <h1>Particle Swarm Optimisation</h1>
+                        <a class="docs-explainer-cta" href="/algorithms/pso/explainer/">▶ Open interactive explainer →</a>
+                <h1>Particle Swarm Optimisation</h1>
 <table class="docs-meta-table">
   <thead><tr><th></th><th></th></tr></thead>
   <tbody>

--- a/teeline-web/public/sitemap.xml
+++ b/teeline-web/public/sitemap.xml
@@ -20,6 +20,7 @@
   <url><loc>https://tspsolver.com/algorithms/som/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/fourier/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/sa/explainer/</loc></url>
+  <url><loc>https://tspsolver.com/algorithms/ga/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/cs/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/fpa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/lk/explainer/</loc></url>

--- a/teeline-web/public/sitemap.xml
+++ b/teeline-web/public/sitemap.xml
@@ -21,6 +21,7 @@
   <url><loc>https://tspsolver.com/algorithms/fourier/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/sa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/ga/explainer/</loc></url>
+  <url><loc>https://tspsolver.com/algorithms/pso/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/cs/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/fpa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/lk/explainer/</loc></url>

--- a/teeline-web/src/explainers/pso-algo.ts
+++ b/teeline-web/src/explainers/pso-algo.ts
@@ -1,0 +1,175 @@
+// Fixed 12-city demo (same layout as SA / CS / FPA / GA explainers)
+export const CITIES: [number, number][] = [
+  [45, 45], [155, 18], [265, 45], [285, 150],
+  [255, 265], [150, 285], [40, 260], [18, 150],
+  [110, 115], [200, 95], [220, 210], [95, 215],
+]
+export const N_CITIES = CITIES.length
+
+// PSO constants (mirrors particle_swarm.rs)
+const W_MAX = 0.9
+const W_MIN = 0.4
+const C1 = 1.5
+const C2 = 1.5
+const V_MAX_FACTOR = 0.35
+// ω reaches W_MIN at this epoch; stays there indefinitely after
+const MAX_DISPLAY_EPOCHS = 100
+
+// ---------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------
+export type Swap = [number, number]
+
+export type Particle = {
+  position: number[]
+  velocity: Swap[]
+  pbest: number[]
+  pbest_cost: number
+  cost: number
+}
+
+export type VelocityBreakdown = {
+  inertia: number    // total inertia swaps kept across all particles this epoch
+  cognitive: number  // total cognitive swaps added (toward pbest)
+  social: number     // total social swaps added (toward gbest)
+  applied: number    // total swaps applied after v_max cap
+}
+
+export type SimState = {
+  particles: Particle[]
+  gbest: number[]
+  gbest_cost: number
+  epoch: number
+  w: number
+  lastBreakdown: VelocityBreakdown | null
+  newGbest: boolean
+}
+
+// ---------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------
+export function tourLength(tour: number[]): number {
+  if (tour.length <= 1) return 0
+  let d = 0
+  for (let i = 0; i < tour.length; i++) {
+    const [x1, y1] = CITIES[tour[i]]
+    const [x2, y2] = CITIES[tour[(i + 1) % tour.length]]
+    d += Math.hypot(x2 - x1, y2 - y1)
+  }
+  return d
+}
+
+// Adjacent transpositions transforming a into b — mirrors swap_sequence in Rust
+export function swapSequence(a: number[], b: number[]): Swap[] {
+  const arr = a.slice()
+  const swaps: Swap[] = []
+  for (let i = 0; i < b.length; i++) {
+    const j = arr.indexOf(b[i], i)
+    if (j === i) continue
+    for (let k = j; k > i; k--) {
+      swaps.push([k - 1, k])
+      ;[arr[k - 1], arr[k]] = [arr[k], arr[k - 1]]
+    }
+  }
+  return swaps
+}
+
+// Apply first n swaps to a copy of tour — mirrors apply_swaps in Rust
+export function applySwaps(tour: number[], swaps: Swap[], n: number): number[] {
+  const t = tour.slice()
+  const lim = Math.min(n, swaps.length)
+  for (let i = 0; i < lim; i++) {
+    const [a, b] = swaps[i]
+    ;[t[a], t[b]] = [t[b], t[a]]
+  }
+  return t
+}
+
+export function shuffle(n: number): number[] {
+  const t = Array.from({ length: n }, (_, i) => i)
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[t[i], t[j]] = [t[j], t[i]]
+  }
+  return t
+}
+
+// ---------------------------------------------------------------
+// Simulation
+// ---------------------------------------------------------------
+export function makeInitState(nParticles: number): SimState {
+  const particles: Particle[] = Array.from({ length: nParticles }, () => {
+    const position = shuffle(N_CITIES)
+    const cost = tourLength(position)
+    return { position, velocity: [], pbest: position.slice(), pbest_cost: cost, cost }
+  })
+  const gbestIdx = particles.reduce((b, p, i) => p.cost < particles[b].cost ? i : b, 0)
+  return {
+    particles,
+    gbest: particles[gbestIdx].position.slice(),
+    gbest_cost: particles[gbestIdx].cost,
+    epoch: 0,
+    w: W_MAX,
+    lastBreakdown: null,
+    newGbest: false,
+  }
+}
+
+// Advance one full epoch (all particles) — mirrors the epoch loop in particle_swarm.rs
+export function stepEpoch(s: SimState): SimState {
+  const epoch = s.epoch + 1
+  const w = W_MAX - (W_MAX - W_MIN) * Math.min(epoch / MAX_DISPLAY_EPOCHS, 1.0)
+  const v_max = Math.max(1, Math.ceil(N_CITIES * V_MAX_FACTOR))
+
+  let gbest = s.gbest.slice()
+  let gbest_cost = s.gbest_cost
+  let newGbest = false
+
+  let totalInertia = 0, totalCognitive = 0, totalSocial = 0, totalApplied = 0
+
+  const particles: Particle[] = s.particles.map(p => {
+    const r1 = Math.random()
+    const r2 = Math.random()
+
+    const inertia_keep = Math.round(w * p.velocity.length)
+    const cog_diff = swapSequence(p.position, p.pbest)
+    const cog_keep = Math.round(C1 * r1 * cog_diff.length)
+    const soc_diff = swapSequence(p.position, gbest)
+    const soc_keep = Math.round(C2 * r2 * soc_diff.length)
+
+    const new_vel: Swap[] = [
+      ...p.velocity.slice(0, inertia_keep),
+      ...cog_diff.slice(0, cog_keep),
+      ...soc_diff.slice(0, soc_keep),
+    ].slice(0, v_max)
+
+    totalInertia += inertia_keep
+    totalCognitive += cog_keep
+    totalSocial += soc_keep
+    totalApplied += new_vel.length
+
+    const new_pos = applySwaps(p.position, new_vel, new_vel.length)
+    const cost = tourLength(new_pos)
+    const improved = cost < p.pbest_cost
+
+    if (cost < gbest_cost) {
+      gbest = new_pos.slice()
+      gbest_cost = cost
+      newGbest = true
+    }
+
+    return {
+      position: new_pos,
+      velocity: new_vel,
+      pbest: improved ? new_pos.slice() : p.pbest,
+      pbest_cost: improved ? cost : p.pbest_cost,
+      cost,
+    }
+  })
+
+  return {
+    particles, gbest, gbest_cost, epoch, w,
+    lastBreakdown: { inertia: totalInertia, cognitive: totalCognitive, social: totalSocial, applied: totalApplied },
+    newGbest,
+  }
+}

--- a/teeline-web/src/explainers/pso-page.ts
+++ b/teeline-web/src/explainers/pso-page.ts
@@ -1,0 +1,11 @@
+import '@picocss/pico/css/pico.min.css'
+import '../docs.css'
+import { initTopbar } from '../topbar'
+import { render, h } from 'preact'
+import PSOExplainer from './pso'
+
+initTopbar()
+const appEl = document.getElementById('app')
+if (appEl) {
+  render(h(PSOExplainer, null), appEl)
+}

--- a/teeline-web/src/explainers/pso.test.ts
+++ b/teeline-web/src/explainers/pso.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, tourLength, swapSequence, applySwaps,
+  makeInitState, stepEpoch,
+} from './pso-algo'
+
+describe('tourLength', () => {
+  it('is positive for a multi-city tour', () => {
+    const tour = Array.from({ length: N_CITIES }, (_, i) => i)
+    expect(tourLength(tour)).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for a single-city tour', () => {
+    expect(tourLength([0])).toBe(0)
+  })
+})
+
+describe('swapSequence', () => {
+  it('returns empty for identical tours', () => {
+    expect(swapSequence([0, 1, 2, 3], [0, 1, 2, 3])).toEqual([])
+  })
+
+  it('applying result of swapSequence(a, b) to a yields b', () => {
+    const a = [0, 3, 1, 2]
+    const b = [0, 1, 2, 3]
+    const swaps = swapSequence(a, b)
+    expect(applySwaps(a, swaps, swaps.length)).toEqual(b)
+  })
+
+  it('works for fully reversed tours', () => {
+    const a = [3, 2, 1, 0]
+    const b = [0, 1, 2, 3]
+    const swaps = swapSequence(a, b)
+    expect(applySwaps(a, swaps, swaps.length)).toEqual(b)
+  })
+})
+
+describe('applySwaps', () => {
+  it('returns original tour when n=0', () => {
+    expect(applySwaps([0, 1, 2, 3], [[0, 1], [1, 2]], 0)).toEqual([0, 1, 2, 3])
+  })
+
+  it('does not mutate the input tour', () => {
+    const tour = [0, 1, 2, 3]
+    applySwaps(tour, [[0, 1]], 1)
+    expect(tour).toEqual([0, 1, 2, 3])
+  })
+
+  it('swaps adjacent elements in correct order', () => {
+    expect(applySwaps([0, 1, 2, 3], [[1, 2]], 1)).toEqual([0, 2, 1, 3])
+  })
+
+  it('clamps to swaps.length when n exceeds array', () => {
+    const swaps: [number, number][] = [[0, 1]]
+    expect(applySwaps([0, 1, 2], swaps, 99)).toEqual([1, 0, 2])
+  })
+})
+
+describe('makeInitState', () => {
+  it('creates the requested number of particles', () => {
+    expect(makeInitState(5).particles).toHaveLength(5)
+  })
+
+  it('each particle position is a valid permutation of 0..N_CITIES-1', () => {
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    for (const p of makeInitState(4).particles) {
+      expect(p.position.slice().sort((a, b) => a - b)).toEqual(expected)
+    }
+  })
+
+  it('pbest equals initial position and pbest_cost equals cost', () => {
+    for (const p of makeInitState(3).particles) {
+      expect(p.pbest).toEqual(p.position)
+      expect(p.pbest_cost).toBeCloseTo(p.cost, 1)
+    }
+  })
+
+  it('gbest_cost equals minimum particle cost', () => {
+    const s = makeInitState(6)
+    const min = Math.min(...s.particles.map(p => p.cost))
+    expect(s.gbest_cost).toBeCloseTo(min, 1)
+  })
+
+  it('epoch is 0 and w is W_MAX (0.9)', () => {
+    const s = makeInitState(3)
+    expect(s.epoch).toBe(0)
+    expect(s.w).toBeCloseTo(0.9, 5)
+  })
+})
+
+describe('stepEpoch', () => {
+  it('increments epoch by 1', () => {
+    expect(stepEpoch(makeInitState(3)).epoch).toBe(1)
+  })
+
+  it('gbest_cost never increases across 20 epochs', () => {
+    let s = makeInitState(5)
+    for (let i = 0; i < 20; i++) {
+      const prev = s.gbest_cost
+      s = stepEpoch(s)
+      expect(s.gbest_cost).toBeLessThanOrEqual(prev + 0.001)
+    }
+  })
+
+  it('each particle position remains a valid permutation', () => {
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    let s = makeInitState(4)
+    s = stepEpoch(s)
+    for (const p of s.particles) {
+      expect(p.position.slice().sort((a, b) => a - b)).toEqual(expected)
+    }
+  })
+
+  it('populates lastBreakdown with non-negative counts', () => {
+    const next = stepEpoch(makeInitState(3))
+    expect(next.lastBreakdown).not.toBeNull()
+    expect(next.lastBreakdown!.inertia).toBeGreaterThanOrEqual(0)
+    expect(next.lastBreakdown!.cognitive).toBeGreaterThanOrEqual(0)
+    expect(next.lastBreakdown!.social).toBeGreaterThanOrEqual(0)
+    expect(next.lastBreakdown!.applied).toBeGreaterThanOrEqual(0)
+  })
+
+  it('w decreases monotonically across epochs up to MAX_DISPLAY_EPOCHS', () => {
+    let s = makeInitState(2)
+    let prevW = s.w
+    for (let i = 0; i < 50; i++) {
+      s = stepEpoch(s)
+      expect(s.w).toBeLessThanOrEqual(prevW + 0.0001)
+      prevW = s.w
+    }
+  })
+})

--- a/teeline-web/src/explainers/pso.tsx
+++ b/teeline-web/src/explainers/pso.tsx
@@ -1,3 +1,456 @@
-export default function PSOExplainer() {
-  return null
+import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import type { Particle, VelocityBreakdown, SimState } from "./pso-algo"
+import {
+  CITIES, N_CITIES,
+  makeInitState, stepEpoch,
+} from "./pso-algo"
+
+// PSO display constants — for UI labels and gauge only
+const W_MAX = 0.9
+const W_MIN = 0.4
+const C1 = 1.5
+const V_MAX = Math.max(1, Math.ceil(N_CITIES * 0.35))
+
+// ---------------------------------------------------------------
+// SVG helpers
+// ---------------------------------------------------------------
+function polyPts(tour: number[]): string {
+  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  return pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
 }
+
+// ---------------------------------------------------------------
+// SwarmHeatmap — color cells by current tour cost, outline gbest holder
+// ---------------------------------------------------------------
+interface SwarmHeatmapProps {
+  particles: Particle[]
+  gbest_cost: number
+}
+function SwarmHeatmap({ particles, gbest_cost }: SwarmHeatmapProps) {
+  if (!particles.length) return null
+  const costs = particles.map(p => p.cost)
+  const minC = Math.min(...costs)
+  const maxC = Math.max(...costs)
+  const range = maxC - minC || 1
+  return (
+    <div className="pso-heatmap">
+      <div className="pso-heatmap-title">Particles</div>
+      {particles.map((p, i) => {
+        const norm = (maxC - p.cost) / range
+        const hue = Math.round(norm * 120)
+        const bg = `hsl(${hue},55%,42%)`
+        const isGbest = Math.abs(p.cost - gbest_cost) < 0.01
+        const outline = isGbest ? "2px solid #16a34a" : "2px solid transparent"
+        return (
+          <div
+            key={i}
+            className="pso-heatmap-cell"
+            style={{ background: bg, outline, outlineOffset: "1px" }}
+          >
+            <span className="pso-heatmap-idx">{i}</span>
+            <span className="pso-heatmap-cost">{p.cost.toFixed(0)}</span>
+            <div className="pso-heatmap-overlay">{isGbest ? "gbest" : `dist ${p.cost.toFixed(0)}`}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// TourSVG — gbest (green), best-position particle (purple), ghosts (grey)
+// ---------------------------------------------------------------
+interface TourSVGProps {
+  particles: Particle[]
+  gbest: number[]
+  newGbest: boolean
+}
+function TourSVG({ particles, gbest, newGbest }: TourSVGProps) {
+  if (!particles.length) return null
+  const bestIdx = particles.reduce((b, p, i) => p.cost < particles[b].cost ? i : b, 0)
+  return (
+    <svg viewBox="0 0 300 300" className="pso-canvas" role="img" aria-label="PSO tour canvas">
+      <rect x={0} y={0} width={300} height={300} className="pso-bg" />
+      {particles.map((p, i) => i !== bestIdx && (
+        <polyline key={i} className="pso-ghost" points={polyPts(p.position)} />
+      ))}
+      <polyline className="pso-active" points={polyPts(particles[bestIdx].position)} />
+      <polyline
+        className={`pso-gbest${newGbest ? " pso-gbest-pulse" : ""}`}
+        points={polyPts(gbest)}
+      />
+      {CITIES.map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r={4} className="pso-city" />
+      ))}
+      {CITIES.map(([x, y], i) => (
+        <text key={i} x={x + 6} y={y - 5} className="pso-city-label">{i}</text>
+      ))}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// VelocityChip — epoch-level aggregate breakdown of ω / C₁ / C₂ swaps
+// ---------------------------------------------------------------
+function VelocityChip({ breakdown, newGbest }: { breakdown: VelocityBreakdown | null; newGbest: boolean }) {
+  if (!breakdown) {
+    return <div className="pso-chip pso-chip-idle">Press Step or Run to begin</div>
+  }
+  return (
+    <div className={`pso-chip ${newGbest ? "pso-chip-gbest" : "pso-chip-normal"}`}>
+      {newGbest ? "⭐ new gbest!  " : ""}
+      ω: {breakdown.inertia} · C₁: {breakdown.cognitive} · C₂: {breakdown.social} → {breakdown.applied} swaps applied
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// InertiaGauge — horizontal bar showing current ω decaying from W_MAX to W_MIN
+// ---------------------------------------------------------------
+function InertiaGauge({ w }: { w: number }) {
+  const pct = ((w - W_MIN) / (W_MAX - W_MIN)) * 100
+  const hint =
+    w > 0.7 ? "High — broad exploration" :
+    w < 0.5 ? "Low — local exploitation" :
+    "Mid — balanced"
+  return (
+    <div className="pso-gauge">
+      <div className="pso-gauge-label">
+        ω (inertia) = <strong>{w.toFixed(3)}</strong>
+      </div>
+      <div className="pso-gauge-track">
+        <div className="pso-gauge-fill" style={{ width: `${Math.max(0, pct).toFixed(1)}%` }} />
+      </div>
+      <div className="pso-gauge-hint">{hint}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// PSOExplainer — main component
+// ---------------------------------------------------------------
+export default function PSOExplainer() {
+  const [nParticles, setNParticles] = useState(6)
+  const [speed, setSpeed] = useState(5)
+
+  const simRef = useRef<SimState>(makeInitState(6))
+
+  const [particles, setParticles] = useState<Particle[]>(() => simRef.current.particles)
+  const [gbest, setGbest] = useState<number[]>(() => simRef.current.gbest)
+  const [gbest_cost, setGbestCost] = useState(() => simRef.current.gbest_cost)
+  const [epoch, setEpoch] = useState(0)
+  const [w, setW] = useState(W_MAX)
+  const [breakdown, setBreakdown] = useState<VelocityBreakdown | null>(null)
+  const [newGbest, setNewGbest] = useState(false)
+  const [running, setRunning] = useState(false)
+
+  const reinit = useCallback((n: number) => {
+    const s = makeInitState(n)
+    simRef.current = s
+    setParticles(s.particles.slice())
+    setGbest(s.gbest.slice())
+    setGbestCost(s.gbest_cost)
+    setEpoch(0)
+    setW(W_MAX)
+    setBreakdown(null)
+    setNewGbest(false)
+    setRunning(false)
+  }, [])
+
+  const stepOnce = useCallback(() => {
+    const next = stepEpoch(simRef.current)
+    simRef.current = next
+    setParticles(next.particles.slice())
+    setGbest(next.gbest.slice())
+    setGbestCost(next.gbest_cost)
+    setEpoch(next.epoch)
+    setW(next.w)
+    setBreakdown(next.lastBreakdown)
+    setNewGbest(next.newGbest)
+  }, [])
+
+  const delay = Math.max(50, 660 - speed * 66)
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepOnce, delay)
+    return () => clearInterval(id)
+  }, [running, stepOnce, delay])
+
+  const avgDist = particles.length
+    ? (particles.reduce((s, p) => s + p.cost, 0) / particles.length).toFixed(0)
+    : "—"
+
+  return (
+    <div className="pso-root">
+      <style>{CSS}</style>
+
+      <header className="pso-header">
+        <div className="pso-eyebrow">teeline · algorithms/pso</div>
+        <h2 className="pso-title">Particle Swarm Optimisation</h2>
+        <p className="pso-sub">
+          A swarm of tour-particles updates each epoch. Each particle's{" "}
+          <strong>velocity</strong> is a list of city-swap moves built from three
+          components: <code>ω</code> keeps momentum from the previous epoch,{" "}
+          <code>C₁</code> pulls toward the particle's own personal best, and{" "}
+          <code>C₂</code> pulls toward the global best. Inertia <code>ω</code>{" "}
+          decays over time, shifting the swarm from exploration toward exploitation.
+        </p>
+      </header>
+
+      <div className="pso-viz-row">
+        <div className="pso-canvas-wrap">
+          <TourSVG particles={particles} gbest={gbest} newGbest={newGbest} />
+        </div>
+        <SwarmHeatmap particles={particles} gbest_cost={gbest_cost} />
+      </div>
+
+      <div className="pso-legend">
+        <span><span className="pso-dot pso-dot-gbest">●</span> gbest tour</span>
+        <span><span className="pso-dot pso-dot-active">●</span> best particle</span>
+        <span><span className="pso-dot pso-dot-ghost">●</span> swarm</span>
+        <span><span className="pso-dot pso-dot-city">●</span> city</span>
+      </div>
+
+      <VelocityChip breakdown={breakdown} newGbest={newGbest} />
+
+      <InertiaGauge w={w} />
+
+      <div className="pso-statgrid">
+        <div>
+          <div className="pso-statlabel">epoch</div>
+          <div className="pso-mono">{epoch}</div>
+        </div>
+        <div>
+          <div className="pso-statlabel">gbest dist</div>
+          <div className="pso-mono">{gbest_cost.toFixed(1)}</div>
+        </div>
+        <div>
+          <div className="pso-statlabel">avg dist</div>
+          <div className="pso-mono">{avgDist}</div>
+        </div>
+        <div>
+          <div className="pso-statlabel">v_max</div>
+          <div className="pso-mono">{V_MAX} swaps</div>
+        </div>
+      </div>
+
+      <div className="pso-config">
+        <div className="pso-config-row">
+          <label className="pso-config-label">
+            Particles = <strong>{nParticles}</strong>
+          </label>
+          <input
+            type="range" min={3} max={12} step={1} value={nParticles}
+            className="pso-slider"
+            onInput={(e) => {
+              const n = Number((e.target as HTMLInputElement).value)
+              setNParticles(n)
+              reinit(n)
+            }}
+          />
+          <div className="pso-hint">
+            {nParticles <= 4
+              ? "Small swarm — fast but low diversity"
+              : nParticles >= 10
+                ? "Large swarm — high diversity, slower per epoch"
+                : "Balanced swarm size"}
+          </div>
+        </div>
+
+        <div className="pso-config-row">
+          <label className="pso-config-label">Speed</label>
+          <input
+            type="range" min={1} max={10} step={1} value={speed}
+            className="pso-slider"
+            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+          />
+        </div>
+      </div>
+
+      <div className="pso-controls">
+        <button className="pso-btn" onClick={stepOnce} disabled={running}>◀ Step</button>
+        <button
+          className={`pso-btn ${!running ? "pso-btn-primary" : ""}`}
+          onClick={() => setRunning(r => !r)}
+        >
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="pso-btn" onClick={() => reinit(nParticles)}>↺ Reset</button>
+      </div>
+
+      <footer className="pso-footer">
+        <span className="pso-mono">cities: {N_CITIES}</span>
+        <span className="pso-mono">particles: {nParticles}</span>
+        <span className="pso-mono">ω: {W_MIN}→{W_MAX}</span>
+        <span className="pso-mono">C₁=C₂={C1}</span>
+        <span className="pso-mono">v_max: {V_MAX}</span>
+      </footer>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// Styles — self-contained, scoped via pso- prefix
+// ---------------------------------------------------------------
+const CSS = `
+.pso-root {
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --accent: #7c3aed;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --gbest: #16a34a;
+  --active: #7c3aed;
+  --ghost: #9ca3af;
+  --city: #f2a154;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pso-root * { box-sizing: border-box; }
+.pso-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* Header */
+.pso-header { margin-bottom: 2px; }
+.pso-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.pso-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.pso-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+.pso-sub code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em; background: rgba(124,58,237,0.08);
+  padding: 1px 4px; border-radius: 4px;
+}
+
+/* Viz row */
+.pso-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.pso-canvas-wrap { flex: 1; min-width: 0; }
+
+/* Canvas SVG */
+.pso-canvas { width: 100%; display: block; border-radius: 8px; border: 1px solid var(--line); }
+.pso-bg { fill: var(--panel); }
+.pso-ghost { fill: none; stroke: var(--ghost); stroke-width: 1; stroke-opacity: 0.22; stroke-linejoin: round; }
+.pso-active { fill: none; stroke: var(--active); stroke-width: 1.8; stroke-linejoin: round; }
+.pso-gbest { fill: none; stroke: var(--gbest); stroke-width: 2.5; stroke-linejoin: round; }
+.pso-gbest-pulse { animation: pso-pulse 0.5s ease; }
+@keyframes pso-pulse {
+  0% { stroke-width: 5; opacity: 0.4; }
+  100% { stroke-width: 2.5; opacity: 1; }
+}
+.pso-city { fill: var(--city); stroke: var(--bg); stroke-width: 1.5; }
+.pso-city-label {
+  font-size: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  fill: #374151; stroke: white; stroke-width: 2.5; paint-order: stroke fill;
+  dominant-baseline: auto; pointer-events: none; user-select: none;
+}
+
+/* Swarm heatmap */
+.pso-heatmap { width: 100px; flex-shrink: 0; display: flex; flex-direction: column; gap: 3px; }
+.pso-heatmap-title {
+  font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--muted); margin-bottom: 2px;
+}
+.pso-heatmap-cell {
+  flex: 1; border-radius: 5px; min-height: 20px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 7px; position: relative; overflow: hidden;
+  transition: background 0.35s ease;
+}
+.pso-heatmap-idx {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem; font-weight: 700; color: rgba(255,255,255,0.9);
+}
+.pso-heatmap-cost {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.68rem; color: rgba(255,255,255,0.7);
+}
+.pso-heatmap-overlay {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  background: rgba(0,0,0,0.48); border-radius: 5px;
+  font-size: 0.68rem; font-weight: 700; color: #fff;
+  white-space: nowrap; letter-spacing: 0.02em;
+  opacity: 0; transition: opacity 0.12s ease; pointer-events: none;
+}
+.pso-heatmap-cell:hover .pso-heatmap-overlay { opacity: 1; }
+
+/* Legend */
+.pso-legend { display: flex; gap: 14px; flex-wrap: wrap; font-size: 0.8rem; color: var(--muted); }
+.pso-dot { font-size: 1em; }
+.pso-dot-gbest  { color: var(--gbest); }
+.pso-dot-active { color: var(--active); }
+.pso-dot-ghost  { color: var(--ghost); }
+.pso-dot-city   { color: var(--city); }
+
+/* Velocity chip */
+.pso-chip {
+  font-size: 0.88rem; font-weight: 600; padding: 8px 14px;
+  border-radius: 8px; border: 1px solid transparent;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.pso-chip-idle   { background: var(--panel); color: var(--muted); border-color: var(--line); font-weight: 400; }
+.pso-chip-normal { background: rgba(124,58,237,0.08); color: #5b21b6; border-color: rgba(124,58,237,0.25); }
+.pso-chip-gbest  { background: rgba(22,163,74,0.12); color: #14532d; border-color: rgba(22,163,74,0.3); }
+
+/* Inertia gauge */
+.pso-gauge { display: flex; flex-direction: column; gap: 4px; }
+.pso-gauge-label { font-size: 0.88rem; }
+.pso-gauge-label strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.pso-gauge-track {
+  height: 10px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 999px; overflow: hidden;
+}
+.pso-gauge-fill {
+  height: 100%; background: var(--accent); border-radius: 999px;
+  transition: width 0.3s ease;
+}
+.pso-gauge-hint { font-size: 0.78rem; color: var(--muted); }
+
+/* Stats */
+.pso-statgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+@media (max-width: 480px) { .pso-statgrid { grid-template-columns: repeat(2, 1fr); } }
+.pso-statlabel {
+  font-size: 0.7rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+}
+
+/* Config sliders */
+.pso-config { display: flex; flex-direction: column; gap: 10px; }
+.pso-config-row { display: flex; flex-direction: column; gap: 4px; }
+.pso-config-label { font-size: 0.88rem; }
+.pso-slider { width: 100%; accent-color: var(--accent); cursor: pointer; }
+.pso-hint { font-size: 0.78rem; color: var(--muted); }
+
+/* Controls */
+.pso-controls { display: flex; gap: 8px; }
+.pso-btn {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--line); border-radius: 6px;
+  padding: 6px 16px; font-size: 0.88rem; cursor: pointer; font-family: inherit;
+}
+.pso-btn:hover:not(:disabled) { border-color: var(--accent); }
+.pso-btn:disabled { opacity: 0.45; cursor: default; }
+.pso-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+/* Footer */
+.pso-footer {
+  display: flex; flex-wrap: wrap; gap: 14px;
+  padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted);
+}
+`

--- a/teeline-web/src/explainers/pso.tsx
+++ b/teeline-web/src/explainers/pso.tsx
@@ -1,0 +1,3 @@
+export default function PSOExplainer() {
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds interactive PSO explainer at `/algorithms/pso/explainer/` (closes #237)
- Pure algorithm logic in `pso-algo.ts` (exported, tested), UI in `pso.tsx` following the lk.ts / lk.tsx split pattern
- 19 unit tests covering `swapSequence`, `applySwaps`, `tourLength`, `makeInitState`, `stepEpoch`

## What's in the explainer

- **SVG canvas** — gbest tour (green), best-position particle (purple), ghost tours (grey) for the rest of the swarm
- **Swarm heatmap** — 6 colored cells ranked by tour distance; gbest holder outlined in green
- **Velocity chip** — `ω: N · C₁: N · C₂: N → N swaps applied` showing the three-component breakdown each epoch; turns green with ⭐ on new gbest
- **Inertia gauge** — horizontal bar decaying from ω=0.9 → 0.4 over 100 epochs with exploration/exploitation hint
- **Stats grid** — epoch, gbest dist, avg dist, v_max
- **Particles slider** (3–12), speed slider, Step / Run / Pause / Reset controls

## Test plan

- [x] All 129 tests pass (`npm test` in `teeline-web/`)
- [x] `tsc --noEmit` clean
- [x] Navigate to `/algorithms/pso/explainer/` — canvas, heatmap, controls render
- [x] Click Step → epoch increments, velocity chip shows ω/C₁/C₂ breakdown
- [x] Click Run → gbest distance decreases, inertia gauge decays
- [x] At epoch 100+ → gauge at minimum, hint reads "Low — local exploitation"
- [x] Drag Particles slider → reinitialises cleanly
- [x] Back-link to `/algorithms/pso/` works