### PR TITLE
feat(api): request/response DTO types with utoipa schemas (#277)

### DIFF
--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod models;
 pub mod routes;
 pub mod services;
 

--- a/teeline-api/src/models/mod.rs
+++ b/teeline-api/src/models/mod.rs
@@ -1,0 +1,2 @@
+pub mod request;
+pub mod response;

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -1,0 +1,1 @@
+// Request DTOs

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct HeuristicConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub epochs: Option<usize>,

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -1,1 +1,204 @@
 // Request DTOs
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct HeuristicConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epochs: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platoo_epochs: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n_nearest: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct NnConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct TwoOptConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ThreeOptConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct OrOptConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct TabuConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct StochasticHillConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct PsoConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct GsaConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+}
+
+/// Lin-Kernighan ILS. `max_depth` mirrors `LKOptions::max_depth` (default 5).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct LkConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_depth: Option<usize>,
+}
+
+/// Simulated Annealing. Mirrors `SAOptions`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SaConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cooling_rate: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_temperature: Option<f32>,
+}
+
+/// Genetic Algorithm. Mirrors `GAOptions`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct GaConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mutation_probability: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n_elite: Option<usize>,
+}
+
+/// Cuckoo Search. Mirrors `CSOptions`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct CsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mutation_probability: Option<f32>,
+}
+
+/// Flower Pollination Algorithm. Mirrors `FPAOptions`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct FpaConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mutation_probability: Option<f32>,
+}
+
+/// Kohonen SOM. Mirrors `SOMOptions` (f64 fields match the lib).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SomConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epochs: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub learning_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub radius_fraction: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub neuron_multiplier: Option<usize>,
+}
+
+/// Fourier constructive solver. Mirrors `FourierOptions` (f64 fields match the lib).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct FourierConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epochs: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub k_max: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub m: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lambda: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lambda_decay: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lr: Option<f64>,
+}
+
+/// Per-solver optional configuration. Pass only the field matching your chosen solver.
+/// BHK, branch_bound, and Christofides have no tunable parameters and are absent.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SolverConfigs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nn: Option<NnConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub two_opt: Option<TwoOptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub three_opt: Option<ThreeOptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub or_opt: Option<OrOptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tabu: Option<TabuConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stochastic_hill: Option<StochasticHillConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pso: Option<PsoConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gsa: Option<GsaConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lk: Option<LkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sa: Option<SaConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ga: Option<GaConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cs: Option<CsConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fpa: Option<FpaConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub som: Option<SomConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fourier: Option<FourierConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solver_configs_sa_round_trip() {
+        let configs = SolverConfigs {
+            sa: Some(SaConfig {
+                heuristic: Some(HeuristicConfig {
+                    epochs: Some(5000),
+                    platoo_epochs: None,
+                    n_nearest: None,
+                }),
+                cooling_rate: Some(0.0005),
+                min_temperature: None,
+                max_temperature: Some(500.0),
+            }),
+            ..SolverConfigs::default()
+        };
+        let json = serde_json::to_string(&configs).unwrap();
+        let back: SolverConfigs = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.sa.as_ref().unwrap().cooling_rate, Some(0.0005));
+        assert_eq!(back.sa.as_ref().unwrap().min_temperature, None);
+    }
+}

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -177,6 +177,78 @@ pub struct SolverConfigs {
     pub fourier: Option<FourierConfig>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct CityInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<usize>,
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct TspInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cities: Option<Vec<CityInput>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tsplib: Option<String>,
+}
+
+impl TspInput {
+    pub fn validate(&self) -> Result<(), String> {
+        match (&self.cities, &self.tsplib) {
+            (Some(cities), None) => {
+                if cities.is_empty() {
+                    Err("`cities` must not be empty".to_string())
+                } else {
+                    Ok(())
+                }
+            }
+            (None, Some(tsplib)) => {
+                if tsplib.trim().is_empty() {
+                    Err("`tsplib` must not be empty".to_string())
+                } else {
+                    Ok(())
+                }
+            }
+            (Some(_), Some(_)) => {
+                Err("exactly one of `cities` or `tsplib` must be set, not both".to_string())
+            }
+            (None, None) => Err("one of `cities` or `tsplib` must be set".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ParseRequest {
+    pub input: TspInput,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SolveRequest {
+    pub input: TspInput,
+    pub solver: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configs: Option<SolverConfigs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct CompareRequest {
+    pub input: TspInput,
+    pub solvers: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configs: Option<SolverConfigs>,
+}
+
+impl CompareRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        self.input.validate()?;
+        if self.solvers.is_empty() {
+            return Err("`solvers` must contain at least one solver name".to_string());
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,5 +272,157 @@ mod tests {
         let back: SolverConfigs = serde_json::from_str(&json).unwrap();
         assert_eq!(back.sa.as_ref().unwrap().cooling_rate, Some(0.0005));
         assert_eq!(back.sa.as_ref().unwrap().min_temperature, None);
+    }
+
+    #[test]
+    fn solve_request_cities_round_trip() {
+        let req = SolveRequest {
+            input: TspInput {
+                cities: Some(vec![
+                    CityInput {
+                        id: Some(1),
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(2),
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(3),
+                        x: 0.5,
+                        y: 1.0,
+                    },
+                ]),
+                tsplib: None,
+            },
+            solver: "nn".to_string(),
+            configs: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: SolveRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.solver, "nn");
+        assert_eq!(back.input.cities.as_ref().unwrap().len(), 3);
+        assert!(back.input.tsplib.is_none());
+    }
+
+    #[test]
+    fn solve_request_with_configs_round_trip() {
+        let req = SolveRequest {
+            input: TspInput {
+                cities: Some(vec![CityInput {
+                    id: None,
+                    x: 1.0,
+                    y: 2.0,
+                }]),
+                tsplib: None,
+            },
+            solver: "sa".to_string(),
+            configs: Some(SolverConfigs {
+                sa: Some(SaConfig {
+                    heuristic: Some(HeuristicConfig {
+                        epochs: Some(1000),
+                        platoo_epochs: None,
+                        n_nearest: None,
+                    }),
+                    cooling_rate: Some(0.001),
+                    min_temperature: None,
+                    max_temperature: None,
+                }),
+                ..SolverConfigs::default()
+            }),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: SolveRequest = serde_json::from_str(&json).unwrap();
+        let sa = back.configs.unwrap().sa.unwrap();
+        assert_eq!(sa.cooling_rate, Some(0.001));
+        assert_eq!(sa.heuristic.unwrap().epochs, Some(1000));
+    }
+
+    #[test]
+    fn tsp_input_validate_rejects_both() {
+        let input = TspInput {
+            cities: Some(vec![CityInput {
+                id: Some(1),
+                x: 0.0,
+                y: 0.0,
+            }]),
+            tsplib: Some("NAME: test".to_string()),
+        };
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
+    fn tsp_input_validate_rejects_neither() {
+        let input = TspInput {
+            cities: None,
+            tsplib: None,
+        };
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
+    fn tsp_input_validate_rejects_empty_cities() {
+        let input = TspInput {
+            cities: Some(vec![]),
+            tsplib: None,
+        };
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
+    fn tsp_input_validate_rejects_blank_tsplib() {
+        let input = TspInput {
+            cities: None,
+            tsplib: Some("   ".to_string()),
+        };
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
+    fn tsp_input_validate_accepts_cities_only() {
+        let input = TspInput {
+            cities: Some(vec![CityInput {
+                id: Some(1),
+                x: 0.0,
+                y: 0.0,
+            }]),
+            tsplib: None,
+        };
+        assert!(input.validate().is_ok());
+    }
+
+    #[test]
+    fn tsp_input_validate_accepts_tsplib_only() {
+        let input = TspInput {
+            cities: None,
+            tsplib: Some("NAME: test".to_string()),
+        };
+        assert!(input.validate().is_ok());
+    }
+
+    #[test]
+    fn compare_request_validate_rejects_empty_solvers() {
+        let req = CompareRequest {
+            input: TspInput {
+                cities: Some(vec![CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                }]),
+                tsplib: None,
+            },
+            solvers: vec![],
+            configs: None,
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn solve_request_schema_builds() {
+        use utoipa::ToSchema;
+        let name = SolveRequest::name();
+        assert_eq!(name, "SolveRequest");
     }
 }

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -239,6 +239,16 @@ pub struct CompareRequest {
     pub configs: Option<SolverConfigs>,
 }
 
+impl SolveRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        self.input.validate()?;
+        if self.solver.trim().is_empty() {
+            return Err("`solver` must not be empty".to_string());
+        }
+        Ok(())
+    }
+}
+
 impl CompareRequest {
     pub fn validate(&self) -> Result<(), String> {
         self.input.validate()?;
@@ -417,6 +427,40 @@ mod tests {
             configs: None,
         };
         assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn solve_request_validate_rejects_blank_solver() {
+        let req = SolveRequest {
+            input: TspInput {
+                cities: Some(vec![CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                }]),
+                tsplib: None,
+            },
+            solver: "   ".to_string(),
+            configs: None,
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn solve_request_validate_accepts_valid() {
+        let req = SolveRequest {
+            input: TspInput {
+                cities: Some(vec![CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                }]),
+                tsplib: None,
+            },
+            solver: "nn".to_string(),
+            configs: None,
+        };
+        assert!(req.validate().is_ok());
     }
 
     #[test]

--- a/teeline-api/src/models/response.rs
+++ b/teeline-api/src/models/response.rs
@@ -1,0 +1,1 @@
+// Response DTOs

--- a/teeline-api/src/models/response.rs
+++ b/teeline-api/src/models/response.rs
@@ -132,6 +132,7 @@ mod tests {
         let json = serde_json::to_string(&resp).unwrap();
         let back: SolveResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(back.solver, "nn");
+        assert_eq!(back.total, 1234.5_f32);
         assert_eq!(back.route, vec![1, 3, 2]);
         assert_eq!(back.duration_ms, 42);
     }

--- a/teeline-api/src/models/response.rs
+++ b/teeline-api/src/models/response.rs
@@ -1,1 +1,197 @@
 // Response DTOs
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Mirrors `SolverInfo` from `teeline::tsp`. Field names match the lib (`desc`, `alias`).
+/// `alias` is always present — every solver in `SOLVER_LIST` has a non-empty alias.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct AlgorithmInfo {
+    pub name: String,
+    pub alias: String,
+    pub category: String,
+    pub desc: String,
+    pub complexity: String,
+    pub has_options: bool,
+    pub exact: bool,
+}
+
+/// A city in a parsed or solved tour. `id` is 1-based, matching the lib.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct CityDto {
+    pub id: usize,
+    pub x: f32,
+    pub y: f32,
+}
+
+/// `distance_type` is the TSPLIB canonical uppercase string, e.g. `"EUC_2D"` or `"GEO"`.
+/// The service layer maps `DistanceType` enum → String before building this response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ParseResponse {
+    pub name: String,
+    pub comment: String,
+    pub distance_type: String,
+    pub cities: Vec<CityDto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SolveResponse {
+    /// The solver alias that produced this result (e.g. `"nn"`, `"sa"`).
+    pub solver: String,
+    /// Total tour distance (sum of EUC_2D edges, closing the cycle).
+    pub total: f32,
+    /// Ordered 1-based city IDs. Read from `Solution::route()` — the field is private in the lib.
+    pub route: Vec<usize>,
+    /// Wall-clock time for the solve call, measured by the service layer.
+    pub duration_ms: u64,
+}
+
+/// A per-solver result in a compare response.
+///
+/// Tagged enum: JSON carries `"status": "ok"` or `"status": "error"`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum CompareEntry {
+    Ok {
+        solver: String,
+        total: f32,
+        route: Vec<usize>,
+        duration_ms: u64,
+    },
+    Error {
+        solver: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct CompareResponse {
+    pub entries: Vec<CompareEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn algorithm_info_round_trip() {
+        let info = AlgorithmInfo {
+            name: "Nearest Neighbor".to_string(),
+            alias: "nn".to_string(),
+            category: "Constructive".to_string(),
+            desc: "Greedy heuristic.".to_string(),
+            complexity: "O(n²)".to_string(),
+            has_options: false,
+            exact: false,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let back: AlgorithmInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.alias, "nn");
+        assert_eq!(back.desc, "Greedy heuristic.");
+        // field serializes as "desc", not "description"
+        assert!(json.contains(r#""desc":"#));
+    }
+
+    #[test]
+    fn city_dto_round_trip() {
+        let city = CityDto {
+            id: 7,
+            x: 1.5,
+            y: 2.5,
+        };
+        let json = serde_json::to_string(&city).unwrap();
+        let back: CityDto = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, 7);
+    }
+
+    #[test]
+    fn parse_response_round_trip() {
+        let resp = ParseResponse {
+            name: "berlin52".to_string(),
+            comment: "52 locations in Berlin".to_string(),
+            distance_type: "EUC_2D".to_string(),
+            cities: vec![CityDto {
+                id: 1,
+                x: 565.0,
+                y: 575.0,
+            }],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: ParseResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.distance_type, "EUC_2D");
+        assert_eq!(back.cities.len(), 1);
+    }
+
+    #[test]
+    fn solve_response_round_trip() {
+        let resp = SolveResponse {
+            solver: "nn".to_string(),
+            total: 1234.5,
+            route: vec![1, 3, 2],
+            duration_ms: 42,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: SolveResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.solver, "nn");
+        assert_eq!(back.route, vec![1, 3, 2]);
+        assert_eq!(back.duration_ms, 42);
+    }
+
+    #[test]
+    fn compare_entry_ok_has_status_ok() {
+        let entry = CompareEntry::Ok {
+            solver: "nn".to_string(),
+            total: 100.0,
+            route: vec![1, 2, 3],
+            duration_ms: 5,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(r#""status":"ok""#));
+        assert!(!json.contains("error"));
+    }
+
+    #[test]
+    fn compare_entry_error_has_status_error() {
+        let entry = CompareEntry::Error {
+            solver: "bhk".to_string(),
+            error: "timeout".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(r#""status":"error""#));
+        assert!(json.contains("timeout"));
+    }
+
+    #[test]
+    fn compare_response_round_trip() {
+        let resp = CompareResponse {
+            entries: vec![
+                CompareEntry::Ok {
+                    solver: "nn".to_string(),
+                    total: 100.0,
+                    route: vec![1, 2, 3],
+                    duration_ms: 5,
+                },
+                CompareEntry::Error {
+                    solver: "bhk".to_string(),
+                    error: "too many cities".to_string(),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: CompareResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.entries.len(), 2);
+    }
+
+    #[test]
+    fn solve_response_schema_builds() {
+        use utoipa::ToSchema;
+        let name = SolveResponse::name();
+        assert_eq!(name, "SolveResponse");
+    }
+
+    #[test]
+    fn compare_entry_schema_builds() {
+        use utoipa::ToSchema;
+        let name = CompareEntry::name();
+        assert_eq!(name, "CompareEntry");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `teeline-api/src/models/` with `request.rs` and `response.rs`
- `SolverConfigs` replaces a flat DTO — 15 per-solver structs each embedding `Option<HeuristicConfig>`, enabling pipeline reuse in future PRs
- `TspInput::validate()` enforces exactly-one-of-cities-or-tsplib, rejects empty vecs and whitespace-only strings
- `CompareRequest::validate()` rejects empty `solvers`
- `CompareEntry` is a `#[serde(tag = "status", rename_all = "lowercase")]` enum for clean ok/error JSON
- `AlgorithmInfo` mirrors lib's `SolverInfo` exactly (field names `desc`, `alias: String`) — no renames
- All types derive `Serialize, Deserialize, ToSchema` (utoipa 5.5)

## Test plan

- [ ] `cargo test -p teeline-api` — 20 model tests + 1 integration test pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] JSON round-trip verified for all request and response types
- [ ] `TspInput::validate()` covers both/neither/empty-vec/whitespace cases
- [ ] `ToSchema` derivation smoke-tested via `ToSchema::name()` (utoipa 5.5 API)

Closes #277