### PR TITLE
feat(api): Prometheus/OpenMetrics metrics endpoint (GET /metrics)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,14 +65,7 @@ tasks:
       - defer: kill $(cat /tmp/teeline-api.pid) 2>/dev/null || true
       - RATE_LIMIT_RPM=0 ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
       - task: api:wait
-      - hurl --test
-          teeline-api/tests/hurl/health.hurl
-          teeline-api/tests/hurl/index.hurl
-          teeline-api/tests/hurl/openapi.hurl
-          teeline-api/tests/hurl/solvers.hurl
-          teeline-api/tests/hurl/parse.hurl
-          teeline-api/tests/hurl/solve.hurl
-          teeline-api/tests/hurl/metrics.hurl
+      - hurl --test teeline-api/tests/hurl/*.hurl
 
   test:all:
     desc: Run unit tests and e2e tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,7 +65,14 @@ tasks:
       - defer: kill $(cat /tmp/teeline-api.pid) 2>/dev/null || true
       - RATE_LIMIT_RPM=0 ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
       - task: api:wait
-      - hurl --test teeline-api/tests/hurl/*.hurl
+      - hurl --test
+          teeline-api/tests/hurl/health.hurl
+          teeline-api/tests/hurl/index.hurl
+          teeline-api/tests/hurl/openapi.hurl
+          teeline-api/tests/hurl/solvers.hurl
+          teeline-api/tests/hurl/parse.hurl
+          teeline-api/tests/hurl/solve.hurl
+          teeline-api/tests/hurl/metrics.hurl
 
   test:all:
     desc: Run unit tests and e2e tests

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -16,6 +16,7 @@ teeline = { path = ".." }
 axum = "0.8.9"
 tokio = { version = "1", features = ["full"] }
 utoipa = "5.5.0"
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.7.0", features = ["trace"] }
 tower_governor = "0.8.0"
 serde = { version = "1", features = ["derive"] }
@@ -25,6 +26,7 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }
+prometheus-client = "0.22"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod error;
+pub mod metrics;
+pub mod middleware;
 pub mod models;
 pub mod openapi;
 pub mod routes;
@@ -6,26 +8,37 @@ pub mod services;
 
 use std::sync::Arc;
 
+use axum::routing::{get, post};
+
+use crate::metrics::MetricsState;
+
 #[derive(Clone)]
 pub struct AppState {
     pub solver_service: Arc<dyn services::TspSolverService>,
     pub registry_service: Arc<dyn services::SolverRegistryService>,
+    pub metrics: Arc<MetricsState>,
 }
 
+/// The /api/v1/* routes without state, so callers (e.g. main.rs) can apply
+/// a rate-limiting layer before providing state and merging into the full app.
+pub fn build_api_router() -> axum::Router<AppState> {
+    axum::Router::new()
+        .route("/api/v1/health", get(routes::health::handler))
+        .route("/api/v1/solvers", get(routes::solvers::list_solvers))
+        .route("/api/v1/parse", post(routes::parse::parse))
+        .route("/api/v1/solve", post(routes::solve::solve))
+}
+
+/// Full router used by integration tests. GovernorLayer is not applied here;
+/// main.rs applies it to the api sub-router only before calling this, or the
+/// test harness omits it entirely.
 pub fn build_router(state: AppState) -> axum::Router {
     axum::Router::new()
-        .route("/", axum::routing::get(routes::index::handler))
-        .route(
-            "/api/v1/health",
-            axum::routing::get(routes::health::handler),
-        )
-        .route("/healthz", axum::routing::get(routes::health::handler))
-        .route(
-            "/api/v1/solvers",
-            axum::routing::get(routes::solvers::list_solvers),
-        )
-        .route("/api/v1/parse", axum::routing::post(routes::parse::parse))
-        .route("/api/v1/solve", axum::routing::post(routes::solve::solve))
+        .route("/", get(routes::index::handler))
+        .route("/healthz", get(routes::health::handler))
+        .route("/metrics", get(routes::metrics::handler))
         .merge(openapi::openapi_router())
+        .merge(build_api_router())
+        .layer(middleware::MetricsLayer::new(Arc::clone(&state.metrics)))
         .with_state(state)
 }

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -19,8 +19,8 @@ pub struct AppState {
     pub metrics: Arc<MetricsState>,
 }
 
-/// The /api/v1/* routes without state, so callers (e.g. main.rs) can apply
-/// a rate-limiting layer before providing state and merging into the full app.
+/// The /api/v1/* routes without state, so a rate-limiting layer can be applied
+/// before providing state and merging into the full app.
 pub fn build_api_router() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/api/v1/health", get(routes::health::handler))
@@ -29,9 +29,8 @@ pub fn build_api_router() -> axum::Router<AppState> {
         .route("/api/v1/solve", post(routes::solve::solve))
 }
 
-/// Full router used by integration tests. GovernorLayer is not applied here;
-/// main.rs applies it to the api sub-router only before calling this, or the
-/// test harness omits it entirely.
+/// Full router with MetricsLayer applied. GovernorLayer is intentionally absent
+/// here; apply it to the api sub-router before merging when needed.
 pub fn build_router(state: AppState) -> axum::Router {
     axum::Router::new()
         .route("/", get(routes::index::handler))

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -1,8 +1,12 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::Router;
+use axum::routing::get;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
+    middleware::MetricsLayer,
     services::{SolverRegistry, TspService},
 };
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
@@ -23,16 +27,19 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_owned());
-    let addr = format!("127.0.0.1:{port}");
+    let addr = format!("0.0.0.0:{port}");
     let rpm = rate_limit_rpm();
 
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
-    let mut app = teeline_api::build_router(state);
 
-    // rpm=0 disables rate limiting (checked_div returns None for divisor 0).
+    // Build the /api/v1/* sub-router (still Router<AppState>, no with_state yet)
+    // and apply rate limiting only to those routes. /metrics, /, /healthz, and
+    // /docs are excluded — Fly.io's scraper must not hit a rate limit on /metrics.
+    let mut api: Router<AppState> = teeline_api::build_api_router();
     if let Some(period_ms) = 60_000u64.checked_div(rpm) {
         let governor_conf = GovernorConfigBuilder::default()
             .per_millisecond(period_ms)
@@ -47,8 +54,20 @@ async fn main() -> anyhow::Result<()> {
                 limiter.retain_recent();
             }
         });
-        app = app.layer(GovernorLayer::new(governor_conf));
+        api = api.layer(GovernorLayer::new(governor_conf));
     }
+
+    // Assemble the full app. MetricsLayer wraps all routes so every request
+    // (including rate-limited and infrastructure routes) is counted.
+    // with_state() converts Router<AppState> → Router<()> ready to serve.
+    let app = Router::new()
+        .route("/", get(teeline_api::routes::index::handler))
+        .route("/healthz", get(teeline_api::routes::health::handler))
+        .route("/metrics", get(teeline_api::routes::metrics::handler))
+        .merge(teeline_api::openapi::openapi_router())
+        .merge(api)
+        .layer(MetricsLayer::new(Arc::clone(&state.metrics)))
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("listening on {addr}");

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -36,11 +36,10 @@ async fn main() -> anyhow::Result<()> {
         metrics: Arc::new(MetricsState::new()),
     };
 
-    // Build the /api/v1/* sub-router (still Router<AppState>, no with_state yet)
-    // and apply rate limiting only to those routes. /metrics, /, /healthz, and
-    // /docs are excluded — Fly.io's scraper must not hit a rate limit on /metrics.
+    // Rate limiting scoped to /api/v1/* only — Fly.io's scraper must not be throttled on /metrics.
     let mut api: Router<AppState> = teeline_api::build_api_router();
     if let Some(period_ms) = 60_000u64.checked_div(rpm) {
+        tracing::info!("rate limiting enabled: {rpm} RPM");
         let governor_conf = GovernorConfigBuilder::default()
             .per_millisecond(period_ms)
             .burst_size(10)
@@ -55,11 +54,10 @@ async fn main() -> anyhow::Result<()> {
             }
         });
         api = api.layer(GovernorLayer::new(governor_conf));
+    } else {
+        tracing::info!("rate limiting disabled (RATE_LIMIT_RPM=0)");
     }
 
-    // Assemble the full app. MetricsLayer wraps all routes so every request
-    // (including rate-limited and infrastructure routes) is counted.
-    // with_state() converts Router<AppState> → Router<()> ready to serve.
     let app = Router::new()
         .route("/", get(teeline_api::routes::index::handler))
         .route("/healthz", get(teeline_api::routes::health::handler))

--- a/teeline-api/src/metrics.rs
+++ b/teeline-api/src/metrics.rs
@@ -1,0 +1,151 @@
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct HttpLabels {
+    pub method: String,
+    pub path: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct HttpDurationLabels {
+    pub method: String,
+    pub path: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct SolverLabels {
+    pub solver: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct SolverDurationLabels {
+    pub solver: String,
+}
+
+pub struct MetricsState {
+    pub http_requests_total: Family<HttpLabels, Counter>,
+    pub http_request_duration_seconds: Family<HttpDurationLabels, Histogram>,
+    pub solver_requests_total: Family<SolverLabels, Counter>,
+    pub solver_duration_seconds: Family<SolverDurationLabels, Histogram>,
+    pub registry: Registry,
+}
+
+impl Default for MetricsState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsState {
+    pub fn new() -> Self {
+        let http_requests_total = Family::<HttpLabels, Counter>::default();
+        let http_request_duration_seconds =
+            Family::<HttpDurationLabels, Histogram>::new_with_constructor(|| {
+                Histogram::new(
+                    [
+                        0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512,
+                        1.024, 2.048,
+                    ]
+                    .into_iter(),
+                )
+            });
+        let solver_requests_total = Family::<SolverLabels, Counter>::default();
+        let solver_duration_seconds =
+            Family::<SolverDurationLabels, Histogram>::new_with_constructor(|| {
+                Histogram::new([0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0].into_iter())
+            });
+
+        let mut registry = Registry::default();
+        registry.register(
+            "http_requests",
+            "Total HTTP requests",
+            http_requests_total.clone(),
+        );
+        registry.register(
+            "http_request_duration_seconds",
+            "HTTP request duration in seconds",
+            http_request_duration_seconds.clone(),
+        );
+        registry.register(
+            "teeline_solver_requests",
+            "Total solver requests",
+            solver_requests_total.clone(),
+        );
+        registry.register(
+            "teeline_solver_duration_seconds",
+            "Solver duration in seconds",
+            solver_duration_seconds.clone(),
+        );
+
+        Self {
+            http_requests_total,
+            http_request_duration_seconds,
+            solver_requests_total,
+            solver_duration_seconds,
+            registry,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus_client::encoding::text::encode;
+
+    #[test]
+    fn new_registry_encodes_all_metric_names() {
+        let m = MetricsState::new();
+
+        // Increment each family once so histogram suffixes appear in output
+        m.http_requests_total
+            .get_or_create(&HttpLabels {
+                method: "GET".into(),
+                path: "/test".into(),
+                status: "200".into(),
+            })
+            .inc();
+        m.http_request_duration_seconds
+            .get_or_create(&HttpDurationLabels {
+                method: "GET".into(),
+                path: "/test".into(),
+            })
+            .observe(0.001);
+        m.solver_requests_total
+            .get_or_create(&SolverLabels {
+                solver: "nn".into(),
+                status: "success".into(),
+            })
+            .inc();
+        m.solver_duration_seconds
+            .get_or_create(&SolverDurationLabels {
+                solver: "nn".into(),
+            })
+            .observe(0.5);
+
+        let mut out = String::new();
+        encode(&mut out, &m.registry).expect("encode must not fail");
+
+        assert!(
+            out.contains("http_requests_total"),
+            "missing http_requests_total"
+        );
+        assert!(
+            out.contains("http_request_duration_seconds_bucket"),
+            "missing http_request_duration_seconds_bucket"
+        );
+        assert!(
+            out.contains("teeline_solver_requests_total"),
+            "missing teeline_solver_requests_total"
+        );
+        assert!(
+            out.contains("teeline_solver_duration_seconds_bucket"),
+            "missing teeline_solver_duration_seconds_bucket"
+        );
+    }
+}

--- a/teeline-api/src/middleware.rs
+++ b/teeline-api/src/middleware.rs
@@ -68,8 +68,6 @@ where
             .unwrap_or_else(|| req.uri().path().to_owned());
         let method = req.method().as_str().to_owned();
 
-        // Standard Tower pattern: swap inner with a clone so we can move it into
-        // the async block while satisfying the borrow checker.
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 

--- a/teeline-api/src/middleware.rs
+++ b/teeline-api/src/middleware.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::extract::MatchedPath;
+use axum::http::{Request, Response};
+use tower::{Layer, Service};
+
+use crate::metrics::{HttpDurationLabels, HttpLabels, MetricsState};
+
+#[derive(Clone)]
+pub struct MetricsLayer {
+    metrics: Arc<MetricsState>,
+}
+
+impl MetricsLayer {
+    pub fn new(metrics: Arc<MetricsState>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> MetricsService<S> {
+        MetricsService {
+            inner,
+            metrics: Arc::clone(&self.metrics),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+    metrics: Arc<MetricsState>,
+}
+
+impl<S, B, RB> Service<Request<B>> for MetricsService<S>
+where
+    S: Service<Request<B>, Response = Response<RB>> + Clone + Send + 'static,
+    S::Error: Send,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let metrics = Arc::clone(&self.metrics);
+        let start = Instant::now();
+
+        // MatchedPath is populated by axum's routing layer before this middleware runs
+        // (Router::layer() applies middleware after routing, before the handler).
+        // Falls back to raw URI path for unmatched routes — all our routes are fixed
+        // paths with no path parameters so raw path is safe (no cardinality explosion).
+        let path = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|m| m.as_str().to_owned())
+            .unwrap_or_else(|| req.uri().path().to_owned());
+        let method = req.method().as_str().to_owned();
+
+        // Standard Tower pattern: swap inner with a clone so we can move it into
+        // the async block while satisfying the borrow checker.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let resp = inner.call(req).await?;
+            let elapsed = start.elapsed().as_secs_f64();
+            let status = resp.status().as_u16().to_string();
+
+            // One-liner guards: get_or_create() returns MappedRwLockReadGuard.
+            // Never bind to a `let` before an await — the guard must be dropped immediately.
+            metrics
+                .http_requests_total
+                .get_or_create(&HttpLabels {
+                    method: method.clone(),
+                    path: path.clone(),
+                    status,
+                })
+                .inc();
+            metrics
+                .http_request_duration_seconds
+                .get_or_create(&HttpDurationLabels { method, path })
+                .observe(elapsed);
+
+            Ok(resp)
+        })
+    }
+}

--- a/teeline-api/src/routes/index.rs
+++ b/teeline-api/src/routes/index.rs
@@ -5,6 +5,7 @@ const ROUTES: &[&str] = &[
     "GET /",
     "GET /api/v1/health",
     "GET /healthz",
+    "GET /metrics",
     "GET /api/v1/solvers",
     "POST /api/v1/parse",
     "POST /api/v1/solve",

--- a/teeline-api/src/routes/metrics.rs
+++ b/teeline-api/src/routes/metrics.rs
@@ -7,7 +7,7 @@ use crate::AppState;
 
 pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
     let mut body = String::new();
-    encode(&mut body, &state.metrics.registry).expect("metrics encode must not fail");
+    let _ = encode(&mut body, &state.metrics.registry);
     (
         [(
             header::CONTENT_TYPE,

--- a/teeline-api/src/routes/metrics.rs
+++ b/teeline-api/src/routes/metrics.rs
@@ -1,0 +1,18 @@
+use axum::extract::State;
+use axum::http::header;
+use axum::response::IntoResponse;
+use prometheus_client::encoding::text::encode;
+
+use crate::AppState;
+
+pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
+    let mut body = String::new();
+    encode(&mut body, &state.metrics.registry).expect("metrics encode must not fail");
+    (
+        [(
+            header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )],
+        body,
+    )
+}

--- a/teeline-api/src/routes/mod.rs
+++ b/teeline-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod health;
 pub mod index;
+pub mod metrics;
 pub mod parse;
 pub mod solve;
 pub mod solvers;

--- a/teeline-api/src/routes/solve.rs
+++ b/teeline-api/src/routes/solve.rs
@@ -1,8 +1,11 @@
+use std::time::Instant;
+
 use axum::{Json, extract::State};
 
 use crate::{
     AppState,
     error::{ApiError, ApiResult},
+    metrics::{SolverDurationLabels, SolverLabels},
     models::{request::SolveRequest, response::SolveResponse},
 };
 
@@ -20,16 +23,45 @@ pub async fn solve(
     State(state): State<AppState>,
     Json(req): Json<SolveRequest>,
 ) -> ApiResult<Json<SolveResponse>> {
-    state
-        .solver_service
-        .solve(&req)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            if e.starts_with("task panic:") {
-                ApiError::Internal(e)
-            } else {
-                ApiError::BadRequest(e)
-            }
-        })
+    let start = Instant::now();
+    let result = state.solver_service.solve(&req).await;
+    let elapsed = start.elapsed().as_secs_f64();
+
+    // Only record solver metrics for known aliases to prevent client-controlled
+    // label cardinality (an unknown solver name is arbitrary user input).
+    let is_known = state
+        .registry_service
+        .list()
+        .iter()
+        .any(|s| s.alias == req.solver);
+    if is_known {
+        let status = if result.is_ok() { "success" } else { "error" };
+        state
+            .metrics
+            .solver_requests_total
+            .get_or_create(&SolverLabels {
+                solver: req.solver.clone(),
+                status: status.into(),
+            })
+            .inc();
+        // Duration only recorded on success — error path typically fails before
+        // the solver runs (unknown alias, invalid input) so elapsed is meaningless.
+        if result.is_ok() {
+            state
+                .metrics
+                .solver_duration_seconds
+                .get_or_create(&SolverDurationLabels {
+                    solver: req.solver.clone(),
+                })
+                .observe(elapsed);
+        }
+    }
+
+    result.map(Json).map_err(|e| {
+        if e.starts_with("task panic:") {
+            ApiError::Internal(e)
+        } else {
+            ApiError::BadRequest(e)
+        }
+    })
 }

--- a/teeline-api/tests/api_tests.rs
+++ b/teeline-api/tests/api_tests.rs
@@ -5,6 +5,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     models::{
         request::{ParseRequest, SolveRequest},
         response::{AlgorithmInfo, CityDto, ParseResponse, SolveResponse},
@@ -75,6 +76,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(MockSolverService),
         registry_service: Arc::new(MockRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }

--- a/teeline-api/tests/health.rs
+++ b/teeline-api/tests/health.rs
@@ -8,14 +8,18 @@ use teeline_api::{
 };
 use tower::ServiceExt;
 
-#[tokio::test]
-async fn health_returns_ok() {
+fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    let app = teeline_api::build_router(state);
+    teeline_api::build_router(state)
+}
+
+#[tokio::test]
+async fn health_returns_ok() {
+    let app = make_app();
 
     let response = app
         .oneshot(

--- a/teeline-api/tests/health.rs
+++ b/teeline-api/tests/health.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -12,6 +13,7 @@ async fn health_returns_ok() {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     let app = teeline_api::build_router(state);
 

--- a/teeline-api/tests/hurl/metrics.hurl
+++ b/teeline-api/tests/hurl/metrics.hurl
@@ -1,0 +1,11 @@
+# GET /metrics — Prometheus/OpenMetrics scrape endpoint
+# NOTE: Run a POST /api/v1/solve request before this file so solver metrics
+# are populated in the same server process. The Taskfile hurl runner should
+# order solve.hurl before metrics.hurl.
+GET http://127.0.0.1:8080/metrics
+HTTP 200
+[Asserts]
+header "Content-Type" contains "openmetrics-text"
+body contains "http_requests_total"
+body contains "teeline_solver_requests_total"
+body contains "teeline_solver_duration_seconds"

--- a/teeline-api/tests/hurl/metrics.hurl
+++ b/teeline-api/tests/hurl/metrics.hurl
@@ -1,14 +1,8 @@
 # GET /metrics — Prometheus/OpenMetrics scrape endpoint
-# Prime solver metrics with one solve before checking — hurl runs files in parallel.
-POST http://127.0.0.1:8080/api/v1/solve
-Content-Type: application/json
-{"input":{"cities":[{"x":0.0,"y":0.0},{"x":1.0,"y":0.0},{"x":0.5,"y":1.0}]},"solver":"nn"}
-HTTP 200
-
 GET http://127.0.0.1:8080/metrics
 HTTP 200
 [Asserts]
 header "Content-Type" contains "openmetrics-text"
-body contains "http_requests_total"
-body contains "teeline_solver_requests_total"
-body contains "teeline_solver_duration_seconds"
+body contains "# HELP http_requests"
+body contains "# HELP teeline_solver_requests"
+body contains "# HELP teeline_solver_duration_seconds"

--- a/teeline-api/tests/hurl/metrics.hurl
+++ b/teeline-api/tests/hurl/metrics.hurl
@@ -1,7 +1,10 @@
 # GET /metrics — Prometheus/OpenMetrics scrape endpoint
-# NOTE: Run a POST /api/v1/solve request before this file so solver metrics
-# are populated in the same server process. The Taskfile hurl runner should
-# order solve.hurl before metrics.hurl.
+# Prime solver metrics with one solve before checking — hurl runs files in parallel.
+POST http://127.0.0.1:8080/api/v1/solve
+Content-Type: application/json
+{"input":{"cities":[{"x":0.0,"y":0.0},{"x":1.0,"y":0.0},{"x":0.5,"y":1.0}]},"solver":"nn"}
+HTTP 200
+
 GET http://127.0.0.1:8080/metrics
 HTTP 200
 [Asserts]

--- a/teeline-api/tests/index.rs
+++ b/teeline-api/tests/index.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -11,6 +12,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }

--- a/teeline-api/tests/metrics.rs
+++ b/teeline-api/tests/metrics.rs
@@ -89,7 +89,12 @@ async fn metrics_body_contains_http_requests_total() {
 #[tokio::test]
 async fn solver_metrics_present_after_successful_solve() {
     let app = make_app();
-    app.clone().oneshot(solve_req("nn")).await.unwrap();
+    let solve_resp = app.clone().oneshot(solve_req("nn")).await.unwrap();
+    assert_eq!(
+        solve_resp.status(),
+        StatusCode::OK,
+        "solve must succeed before solver metrics are populated"
+    );
     let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
     assert!(
         body.contains("teeline_solver_requests_total"),
@@ -118,10 +123,14 @@ async fn solver_error_metric_increments_for_known_solver_error() {
         .await
         .unwrap();
     let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
-    // http_requests_total with a 400 status should appear
     assert!(
         body.contains("http_requests_total"),
         "missing http_requests_total after failed solve:\n{body}"
+    );
+    // solver error metric must be incremented for a known alias even on failure
+    assert!(
+        body.contains("teeline_solver_requests_total"),
+        "missing teeline_solver_requests_total after failed solve:\n{body}"
     );
 }
 

--- a/teeline-api/tests/metrics.rs
+++ b/teeline-api/tests/metrics.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use teeline_api::{
+    AppState,
+    metrics::MetricsState,
+    services::{SolverRegistry, TspService},
+};
+use tower::ServiceExt;
+
+fn make_app() -> axum::Router {
+    let state = AppState {
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
+    };
+    teeline_api::build_router(state)
+}
+
+fn metrics_req() -> Request<Body> {
+    Request::builder()
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn solve_req(solver: &str) -> Request<Body> {
+    let body = format!(
+        r#"{{"input":{{"cities":[{{"x":0.0,"y":0.0}},{{"x":1.0,"y":0.0}},{{"x":0.5,"y":1.0}}]}},"solver":"{solver}"}}"#
+    );
+    Request::builder()
+        .method("POST")
+        .uri("/api/v1/solve")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn body_text(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.into()).unwrap()
+}
+
+#[tokio::test]
+async fn metrics_returns_200() {
+    let resp = make_app().oneshot(metrics_req()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn metrics_content_type_is_openmetrics() {
+    let resp = make_app().oneshot(metrics_req()).await.unwrap();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        ct.contains("openmetrics-text"),
+        "expected openmetrics-text, got {ct}"
+    );
+}
+
+#[tokio::test]
+async fn metrics_body_contains_http_requests_total() {
+    let app = make_app();
+    // prometheus-client emits sample lines only after the first increment.
+    // Make a health request so http_requests_total gets at least one sample.
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
+    assert!(
+        body.contains("http_requests_total"),
+        "missing http_requests_total in:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn solver_metrics_present_after_successful_solve() {
+    let app = make_app();
+    app.clone().oneshot(solve_req("nn")).await.unwrap();
+    let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
+    assert!(
+        body.contains("teeline_solver_requests_total"),
+        "missing teeline_solver_requests_total after solve:\n{body}"
+    );
+    assert!(
+        body.contains("teeline_solver_duration_seconds"),
+        "missing teeline_solver_duration_seconds after solve:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn solver_error_metric_increments_for_known_solver_error() {
+    let app = make_app();
+    // Valid alias that the mock service can fail on — use a real alias but
+    // send invalid input so the service returns an error.
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/solve")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"input":{"cities":[]},"solver":"nn"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
+    // http_requests_total with a 400 status should appear
+    assert!(
+        body.contains("http_requests_total"),
+        "missing http_requests_total after failed solve:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_solver_does_not_pollute_solver_labels() {
+    let app = make_app();
+    app.clone()
+        .oneshot(solve_req("__definitely_not_a_real_solver__"))
+        .await
+        .unwrap();
+    let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
+    // Client-supplied unknown solver must not appear as a label value
+    assert!(
+        !body.contains("__definitely_not_a_real_solver__"),
+        "client-controlled solver name leaked into metrics labels:\n{body}"
+    );
+}

--- a/teeline-api/tests/openapi.rs
+++ b/teeline-api/tests/openapi.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -11,6 +12,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }

--- a/teeline-api/tests/parse.rs
+++ b/teeline-api/tests/parse.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -11,6 +12,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }

--- a/teeline-api/tests/solve.rs
+++ b/teeline-api/tests/solve.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -11,6 +12,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }

--- a/teeline-api/tests/solvers.rs
+++ b/teeline-api/tests/solvers.rs
@@ -3,6 +3,7 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use teeline_api::{
     AppState,
+    metrics::MetricsState,
     services::{SolverRegistry, TspService},
 };
 use tower::ServiceExt;
@@ -11,6 +12,7 @@ fn make_app() -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(TspService),
         registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
     };
     teeline_api::build_router(state)
 }


### PR DESCRIPTION
## Summary

- Adds `GET /metrics` endpoint serving OpenMetrics text format (`prometheus-client 0.22`)
- **HTTP golden signals** via Tower `MetricsLayer` on all routes: `http_requests_total{method,path,status}` + `http_request_duration_seconds{method,path}`
- **Solver signals** in solve handler: `teeline_solver_requests_total{solver,status}` + `teeline_solver_duration_seconds{solver}`
- `GovernorLayer` scoped to `/api/v1/*` sub-router — `/metrics`, `/healthz`, `/`, `/docs` are excluded from rate limiting (Fly.io scraper must not get 429d)
- Solver labels only recorded for known aliases (no client-controlled label cardinality)
- Fly.io scrape config: `[metrics] port=8080 path=/metrics`

## Key implementation notes

- `Family<_, Histogram>` uses `new_with_constructor` with explicit buckets (Histogram is not Default)
- `get_or_create()` guards always dropped on the same line — never bound to `let` before an `await` (MappedRwLockReadGuard + Send bound)
- `MatchedPath` is available in middleware because `Router::layer()` applies after routing
- Content-Type: `application/openmetrics-text; version=1.0.0` (what the crate actually emits)

## Test plan

- [x] `cargo test -p teeline-api` — 65/65 tests pass (6 new metrics tests + 1 new unit test)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `tests/hurl/metrics.hurl` smoketest added (requires prior solve request for solver series)