### PR TITLE
feat(api): self-serve API key auth via Clerk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,8 +568,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -784,6 +797,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,13 +831,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -841,10 +873,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -873,6 +1008,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -943,6 +1084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1103,12 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1251,6 +1404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1476,61 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1461,10 +1678,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -1702,6 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +2066,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "teeline"
@@ -1774,13 +2104,14 @@ dependencies = [
  "async-trait",
  "axum",
  "prometheus-client",
+ "reqwest",
  "serde",
  "serde_json",
  "subtle",
  "teeline",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -1872,6 +2203,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,6 +2253,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2008,6 +2374,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2161,6 +2545,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "usage-lib"
 version = "3.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2585,12 @@ dependencies = [
  "versions",
  "xx",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2304,6 +2712,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2805,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2567,11 +2994,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2585,19 +3021,35 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link 0.2.1",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2611,9 +3063,21 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2623,9 +3087,21 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2635,9 +3111,21 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2647,9 +3135,21 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2767,6 +3267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xx"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +3291,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,6 +3327,66 @@ name = "zerocopy-derive"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -28,6 +28,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }
 prometheus-client = "0.22"
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/teeline-api/src/clerk.rs
+++ b/teeline-api/src/clerk.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Identifies which Clerk user/org/machine a verified API key belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedKey {
+    pub subject: String,
+}
+
+/// Verifies an opaque API key secret, returning the key's owner if valid.
+/// Implementations must reject revoked/expired keys even if the underlying
+/// transport reports success — see `ClerkVerifier` for why that matters.
+#[async_trait]
+pub trait ApiKeyVerifier: Send + Sync {
+    async fn verify(&self, key: &str) -> Option<VerifiedKey>;
+}
+
+const CLERK_VERIFY_URL: &str = "https://api.clerk.com/v1/api_keys/verify";
+
+/// Verifies keys issued via Clerk's self-serve "API Keys" feature by calling
+/// Clerk's Backend API (https://clerk.com/docs/reference/backend-api).
+pub struct ClerkVerifier {
+    secret_key: Arc<str>,
+    client: reqwest::Client,
+}
+
+impl ClerkVerifier {
+    pub fn new(secret_key: impl Into<Arc<str>>) -> Self {
+        Self {
+            secret_key: secret_key.into(),
+            client: reqwest::Client::builder()
+                // A slow/hung Clerk response must not tie up our request
+                // handling indefinitely — reqwest's default is no timeout.
+                .timeout(Duration::from_secs(3))
+                .build()
+                .expect("reqwest client with only a timeout configured always builds"),
+        }
+    }
+
+    /// Cheap local rejection of obviously-bogus tokens before spending a
+    /// metered Clerk API call. Not a security control (an attacker can still
+    /// send `ak_`-shaped garbage for free) — just avoids paying for
+    /// accidental/naive junk under a flood.
+    fn passes_shape_check(key: &str) -> bool {
+        key.starts_with("ak_") && key.len() >= 10
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct VerifyResponse {
+    subject: String,
+    revoked: bool,
+    expired: bool,
+}
+
+/// A revoked or expired key still returns HTTP 200 from Clerk — only the
+/// response body says so. Checking status alone would let a revoked/expired
+/// key keep authenticating. Pure function so this decision is unit-testable
+/// without a network mock.
+fn decide(body: VerifyResponse) -> Option<VerifiedKey> {
+    (!body.revoked && !body.expired).then_some(VerifiedKey {
+        subject: body.subject,
+    })
+}
+
+#[async_trait]
+impl ApiKeyVerifier for ClerkVerifier {
+    async fn verify(&self, key: &str) -> Option<VerifiedKey> {
+        if !Self::passes_shape_check(key) {
+            return None;
+        }
+
+        let resp = self
+            .client
+            .post(CLERK_VERIFY_URL)
+            .bearer_auth(&*self.secret_key)
+            .json(&serde_json::json!({ "secret": key }))
+            .send()
+            .await
+            .ok()?;
+
+        if !resp.status().is_success() {
+            return None; // secret unknown to Clerk (400/404)
+        }
+
+        let body: VerifyResponse = resp.json().await.ok()?;
+        decide(body)
+    }
+}
+
+/// Used when `CLERK_SECRET_KEY` is unset — Clerk-based auth is simply
+/// disabled, and only the static break-glass key (if any) authorizes.
+pub struct NullVerifier;
+
+#[async_trait]
+impl ApiKeyVerifier for NullVerifier {
+    async fn verify(&self, _key: &str) -> Option<VerifiedKey> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn null_verifier_always_rejects() {
+        assert!(NullVerifier.verify("ak_anything").await.is_none());
+    }
+
+    #[test]
+    fn shape_check_rejects_missing_prefix() {
+        assert!(!ClerkVerifier::passes_shape_check("not-a-key"));
+    }
+
+    #[test]
+    fn shape_check_rejects_too_short() {
+        assert!(!ClerkVerifier::passes_shape_check("ak_1"));
+    }
+
+    #[test]
+    fn shape_check_accepts_well_formed_key() {
+        assert!(ClerkVerifier::passes_shape_check(
+            "ak_3beecc9c60adb5f9b850e91a8ee1e992"
+        ));
+    }
+
+    #[test]
+    fn decide_rejects_revoked_key_despite_200_shape() {
+        let body = VerifyResponse {
+            subject: "user_abc".to_string(),
+            revoked: true,
+            expired: false,
+        };
+        assert_eq!(decide(body), None);
+    }
+
+    #[test]
+    fn decide_rejects_expired_key() {
+        let body = VerifyResponse {
+            subject: "user_abc".to_string(),
+            revoked: false,
+            expired: true,
+        };
+        assert_eq!(decide(body), None);
+    }
+
+    #[test]
+    fn decide_accepts_valid_key() {
+        let body = VerifyResponse {
+            subject: "user_abc".to_string(),
+            revoked: false,
+            expired: false,
+        };
+        assert_eq!(
+            decide(body),
+            Some(VerifiedKey {
+                subject: "user_abc".to_string()
+            })
+        );
+    }
+}

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod clerk;
 pub mod error;
 pub mod metrics;
 pub mod middleware;

--- a/teeline-api/src/main.rs
+++ b/teeline-api/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use axum::Router;
 use teeline_api::{
     AppState,
+    clerk::{ApiKeyVerifier, ClerkVerifier, NullVerifier},
     metrics::MetricsState,
     middleware,
     services::{SolverRegistry, TspService},
@@ -21,14 +22,22 @@ fn rate_limit_rpm() -> u64 {
         .unwrap_or(100)
 }
 
-/// Returns the configured API key, if any. When unset OR empty, auth is
-/// disabled entirely (back-compat with the original no-auth MVP behavior).
-/// `std::env::var(...).ok()` alone would treat `API_KEY=""` as "set" (an
-/// empty-but-present token), silently enabling auth with a trivially
-/// guessable blank credential — worse than disabled, since operators
-/// wouldn't know from the logs.
+/// Returns the configured static break-glass API key, if any. When unset OR
+/// empty, this credential is disabled entirely (back-compat with the
+/// original no-auth MVP behavior). `std::env::var(...).ok()` alone would
+/// treat `API_KEY=""` as "set" (an empty-but-present token), silently
+/// enabling auth with a trivially guessable blank credential — worse than
+/// disabled, since operators wouldn't know from the logs.
 fn api_key() -> Option<String> {
     std::env::var("API_KEY")
+        .ok()
+        .filter(|token| !token.is_empty())
+}
+
+/// Returns the configured Clerk backend secret key, if any. Same
+/// empty-string-safety as `api_key()`.
+fn clerk_secret_key() -> Option<String> {
+    std::env::var("CLERK_SECRET_KEY")
         .ok()
         .filter(|token| !token.is_empty())
 }
@@ -75,14 +84,29 @@ async fn main() -> anyhow::Result<()> {
     // Applied after GovernorLayer, so auth wraps outermost for matched
     // routes (each subsequent .layer()/.route_layer() call wraps the
     // previous stack) — unauthenticated requests are rejected before
-    // consuming rate-limit budget. require_auth uses route_layer
-    // internally (not layer) so it only runs for requests that actually
-    // match a route.
-    if let Some(token) = api_key() {
-        tracing::info!("API key auth enabled");
-        api = middleware::require_auth(api, token);
+    // consuming rate-limit budget for the static-key path (the Clerk path is
+    // itself a network call and isn't cheap, but that's an accepted v1
+    // tradeoff, not something layering order can fix). require_auth uses
+    // route_layer internally (not layer) so it only runs for requests that
+    // actually match a route.
+    let static_key = api_key();
+    let clerk_secret = clerk_secret_key();
+    let verifier: Arc<dyn ApiKeyVerifier> = match &clerk_secret {
+        Some(secret) => Arc::new(ClerkVerifier::new(secret.clone())),
+        None => Arc::new(NullVerifier),
+    };
+    if static_key.is_some() || clerk_secret.is_some() {
+        tracing::info!(
+            static_key = static_key.is_some(),
+            clerk = clerk_secret.is_some(),
+            "API auth enabled"
+        );
+        // An absent static key becomes "" here, which `token_matches` always
+        // rejects (defense in depth against an empty configured token) — so
+        // Clerk-only setups (no API_KEY) work correctly too.
+        api = middleware::require_auth(api, static_key.unwrap_or_default(), verifier);
     } else {
-        tracing::info!("API key auth disabled (API_KEY unset)");
+        tracing::info!("API auth disabled (neither API_KEY nor CLERK_SECRET_KEY set)");
     }
 
     let app = teeline_api::build_router(state, api);

--- a/teeline-api/src/middleware.rs
+++ b/teeline-api/src/middleware.rs
@@ -8,6 +8,7 @@ use axum::response::IntoResponse;
 use subtle::ConstantTimeEq;
 use tower::{Layer, Service};
 
+use crate::clerk::ApiKeyVerifier;
 use crate::error::ApiError;
 use crate::metrics::{HttpDurationLabels, HttpLabels, MetricsState};
 
@@ -101,15 +102,19 @@ where
 
 const AUTH_EXEMPT_PATH: &str = "/api/v1/health";
 
-/// Wraps `router` so every request must present a valid bearer/API-key
-/// token matching `token`, except `AUTH_EXEMPT_PATH`. Uses `route_layer`
-/// (not `layer`) so requests that don't match any route on `router` fall
-/// through to axum's normal 404 instead of getting a 401 — `.layer()`
-/// would also wrap the router's fallback, turning every unmatched path
-/// into a 401 (axum's `route_layer` docs call this exact scenario out).
+/// Wraps `router` so every request must present a valid credential, except
+/// `AUTH_EXEMPT_PATH`. A request is authorized if it presents either the
+/// static break-glass `token` (operator credential, works even if Clerk is
+/// unreachable) or a key that `verifier` confirms is a live, non-revoked,
+/// non-expired Clerk-issued API key. Uses `route_layer` (not `layer`) so
+/// requests that don't match any route on `router` fall through to axum's
+/// normal 404 instead of getting a 401 — `.layer()` would also wrap the
+/// router's fallback, turning every unmatched path into a 401 (axum's
+/// `route_layer` docs call this exact scenario out).
 pub fn require_auth(
     router: axum::Router<crate::AppState>,
     token: impl Into<Arc<str>>,
+    verifier: Arc<dyn ApiKeyVerifier>,
 ) -> axum::Router<crate::AppState> {
     let token: Arc<str> = token.into();
     router.route_layer(axum::middleware::from_fn(
@@ -118,12 +123,23 @@ pub fn require_auth(
               request: axum::extract::Request,
               next: axum::middleware::Next| {
             let token = Arc::clone(&token);
+            let verifier = Arc::clone(&verifier);
             async move {
                 // MatchedPath is populated by axum's routing before route_layer
                 // middleware runs. The api sub-router only ever matches
                 // "/api/v1/health" as the exempt path.
                 let is_health = matched_path.is_some_and(|m| m.as_str() == AUTH_EXEMPT_PATH);
-                if is_health || token_matches(&token, &headers) {
+                if is_health {
+                    return next.run(request).await;
+                }
+                if token_matches(&token, &headers) {
+                    tracing::info!("request authorized via static break-glass API_KEY");
+                    return next.run(request).await;
+                }
+                if let Some(presented) = extract_token(&headers)
+                    && let Some(verified) = verifier.verify(presented).await
+                {
+                    tracing::info!(subject = %verified.subject, "request authorized via Clerk API key");
                     return next.run(request).await;
                 }
                 ApiError::Unauthorized.into_response()

--- a/teeline-api/tests/api_tests.rs
+++ b/teeline-api/tests/api_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -5,6 +6,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use teeline_api::{
     AppState,
+    clerk::{ApiKeyVerifier, NullVerifier, VerifiedKey},
     metrics::MetricsState,
     middleware,
     models::{
@@ -69,6 +71,17 @@ impl SolverRegistryService for MockRegistry {
     }
 }
 
+/// Test double for `ApiKeyVerifier` — looks up presented keys in a fixed
+/// map, so tests never need a real network call to Clerk.
+struct StaticVerifier(HashMap<String, VerifiedKey>);
+
+#[async_trait]
+impl ApiKeyVerifier for StaticVerifier {
+    async fn verify(&self, key: &str) -> Option<VerifiedKey> {
+        self.0.get(key).cloned()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -84,14 +97,20 @@ fn make_app() -> axum::Router {
 
 const TEST_TOKEN: &str = "test-secret-token";
 
-fn make_authed_app() -> axum::Router {
+fn make_authed_app_with_verifier(verifier: Arc<dyn ApiKeyVerifier>) -> axum::Router {
     let state = AppState {
         solver_service: Arc::new(MockSolverService),
         registry_service: Arc::new(MockRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    let api = middleware::require_auth(teeline_api::build_api_router(), TEST_TOKEN);
+    let api = middleware::require_auth(teeline_api::build_api_router(), TEST_TOKEN, verifier);
     teeline_api::build_router(state, api)
+}
+
+/// Static-key-only auth (no Clerk verifier configured) — used by all the
+/// existing tests below that only exercise the break-glass credential.
+fn make_authed_app() -> axum::Router {
+    make_authed_app_with_verifier(Arc::new(NullVerifier))
 }
 
 fn get_with_header(uri: &str, header: &str, value: &str) -> Request<Body> {
@@ -388,7 +407,7 @@ async fn empty_configured_token_never_matches_empty_presented_token() {
         registry_service: Arc::new(MockRegistry),
         metrics: Arc::new(MetricsState::new()),
     };
-    let api = middleware::require_auth(teeline_api::build_api_router(), "");
+    let api = middleware::require_auth(teeline_api::build_api_router(), "", Arc::new(NullVerifier));
     let app = teeline_api::build_router(state, api);
 
     let resp = app
@@ -409,4 +428,75 @@ async fn unmatched_path_returns_404_not_401_when_auth_enabled() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// Auth — Clerk verifier path (StaticVerifier stands in for a real Clerk call)
+// ---------------------------------------------------------------------------
+
+const CLERK_TEST_KEY: &str = "ak_validkeyforintegrationtests";
+
+fn clerk_verifier_with(key: &str, subject: &str) -> Arc<dyn ApiKeyVerifier> {
+    let mut keys = HashMap::new();
+    keys.insert(
+        key.to_string(),
+        VerifiedKey {
+            subject: subject.to_string(),
+        },
+    );
+    Arc::new(StaticVerifier(keys))
+}
+
+#[tokio::test]
+async fn solvers_with_valid_clerk_key_returns_200() {
+    let app = make_authed_app_with_verifier(clerk_verifier_with(CLERK_TEST_KEY, "user_test123"));
+    let resp = app
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            &format!("Bearer {CLERK_TEST_KEY}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn solvers_with_unknown_clerk_shaped_key_returns_401() {
+    // A key the verifier doesn't recognize (not revoked — simply never
+    // issued) must still 401, not be treated as valid by default.
+    let app = make_authed_app_with_verifier(Arc::new(StaticVerifier(HashMap::new())));
+    let resp = app
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            "Bearer ak_unknownkeyneverissued",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn solvers_with_static_break_glass_key_still_works_alongside_clerk_verifier() {
+    // Even with a Clerk verifier configured, the static break-glass key
+    // must still authorize independently — the two credentials are OR'd,
+    // not one replacing the other.
+    let app = make_authed_app_with_verifier(Arc::new(StaticVerifier(HashMap::new())));
+    let resp = app
+        .oneshot(get_with_header(
+            "/api/v1/solvers",
+            "Authorization",
+            &format!("Bearer {TEST_TOKEN}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn solvers_with_neither_static_nor_clerk_credential_returns_401() {
+    let app = make_authed_app_with_verifier(clerk_verifier_with(CLERK_TEST_KEY, "user_test123"));
+    let resp = app.oneshot(get("/api/v1/solvers")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }

--- a/teeline-web/src/feature-cards.mjs
+++ b/teeline-web/src/feature-cards.mjs
@@ -16,7 +16,7 @@ const FEATURES = [
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 5 L2.5 10 L7 15"/><path d="M13 5 L17.5 10 L13 15"/></svg>',
     links: [
       { href: 'https://api.tspsolver.com/docs', text: 'View API docs ↗', external: true },
-      { href: 'https://lasting-stag-95.accounts.dev/sign-in', text: 'Get your API key ↗', external: true },
+      { href: 'https://accounts.tspsolver.com/sign-in', text: 'Get your API key ↗', external: true },
     ],
   },
   {

--- a/teeline-web/src/feature-cards.mjs
+++ b/teeline-web/src/feature-cards.mjs
@@ -7,35 +7,40 @@ const FEATURES = [
     title: 'WebMCP',
     description: 'Solve TSP problems directly from an AI agent in the browser — no server, no API key, just a page an agent can call.',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="10" cy="5" r="2"/><circle cx="4.5" cy="15.5" r="2"/><circle cx="15.5" cy="15.5" r="2"/><path d="M8.6 6.8 L5.9 13.7"/><path d="M11.4 6.8 L14.1 13.7"/></svg>',
-    link: { href: '/webmcp/', text: 'Learn more' },
+    links: [{ href: '/webmcp/', text: 'Learn more' }],
   },
   {
     slug: 'api',
     title: 'API',
     description: 'A REST API for solving TSP problems programmatically, with OpenAPI docs and rate limiting built in.',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 5 L2.5 10 L7 15"/><path d="M13 5 L17.5 10 L13 15"/></svg>',
-    link: { href: 'https://api.tspsolver.com/docs', text: 'View API docs ↗', external: true },
+    links: [
+      { href: 'https://api.tspsolver.com/docs', text: 'View API docs ↗', external: true },
+      { href: 'https://lasting-stag-95.accounts.dev/sign-in', text: 'Get your API key ↗', external: true },
+    ],
   },
   {
     slug: 'tools',
     title: 'Tools',
     description: 'A command-line binary for scripts and pipelines, plus a graphical desktop app built with Qt.',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12.3 3.8 a3 3 0 1 0 -3.9 3.9 L3.6 13.4 a1.6 1.6 0 0 0 2.3 2.3 L11.6 10 a3 3 0 0 0 3.9 -3.9 l-2 2 -1.6-1.6 z"/></svg>',
-    link: { href: 'https://github.com/timgluz/teeline', text: 'View on GitHub ↗', external: true },
+    links: [{ href: 'https://github.com/timgluz/teeline', text: 'View on GitHub ↗', external: true }],
   },
   {
     slug: 'wasm',
     title: 'WebAssembly',
     description: 'Every solver is compiled to WebAssembly and runs client-side at near-native speed — no install, nothing sent to a server.',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6"/></svg>',
-    link: { href: 'https://github.com/timgluz/teeline#webassembly', text: 'View on GitHub ↗', external: true },
+    links: [{ href: 'https://github.com/timgluz/teeline#webassembly', text: 'View on GitHub ↗', external: true }],
   },
 ]
 
 export function renderFeatureCardsHtml() {
   const cards = FEATURES.map(f => {
-    const links = f.link
-      ? `<ul class="card-links"><li><a href="${f.link.href}"${f.link.external ? ' target="_blank" rel="noopener noreferrer"' : ''}>${f.link.text}</a></li></ul>`
+    const links = f.links.length
+      ? `<ul class="card-links">${f.links
+          .map(l => `<li><a href="${l.href}"${l.external ? ' target="_blank" rel="noopener noreferrer"' : ''}>${l.text}</a></li>`)
+          .join('')}</ul>`
       : ''
     return `
       <article class="card card--${f.slug}">


### PR DESCRIPTION
## Summary
- Adds `teeline-api/src/clerk.rs`: `ApiKeyVerifier` trait + `ClerkVerifier` (calls Clerk's Backend API `POST /api_keys/verify`) + `NullVerifier`
- `middleware::require_auth` now checks the static break-glass `API_KEY` OR a Clerk-verified key (either authorizes); logs which credential path authorized each request
- `main.rs` reads `CLERK_SECRET_KEY`; works correctly whether only `API_KEY`, only Clerk, both, or neither are configured
- teeline-web homepage's "API" card now also links to the Clerk Account Portal for self-serve key generation

## Security review (pre-implementation, Opus)
An adversarial review ran against the plan before any code was written. Findings folded into the design:
- **Revoked/expired keys still return HTTP 200** from Clerk's verify endpoint — confirmed against the actual OpenAPI spec, not assumed. `ClerkVerifier` checks the response body explicitly, with a dedicated regression test (`decide_rejects_revoked_key_despite_200_shape`).
- **Explicit 3s timeout** on the reqwest client — a slow/hung Clerk response must not tie up request handling indefinitely.
- **Cheap local shape-check** (`ak_` prefix) before ever calling Clerk, to blunt a cost/DoS-amplification path (unauthenticated garbage tokens triggering metered third-party calls).
- **Verifier returns the key's Clerk `subject`**, not a bare bool — supports auditability/logging now and per-user features later without a breaking signature change.
- Confirmed as correct/no-change-needed: fail-closed behavior on any Clerk error, no SSRF risk (hardcoded URL, no user input in the request path).

Full details in this session; the Clerk instance backing this PR is currently `sk_test_` (development) — production promotion is a follow-up, tracked separately, not part of this PR.

## Test plan
- [x] `cargo test -p teeline-api`: 31 unit + 26 integration tests, all passing (including new Clerk-path tests and the revoked/expired regression test)
- [x] `cargo clippy -p teeline -p teeline-cli -p teeline-api -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `task test:e2e:api` / `task test:e2e:auth`: both green, unmodified (static-key path has zero regression)
- [x] Manual local smoke test: static key → 200, no token → 401, unknown Clerk-shaped garbage key → 401 (real network call to Clerk confirmed working)
- [x] `npm test` (teeline-web): 198/198 passing; `npm run build:check` confirms both API-card links present in built HTML
- [ ] Manual, once a real key is generated via the Account Portal: `curl -H "Authorization: Bearer ak_..." https://api.tspsolver.com/api/v1/solvers` → 200
- [ ] `CLERK_SECRET_KEY` Fly secret intentionally **not yet set** — holding off until ready to flip this on in production