### PR TITLE
feat(web): add Big Dipper constellation favicon

### DIFF
--- a/teeline-web/algorithms/2opt/index.html
+++ b/teeline-web/algorithms/2opt/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="2-opt — Teeline" />
     <meta property="og:description" content="Local search algorithm that iteratively improves a tour by removing two edges and reconnecting the resulting segments in the only other valid way (reversing the segment between the two removed edges). Repeats until no improving swap exists — a local" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/2opt/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/3opt/index.html
+++ b/teeline-web/algorithms/3opt/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="3-opt — Teeline" />
     <meta property="og:description" content="Extension of 2-opt that removes three edges per iteration and reconnects the three segments in the best of the eight possible reconnection configurations. Each pass tries every triple of edges, keeps the single best improvement found, and repeats unt" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/3opt/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/bhk/index.html
+++ b/teeline-web/algorithms/bhk/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Bellman–Held–Karp — Teeline" />
     <meta property="og:description" content="Dynamic programming algorithm that solves TSP exactly. It builds up solutions for subsets of cities, combining the optimal sub-tour results to find the globally optimal tour. Returns the provably shortest Hamiltonian circuit." />
     <link rel="canonical" href="https://tspsolver.com/algorithms/bhk/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/branch_bound/index.html
+++ b/teeline-web/algorithms/branch_bound/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Branch and Bound — Teeline" />
     <meta property="og:description" content="Systematic enumeration of candidate tours that prunes any branch whose lower-bound cost already exceeds the best complete tour found so far. Explores the search tree depth-first, backtracking whenever it can prove no improvement is possible below the" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/branch_bound/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/christofides/index.html
+++ b/teeline-web/algorithms/christofides/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Christofides — Teeline" />
     <meta property="og:description" content="The only TSP heuristic with a provable worst-case bound: the output tour is always within 1.5× the optimal length, provided the distance matrix satisfies the triangle inequality (TSPLIB EUC_2D instances do; arbitrary FULL_MATRIX instances may not)." />
     <link rel="canonical" href="https://tspsolver.com/algorithms/christofides/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/cs/explainer/index.html
+++ b/teeline-web/algorithms/cs/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cuckoo Search — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of Cuckoo Search: watch nests evolve via Lévy-flight 2-opt reversals, host competition, and Bernoulli nest abandonment." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/cs/index.html
+++ b/teeline-web/algorithms/cs/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Cuckoo Search — Teeline" />
     <meta property="og:description" content="Nature-inspired metaheuristic that models brood parasitism in cuckoos. Maintains a population of *nests* (candidate tours). Each epoch:" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/cs/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/fourier/explainer/index.html
+++ b/teeline-web/algorithms/fourier/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fourier Solver — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of the Fourier-basis constructive TSP solver: watch gradient descent shape a closed curve into a valid tour." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/fourier/index.html
+++ b/teeline-web/algorithms/fourier/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Fourier-basis Constructive Solver — Teeline" />
     <meta property="og:description" content="Encodes a TSP tour as a closed curve in the complex plane and optimises the Fourier" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/fourier/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/fpa/explainer/index.html
+++ b/teeline-web/algorithms/fpa/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Flower Pollination — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of the Flower Pollination Algorithm: watch a population of tours evolve via Lévy-flight global pollination and ε-scaled local cross-pollination." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/fpa/index.html
+++ b/teeline-web/algorithms/fpa/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Flower Pollination Algorithm — Teeline" />
     <meta property="og:description" content="Nature-inspired metaheuristic modelling the pollination process of flowering plants. Maintains a population of *flowers* (candidate tours). Each epoch, each flower applies either:" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/fpa/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/ga/explainer/index.html
+++ b/teeline-web/algorithms/ga/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Genetic Algorithm — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of the Genetic Algorithm: watch selection, ordered crossover, and mutation evolve a population of tours generation by generation." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/ga/index.html
+++ b/teeline-web/algorithms/ga/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Genetic Algorithm — Teeline" />
     <meta property="og:description" content="Evolutionary metaheuristic that maintains a population of candidate tours. Each generation applies:" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/ga/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/gsa/index.html
+++ b/teeline-web/algorithms/gsa/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Gravitational Search Algorithm — Teeline" />
     <meta property="og:description" content="Physics-inspired swarm metaheuristic where each agent is a candidate tour with a mass proportional to its fitness and a velocity (an ordered list of position swaps). Heavier agents (shorter tours) attract lighter ones; each epoch the gravitational co" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/gsa/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/lk/explainer/index.html
+++ b/teeline-web/algorithms/lk/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lin-Kernighan ILS — Interactive Explainer — Teeline</title>
     <meta name="description" content="Watch simplified 2-opt local search and double-bridge perturbation run step-by-step in your browser." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/lk/index.html
+++ b/teeline-web/algorithms/lk/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Lin-Kernighan ILS — Teeline" />
     <meta property="og:description" content="Iterated Local Search (ILS) built around a candidate-list 2-opt move with the Lin-Kernighan gain criterion. Each iteration of the inner loop scans every edge of the tour and tests replacements restricted to a pre-built candidate list of the k nearest" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/lk/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/nn/index.html
+++ b/teeline-web/algorithms/nn/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Nearest Neighbor — Teeline" />
     <meta property="og:description" content="Greedy construction heuristic: start from an arbitrary city and repeatedly move to the closest unvisited city until all cities have been visited. Uses a KD-tree for efficient nearest-neighbor queries." />
     <link rel="canonical" href="https://tspsolver.com/algorithms/nn/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/or_opt/index.html
