### PR TITLE
feat(api): utoipa OpenAPI 3.1 spec + Scalar docs UI (#283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "utoipa",
+ "utoipa-scalar",
 ]
 
 [[package]]
@@ -2173,6 +2174,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
 ]
 
 [[package]]

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -25,7 +25,6 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }
-utoipa-axum = "0.2.0"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -24,6 +24,8 @@ anyhow = "1"
 async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+utoipa-scalar = { version = "0.3.0", features = ["axum"] }
+utoipa-axum = "0.2.0"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod models;
+pub mod openapi;
 pub mod routes;
 pub mod services;
 
@@ -28,5 +29,6 @@ pub fn build_router(state: AppState) -> axum::Router {
             "/api/v1/compare",
             axum::routing::post(routes::compare::compare),
         )
+        .merge(openapi::openapi_router())
         .with_state(state)
 }

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -1,0 +1,68 @@
+use axum::Router;
+use utoipa::OpenApi;
+use utoipa_scalar::{Scalar, Servable};
+
+use crate::{
+    AppState,
+    models::{request, response},
+    routes,
+};
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        routes::health::handler,
+        routes::solvers::list_solvers,
+        routes::parse::parse,
+        routes::solve::solve,
+        routes::compare::compare,
+    ),
+    components(schemas(
+        routes::health::HealthResponse,
+        request::HeuristicConfig,
+        request::NnConfig,
+        request::TwoOptConfig,
+        request::ThreeOptConfig,
+        request::OrOptConfig,
+        request::TabuConfig,
+        request::StochasticHillConfig,
+        request::PsoConfig,
+        request::GsaConfig,
+        request::LkConfig,
+        request::SaConfig,
+        request::GaConfig,
+        request::CsConfig,
+        request::FpaConfig,
+        request::SomConfig,
+        request::FourierConfig,
+        request::SolverConfigs,
+        request::CityInput,
+        request::TspInput,
+        request::ParseRequest,
+        request::SolveRequest,
+        request::CompareRequest,
+        response::AlgorithmInfo,
+        response::CityDto,
+        response::ParseResponse,
+        response::SolveResponse,
+        response::CompareEntry,
+        response::CompareResponse,
+    )),
+    tags(
+        (name = "tsp", description = "Traveling Salesman Problem solver endpoints")
+    )
+)]
+pub struct ApiDoc;
+
+pub fn openapi_router() -> Router<AppState> {
+    let openapi = ApiDoc::openapi();
+    Router::new()
+        .route(
+            "/openapi.json",
+            axum::routing::get({
+                let openapi = openapi.clone();
+                move || async move { axum::Json(openapi.clone()) }
+            }),
+        )
+        .merge(Router::from(Scalar::with_url("/docs", openapi)))
+}

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -61,8 +61,8 @@ pub fn openapi_router() -> Router<AppState> {
             "/openapi.json",
             axum::routing::get({
                 let openapi = openapi.clone();
-                move || async move { axum::Json(openapi.clone()) }
+                move || async move { axum::Json(openapi) }
             }),
         )
-        .merge(Router::from(Scalar::with_url("/docs", openapi)))
+        .merge(Scalar::with_url("/docs", openapi))
 }

--- a/teeline-api/tests/hurl/openapi.hurl
+++ b/teeline-api/tests/hurl/openapi.hurl
@@ -1,0 +1,15 @@
+# GET /openapi.json — serves OpenAPI 3.1.0 spec as JSON
+GET http://127.0.0.1:8080/openapi.json
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.openapi" == "3.1.0"
+jsonpath "$.paths" isCollection
+jsonpath "$.components.schemas" isCollection
+
+# GET /docs — serves Scalar interactive docs UI
+GET http://127.0.0.1:8080/docs
+HTTP 200
+[Asserts]
+header "Content-Type" contains "text/html"
+body contains "<!doctype html>"

--- a/teeline-api/tests/openapi.rs
+++ b/teeline-api/tests/openapi.rs
@@ -1,0 +1,125 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use teeline_api::{
+    AppState,
+    services::{SolverRegistry, TspService},
+};
+use tower::ServiceExt;
+
+fn make_app() -> axum::Router {
+    let state = AppState {
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
+    };
+    teeline_api::build_router(state)
+}
+
+#[tokio::test]
+async fn openapi_json_returns_ok() {
+    let resp = make_app()
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn openapi_json_is_valid_json() {
+    let resp = make_app()
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["openapi"], "3.1.0");
+}
+
+#[tokio::test]
+async fn openapi_json_contains_all_five_paths() {
+    let resp = make_app()
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let paths = json["paths"].as_object().unwrap();
+    assert!(
+        paths.contains_key("/api/v1/health"),
+        "missing /api/v1/health"
+    );
+    assert!(
+        paths.contains_key("/api/v1/solvers"),
+        "missing /api/v1/solvers"
+    );
+    assert!(paths.contains_key("/api/v1/parse"), "missing /api/v1/parse");
+    assert!(paths.contains_key("/api/v1/solve"), "missing /api/v1/solve");
+    assert!(
+        paths.contains_key("/api/v1/compare"),
+        "missing /api/v1/compare"
+    );
+}
+
+#[tokio::test]
+async fn openapi_json_has_schemas_in_components() {
+    let resp = make_app()
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let schemas = json["components"]["schemas"].as_object().unwrap();
+    assert!(!schemas.is_empty(), "components/schemas must not be empty");
+    assert!(
+        schemas.contains_key("SolveRequest"),
+        "missing SolveRequest schema"
+    );
+    assert!(
+        schemas.contains_key("CompareRequest"),
+        "missing CompareRequest schema"
+    );
+    assert!(
+        schemas.contains_key("ParseResponse"),
+        "missing ParseResponse schema"
+    );
+}
+
+#[tokio::test]
+async fn scalar_docs_returns_html() {
+    let resp = make_app()
+        .oneshot(Request::builder().uri("/docs").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+    assert!(body.contains("<!doctype html>") || body.contains("<!DOCTYPE html>"));
+}


### PR DESCRIPTION
## Summary

- Adds `teeline-api/src/openapi.rs` with `ApiDoc` (`#[derive(OpenApi)]`) referencing all 5 route handlers and all 28 DTO schemas in `components/schemas`
- Mounts `GET /openapi.json` (returns the spec as JSON) and `GET /docs` (Scalar HTML UI) via `openapi_router()` merged into `build_router()`
- Adds `utoipa-scalar 0.3` (with `axum` feature) and `utoipa-axum 0.2` to Cargo.toml

## Test plan

- [ ] `openapi_json_returns_ok` — `/openapi.json` returns 200
- [ ] `openapi_json_is_valid_json` — response is valid OpenAPI 3.1 JSON (`"openapi": "3.1.0"`)
- [ ] `openapi_json_contains_all_five_paths` — all 5 paths present in `paths`
- [ ] `openapi_json_has_schemas_in_components` — `components/schemas` is non-empty and contains `SolveRequest`, `CompareRequest`, `ParseResponse`
- [ ] `scalar_docs_returns_html` — `/docs` returns 200 HTML with doctype

Closes #283. Depends on #280 (parse/solve/compare routes) being merged first.