### PR TITLE
feat(api): GET / index endpoint with route list

### DIFF
--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -14,6 +14,7 @@ pub struct AppState {
 
 pub fn build_router(state: AppState) -> axum::Router {
     axum::Router::new()
+        .route("/", axum::routing::get(routes::index::handler))
         .route(
             "/api/v1/health",
             axum::routing::get(routes::health::handler),

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -11,12 +11,14 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        routes::index::handler,
         routes::health::handler,
         routes::solvers::list_solvers,
         routes::parse::parse,
         routes::solve::solve,
     ),
     components(schemas(
+        routes::index::IndexResponse,
         routes::health::HealthResponse,
         request::HeuristicConfig,
         request::NnConfig,

--- a/teeline-api/src/routes/index.rs
+++ b/teeline-api/src/routes/index.rs
@@ -1,0 +1,35 @@
+use axum::Json;
+use utoipa::ToSchema;
+
+const ROUTES: &[&str] = &[
+    "GET /",
+    "GET /api/v1/health",
+    "GET /healthz",
+    "GET /api/v1/solvers",
+    "POST /api/v1/parse",
+    "POST /api/v1/solve",
+    "GET /openapi.json",
+    "GET /docs",
+];
+
+#[derive(serde::Serialize, ToSchema)]
+pub struct IndexResponse {
+    pub status: &'static str,
+    pub name: &'static str,
+    pub routes: Vec<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/",
+    responses(
+        (status = 200, description = "API index with available routes", body = IndexResponse)
+    )
+)]
+pub async fn handler() -> Json<IndexResponse> {
+    Json(IndexResponse {
+        status: "ok",
+        name: env!("CARGO_PKG_NAME"),
+        routes: ROUTES.iter().map(|r| r.to_string()).collect(),
+    })
+}

--- a/teeline-api/src/routes/mod.rs
+++ b/teeline-api/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod health;
+pub mod index;
 pub mod parse;
 pub mod solve;
 pub mod solvers;

--- a/teeline-api/tests/hurl/index.hurl
+++ b/teeline-api/tests/hurl/index.hurl
@@ -1,0 +1,9 @@
+# GET / — index endpoint
+GET http://127.0.0.1:8080/
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.status" == "ok"
+jsonpath "$.name" == "teeline-api"
+jsonpath "$.routes" isCollection
+jsonpath "$.routes" count > 0

--- a/teeline-api/tests/index.rs
+++ b/teeline-api/tests/index.rs
@@ -1,0 +1,41 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use teeline_api::{
+    AppState,
+    services::{SolverRegistry, TspService},
+};
+use tower::ServiceExt;
+
+fn make_app() -> axum::Router {
+    let state = AppState {
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
+    };
+    teeline_api::build_router(state)
+}
+
+#[tokio::test]
+async fn index_returns_ok() {
+    let resp = make_app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn index_returns_expected_fields() {
+    let resp = make_app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["name"], "teeline-api");
+    assert!(json["routes"].is_array());
+    assert!(!json["routes"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

- Adds `GET /` returning `{ status: "ok", name: "teeline-api", routes: [...] }` with all available routes listed
- New file `src/routes/index.rs` following the same pattern as `health.rs`
- Wired into `build_router()` and registered in the OpenAPI spec (paths + schemas)
- 2 integration tests: status 200, and presence of all three fields

## Test plan

- [x] `cargo build -p teeline-api` — clean
- [x] `cargo test -p teeline-api` — all tests pass including new `index_returns_ok` and `index_returns_expected_fields`