### PR TITLE
feat(web): add SOM interactive explainer (#250)

### DIFF
--- a/teeline-web/algorithms/som/explainer/index.html
+++ b/teeline-web/algorithms/som/explainer/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kohonen SOM — Interactive Explainer — Teeline</title>
+    <meta name="description" content="Interactive walkthrough of the Kohonen Self-Organizing Map: watch the neuron ring expand, order itself around cities, and extract a tour." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 900px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/algorithms/som/">← Back to SOM docs</a>
+      </p>
+      <div id="app"></div>
+    </main>
+    <script type="module" src="/src/explainers/som-page.ts"></script>
+  </body>
+</html>

--- a/teeline-web/algorithms/som/index.html
+++ b/teeline-web/algorithms/som/index.html
@@ -29,7 +29,8 @@
         </nav>
 
                 <p class="docs-type-badge">Heuristic — constructive</p>
-                        <h1>Kohonen Self-Organizing Map</h1>
+                        <a class="docs-explainer-cta" href="/algorithms/som/explainer/">▶ Open interactive explainer →</a>
+                <h1>Kohonen Self-Organizing Map</h1>
 <table class="docs-meta-table">
   <thead><tr><th></th><th></th></tr></thead>
   <tbody>

--- a/teeline-web/public/sitemap.xml
+++ b/teeline-web/public/sitemap.xml
@@ -27,4 +27,5 @@
   <url><loc>https://tspsolver.com/algorithms/fpa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/gsa/explainer/</loc></url>
   <url><loc>https://tspsolver.com/algorithms/lk/explainer/</loc></url>
+  <url><loc>https://tspsolver.com/algorithms/som/explainer/</loc></url>
 </urlset>

--- a/teeline-web/src/explainers/som-algo.ts
+++ b/teeline-web/src/explainers/som-algo.ts
@@ -1,0 +1,154 @@
+// 12 cities on a circle, canvas 300×300
+const CX = 150, CY = 150, CITY_R = 110
+export const N_CITIES = 12
+export const CITIES: [number, number][] = Array.from({ length: N_CITIES }, (_, i) => {
+  const theta = (2 * Math.PI * i) / N_CITIES
+  return [CX + CITY_R * Math.cos(theta), CY + CITY_R * Math.sin(theta)] as [number, number]
+})
+
+export const N_NEURONS = Math.round(N_CITIES * 1.5)  // 18
+export const ALPHA0 = 0.8
+export const SIGMA0 = 4.0
+const SIGMA_FLOOR = 1.0
+export const MAX_STEPS = 200
+const H_THRESHOLD = 0.01
+
+export type Phase = 'init' | 'expanding' | 'converging' | 'fine-tuning' | 'done'
+
+export type SomState = {
+  neurons: [number, number][]
+  step: number
+  alpha: number
+  sigma: number
+  bmu: number | null
+  neighbors: number[]
+  lastCityIdx: number | null
+  phase: Phase
+  tour: number[] | null
+  lastTourLength: number | null
+}
+
+export function dist([x1, y1]: [number, number], [x2, y2]: [number, number]): number {
+  return Math.hypot(x2 - x1, y2 - y1)
+}
+
+export function tourLength(tour: number[]): number {
+  const n = tour.length
+  if (n <= 1) return 0
+  let d = 0
+  for (let i = 0; i < n; i++) {
+    d += dist(CITIES[tour[i]], CITIES[tour[(i + 1) % n]])
+  }
+  return d
+}
+
+function ringDist(i: number, j: number): number {
+  const d = Math.abs(i - j)
+  return Math.min(d, N_NEURONS - d)
+}
+
+function gaussian(dRing: number, sigma: number): number {
+  return Math.exp(-(dRing * dRing) / (2 * sigma * sigma))
+}
+
+function extractTour(neurons: [number, number][]): number[] {
+  const cityBmu = CITIES.map(city =>
+    neurons
+      .map((n, ni) => ({ ni, d: dist(n, city) }))
+      .sort((a, b) => a.d - b.d || a.ni - b.ni)[0].ni
+  )
+  return Array.from({ length: N_CITIES }, (_, ci) => ci).sort((a, b) => {
+    if (cityBmu[a] !== cityBmu[b]) return cityBmu[a] - cityBmu[b]
+    return dist(neurons[cityBmu[a]], CITIES[a]) - dist(neurons[cityBmu[b]], CITIES[b])
+  })
+}
+
+export function makeInitState(): SomState {
+  const neurons: [number, number][] = Array.from({ length: N_NEURONS }, (_, i) => {
+    const theta = (2 * Math.PI * i) / N_NEURONS
+    return [CX + 15 * Math.cos(theta), CY + 15 * Math.sin(theta)] as [number, number]
+  })
+  return {
+    neurons,
+    step: 0,
+    alpha: ALPHA0,
+    sigma: SIGMA0,
+    bmu: null,
+    neighbors: [],
+    lastCityIdx: null,
+    phase: 'init',
+    tour: null,
+    lastTourLength: null,
+  }
+}
+
+export function stepOnce(s: SomState): SomState {
+  if (s.phase === 'done') return s
+
+  if (s.step >= MAX_STEPS) {
+    const tour = extractTour(s.neurons)
+    return {
+      ...s,
+      phase: 'done',
+      tour,
+      lastTourLength: tourLength(tour),
+      bmu: null,
+      neighbors: [],
+      lastCityIdx: null,
+    }
+  }
+
+  const t = s.step + 1
+  const alpha = ALPHA0 * Math.exp(-t / MAX_STEPS)
+  const sigma = Math.max(SIGMA_FLOOR, SIGMA0 * Math.exp(-t / MAX_STEPS))
+
+  const cityIdx = Math.floor(Math.random() * N_CITIES)
+  const city = CITIES[cityIdx]
+
+  // Find BMU (closest neuron to city)
+  let bmu = 0, bmuD = Infinity
+  for (let i = 0; i < N_NEURONS; i++) {
+    const d = dist(s.neurons[i], city)
+    if (d < bmuD) { bmuD = d; bmu = i }
+  }
+
+  // Update all neurons via Gaussian neighbourhood kernel (ring topology)
+  const newNeurons: [number, number][] = s.neurons.map(([nx, ny], i) => {
+    const h = gaussian(ringDist(i, bmu), sigma)
+    if (h < H_THRESHOLD) return [nx, ny]
+    return [nx + alpha * h * (city[0] - nx), ny + alpha * h * (city[1] - ny)]
+  })
+
+  // Neighbours: h > 0.1 (visually significant pull), excluding BMU itself
+  const neighbors: number[] = []
+  for (let i = 0; i < N_NEURONS; i++) {
+    if (i !== bmu && gaussian(ringDist(i, bmu), sigma) > 0.1) neighbors.push(i)
+  }
+
+  const phase: Phase =
+    sigma > SIGMA0 * 0.5 ? 'expanding'
+    : sigma > SIGMA_FLOOR * 2 ? 'converging'
+    : 'fine-tuning'
+
+  return { ...s, neurons: newNeurons, step: t, alpha, sigma, bmu, neighbors, lastCityIdx: cityIdx, phase }
+}
+
+// Convert σ (neuron-ring-index units) to canvas pixels for the radius circle.
+// Uses average neuron ring radius so the circle scales as the ring expands.
+export function neighbourRadiusPx(sigma: number, neurons: [number, number][]): number {
+  const cx = neurons.reduce((s, [x]) => s + x, 0) / neurons.length
+  const cy = neurons.reduce((s, [, y]) => s + y, 0) / neurons.length
+  const avgR = neurons.reduce((s, [x, y]) => s + Math.hypot(x - cx, y - cy), 0) / neurons.length
+  const arcPerNeuron = (2 * Math.PI * Math.max(avgR, 10)) / N_NEURONS
+  return sigma * arcPerNeuron
+}
+
+export function phaseLabel(phase: Phase, lastTourLength: number | null): string {
+  switch (phase) {
+    case 'init':        return 'Neurons initialised in a small ring around the centroid.'
+    case 'expanding':   return 'Wide neighbourhood — ring expands and rotates to cover city clusters.'
+    case 'converging':  return 'Neighbourhood shrinking — neurons approach individual cities.'
+    case 'fine-tuning': return 'Fine-tuning — neurons lock onto city positions.'
+    case 'done':        return `Tour extracted from ring order. Length: ${lastTourLength?.toFixed(0) ?? '—'}`
+  }
+}

--- a/teeline-web/src/explainers/som-algo.ts
+++ b/teeline-web/src/explainers/som-algo.ts
@@ -127,7 +127,7 @@ export function stepOnce(s: SomState): SomState {
 
   const phase: Phase =
     sigma > SIGMA0 * 0.5 ? 'expanding'
-    : sigma > SIGMA_FLOOR * 2 ? 'converging'
+    : sigma > SIGMA_FLOOR * 1.5 ? 'converging'
     : 'fine-tuning'
 
   return { ...s, neurons: newNeurons, step: t, alpha, sigma, bmu, neighbors, lastCityIdx: cityIdx, phase }

--- a/teeline-web/src/explainers/som-page.ts
+++ b/teeline-web/src/explainers/som-page.ts
@@ -1,0 +1,9 @@
+import '@picocss/pico/css/pico.min.css'
+import '../docs.css'
+import { initTopbar } from '../topbar'
+import { render, h } from 'preact'
+import SomExplainer from './som'
+
+initTopbar()
+const appEl = document.getElementById('app')
+if (appEl) { render(h(SomExplainer, null), appEl) }

--- a/teeline-web/src/explainers/som.test.ts
+++ b/teeline-web/src/explainers/som.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'vitest'
+import {
+  N_CITIES, N_NEURONS, SIGMA0, MAX_STEPS,
+  makeInitState, stepOnce, tourLength, neighbourRadiusPx,
+} from './som-algo'
+
+describe('tourLength', () => {
+  test('returns 0 for empty tour', () => {
+    expect(tourLength([])).toBe(0)
+  })
+  test('returns 0 for single-city tour', () => {
+    expect(tourLength([0])).toBe(0)
+  })
+  test('positive for two cities', () => {
+    expect(tourLength([0, 1])).toBeGreaterThan(0)
+  })
+  test('symmetric: reversing tour gives same length', () => {
+    const tour = Array.from({ length: N_CITIES }, (_, i) => i)
+    expect(tourLength(tour)).toBeCloseTo(tourLength([...tour].reverse()), 5)
+  })
+})
+
+describe('makeInitState', () => {
+  test('produces N_NEURONS neurons', () => {
+    expect(makeInitState().neurons).toHaveLength(N_NEURONS)
+  })
+  test('neurons form a ring of radius ~15 around centroid (150,150)', () => {
+    for (const [nx, ny] of makeInitState().neurons) {
+      expect(Math.hypot(nx - 150, ny - 150)).toBeCloseTo(15, 0)
+    }
+  })
+  test('phase is init', () => {
+    expect(makeInitState().phase).toBe('init')
+  })
+  test('step is 0', () => {
+    expect(makeInitState().step).toBe(0)
+  })
+  test('sigma equals SIGMA0', () => {
+    expect(makeInitState().sigma).toBe(SIGMA0)
+  })
+})
+
+describe('stepOnce', () => {
+  test('advances step by 1', () => {
+    expect(stepOnce(makeInitState()).step).toBe(1)
+  })
+  test('returns a new object (immutable update)', () => {
+    const s = makeInitState()
+    const next = stepOnce(s)
+    expect(next).not.toBe(s)
+    expect(next.neurons).not.toBe(s.neurons)
+  })
+  test('neuron count is unchanged', () => {
+    expect(stepOnce(makeInitState()).neurons).toHaveLength(N_NEURONS)
+  })
+  test('alpha decays monotonically over first 10 steps', () => {
+    let s = makeInitState()
+    let prev = s.alpha
+    for (let i = 0; i < 10; i++) {
+      s = stepOnce(s)
+      expect(s.alpha).toBeLessThanOrEqual(prev)
+      prev = s.alpha
+    }
+  })
+  test('sigma never falls below 1.0 (floor)', () => {
+    let s = makeInitState()
+    for (let i = 0; i <= MAX_STEPS; i++) s = stepOnce(s)
+    // sigma is clamped on each step; check the training steps
+    // (after MAX_STEPS, phase is done and sigma is from last training step)
+    expect(s.sigma === null || s.sigma >= 1.0).toBe(true)
+  })
+  test('phase becomes done after MAX_STEPS+1 calls', () => {
+    let s = makeInitState()
+    for (let i = 0; i <= MAX_STEPS; i++) s = stepOnce(s)
+    expect(s.phase).toBe('done')
+  })
+  test('tour contains each city index exactly once when done', () => {
+    let s = makeInitState()
+    for (let i = 0; i <= MAX_STEPS; i++) s = stepOnce(s)
+    expect(s.tour).not.toBeNull()
+    const sorted = [...s.tour!].sort((a, b) => a - b)
+    expect(sorted).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+  })
+  test('done state is idempotent', () => {
+    let s = makeInitState()
+    for (let i = 0; i <= MAX_STEPS; i++) s = stepOnce(s)
+    expect(stepOnce(s)).toBe(s)
+  })
+})
+
+describe('neighbourRadiusPx', () => {
+  test('returns a positive number', () => {
+    expect(neighbourRadiusPx(4, makeInitState().neurons)).toBeGreaterThan(0)
+  })
+  test('larger sigma gives larger radius', () => {
+    const { neurons } = makeInitState()
+    expect(neighbourRadiusPx(4, neurons)).toBeGreaterThan(neighbourRadiusPx(2, neurons))
+  })
+})

--- a/teeline-web/src/explainers/som.test.ts
+++ b/teeline-web/src/explainers/som.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import {
   N_CITIES, N_NEURONS, SIGMA0, MAX_STEPS,
-  makeInitState, stepOnce, tourLength, neighbourRadiusPx,
+  makeInitState, stepOnce, tourLength, neighbourRadiusPx, phaseLabel,
 } from './som-algo'
 
 describe('tourLength', () => {
@@ -67,7 +67,7 @@ describe('stepOnce', () => {
     for (let i = 0; i <= MAX_STEPS; i++) s = stepOnce(s)
     // sigma is clamped on each step; check the training steps
     // (after MAX_STEPS, phase is done and sigma is from last training step)
-    expect(s.sigma === null || s.sigma >= 1.0).toBe(true)
+    expect(s.sigma).toBeGreaterThanOrEqual(1.0)
   })
   test('phase becomes done after MAX_STEPS+1 calls', () => {
     let s = makeInitState()
@@ -95,5 +95,36 @@ describe('neighbourRadiusPx', () => {
   test('larger sigma gives larger radius', () => {
     const { neurons } = makeInitState()
     expect(neighbourRadiusPx(4, neurons)).toBeGreaterThan(neighbourRadiusPx(2, neurons))
+  })
+})
+
+describe('phaseLabel', () => {
+  test('init phase returns non-empty string', () => {
+    const label = phaseLabel('init', null)
+    expect(label).toBeTruthy()
+    expect(typeof label).toBe('string')
+  })
+  test('expanding phase returns non-empty string', () => {
+    const label = phaseLabel('expanding', null)
+    expect(label).toBeTruthy()
+    expect(typeof label).toBe('string')
+  })
+  test('converging phase returns non-empty string', () => {
+    const label = phaseLabel('converging', null)
+    expect(label).toBeTruthy()
+    expect(typeof label).toBe('string')
+  })
+  test('fine-tuning phase returns non-empty string', () => {
+    const label = phaseLabel('fine-tuning', null)
+    expect(label).toBeTruthy()
+    expect(typeof label).toBe('string')
+  })
+  test('done phase interpolates lastTourLength when provided', () => {
+    const label = phaseLabel('done', 123.456)
+    expect(label).toContain('123')
+  })
+  test('done phase shows — when lastTourLength is null', () => {
+    const label = phaseLabel('done', null)
+    expect(label).toContain('—')
   })
 })

--- a/teeline-web/src/explainers/som.tsx
+++ b/teeline-web/src/explainers/som.tsx
@@ -1,0 +1,6 @@
+// Placeholder for SOM explainer component
+// Implemented in Task 3
+
+export default function SomExplainer() {
+  return <div>SOM Explainer (Task 3)</div>
+}

--- a/teeline-web/src/explainers/som.tsx
+++ b/teeline-web/src/explainers/som.tsx
@@ -1,6 +1,416 @@
-// Placeholder for SOM explainer component
-// Implemented in Task 3
+import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import type { SomState, Phase } from "./som-algo"
+import {
+  CITIES, ALPHA0, SIGMA0, MAX_STEPS,
+  makeInitState, stepOnce, neighbourRadiusPx, phaseLabel,
+} from "./som-algo"
+
+function polyPts(pts: [number, number][]): string {
+  return pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
+}
+
+const PHASE_COLOR: Record<Phase, string> = {
+  'init':        '#6b7280',
+  'expanding':   '#7c3aed',
+  'converging':  '#a855f7',
+  'fine-tuning': '#c084fc',
+  'done':        '#16a34a',
+}
 
 export default function SomExplainer() {
-  return <div>SOM Explainer (Task 3)</div>
+  const simRef = useRef<SomState>(makeInitState())
+
+  const [neurons, setNeurons] = useState(simRef.current.neurons)
+  const [bmu, setBmu] = useState<number | null>(null)
+  const [neighbors, setNeighbors] = useState<number[]>([])
+  const [lastCityIdx, setLastCityIdx] = useState<number | null>(null)
+  const [phase, setPhase] = useState<Phase>('init')
+  const [step, setStep] = useState(0)
+  const [alpha, setAlpha] = useState(ALPHA0)
+  const [sigma, setSigma] = useState(SIGMA0)
+  const [tour, setTour] = useState<number[] | null>(null)
+  const [lastTourLength, setLastTourLength] = useState<number | null>(null)
+  const [running, setRunning] = useState(false)
+  const [speed, setSpeed] = useState(5)
+
+  const syncState = (s: SomState) => {
+    setNeurons(s.neurons)
+    setBmu(s.bmu)
+    setNeighbors(s.neighbors)
+    setLastCityIdx(s.lastCityIdx)
+    setPhase(s.phase)
+    setStep(s.step)
+    setAlpha(s.alpha)
+    setSigma(s.sigma)
+    setTour(s.tour)
+    setLastTourLength(s.lastTourLength)
+  }
+
+  const stepFn = useCallback(() => {
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    syncState(next)
+    if (next.phase === 'done') setRunning(false)
+  }, [])
+
+  const reinit = useCallback(() => {
+    const s = makeInitState()
+    simRef.current = s
+    syncState(s)
+    setRunning(false)
+  }, [])
+
+  const delay = Math.max(50, 660 - speed * 60)
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepFn, delay)
+    return () => clearInterval(id)
+  }, [running, stepFn, delay])
+
+  const bmuPos = bmu !== null ? neurons[bmu] : null
+  const nbRadiusPx = bmuPos ? neighbourRadiusPx(sigma, neurons) : 0
+
+  // Tour polyline: cities in ring order, closed
+  const tourPts = tour !== null
+    ? polyPts([...tour.map(i => CITIES[i]), CITIES[tour[0]]])
+    : null
+
+  // Neuron ring polyline: close the ring back to first neuron
+  const neuronRingPts = polyPts([...neurons, neurons[0]])
+
+  const isDone = phase === 'done'
+
+  return (
+    <div class="som-root">
+      <style>{CSS}</style>
+
+      <header class="som-header">
+        <span class="som-emoji">🧠</span>
+        <div>
+          <h2 class="som-title">Kohonen SOM</h2>
+          <p class="som-subtitle">Self-Organising Map — topology-preserving TSP heuristic</p>
+        </div>
+      </header>
+
+      <div class="som-viz-row">
+        {/* 300×300 SVG canvas */}
+        <svg class="som-canvas" viewBox="0 0 300 300" aria-label="SOM visualisation">
+
+          {/* 1. Tour overlay (only when done) */}
+          {tourPts && (
+            <polyline points={tourPts} class="som-tour" />
+          )}
+
+          {/* 2. Neuron ring polyline */}
+          <polyline points={neuronRingPts} class="som-neuron-ring" />
+
+          {/* 3. Neighbourhood radius circle */}
+          {bmuPos && !isDone && (
+            <circle
+              cx={bmuPos[0].toFixed(1)}
+              cy={bmuPos[1].toFixed(1)}
+              r={nbRadiusPx.toFixed(1)}
+              class="som-nb-circle"
+            />
+          )}
+
+          {/* 4. Attraction line: last city → BMU */}
+          {lastCityIdx !== null && bmuPos && !isDone && (
+            <line
+              x1={CITIES[lastCityIdx][0].toFixed(1)}
+              y1={CITIES[lastCityIdx][1].toFixed(1)}
+              x2={bmuPos[0].toFixed(1)}
+              y2={bmuPos[1].toFixed(1)}
+              class="som-attraction"
+            />
+          )}
+
+          {/* 5. Active neighbour circles */}
+          {!isDone && neighbors.map(ni => (
+            <circle
+              key={ni}
+              cx={neurons[ni][0].toFixed(1)}
+              cy={neurons[ni][1].toFixed(1)}
+              r="5.5"
+              class="som-nb-neuron"
+            />
+          ))}
+
+          {/* 6. All neuron circles (BMU rendered larger) */}
+          {neurons.map(([nx, ny], ni) => (
+            <circle
+              key={ni}
+              cx={nx.toFixed(1)}
+              cy={ny.toFixed(1)}
+              r={ni === bmu ? "8" : "4"}
+              class={ni === bmu ? 'som-neuron som-neuron-bmu' : 'som-neuron'}
+            />
+          ))}
+
+          {/* 7. City circles (always on top) */}
+          {CITIES.map(([cx, cy], ci) => (
+            <circle
+              key={ci}
+              cx={cx.toFixed(1)}
+              cy={cy.toFixed(1)}
+              r="7"
+              class={ci === lastCityIdx && !isDone ? 'som-city som-city-active' : 'som-city'}
+            />
+          ))}
+        </svg>
+
+        {/* Right panel */}
+        <div class="som-panel">
+
+          {/* Phase chip */}
+          <div class="som-phase-chip" style={`border-color: ${PHASE_COLOR[phase]}`}>
+            <span class="som-phase-dot" style={`background: ${PHASE_COLOR[phase]}`} />
+            <span class="som-phase-text">{phaseLabel(phase, lastTourLength)}</span>
+          </div>
+
+          {/* Stats grid */}
+          <div class="som-statgrid">
+            <div class="som-stat"><span>Step</span><strong>{step}/{MAX_STEPS}</strong></div>
+            <div class="som-stat"><span>α</span><strong>{alpha.toFixed(3)}</strong></div>
+            <div class="som-stat"><span>σ</span><strong>{sigma.toFixed(2)}</strong></div>
+            <div class="som-stat"><span>Tour</span><strong>{lastTourLength !== null ? lastTourLength.toFixed(0) : '—'}</strong></div>
+          </div>
+
+          {/* Progress bar */}
+          <div class="som-progress-track" role="progressbar" aria-valuenow={step} aria-valuemax={MAX_STEPS}>
+            <div class="som-progress-bar" style={`width: ${(Math.min(step, MAX_STEPS) / MAX_STEPS * 100).toFixed(1)}%`} />
+          </div>
+
+          {/* Speed slider */}
+          <div class="som-config">
+            <label class="som-label">
+              Speed
+              <input
+                type="range" min="1" max="10" value={speed}
+                onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+              />
+              <span>{speed}</span>
+            </label>
+          </div>
+
+          {/* Control buttons */}
+          <div class="som-controls">
+            <button
+              class="som-btn som-btn-step"
+              onClick={stepFn}
+              disabled={running || isDone}
+            >Step</button>
+            <button
+              class="som-btn som-btn-run"
+              onClick={() => setRunning(r => !r)}
+              disabled={isDone}
+            >{running ? 'Pause' : 'Run'}</button>
+            <button class="som-btn som-btn-reset" onClick={reinit}>Reset</button>
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div class="som-legend">
+        <span class="som-leg-item">
+          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="#f97316" /></svg>
+          City
+        </span>
+        <span class="som-leg-item">
+          <svg width="14" height="14"><circle cx="7" cy="7" r="5" fill="#7c3aed" /></svg>
+          Neuron
+        </span>
+        <span class="som-leg-item">
+          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="#4f46e5" /></svg>
+          BMU
+        </span>
+        <span class="som-leg-item">
+          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="3,2" /></svg>
+          σ radius
+        </span>
+        <span class="som-leg-item">
+          <svg width="18" height="4"><line x1="0" y1="2" x2="18" y2="2" stroke="#f97316" stroke-width="1.5" stroke-dasharray="4,2" /></svg>
+          Attraction
+        </span>
+        <span class="som-leg-item">
+          <svg width="18" height="4"><line x1="0" y1="2" x2="18" y2="2" stroke="#16a34a" stroke-width="2" /></svg>
+          Tour
+        </span>
+      </div>
+
+      <footer class="som-footer">
+        12 cities · 18 neurons · η₀={ALPHA0} · σ₀={SIGMA0} · {MAX_STEPS} steps
+      </footer>
+    </div>
+  )
 }
+
+const CSS = `
+.som-root {
+  font-family: system-ui, sans-serif;
+  max-width: 860px;
+}
+
+.som-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+.som-emoji { font-size: 2rem; line-height: 1; }
+.som-title { margin: 0; font-size: 1.25rem; }
+.som-subtitle { margin: 0; color: #6b7280; font-size: 0.875rem; }
+
+.som-viz-row {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.som-canvas {
+  width: 300px;
+  height: 300px;
+  flex-shrink: 0;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.som-city { fill: #f97316; stroke: #fff; stroke-width: 1.5; }
+.som-city-active { fill: #ea580c; stroke: #7c3aed; stroke-width: 2.5; }
+
+.som-neuron-ring { fill: none; stroke: #a78bfa; stroke-width: 1.2; opacity: 0.7; }
+.som-neuron { fill: #7c3aed; stroke: #fff; stroke-width: 1; }
+.som-neuron-bmu { fill: #4f46e5; stroke: #fff; stroke-width: 2; }
+.som-nb-neuron { fill: #a78bfa; stroke: none; opacity: 0.6; }
+
+.som-nb-circle {
+  fill: none;
+  stroke: #7c3aed;
+  stroke-width: 1.5;
+  stroke-dasharray: 5,3;
+  opacity: 0.5;
+}
+
+.som-attraction {
+  stroke: #f97316;
+  stroke-width: 1.5;
+  stroke-dasharray: 4,3;
+  opacity: 0.7;
+}
+
+.som-tour {
+  fill: none;
+  stroke: #16a34a;
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.som-panel {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.som-phase-chip {
+  border: 1.5px solid #7c3aed;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+.som-phase-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+.som-phase-text { color: #374151; }
+
+.som-statgrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.25rem;
+}
+.som-stat {
+  background: #f3f4f6;
+  border-radius: 6px;
+  padding: 0.375rem 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+}
+.som-stat span { display: block; color: #6b7280; }
+.som-stat strong { display: block; font-size: 0.875rem; }
+
+.som-progress-track {
+  height: 4px;
+  background: #e5e7eb;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.som-progress-bar {
+  height: 100%;
+  background: #7c3aed;
+  transition: width 0.1s linear;
+}
+
+.som-config { display: flex; flex-direction: column; gap: 0.5rem; }
+.som-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+}
+.som-label input[type=range] { flex: 1; }
+.som-label span { min-width: 1.5rem; text-align: right; }
+
+.som-controls { display: flex; gap: 0.5rem; }
+.som-btn {
+  flex: 1;
+  padding: 0.4rem 0.75rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+.som-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.som-btn-step { background: #f3f4f6; color: #374151; }
+.som-btn-reset { background: #f3f4f6; color: #374151; }
+.som-btn-run { background: #7c3aed; color: #fff; }
+.som-btn-run:hover:not(:disabled) { background: #6d28d9; }
+
+.som-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-size: 0.8125rem;
+  color: #374151;
+  align-items: center;
+}
+.som-leg-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.som-footer {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+@media (max-width: 600px) {
+  .som-viz-row { flex-direction: column; }
+  .som-canvas { width: 100%; height: auto; }
+  .som-statgrid { grid-template-columns: repeat(2, 1fr); }
+}
+`

--- a/teeline-web/src/explainers/som.tsx
+++ b/teeline-web/src/explainers/som.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "preact/hooks"
 import type { SomState, Phase } from "./som-algo"
 import {
-  CITIES, ALPHA0, SIGMA0, MAX_STEPS,
+  CITIES, ALPHA0, SIGMA0, MAX_STEPS, N_CITIES, N_NEURONS,
   makeInitState, stepOnce, neighbourRadiusPx, phaseLabel,
 } from "./som-algo"
 
@@ -239,7 +239,7 @@ export default function SomExplainer() {
       </div>
 
       <footer class="som-footer">
-        12 cities · 18 neurons · η₀={ALPHA0} · σ₀={SIGMA0} · {MAX_STEPS} steps
+        {N_CITIES} cities · {N_NEURONS} neurons · η₀={ALPHA0} · σ₀={SIGMA0} · {MAX_STEPS} steps
       </footer>
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds an interactive step-by-step visualiser for the Kohonen Self-Organising Map solver at `/algorithms/som/explainer/`
- Pure-TypeScript simulation (no WASM): `som-algo.ts` implements the full SOM training loop with Gaussian neighbourhood kernel, ring-topology BMU selection, and ring-order tour extraction
- Single-panel Preact component (`som.tsx`): 300×300 SVG canvas with neuron ring polyline, BMU highlight, dashed σ-radius circle, city→BMU attraction line, green tour overlay on completion
- Phase chip transitions: init → expanding → converging → fine-tuning → done
- 25 unit tests covering `tourLength`, `makeInitState`, `stepOnce` (lifecycle, purity, idempotency), `neighbourRadiusPx`, `phaseLabel`
- CTA link added to the SOM docs page (`/algorithms/som/`)

## Design decisions

- **Accent colour:** purple `#7c3aed` (unused by any other explainer)
- **Layout:** single panel, no tabs (consistent with GSA/Tabu post-LK convention)
- **Neighbourhood:** dashed radius circle on BMU + highlighted active-neighbour neurons (combination)
- **12 cities on a circle**, 18 neurons (1.5×), η₀=0.8, σ₀=4.0, 200 training steps

## Test plan

- [x] `cd teeline-web && npx vitest run src/explainers/som.test.ts` — 25 tests pass
- [x] `npx tsc --project tsconfig.json --noEmit` — no errors
- [x] `npm run build` — `somExplainer` bundle present in output
- [x] Visit `/algorithms/som/` — "▶ Open interactive explainer →" link visible
- [x] Visit `/algorithms/som/explainer/` — small purple neuron ring at canvas centre
- [x] Click **Step** — ring shifts, BMU highlighted, dashed radius circle and orange attraction line appear
- [x] Click **Run** — neurons expand toward orange city circles, phase chip updates
- [x] Phase chip shows all 4 training phases then "done" with tour length
- [x] At done — green tour polyline visible, attraction/radius hidden
- [x] **Reset** — restores small initial ring
- [x] Resize to <600px — canvas goes full-width, stats grid goes 2-col

Closes #250