### PR TITLE
feat(api): deploy teeline-api MVP to Fly.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Build artifacts
+target/
+teeline-wasm/target/
+
+# Sibling projects/workspaces not needed to build teeline-api
+# (teeline-cli/ and root src/ are kept: they're workspace members/deps
+# needed for `cargo build -p teeline-api` to resolve the workspace)
+teeline-web/
+teeline-qt/
+teeline-wasm/
+
+# VCS / KB / editor / tooling state
+.git/
+.kb/
+.claude/
+.superpowers/
+.remember/
+.playwright-mcp/
+.worktrees/
+.githooks/
+
+# Node/JS
+node_modules/
+
+# Secrets and local env
+.env
+.env.*
+
+# Docs, data, misc not needed for the build
+docs/
+data/
+tests/
+solver.py
+download_data.sh

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,24 @@
+name: deploy-api
+
+"on":
+  push:
+    branches: [master]
+    paths: ['teeline-api/**', 'fly.toml', '.github/workflows/deploy-api.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,6 +82,11 @@ tasks:
     cmds:
       - for i in $(seq 10); do curl -sf http://127.0.0.1:8080/api/v1/health && break || sleep 1; done
 
+  api:release:
+    desc: Deploy teeline-api to Fly.io (requires flyctl auth; app must exist, see fly.toml)
+    cmds:
+      - flyctl deploy --config fly.toml --remote-only
+
   test:e2e:api:
     desc: Build, start, wait, run hurl e2e tests, then shut down teeline-api
     deps: [build:api]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+app = "teeline-api"
+primary_region = "ams"
+
+[build]
+dockerfile = "teeline-api/Dockerfile"
+
+[env]
+PORT = "8080"
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_stop_machines = true
+auto_start_machines = true
+min_machines_running = 0
+
+[[http_service.checks]]
+grace_period = "10s"
+interval = "30s"
+method = "GET"
+path = "/api/v1/health"
+timeout = "5s"

--- a/teeline-api/Dockerfile
+++ b/teeline-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1-slim-bookworm AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p teeline-api
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/teeline-api /usr/local/bin/teeline-api
+ENV PORT=8080
+EXPOSE 8080
+CMD ["/usr/local/bin/teeline-api"]


### PR DESCRIPTION
## Summary
- Adds `teeline-api/Dockerfile` (multi-stage, builds only `-p teeline-api`)
- Adds root `.dockerignore` and `fly.toml` (app `teeline-api`, region `ams`, health check on `/api/v1/health`, scale-to-zero via `min_machines_running = 0`)
- Adds `.github/workflows/deploy-api.yml` mirroring `deploy-web.yml`'s shape: auto-deploy on push to `master` (paths `teeline-api/**`, `fly.toml`) + `workflow_dispatch`, using `flyctl` instead of `wrangler`
- Adds `task api:release` for local manual deploys

## Already done (one-time, out of band)
- Fly.io app `teeline-api` created
- `API_KEY` set as a Fly secret (production auth is live, not left open)
- `FLY_API_TOKEN` GitHub secret set for CI

## Test plan
- [x] Manual `flyctl deploy --config fly.toml --remote-only` succeeded
- [x] `curl https://teeline-api.fly.dev/api/v1/health` → 200
- [x] `curl https://teeline-api.fly.dev/api/v1/solvers` no token → 401; correct bearer token → 200; wrong token → 401
- [x] `curl https://teeline-api.fly.dev/openapi.json` → both `bearer_token`/`api_key` security schemes present
- [ ] After merge: confirm `deploy-api.yml` runs automatically on the merge commit and redeploys cleanly