+++ b/teeline-web/algorithms/or_opt/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Or-opt — Teeline" />
     <meta property="og:description" content="Local search algorithm that relocates *segments* of 1, 2, or 3 consecutive cities to a better position elsewhere in the tour. This is a *relocation* move, as opposed to the *reversal* move used by 2-opt and 3-opt — the two strategies find different l" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/or_opt/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/pso/explainer/index.html
+++ b/teeline-web/algorithms/pso/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Particle Swarm Optimisation — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of Particle Swarm Optimisation: watch a swarm of tours evolve via velocity-capped swap sequences with decaying inertia." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/pso/index.html
+++ b/teeline-web/algorithms/pso/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Particle Swarm Optimisation — Teeline" />
     <meta property="og:description" content="Swarm metaheuristic where each particle is a candidate tour with a velocity — an ordered list of position swaps. Each iteration, the velocity is updated to pull the particle toward both its personal best tour and the global best tour found by any par" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/pso/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/sa/explainer/index.html
+++ b/teeline-web/algorithms/sa/explainer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Simulated Annealing — Interactive Explainer — Teeline</title>
     <meta name="description" content="Interactive walkthrough of Simulated Annealing: watch temperature cooling drive the shift from broad exploration to fine exploitation via Metropolis acceptance." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/sa/index.html
+++ b/teeline-web/algorithms/sa/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Simulated Annealing — Teeline" />
     <meta property="og:description" content="Probabilistic local search inspired by the annealing process in metallurgy. Each iteration proposes a random tour modification. Improvements are always accepted; worsenings are accepted with probability exp(−Δ/T), where T is the current &quot;temperature&quot;" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/sa/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/som/index.html
+++ b/teeline-web/algorithms/som/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Kohonen Self-Organizing Map — Teeline" />
     <meta property="og:description" content="Uses a 1-D ring of neurons — a neural network — that learns a topology-preserving mapping" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/som/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/algorithms/tabu/index.html
+++ b/teeline-web/algorithms/tabu/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Tabu Search — Teeline" />
     <meta property="og:description" content="Local search with short-term memory. Maintains a *tabu list* of recently visited solutions (or recently applied moves) to prevent cycling. At each step the algorithm selects the best non-tabu neighbor of the current solution, even if that neighbor is" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/tabu/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/index.html
+++ b/teeline-web/index.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Teeline TSP Solver" />
     <meta property="og:description" content="Browser-based Traveling Salesman Problem solver. Upload a TSPLIB .tsp file, pick an algorithm and download the optimised tour — runs entirely in-browser via WebAssembly." />
     <link rel="canonical" href="https://tspsolver.com/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>

--- a/teeline-web/public/favicon.svg
+++ b/teeline-web/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#0d1117"/>
+  <!-- Bowl: Dubhe→Merak→Phecda→Megrez→Dubhe -->
+  <polyline points="25,4 27,11 20,15 19,7 25,4" fill="none" stroke="rgba(255,255,255,0.72)" stroke-width="0.8" stroke-linejoin="round" stroke-linecap="round"/>
+  <!-- Handle: Megrez→Alioth→Mizar→Alkaid -->
+  <polyline points="19,7 13,11 8,17 3,24" fill="none" stroke="rgba(255,255,255,0.72)" stroke-width="0.8" stroke-linejoin="round" stroke-linecap="round"/>
+  <!-- Stars sized by apparent magnitude -->
+  <circle cx="25" cy="4"  r="1.5" fill="#f0f0ff"/> <!-- Dubhe α -->
+  <circle cx="27" cy="11" r="1.4" fill="#f0f0ff"/> <!-- Merak β -->
+  <circle cx="20" cy="15" r="1.2" fill="#f0f0ff"/> <!-- Phecda γ -->
+  <circle cx="19" cy="7"  r="0.9" fill="#f0f0ff"/> <!-- Megrez δ -->
+  <circle cx="13" cy="11" r="1.5" fill="#f0f0ff"/> <!-- Alioth ε -->
+  <circle cx="8"  cy="17" r="1.2" fill="#f0f0ff"/> <!-- Mizar ζ -->
+  <circle cx="3"  cy="24" r="1.3" fill="#f0f0ff"/> <!-- Alkaid η -->
+</svg>

--- a/teeline-web/scripts/templates/algorithm-page.eta
+++ b/teeline-web/scripts/templates/algorithm-page.eta
@@ -10,6 +10,7 @@
     <meta property="og:title" content="<%= it.name %> — Teeline" />
     <meta property="og:description" content="<%= it.description %>" />
     <link rel="canonical" href="https://tspsolver.com/algorithms/<%= it.solverId %>/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="topbar"></div>


### PR DESCRIPTION
## Summary

- Adds `public/favicon.svg` — Ursa Major / Big Dipper with 7 stars (α–η, sized by apparent magnitude) connected by tour-route-style lines on a dark navy `#0d1117` rounded-square background. Stars are connected in the classic dipper pattern: Dubhe→Merak→Phecda→Megrez→Dubhe (bowl) + Megrez→Alioth→Mizar→Alkaid (handle)
- Injects `<link rel="icon" type="image/svg+xml" href="/favicon.svg">` into all HTML entry points:
  - `index.html` (main SPA)
  - `scripts/templates/algorithm-page.eta` (covers all 17 generated algorithm docs pages)
  - 7 handcrafted explainer HTML shells (cs, fourier, fpa, ga, lk, pso, sa)
- Fixes the `GET /favicon.ico 404` console error on all pages

## Test plan

- [ ] Navigate to `https://tspsolver.com/` — favicon appears in browser tab
- [ ] Navigate to any algorithm docs page (e.g. `/algorithms/pso/`) — same favicon
- [ ] Navigate to any explainer (e.g. `/algorithms/pso/explainer/`) — same favicon
- [ ] Visually verify: dark navy square, 7 white stars, thin connecting lines forming a dipper shape