### PR TITLE
feat(api): TspSolverService and SolverRegistryService production impls (#278)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ name = "teeline-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "serde",
  "serde_json",

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -21,6 +21,7 @@ tower_governor = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use teeline_api::{
     AppState,
-    services::{StubSolverRegistryService, StubTspSolverService},
+    services::{SolverRegistry, TspService},
 };
 
 #[tokio::main]
@@ -10,8 +10,8 @@ async fn main() -> anyhow::Result<()> {
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_owned());
     let addr = format!("127.0.0.1:{port}");
     let state = AppState {
-        solver_service: Arc::new(StubTspSolverService),
-        registry_service: Arc::new(StubSolverRegistryService),
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
     };
     let app = teeline_api::build_router(state);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -197,8 +197,8 @@ impl TspInput {
     pub fn validate(&self) -> Result<(), String> {
         match (&self.cities, &self.tsplib) {
             (Some(cities), None) => {
-                if cities.is_empty() {
-                    Err("`cities` must not be empty".to_string())
+                if cities.len() < 2 {
+                    Err("`cities` must contain at least 2 cities".to_string())
                 } else {
                     Ok(())
                 }
@@ -382,6 +382,19 @@ mod tests {
     }
 
     #[test]
+    fn tsp_input_validate_rejects_single_city() {
+        let input = TspInput {
+            cities: Some(vec![CityInput {
+                id: Some(1),
+                x: 0.0,
+                y: 0.0,
+            }]),
+            tsplib: None,
+        };
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
     fn tsp_input_validate_rejects_blank_tsplib() {
         let input = TspInput {
             cities: None,
@@ -393,11 +406,18 @@ mod tests {
     #[test]
     fn tsp_input_validate_accepts_cities_only() {
         let input = TspInput {
-            cities: Some(vec![CityInput {
-                id: Some(1),
-                x: 0.0,
-                y: 0.0,
-            }]),
+            cities: Some(vec![
+                CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                },
+                CityInput {
+                    id: Some(2),
+                    x: 1.0,
+                    y: 0.0,
+                },
+            ]),
             tsplib: None,
         };
         assert!(input.validate().is_ok());
@@ -416,11 +436,18 @@ mod tests {
     fn compare_request_validate_rejects_empty_solvers() {
         let req = CompareRequest {
             input: TspInput {
-                cities: Some(vec![CityInput {
-                    id: Some(1),
-                    x: 0.0,
-                    y: 0.0,
-                }]),
+                cities: Some(vec![
+                    CityInput {
+                        id: Some(1),
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(2),
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                ]),
                 tsplib: None,
             },
             solvers: vec![],
@@ -433,11 +460,18 @@ mod tests {
     fn solve_request_validate_rejects_blank_solver() {
         let req = SolveRequest {
             input: TspInput {
-                cities: Some(vec![CityInput {
-                    id: Some(1),
-                    x: 0.0,
-                    y: 0.0,
-                }]),
+                cities: Some(vec![
+                    CityInput {
+                        id: Some(1),
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(2),
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                ]),
                 tsplib: None,
             },
             solver: "   ".to_string(),
@@ -450,11 +484,18 @@ mod tests {
     fn solve_request_validate_accepts_valid() {
         let req = SolveRequest {
             input: TspInput {
-                cities: Some(vec![CityInput {
-                    id: Some(1),
-                    x: 0.0,
-                    y: 0.0,
-                }]),
+                cities: Some(vec![
+                    CityInput {
+                        id: Some(1),
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(2),
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                ]),
                 tsplib: None,
             },
             solver: "nn".to_string(),

--- a/teeline-api/src/services/mod.rs
+++ b/teeline-api/src/services/mod.rs
@@ -1,8 +1,22 @@
-pub trait TspSolverService: Send + Sync {}
-pub trait SolverRegistryService: Send + Sync {}
+use async_trait::async_trait;
 
-pub struct StubTspSolverService;
-impl TspSolverService for StubTspSolverService {}
+use crate::models::{
+    request::{CompareRequest, ParseRequest, SolveRequest},
+    response::{AlgorithmInfo, CompareResponse, ParseResponse, SolveResponse},
+};
 
-pub struct StubSolverRegistryService;
-impl SolverRegistryService for StubSolverRegistryService {}
+#[async_trait]
+pub trait TspSolverService: Send + Sync {
+    async fn parse(&self, req: &ParseRequest) -> Result<ParseResponse, String>;
+    async fn solve(&self, req: &SolveRequest) -> Result<SolveResponse, String>;
+    async fn compare(&self, req: &CompareRequest) -> Result<CompareResponse, String>;
+}
+
+pub trait SolverRegistryService: Send + Sync {
+    fn list(&self) -> Vec<AlgorithmInfo>;
+}
+
+pub mod solver_registry;
+pub mod tsp_service;
+pub use solver_registry::SolverRegistry;
+pub use tsp_service::TspService;

--- a/teeline-api/src/services/solver_registry.rs
+++ b/teeline-api/src/services/solver_registry.rs
@@ -1,0 +1,44 @@
+use teeline::tsp::list_solvers;
+
+use super::SolverRegistryService;
+use crate::models::response::AlgorithmInfo;
+
+pub struct SolverRegistry;
+
+impl SolverRegistryService for SolverRegistry {
+    fn list(&self) -> Vec<AlgorithmInfo> {
+        list_solvers()
+            .iter()
+            .map(|si| AlgorithmInfo {
+                name: si.name.to_string(),
+                alias: si.alias.to_string(),
+                category: si.category.to_string(),
+                desc: si.desc.to_string(),
+                complexity: si.complexity.to_string(),
+                has_options: si.has_options,
+                exact: si.exact,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_returns_non_empty() {
+        let registry = SolverRegistry;
+        let solvers = registry.list();
+        assert!(!solvers.is_empty());
+    }
+
+    #[test]
+    fn list_contains_nn() {
+        let registry = SolverRegistry;
+        let solvers = registry.list();
+        let nn = solvers.iter().find(|s| s.alias == "nn");
+        assert!(nn.is_some());
+        assert_eq!(nn.unwrap().name, "Nearest Neighbor");
+    }
+}

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -236,7 +236,7 @@ impl TspSolverService for TspService {
         let solution = tokio::task::spawn_blocking(move || solve_problem(solver, &problem, &opts))
             .await
             .map_err(|e| format!("task panic: {e}"))??;
-        let duration_ms = start.elapsed().as_millis() as u64;
+        let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(SolveResponse {
             solver: req.solver.clone(),
@@ -265,7 +265,7 @@ impl TspSolverService for TspService {
                 let solver = find_solver(&sname)?;
                 let start = Instant::now();
                 let solution = solve_problem(solver, &prob, &opts)?;
-                let duration_ms = start.elapsed().as_millis() as u64;
+                let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
                 Ok((
                     sname,
                     solution.total,

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -25,11 +25,17 @@ pub struct TspService;
 // ---------------------------------------------------------------------------
 
 fn map_heuristic(h: &HeuristicConfig) -> HeuristicOptions {
-    let d = HeuristicOptions::default();
+    map_heuristic_onto(h, HeuristicOptions::default())
+}
+
+// Maps partial HeuristicConfig onto a caller-supplied base so that solver-specific
+// defaults (e.g. LKOptions has n_nearest=5 vs the global default of 3) are preserved
+// when the caller omits a field.
+fn map_heuristic_onto(h: &HeuristicConfig, base: HeuristicOptions) -> HeuristicOptions {
     HeuristicOptions {
-        epochs: h.epochs.unwrap_or(d.epochs),
-        platoo_epochs: h.platoo_epochs.unwrap_or(d.platoo_epochs),
-        n_nearest: h.n_nearest.unwrap_or(d.n_nearest),
+        epochs: h.epochs.unwrap_or(base.epochs),
+        platoo_epochs: h.platoo_epochs.unwrap_or(base.platoo_epochs),
+        n_nearest: h.n_nearest.unwrap_or(base.n_nearest),
         verbose: false,
     }
 }
@@ -68,17 +74,17 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
     // nn, 2opt, 3opt, or_opt, tabu_search, stochastic_hill, pso, gsa.
     // SA/GA/CS/FPA/LK embed heuristic inside their own options structs.
     let heuristic: Option<HeuristicOptions> = match solver_name {
-        "nn" => cfg.nn.as_ref().and_then(|c| c.heuristic.as_ref()),
-        "2opt" => cfg.two_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
-        "3opt" => cfg.three_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
-        "or_opt" => cfg.or_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "nn" | "nearest_neighbor" => cfg.nn.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "2opt" | "two_opt" => cfg.two_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "3opt" | "three_opt" => cfg.three_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "or_opt" | "or-opt" => cfg.or_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
         "tabu_search" => cfg.tabu.as_ref().and_then(|c| c.heuristic.as_ref()),
         "stochastic_hill" => cfg
             .stochastic_hill
             .as_ref()
             .and_then(|c| c.heuristic.as_ref()),
-        "pso" => cfg.pso.as_ref().and_then(|c| c.heuristic.as_ref()),
-        "gsa" => cfg.gsa.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "pso" | "particle_swarm" => cfg.pso.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "gsa" | "gravitational_search" => cfg.gsa.as_ref().and_then(|c| c.heuristic.as_ref()),
         _ => None,
     }
     .map(map_heuristic);
@@ -140,7 +146,7 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             heuristic: c
                 .heuristic
                 .as_ref()
-                .map(map_heuristic)
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
                 .unwrap_or(d.heuristic),
             max_depth: c.max_depth.unwrap_or(d.max_depth),
         }
@@ -207,7 +213,11 @@ impl TspSolverService for TspService {
                 cities,
             })
         } else {
-            let input_cities = req.input.cities.as_ref().unwrap();
+            let input_cities = req
+                .input
+                .cities
+                .as_ref()
+                .ok_or_else(|| "input requires `cities` or `tsplib`".to_string())?;
             let cities = input_cities
                 .iter()
                 .enumerate()

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -1,0 +1,422 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use teeline::tsp::distance_matrix::DistanceMatrix;
+use teeline::tsp::kdtree::KDPoint;
+use teeline::tsp::tsplib;
+use teeline::tsp::{
+    AppOptions, CSOptions, DistanceType, FPAOptions, FourierOptions, GAOptions, HeuristicOptions,
+    LKOptions, SAOptions, SOMOptions, Solvers, TspProblem, find_solver, solve_problem,
+};
+
+use super::TspSolverService;
+use crate::models::{
+    request::{
+        CompareRequest, HeuristicConfig, ParseRequest, SolveRequest, SolverConfigs, TspInput,
+    },
+    response::{CityDto, CompareEntry, CompareResponse, ParseResponse, SolveResponse},
+};
+
+pub struct TspService;
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn map_heuristic(h: &HeuristicConfig) -> HeuristicOptions {
+    let d = HeuristicOptions::default();
+    HeuristicOptions {
+        epochs: h.epochs.unwrap_or(d.epochs),
+        platoo_epochs: h.platoo_epochs.unwrap_or(d.platoo_epochs),
+        n_nearest: h.n_nearest.unwrap_or(d.n_nearest),
+        verbose: false,
+    }
+}
+
+fn distance_type_str(dt: DistanceType) -> &'static str {
+    match dt {
+        DistanceType::Euc2D => "EUC_2D",
+        DistanceType::Geo => "GEO",
+    }
+}
+
+fn input_to_problem(input: &TspInput) -> Result<TspProblem, String> {
+    if let Some(tsplib_str) = &input.tsplib {
+        let data = tsplib::read_from_str(tsplib_str)?;
+        let dm = data.distance_matrix()?;
+        Ok(TspProblem::new(data.cities().to_vec(), dm))
+    } else if let Some(cities) = &input.cities {
+        let pts: Vec<KDPoint> = cities
+            .iter()
+            .enumerate()
+            .map(|(i, c)| KDPoint::new_with_id(c.id.unwrap_or(i + 1), &[c.x, c.y]))
+            .collect();
+        let dm = DistanceMatrix::from_cities(&pts).map_err(|e| e.to_string())?;
+        Ok(TspProblem::new(pts, dm))
+    } else {
+        Err("input must contain either `cities` or `tsplib`".to_string())
+    }
+}
+
+fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOptions {
+    let Some(cfg) = configs else {
+        return AppOptions::default();
+    };
+
+    // Top-level HeuristicOptions is used by solvers that don't embed their own:
+    // nn, 2opt, 3opt, or_opt, tabu_search, stochastic_hill, pso, gsa.
+    // SA/GA/CS/FPA/LK embed heuristic inside their own options structs.
+    let heuristic: Option<HeuristicOptions> = match solver_name {
+        "nn" => cfg.nn.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "2opt" => cfg.two_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "3opt" => cfg.three_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "or_opt" => cfg.or_opt.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "tabu_search" => cfg.tabu.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "stochastic_hill" => cfg
+            .stochastic_hill
+            .as_ref()
+            .and_then(|c| c.heuristic.as_ref()),
+        "pso" => cfg.pso.as_ref().and_then(|c| c.heuristic.as_ref()),
+        "gsa" => cfg.gsa.as_ref().and_then(|c| c.heuristic.as_ref()),
+        _ => None,
+    }
+    .map(map_heuristic);
+
+    let sa = cfg.sa.as_ref().map(|c| {
+        let d = SAOptions::default();
+        SAOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(map_heuristic)
+                .unwrap_or(d.heuristic),
+            cooling_rate: c.cooling_rate.unwrap_or(d.cooling_rate),
+            min_temperature: c.min_temperature.unwrap_or(d.min_temperature),
+            max_temperature: c.max_temperature.unwrap_or(d.max_temperature),
+        }
+    });
+
+    let ga = cfg.ga.as_ref().map(|c| {
+        let d = GAOptions::default();
+        GAOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(map_heuristic)
+                .unwrap_or(d.heuristic),
+            mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
+            n_elite: c.n_elite.unwrap_or(d.n_elite),
+        }
+    });
+
+    let cs = cfg.cs.as_ref().map(|c| {
+        let d = CSOptions::default();
+        CSOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(map_heuristic)
+                .unwrap_or(d.heuristic),
+            mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
+        }
+    });
+
+    let fpa = cfg.fpa.as_ref().map(|c| {
+        let d = FPAOptions::default();
+        FPAOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(map_heuristic)
+                .unwrap_or(d.heuristic),
+            mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
+        }
+    });
+
+    let lk = cfg.lk.as_ref().map(|c| {
+        let d = LKOptions::default();
+        LKOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(map_heuristic)
+                .unwrap_or(d.heuristic),
+            max_depth: c.max_depth.unwrap_or(d.max_depth),
+        }
+    });
+
+    let fourier = cfg.fourier.as_ref().map(|c| {
+        let d = FourierOptions::default();
+        FourierOptions {
+            k_max: c.k_max.unwrap_or(d.k_max),
+            m: c.m.unwrap_or(d.m),
+            lambda: c.lambda.unwrap_or(d.lambda),
+            lambda_decay: c.lambda_decay.unwrap_or(d.lambda_decay),
+            lr: c.lr.unwrap_or(d.lr),
+            epochs: c.epochs.unwrap_or(d.epochs),
+        }
+    });
+
+    let som = cfg.som.as_ref().map(|c| {
+        let d = SOMOptions::default();
+        SOMOptions {
+            epochs: c.epochs.unwrap_or(d.epochs),
+            learning_rate: c.learning_rate.unwrap_or(d.learning_rate),
+            radius_fraction: c.radius_fraction.unwrap_or(d.radius_fraction),
+            neuron_multiplier: c.neuron_multiplier.unwrap_or(d.neuron_multiplier),
+        }
+    });
+
+    AppOptions {
+        sa,
+        ga,
+        cs,
+        fpa,
+        lk,
+        fourier,
+        som,
+        heuristic,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TspSolverService impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl TspSolverService for TspService {
+    async fn parse(&self, req: &ParseRequest) -> Result<ParseResponse, String> {
+        req.input.validate()?;
+
+        if let Some(tsplib_str) = &req.input.tsplib {
+            let data = tsplib::read_from_str(tsplib_str)?;
+            let cities = data
+                .cities()
+                .iter()
+                .map(|c| CityDto {
+                    id: c.id,
+                    x: c.coords[0],
+                    y: c.coords[1],
+                })
+                .collect();
+            Ok(ParseResponse {
+                name: data.name.clone(),
+                comment: data.comment.clone(),
+                distance_type: distance_type_str(data.distance_type).to_string(),
+                cities,
+            })
+        } else {
+            let input_cities = req.input.cities.as_ref().unwrap();
+            let cities = input_cities
+                .iter()
+                .enumerate()
+                .map(|(i, c)| CityDto {
+                    id: c.id.unwrap_or(i + 1),
+                    x: c.x,
+                    y: c.y,
+                })
+                .collect();
+            Ok(ParseResponse {
+                name: String::new(),
+                comment: String::new(),
+                distance_type: "EUC_2D".to_string(),
+                cities,
+            })
+        }
+    }
+
+    async fn solve(&self, req: &SolveRequest) -> Result<SolveResponse, String> {
+        req.validate()?;
+        let solver: Solvers = find_solver(&req.solver)?;
+        let problem = input_to_problem(&req.input)?;
+        let opts = make_app_options(&req.solver, req.configs.as_ref());
+
+        let start = Instant::now();
+        let solution = tokio::task::spawn_blocking(move || solve_problem(solver, &problem, &opts))
+            .await
+            .map_err(|e| format!("task panic: {e}"))??;
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        Ok(SolveResponse {
+            solver: req.solver.clone(),
+            total: solution.total,
+            route: solution.route().to_vec(),
+            duration_ms,
+        })
+    }
+
+    async fn compare(&self, req: &CompareRequest) -> Result<CompareResponse, String> {
+        req.validate()?;
+        let problem = Arc::new(input_to_problem(&req.input)?);
+
+        let mut handles: Vec<(
+            String,
+            tokio::task::JoinHandle<Result<(String, f32, Vec<usize>, u64), String>>,
+        )> = Vec::new();
+
+        for solver_name in &req.solvers {
+            let sname = solver_name.clone();
+            let fallback = solver_name.clone();
+            let prob = Arc::clone(&problem);
+            let opts = make_app_options(solver_name, req.configs.as_ref());
+
+            let handle = tokio::task::spawn_blocking(move || {
+                let solver = find_solver(&sname)?;
+                let start = Instant::now();
+                let solution = solve_problem(solver, &prob, &opts)?;
+                let duration_ms = start.elapsed().as_millis() as u64;
+                Ok((
+                    sname,
+                    solution.total,
+                    solution.route().to_vec(),
+                    duration_ms,
+                ))
+            });
+            handles.push((fallback, handle));
+        }
+
+        let mut entries: Vec<CompareEntry> = Vec::new();
+        for (fallback, handle) in handles {
+            match handle.await {
+                Ok(Ok((solver, total, route, duration_ms))) => {
+                    entries.push(CompareEntry::Ok {
+                        solver,
+                        total,
+                        route,
+                        duration_ms,
+                    });
+                }
+                Ok(Err(e)) => {
+                    entries.push(CompareEntry::Error {
+                        solver: fallback,
+                        error: e,
+                    });
+                }
+                Err(join_err) => {
+                    entries.push(CompareEntry::Error {
+                        solver: fallback,
+                        error: format!("task panic: {join_err}"),
+                    });
+                }
+            }
+        }
+
+        // Ok entries sorted by cost ascending; Error entries appended last.
+        entries.sort_by(|a, b| match (a, b) {
+            (CompareEntry::Ok { total: ta, .. }, CompareEntry::Ok { total: tb, .. }) => {
+                ta.partial_cmp(tb).unwrap_or(std::cmp::Ordering::Equal)
+            }
+            (CompareEntry::Ok { .. }, CompareEntry::Error { .. }) => std::cmp::Ordering::Less,
+            (CompareEntry::Error { .. }, CompareEntry::Ok { .. }) => std::cmp::Ordering::Greater,
+            (CompareEntry::Error { .. }, CompareEntry::Error { .. }) => std::cmp::Ordering::Equal,
+        });
+
+        Ok(CompareResponse { entries })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::request::{CityInput, TspInput};
+
+    const TINY_TSPLIB: &str = "\
+NAME: test
+TYPE: TSP
+COMMENT: three cities
+DIMENSION: 3
+EDGE_WEIGHT_TYPE: EUC_2D
+NODE_COORD_SECTION
+1 0.0 0.0
+2 1.0 0.0
+3 0.5 1.0
+EOF
+";
+
+    #[tokio::test]
+    async fn test_parse_tsplib_input() {
+        let service = TspService;
+        let req = ParseRequest {
+            input: TspInput {
+                tsplib: Some(TINY_TSPLIB.to_string()),
+                cities: None,
+            },
+        };
+        let resp = service.parse(&req).await.unwrap();
+        assert_eq!(resp.name, "test");
+        assert_eq!(resp.comment, "three cities");
+        assert_eq!(resp.distance_type, "EUC_2D");
+        assert_eq!(resp.cities.len(), 3);
+        assert_eq!(resp.cities[0].id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_parse_json_cities_input() {
+        let service = TspService;
+        let req = ParseRequest {
+            input: TspInput {
+                cities: Some(vec![
+                    CityInput {
+                        id: Some(1),
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(2),
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: Some(3),
+                        x: 0.5,
+                        y: 1.0,
+                    },
+                ]),
+                tsplib: None,
+            },
+        };
+        let resp = service.parse(&req).await.unwrap();
+        assert_eq!(resp.name, "");
+        assert_eq!(resp.comment, "");
+        assert_eq!(resp.distance_type, "EUC_2D");
+        assert_eq!(resp.cities.len(), 3);
+        assert_eq!(resp.cities[0].id, 1);
+        assert_eq!(resp.cities[1].id, 2);
+    }
+
+    #[tokio::test]
+    async fn test_parse_json_cities_assigns_ids_when_missing() {
+        let service = TspService;
+        let req = ParseRequest {
+            input: TspInput {
+                cities: Some(vec![
+                    CityInput {
+                        id: None,
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: None,
+                        x: 1.0,
+                        y: 0.0,
+                    },
+                    CityInput {
+                        id: None,
+                        x: 0.5,
+                        y: 1.0,
+                    },
+                ]),
+                tsplib: None,
+            },
+        };
+        let resp = service.parse(&req).await.unwrap();
+        assert_eq!(resp.cities[0].id, 1);
+        assert_eq!(resp.cities[1].id, 2);
+        assert_eq!(resp.cities[2].id, 3);
+    }
+}

--- a/teeline-api/tests/health.rs
+++ b/teeline-api/tests/health.rs
@@ -3,15 +3,15 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
-    services::{StubSolverRegistryService, StubTspSolverService},
+    services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
 
 #[tokio::test]
 async fn health_returns_ok() {
     let state = AppState {
-        solver_service: Arc::new(StubTspSolverService),
-        registry_service: Arc::new(StubSolverRegistryService),
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
     };
     let app = teeline_api::build_router(state);
 


### PR DESCRIPTION
## Summary

- Adds `async-trait = "0.1"` to `teeline-api/Cargo.toml`
- Replaces empty stubs in `services/mod.rs` with full `#[async_trait]` trait definitions for `TspSolverService` (parse/solve/compare) and sync `SolverRegistryService` (list)
- Adds `services/solver_registry.rs`: unit struct `SolverRegistry` wrapping `teeline::tsp::list_solvers()` → `Vec<AlgorithmInfo>`
- Adds `services/tsp_service.rs`: `TspService` with private helpers (`input_to_problem`, `make_app_options`, `map_heuristic`) and full `#[async_trait]` impl — `parse()` handles both TSPLIB and JSON-cities inputs; `solve()` uses `spawn_blocking`; `compare()` spawns one blocking task per solver in parallel and sorts Ok entries by cost (errors last)
- Updates `main.rs` and `tests/health.rs` to use real services instead of stubs

Closes #278

## Test plan

- [x] `cargo test -p teeline-api` — 27 unit tests + 1 integration test pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo build -p teeline-api` — builds without warnings