### PR TITLE
feat(api): static bearer-token auth for teeline-api (#286)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
         uses: jdx/mise-action@v4
       - name: Run hurl e2e tests (teeline-api)
         run: task test:e2e:api
+      - name: Run hurl e2e auth tests (teeline-api)
+        run: task test:e2e:auth
       - name: Clippy
         run: cargo clippy -p teeline -p teeline-cli -p teeline-api -- -D warnings
       - name: Install cargo-llvm-cov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
 name = "duct"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1279,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,8 +1773,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "prometheus-client",
  "serde",
  "serde_json",
+ "subtle",
  "teeline",
  "tokio",
  "tower",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,10 @@ tasks:
   api:serve:
     desc: Start teeline-api server in background (writes PID to /tmp/teeline-api.pid)
     cmds:
-      - ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
+      # go-task's bundled shell interpreter doesn't preserve backgrounded
+      # processes past the end of the task run, and mis-captures $!.
+      # bash -c ... & disown bypasses it so the server actually survives.
+      - bash -c 'nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
 
   api:stop:
     desc: Stop the background teeline-api server (kills by PID file and any stale instances)
@@ -62,8 +65,9 @@ tasks:
     desc: Build, start, wait, run hurl e2e tests, then shut down teeline-api
     deps: [build:api]
     cmds:
-      - defer: kill $(cat /tmp/teeline-api.pid) 2>/dev/null || true
-      - RATE_LIMIT_RPM=0 ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
+      - defer:
+          task: api:stop
+      - bash -c 'RATE_LIMIT_RPM=0 nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
       - task: api:wait
       - hurl --test teeline-api/tests/hurl/*.hurl
 
@@ -75,7 +79,7 @@ tasks:
     cmds:
       - defer:
           task: api:stop
-      - API_KEY={{.API_TOKEN}} RATE_LIMIT_RPM=0 ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
+      - bash -c 'API_KEY={{.API_TOKEN}} RATE_LIMIT_RPM=0 nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
       - task: api:wait
       - hurl --test --variable api_token={{.API_TOKEN}} teeline-api/tests/hurl/auth/*.hurl
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,6 +67,18 @@ tasks:
       - task: api:wait
       - hurl --test teeline-api/tests/hurl/*.hurl
 
+  test:e2e:auth:
+    desc: Build, start with API_KEY set, wait, run hurl auth e2e tests, then shut down teeline-api
+    deps: [build:api]
+    vars:
+      API_TOKEN: test-secret-token
+    cmds:
+      - defer:
+          task: api:stop
+      - API_KEY={{.API_TOKEN}} RATE_LIMIT_RPM=0 ./target/debug/teeline-api & echo $! > /tmp/teeline-api.pid
+      - task: api:wait
+      - hurl --test --variable api_token={{.API_TOKEN}} teeline-api/tests/hurl/auth/*.hurl
+
   test:all:
     desc: Run unit tests and e2e tests
     deps: [test, test:e2e]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,14 +42,35 @@ tasks:
     cmds:
       - cargo build -p teeline-api
 
-  api:serve:
-    desc: Start teeline-api server in background (writes PID to /tmp/teeline-api.pid)
+  api:_launch:
+    internal: true
+    desc: "(internal) Launch teeline-api in the background; shared by api:serve, test:e2e:api, test:e2e:auth"
+    vars:
+      API_KEY: '{{.API_KEY | default ""}}'
+      RATE_LIMIT_RPM: '{{.RATE_LIMIT_RPM | default ""}}'
+    # Values are threaded through as opaque env vars (never interpolated
+    # into the bash -c string itself) so a token containing a quote or
+    # `$(...)` can't break out and inject commands — same reasoning as the
+    # TEST_API_TOKEN handling in test:e2e:auth below.
+    env:
+      TASK_API_KEY: '{{.API_KEY}}'
+      TASK_RATE_LIMIT_RPM: '{{.RATE_LIMIT_RPM}}'
     cmds:
       # go-task's bundled shell interpreter doesn't preserve backgrounded
       # processes past the end of the task run, and mis-captures $!.
       # bash -c ... & disown bypasses it so the server actually survives.
-      - bash -c 'nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
+      - bash -c 'API_KEY="$TASK_API_KEY" RATE_LIMIT_RPM="$TASK_RATE_LIMIT_RPM" nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
 
+  api:serve:
+    desc: Start teeline-api server in background (writes PID to /tmp/teeline-api.pid)
+    cmds:
+      - task: api:_launch
+
+  # NOTE: api:serve, test:e2e:api, and test:e2e:auth all share the single
+  # /tmp/teeline-api.pid file. This is only safe because they're never run
+  # concurrently (CI runs the two e2e tasks as separate sequential steps).
+  # Running two of these at the same time would let the second one's PID
+  # write clobber the first's, and api:stop could then kill the wrong server.
   api:stop:
     desc: Stop the background teeline-api server (kills by PID file and any stale instances)
     cmds:
@@ -67,7 +88,9 @@ tasks:
     cmds:
       - defer:
           task: api:stop
-      - bash -c 'RATE_LIMIT_RPM=0 nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
+      - task: api:_launch
+        vars:
+          RATE_LIMIT_RPM: "0"
       - task: api:wait
       - hurl --test teeline-api/tests/hurl/*.hurl
 
@@ -76,12 +99,21 @@ tasks:
     deps: [build:api]
     vars:
       API_TOKEN: test-secret-token
+    # Passed as a real env var (not interpolated into the hurl command
+    # below) so the token's value is never re-parsed as shell syntax —
+    # {{.API_TOKEN}} directly inline would let a value containing a quote
+    # or `$(...)` break out and inject commands.
+    env:
+      TEST_API_TOKEN: '{{.API_TOKEN}}'
     cmds:
       - defer:
           task: api:stop
-      - bash -c 'API_KEY={{.API_TOKEN}} RATE_LIMIT_RPM=0 nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
+      - task: api:_launch
+        vars:
+          API_KEY: "{{.API_TOKEN}}"
+          RATE_LIMIT_RPM: "0"
       - task: api:wait
-      - hurl --test --variable api_token={{.API_TOKEN}} teeline-api/tests/hurl/auth/*.hurl
+      - hurl --test --variable api_token="$TEST_API_TOKEN" teeline-api/tests/hurl/auth/*.hurl
 
   test:all:
     desc: Run unit tests and e2e tests

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
 async-trait = "0.1"
+subtle = "2.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }

--- a/teeline-api/src/error.rs
+++ b/teeline-api/src/error.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    http::StatusCode,
+    http::{HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
 
@@ -14,12 +14,23 @@ pub enum ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        // RFC 7235 §3.1: a 401 response must include WWW-Authenticate
+        // naming the scheme(s) this API accepts.
+        let www_authenticate = matches!(self, ApiError::Unauthorized)
+            .then(|| HeaderValue::from_static(r#"Bearer, ApiKey realm="teeline-api""#));
+
         let (status, message) = match self {
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
         };
         let body = Json(serde_json::json!({ "error": message }));
-        (status, body).into_response()
+        let mut response = (status, body).into_response();
+        if let Some(value) = www_authenticate {
+            response
+                .headers_mut()
+                .insert(header::WWW_AUTHENTICATE, value);
+        }
+        response
     }
 }

--- a/teeline-api/src/error.rs
+++ b/teeline-api/src/error.rs
@@ -9,6 +9,7 @@ pub type ApiResult<T> = Result<T, ApiError>;
 pub enum ApiError {
     BadRequest(String),
     Internal(String),
+    Unauthorized,
 }
 
 impl IntoResponse for ApiError {
@@ -16,6 +17,7 @@ impl IntoResponse for ApiError {
         let (status, message) = match self {
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
         };
         let body = Json(serde_json::json!({ "error": message }));
         (status, body).into_response()

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -29,15 +29,17 @@ pub fn build_api_router() -> axum::Router<AppState> {
         .route("/api/v1/solve", post(routes::solve::solve))
 }
 
-/// Full router with MetricsLayer applied. GovernorLayer is intentionally absent
-/// here; apply it to the api sub-router before merging when needed.
-pub fn build_router(state: AppState) -> axum::Router {
+/// Full router with MetricsLayer applied. `api` is the already-assembled
+/// (and optionally layered, e.g. with GovernorLayer/AuthLayer) `/api/v1/*`
+/// sub-router — callers build it via `build_api_router()` plus whatever
+/// layers they need, then pass it here so route wiring lives in one place.
+pub fn build_router(state: AppState, api: axum::Router<AppState>) -> axum::Router {
     axum::Router::new()
         .route("/", get(routes::index::handler))
         .route("/healthz", get(routes::health::handler))
         .route("/metrics", get(routes::metrics::handler))
         .merge(openapi::openapi_router())
-        .merge(build_api_router())
+        .merge(api)
         .layer(middleware::MetricsLayer::new(Arc::clone(&state.metrics)))
         .with_state(state)
 }

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -5,7 +5,7 @@ use axum::Router;
 use teeline_api::{
     AppState,
     metrics::MetricsState,
-    middleware::AuthLayer,
+    middleware,
     services::{SolverRegistry, TspService},
 };
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
@@ -21,10 +21,16 @@ fn rate_limit_rpm() -> u64 {
         .unwrap_or(100)
 }
 
-/// Returns the configured API key, if any. When unset, auth is disabled
-/// entirely (back-compat with the original no-auth MVP behavior).
+/// Returns the configured API key, if any. When unset OR empty, auth is
+/// disabled entirely (back-compat with the original no-auth MVP behavior).
+/// `std::env::var(...).ok()` alone would treat `API_KEY=""` as "set" (an
+/// empty-but-present token), silently enabling auth with a trivially
+/// guessable blank credential — worse than disabled, since operators
+/// wouldn't know from the logs.
 fn api_key() -> Option<String> {
-    std::env::var("API_KEY").ok()
+    std::env::var("API_KEY")
+        .ok()
+        .filter(|token| !token.is_empty())
 }
 
 #[tokio::main]
@@ -66,12 +72,15 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("rate limiting disabled (RATE_LIMIT_RPM=0)");
     }
 
-    // Applied after GovernorLayer, so AuthLayer wraps outermost (each
-    // subsequent .layer() call wraps the previous stack) — unauthenticated
-    // requests are rejected before consuming rate-limit budget.
+    // Applied after GovernorLayer, so auth wraps outermost for matched
+    // routes (each subsequent .layer()/.route_layer() call wraps the
+    // previous stack) — unauthenticated requests are rejected before
+    // consuming rate-limit budget. require_auth uses route_layer
+    // internally (not layer) so it only runs for requests that actually
+    // match a route.
     if let Some(token) = api_key() {
         tracing::info!("API key auth enabled");
-        api = api.layer(AuthLayer::new(token));
+        api = middleware::require_auth(api, token);
     } else {
         tracing::info!("API key auth disabled (API_KEY unset)");
     }

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -2,11 +2,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
-use axum::routing::get;
 use teeline_api::{
     AppState,
     metrics::MetricsState,
-    middleware::MetricsLayer,
+    middleware::AuthLayer,
     services::{SolverRegistry, TspService},
 };
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
@@ -20,6 +19,12 @@ fn rate_limit_rpm() -> u64 {
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|&v| v <= 60_000)
         .unwrap_or(100)
+}
+
+/// Returns the configured API key, if any. When unset, auth is disabled
+/// entirely (back-compat with the original no-auth MVP behavior).
+fn api_key() -> Option<String> {
+    std::env::var("API_KEY").ok()
 }
 
 #[tokio::main]
@@ -36,8 +41,11 @@ async fn main() -> anyhow::Result<()> {
         metrics: Arc::new(MetricsState::new()),
     };
 
-    // Rate limiting scoped to /api/v1/* only — Fly.io's scraper must not be throttled on /metrics.
+    // Rate limiting and auth are both scoped to /api/v1/* only — Fly.io's
+    // scraper must not be throttled or challenged on /metrics, and ops
+    // endpoints (/, /healthz, /metrics, /docs, /openapi.json) stay open.
     let mut api: Router<AppState> = teeline_api::build_api_router();
+
     if let Some(period_ms) = 60_000u64.checked_div(rpm) {
         tracing::info!("rate limiting enabled: {rpm} RPM");
         let governor_conf = GovernorConfigBuilder::default()
@@ -58,14 +66,17 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("rate limiting disabled (RATE_LIMIT_RPM=0)");
     }
 
-    let app = Router::new()
-        .route("/", get(teeline_api::routes::index::handler))
-        .route("/healthz", get(teeline_api::routes::health::handler))
-        .route("/metrics", get(teeline_api::routes::metrics::handler))
-        .merge(teeline_api::openapi::openapi_router())
-        .merge(api)
-        .layer(MetricsLayer::new(Arc::clone(&state.metrics)))
-        .with_state(state);
+    // Applied after GovernorLayer, so AuthLayer wraps outermost (each
+    // subsequent .layer() call wraps the previous stack) — unauthenticated
+    // requests are rejected before consuming rate-limit budget.
+    if let Some(token) = api_key() {
+        tracing::info!("API key auth enabled");
+        api = api.layer(AuthLayer::new(token));
+    } else {
+        tracing::info!("API key auth disabled (API_KEY unset)");
+    }
+
+    let app = teeline_api::build_router(state, api);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("listening on {addr}");

--- a/teeline-api/src/middleware.rs
+++ b/teeline-api/src/middleware.rs
@@ -101,97 +101,67 @@ where
 
 const AUTH_EXEMPT_PATH: &str = "/api/v1/health";
 
-#[derive(Clone)]
-pub struct AuthLayer {
-    token: Arc<str>,
+/// Wraps `router` so every request must present a valid bearer/API-key
+/// token matching `token`, except `AUTH_EXEMPT_PATH`. Uses `route_layer`
+/// (not `layer`) so requests that don't match any route on `router` fall
+/// through to axum's normal 404 instead of getting a 401 — `.layer()`
+/// would also wrap the router's fallback, turning every unmatched path
+/// into a 401 (axum's `route_layer` docs call this exact scenario out).
+pub fn require_auth(
+    router: axum::Router<crate::AppState>,
+    token: impl Into<Arc<str>>,
+) -> axum::Router<crate::AppState> {
+    let token: Arc<str> = token.into();
+    router.route_layer(axum::middleware::from_fn(
+        move |matched_path: Option<MatchedPath>,
+              headers: HeaderMap,
+              request: axum::extract::Request,
+              next: axum::middleware::Next| {
+            let token = Arc::clone(&token);
+            async move {
+                // MatchedPath is populated by axum's routing before route_layer
+                // middleware runs. The api sub-router only ever matches
+                // "/api/v1/health" as the exempt path.
+                let is_health = matched_path.is_some_and(|m| m.as_str() == AUTH_EXEMPT_PATH);
+                if is_health || token_matches(&token, &headers) {
+                    return next.run(request).await;
+                }
+                ApiError::Unauthorized.into_response()
+            }
+        },
+    ))
 }
 
-impl AuthLayer {
-    pub fn new(token: impl Into<Arc<str>>) -> Self {
-        Self {
-            token: token.into(),
-        }
+fn token_matches(token: &str, headers: &HeaderMap) -> bool {
+    // Defense in depth: an empty configured token must never match, even
+    // though the real fix is api_key() in main.rs never producing one.
+    // Without this, an empty configured token would authenticate any
+    // request presenting an empty (but present) credential.
+    if token.is_empty() {
+        return false;
     }
-}
-
-impl<S> Layer<S> for AuthLayer {
-    type Service = AuthService<S>;
-
-    fn layer(&self, inner: S) -> AuthService<S> {
-        AuthService {
-            inner,
-            token: Arc::clone(&self.token),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct AuthService<S> {
-    inner: S,
-    token: Arc<str>,
-}
-
-impl<S, B> Service<Request<B>> for AuthService<S>
-where
-    S: Service<Request<B>, Response = Response<axum::body::Body>> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Send,
-    B: Send + 'static,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
-    >;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Request<B>) -> Self::Future {
-        // MatchedPath is populated by axum's routing layer before middleware
-        // added via Router::layer() runs (same ordering MetricsService above
-        // already relies on). The api sub-router only ever matches
-        // "/api/v1/health" as the exempt path.
-        let is_health = req
-            .extensions()
-            .get::<MatchedPath>()
-            .is_some_and(|m| m.as_str() == AUTH_EXEMPT_PATH);
-
-        if is_health || self.token_ok(req.headers()) {
-            let clone = self.inner.clone();
-            let mut inner = std::mem::replace(&mut self.inner, clone);
-            return Box::pin(async move { inner.call(req).await });
-        }
-
-        Box::pin(async move { Ok(ApiError::Unauthorized.into_response()) })
-    }
-}
-
-impl<S> AuthService<S> {
-    fn token_ok(&self, headers: &HeaderMap) -> bool {
-        extract_token(headers).is_some_and(|presented| {
-            let expected = self.token.as_bytes();
-            let presented = presented.as_bytes();
-            // Constant-time comparison to avoid timing side-channels. Token
-            // length is not itself secret, so a plain length check first is
-            // fine; ct_eq handles the equal-length byte comparison.
-            expected.len() == presented.len() && expected.ct_eq(presented).into()
-        })
-    }
+    extract_token(headers).is_some_and(|presented| {
+        let expected = token.as_bytes();
+        let presented = presented.as_bytes();
+        // Constant-time comparison to avoid timing side-channels. Token
+        // length is not itself secret, so a plain length check first is
+        // fine; ct_eq handles the equal-length byte comparison.
+        expected.len() == presented.len() && expected.ct_eq(presented).into()
+    })
 }
 
 /// Extracts the bearer/api-key token from either `Authorization: Bearer <token>`
 /// or `X-Api-Key: <token>`, preferring `Authorization` if both are present.
-fn extract_token(headers: &HeaderMap) -> Option<String> {
+/// The `Bearer` scheme name is matched case-insensitively per RFC 7235 §2.1.
+/// Borrows from `headers` rather than allocating — this runs on every
+/// authenticated request.
+fn extract_token(headers: &HeaderMap) -> Option<&str> {
     if let Some(v) = headers.get(axum::http::header::AUTHORIZATION)
         && let Ok(s) = v.to_str()
-        && let Some(token) = s.strip_prefix("Bearer ")
+        && let Some((scheme, token)) = s.split_once(' ')
+        && scheme.eq_ignore_ascii_case("bearer")
     {
-        return Some(token.to_string());
+        return Some(token);
     }
-    headers
-        .get("X-Api-Key")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
+    headers.get("X-Api-Key").and_then(|v| v.to_str().ok())
 }

--- a/teeline-api/src/middleware.rs
+++ b/teeline-api/src/middleware.rs
@@ -3,9 +3,12 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use axum::extract::MatchedPath;
-use axum::http::{Request, Response};
+use axum::http::{HeaderMap, Request, Response};
+use axum::response::IntoResponse;
+use subtle::ConstantTimeEq;
 use tower::{Layer, Service};
 
+use crate::error::ApiError;
 use crate::metrics::{HttpDurationLabels, HttpLabels, MetricsState};
 
 #[derive(Clone)]
@@ -94,4 +97,101 @@ where
             Ok(resp)
         })
     }
+}
+
+const AUTH_EXEMPT_PATH: &str = "/api/v1/health";
+
+#[derive(Clone)]
+pub struct AuthLayer {
+    token: Arc<str>,
+}
+
+impl AuthLayer {
+    pub fn new(token: impl Into<Arc<str>>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> AuthService<S> {
+        AuthService {
+            inner,
+            token: Arc::clone(&self.token),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    token: Arc<str>,
+}
+
+impl<S, B> Service<Request<B>> for AuthService<S>
+where
+    S: Service<Request<B>, Response = Response<axum::body::Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        // MatchedPath is populated by axum's routing layer before middleware
+        // added via Router::layer() runs (same ordering MetricsService above
+        // already relies on). The api sub-router only ever matches
+        // "/api/v1/health" as the exempt path.
+        let is_health = req
+            .extensions()
+            .get::<MatchedPath>()
+            .is_some_and(|m| m.as_str() == AUTH_EXEMPT_PATH);
+
+        if is_health || self.token_ok(req.headers()) {
+            let clone = self.inner.clone();
+            let mut inner = std::mem::replace(&mut self.inner, clone);
+            return Box::pin(async move { inner.call(req).await });
+        }
+
+        Box::pin(async move { Ok(ApiError::Unauthorized.into_response()) })
+    }
+}
+
+impl<S> AuthService<S> {
+    fn token_ok(&self, headers: &HeaderMap) -> bool {
+        extract_token(headers).is_some_and(|presented| {
+            let expected = self.token.as_bytes();
+            let presented = presented.as_bytes();
+            // Constant-time comparison to avoid timing side-channels. Token
+            // length is not itself secret, so a plain length check first is
+            // fine; ct_eq handles the equal-length byte comparison.
+            expected.len() == presented.len() && expected.ct_eq(presented).into()
+        })
+    }
+}
+
+/// Extracts the bearer/api-key token from either `Authorization: Bearer <token>`
+/// or `X-Api-Key: <token>`, preferring `Authorization` if both are present.
+fn extract_token(headers: &HeaderMap) -> Option<String> {
+    if let Some(v) = headers.get(axum::http::header::AUTHORIZATION)
+        && let Ok(s) = v.to_str()
+        && let Some(token) = s.strip_prefix("Bearer ")
+    {
+        return Some(token.to_string());
+    }
+    headers
+        .get("X-Api-Key")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
 }

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -1,5 +1,8 @@
 use axum::Router;
-use utoipa::OpenApi;
+use utoipa::{
+    Modify, OpenApi,
+    openapi::security::{ApiKey, ApiKeyValue, HttpAuthScheme, HttpBuilder, SecurityScheme},
+};
 use utoipa_scalar::{Scalar, Servable};
 
 use crate::{
@@ -7,6 +10,25 @@ use crate::{
     models::{request, response},
     routes,
 };
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .as_mut()
+            .expect("components are registered via #[openapi(components(...))]");
+        components.add_security_scheme(
+            "bearer_token",
+            SecurityScheme::Http(HttpBuilder::new().scheme(HttpAuthScheme::Bearer).build()),
+        );
+        components.add_security_scheme(
+            "api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Api-Key"))),
+        );
+    }
+}
 
 #[derive(OpenApi)]
 #[openapi(
@@ -48,7 +70,8 @@ use crate::{
     )),
     tags(
         (name = "tsp", description = "Traveling Salesman Problem solver endpoints")
-    )
+    ),
+    modifiers(&SecurityAddon)
 )]
 pub struct ApiDoc;
 

--- a/teeline-api/src/routes/parse.rs
+++ b/teeline-api/src/routes/parse.rs
@@ -9,10 +9,15 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/api/v1/parse",
+    security(
+        ("bearer_token" = []),
+        ("api_key" = [])
+    ),
     request_body = ParseRequest,
     responses(
         (status = 200, description = "Parsed city list", body = ParseResponse),
-        (status = 400, description = "Invalid input or malformed TSPLIB")
+        (status = 400, description = "Invalid input or malformed TSPLIB"),
+        (status = 401, description = "Missing or invalid API key")
     )
 )]
 pub async fn parse(

--- a/teeline-api/src/routes/solve.rs
+++ b/teeline-api/src/routes/solve.rs
@@ -12,10 +12,15 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/api/v1/solve",
+    security(
+        ("bearer_token" = []),
+        ("api_key" = [])
+    ),
     request_body = SolveRequest,
     responses(
         (status = 200, description = "Solved tour", body = SolveResponse),
         (status = 400, description = "Invalid input or unknown solver"),
+        (status = 401, description = "Missing or invalid API key"),
         (status = 500, description = "Solver failure")
     )
 )]

--- a/teeline-api/src/routes/solvers.rs
+++ b/teeline-api/src/routes/solvers.rs
@@ -5,6 +5,10 @@ use crate::{AppState, models::response::AlgorithmInfo};
 #[utoipa::path(
     get,
     path = "/api/v1/solvers",
+    security(
+        ("bearer_token" = []),
+        ("api_key" = [])
+    ),
     responses(
         (status = 200, description = "List of all TSP solvers", body = Vec<AlgorithmInfo>)
     )

--- a/teeline-api/tests/api_tests.rs
+++ b/teeline-api/tests/api_tests.rs
@@ -6,6 +6,7 @@ use axum::http::{Request, StatusCode};
 use teeline_api::{
     AppState,
     metrics::MetricsState,
+    middleware::AuthLayer,
     models::{
         request::{ParseRequest, SolveRequest},
         response::{AlgorithmInfo, CityDto, ParseResponse, SolveResponse},
@@ -78,7 +79,27 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(MockRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
+}
+
+const TEST_TOKEN: &str = "test-secret-token";
+
+fn make_authed_app() -> axum::Router {
+    let state = AppState {
+        solver_service: Arc::new(MockSolverService),
+        registry_service: Arc::new(MockRegistry),
+        metrics: Arc::new(MetricsState::new()),
+    };
+    let api = teeline_api::build_api_router().layer(AuthLayer::new(TEST_TOKEN));
+    teeline_api::build_router(state, api)
+}
+
+fn get_with_header(uri: &str, header: &str, value: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header(header, value)
+        .body(Body::empty())
+        .unwrap()
 }
 
 fn get(uri: &str) -> Request<Body> {
@@ -223,4 +244,86 @@ async fn docs_returns_html() {
         body.contains("<!doctype html>") || body.contains("<!DOCTYPE html>"),
         "expected HTML doctype in /docs response"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Auth (AuthLayer applied on top of build_api_router() — see make_authed_app)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn health_open_without_token_when_auth_enabled() {
+    let resp = make_authed_app()
+        .oneshot(get("/api/v1/health"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn solvers_without_token_returns_401() {
+    let resp = make_authed_app()
+        .oneshot(get("/api/v1/solvers"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = json_body(resp).await;
+    assert_eq!(json["error"], "Unauthorized");
+}
+
+#[tokio::test]
+async fn solvers_with_wrong_token_returns_401() {
+    let resp = make_authed_app()
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            "Bearer wrong-token",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn solvers_with_correct_bearer_token_returns_200() {
+    let resp = make_authed_app()
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            &format!("Bearer {TEST_TOKEN}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn solvers_with_correct_x_api_key_returns_200() {
+    let resp = make_authed_app()
+        .oneshot(get_with_header("/api/v1/solvers", "X-Api-Key", TEST_TOKEN))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn solvers_with_non_bearer_auth_scheme_returns_401() {
+    // Locks in that a non-Bearer Authorization scheme (e.g. Basic) is rejected
+    // rather than silently falling through to the X-Api-Key branch unverified.
+    let resp = make_authed_app()
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            "Basic dXNlcjpwYXNz",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn parse_without_token_returns_401() {
+    let body = format!(r#"{{"input":{TINY_CITIES}}}"#);
+    let req = post_json("/api/v1/parse", &body);
+    let resp = make_authed_app().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }

--- a/teeline-api/tests/api_tests.rs
+++ b/teeline-api/tests/api_tests.rs
@@ -6,7 +6,7 @@ use axum::http::{Request, StatusCode};
 use teeline_api::{
     AppState,
     metrics::MetricsState,
-    middleware::AuthLayer,
+    middleware,
     models::{
         request::{ParseRequest, SolveRequest},
         response::{AlgorithmInfo, CityDto, ParseResponse, SolveResponse},
@@ -90,7 +90,7 @@ fn make_authed_app() -> axum::Router {
         registry_service: Arc::new(MockRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    let api = teeline_api::build_api_router().layer(AuthLayer::new(TEST_TOKEN));
+    let api = middleware::require_auth(teeline_api::build_api_router(), TEST_TOKEN);
     teeline_api::build_router(state, api)
 }
 
@@ -247,7 +247,7 @@ async fn docs_returns_html() {
 }
 
 // ---------------------------------------------------------------------------
-// Auth (AuthLayer applied on top of build_api_router() — see make_authed_app)
+// Auth (require_auth applied on top of build_api_router() — see make_authed_app)
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -260,12 +260,43 @@ async fn health_open_without_token_when_auth_enabled() {
 }
 
 #[tokio::test]
+async fn health_path_documented_in_openapi_matches_auth_exemption() {
+    // Ties AUTH_EXEMPT_PATH (a private const in middleware.rs) to the actual
+    // health route via an independent source of truth: the OpenAPI spec
+    // generated from routes/health.rs's #[utoipa::path] annotation, rather
+    // than re-hardcoding "/api/v1/health" a third time in this test. If the
+    // route is ever renamed in one place but not the others, this fails
+    // instead of the exemption silently breaking in production.
+    let openapi_resp = make_authed_app()
+        .oneshot(get("/openapi.json"))
+        .await
+        .unwrap();
+    let openapi = json_body(openapi_resp).await;
+    let paths = openapi["paths"].as_object().unwrap();
+    let health_path = paths
+        .keys()
+        .find(|p| p.contains("health"))
+        .expect("openapi spec must document a health path");
+
+    let resp = make_authed_app().oneshot(get(health_path)).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "path {health_path} documented in OpenAPI spec must be exempt from auth"
+    );
+}
+
+#[tokio::test]
 async fn solvers_without_token_returns_401() {
     let resp = make_authed_app()
         .oneshot(get("/api/v1/solvers"))
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        resp.headers().contains_key("www-authenticate"),
+        "401 response must include WWW-Authenticate per RFC 7235 §3.1"
+    );
     let json = json_body(resp).await;
     assert_eq!(json["error"], "Unauthorized");
 }
@@ -321,9 +352,61 @@ async fn solvers_with_non_bearer_auth_scheme_returns_401() {
 }
 
 #[tokio::test]
+async fn solvers_with_lowercase_bearer_scheme_returns_200() {
+    // RFC 7235 §2.1: the auth-scheme token is case-insensitive, so
+    // "bearer" (lowercase, as some HTTP clients default to) must be
+    // accepted just like "Bearer".
+    let resp = make_authed_app()
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            &format!("bearer {TEST_TOKEN}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn parse_without_token_returns_401() {
     let body = format!(r#"{{"input":{TINY_CITIES}}}"#);
     let req = post_json("/api/v1/parse", &body);
     let resp = make_authed_app().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn empty_configured_token_never_matches_empty_presented_token() {
+    // Regression test for a real bypass: an empty configured token must
+    // never authenticate an empty (but present) credential. This is a
+    // defense-in-depth check at the require_auth/token_matches level — the
+    // actual fix is api_key() in main.rs never producing an empty
+    // Some(String) in the first place, which isn't unit-testable here
+    // since it reads a process-wide env var.
+    let state = AppState {
+        solver_service: Arc::new(MockSolverService),
+        registry_service: Arc::new(MockRegistry),
+        metrics: Arc::new(MetricsState::new()),
+    };
+    let api = middleware::require_auth(teeline_api::build_api_router(), "");
+    let app = teeline_api::build_router(state, api);
+
+    let resp = app
+        .oneshot(get_with_header("/api/v1/solvers", "X-Api-Key", ""))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn unmatched_path_returns_404_not_401_when_auth_enabled() {
+    // Regression test: require_auth must apply the middleware via
+    // route_layer (not layer), or it wraps the router's fallback too and
+    // turns every unmatched path into a 401 instead of axum's normal 404 —
+    // including paths entirely outside /api/v1/* once merged into the full app.
+    let resp = make_authed_app()
+        .oneshot(get("/api/v1/this-route-does-not-exist"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }

--- a/teeline-api/tests/health.rs
+++ b/teeline-api/tests/health.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 #[tokio::test]

--- a/teeline-api/tests/hurl/auth/auth.hurl
+++ b/teeline-api/tests/hurl/auth/auth.hurl
@@ -1,0 +1,116 @@
+# GET /api/v1/health — always exempt, no header needed even when API_KEY is set
+GET http://127.0.0.1:8080/api/v1/health
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "ok"
+
+
+# GET /api/v1/solvers — no header returns 401
+GET http://127.0.0.1:8080/api/v1/solvers
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "Unauthorized"
+
+
+# GET /api/v1/solvers — wrong Authorization: Bearer token returns 401
+GET http://127.0.0.1:8080/api/v1/solvers
+Authorization: Bearer wrong-token
+HTTP 401
+
+
+# GET /api/v1/solvers — wrong X-Api-Key returns 401
+GET http://127.0.0.1:8080/api/v1/solvers
+X-Api-Key: wrong-token
+HTTP 401
+
+
+# POST /api/v1/parse — valid body but no header returns 401
+POST http://127.0.0.1:8080/api/v1/parse
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  }
+}
+```
+HTTP 401
+
+
+# POST /api/v1/solve — valid body but no header returns 401
+POST http://127.0.0.1:8080/api/v1/solve
+Content-Type: application/json
+```json
+{
+  "solver": "nn",
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  }
+}
+```
+HTTP 401
+
+
+# GET /api/v1/solvers — correct Authorization: Bearer token returns 200
+GET http://127.0.0.1:8080/api/v1/solvers
+Authorization: Bearer {{api_token}}
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+
+# GET /api/v1/solvers — correct X-Api-Key returns 200
+GET http://127.0.0.1:8080/api/v1/solvers
+X-Api-Key: {{api_token}}
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+
+# POST /api/v1/parse — correct Authorization: Bearer token returns 200
+POST http://127.0.0.1:8080/api/v1/parse
+Authorization: Bearer {{api_token}}
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.cities" count == 3
+
+
+# POST /api/v1/solve — correct X-Api-Key returns 200
+POST http://127.0.0.1:8080/api/v1/solve
+X-Api-Key: {{api_token}}
+Content-Type: application/json
+```json
+{
+  "solver": "nn",
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.solver" == "nn"

--- a/teeline-api/tests/index.rs
+++ b/teeline-api/tests/index.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 #[tokio::test]

--- a/teeline-api/tests/metrics.rs
+++ b/teeline-api/tests/metrics.rs
@@ -15,7 +15,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 fn metrics_req() -> Request<Body> {

--- a/teeline-api/tests/openapi.rs
+++ b/teeline-api/tests/openapi.rs
@@ -105,6 +105,46 @@ async fn openapi_json_has_schemas_in_components() {
 }
 
 #[tokio::test]
+async fn all_protected_paths_have_security_requirement_except_health() {
+    // Enforces that every route under /api/v1/* except the health exemption
+    // documents a non-empty `security` requirement in its OpenAPI annotation.
+    // AuthLayer protects all of build_api_router() at runtime structurally,
+    // but the OpenAPI spec only reflects that via manually-added
+    // `security(...)` blocks on each #[utoipa::path] — nothing else ties the
+    // two together, so this is what catches a future route that forgets it.
+    let resp = make_app()
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let paths = json["paths"].as_object().unwrap();
+
+    const AUTH_EXEMPT_PATHS: &[&str] = &["/api/v1/health"];
+
+    for (path, methods) in paths {
+        if !path.starts_with("/api/v1/") || AUTH_EXEMPT_PATHS.contains(&path.as_str()) {
+            continue;
+        }
+        for (method, spec) in methods.as_object().unwrap() {
+            let security = spec.get("security").and_then(|s| s.as_array());
+            assert!(
+                security.is_some_and(|s| !s.is_empty()),
+                "{method} {path} is protected by AuthLayer at runtime but has no \
+                 security(...) in its #[utoipa::path] annotation"
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn scalar_docs_returns_html() {
     let resp = make_app()
         .oneshot(Request::builder().uri("/docs").body(Body::empty()).unwrap())

--- a/teeline-api/tests/openapi.rs
+++ b/teeline-api/tests/openapi.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 #[tokio::test]

--- a/teeline-api/tests/parse.rs
+++ b/teeline-api/tests/parse.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 const TINY_TSPLIB: &str = "\

--- a/teeline-api/tests/solve.rs
+++ b/teeline-api/tests/solve.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 fn json_body(json: &str) -> Body {

--- a/teeline-api/tests/solvers.rs
+++ b/teeline-api/tests/solvers.rs
@@ -14,7 +14,7 @@ fn make_app() -> axum::Router {
         registry_service: Arc::new(SolverRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    teeline_api::build_router(state)
+    teeline_api::build_router(state, teeline_api::build_api_router())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds optional `API_KEY`-gated bearer-token auth to `teeline-api`. When set, all `/api/v1/*` routes except `GET /api/v1/health` require `Authorization: Bearer <token>` or `X-Api-Key: <token>`, else `401 {"error":"Unauthorized"}`. When unset, fully back-compat (no auth) — matches current MVP behavior.
- Folds in #307 (router-assembly dedup) as a prerequisite: `build_router` now takes an already-layered `api` sub-router instead of `main.rs` hand-duplicating route wiring to apply `GovernorLayer` before `with_state()`. This is what let the new `AuthLayer` get threaded through one place instead of two.
- `AuthLayer`/`AuthService` mirrors the existing `MetricsLayer`/`MetricsService` Tower `Layer`/`Service` pattern, uses a constant-time comparison (`subtle` crate), and exempts `/api/v1/health` via `MatchedPath`. It's scoped to the `/api/v1/*` sub-router the same way `GovernorLayer` already is, so `/`, `/healthz`, `/metrics`, `/docs`, `/openapi.json` stay open with no special-casing.
- OpenAPI spec documents both security schemes (`bearer_token`, `api_key`) via `utoipa::Modify`.
- New `test:e2e:auth` Taskfile task runs a dedicated hurl suite (using hurl's `{{api_token}}` variable instead of duplicating the token string across files) against a second server instance with `API_KEY` set — the existing `test:e2e:api` suite is fully unmodified.

Plan was reviewed by Opus before implementation, which caught that 8 test files call `build_router` (not just `api_tests.rs`) and a missing `S::Error: Send` bound — both fixed before coding began.

Closes #286, #307

## Test plan

- [x] `cargo test -p teeline-api` — all passing (24 unit + 18 in `api_tests.rs` incl. 7 new auth tests + the other 6 route-specific test files)
- [x] `cargo clippy --workspace -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manual smoke test, auth disabled: `/api/v1/solvers` with no header → 200
- [x] Manual smoke test, auth enabled: health open (200, no header), solvers without token (401), wrong bearer (401), correct bearer (200), correct `X-Api-Key` (200), 401 body exactly `{"error":"Unauthorized"}`
- [x] `openapi.json`: both security schemes registered, `/api/v1/solvers` requires either, `/api/v1/health` has no security requirement
- [x] `task test:e2e:api` — 7/7 files, 14 requests, all pass (unmodified, confirms back-compat)
- [x] `task test:e2e:auth` — 1/1 file, 10 requests, all pass
- [x] `task check` — clean (core `teeline`/`teeline-cli` unaffected)