### PR TITLE
docs(web,api): add step-by-step guide for getting an API key

### DIFF
--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -32,6 +32,9 @@ impl Modify for SecurityAddon {
 
 #[derive(OpenApi)]
 #[openapi(
+    info(
+        description = "Don't have an API key yet? [Sign in to get one](https://accounts.tspsolver.com/sign-in) — takes about a minute, no password required. See the [full guide](https://tspsolver.com/api-key/) for step-by-step instructions."
+    ),
     paths(
         routes::index::handler,
         routes::health::handler,

--- a/teeline-web/api-key/index.html
+++ b/teeline-web/api-key/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Get an API key — Teeline</title>
+    <meta name="description" content="How to sign in and generate a personal API key for the Teeline TSP solver REST API." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://tspsolver.com/api-key/" />
+    <meta property="og:title" content="Get an API key — Teeline" />
+    <meta property="og:description" content="How to sign in and generate a personal API key for the Teeline TSP solver REST API." />
+    <link rel="canonical" href="https://tspsolver.com/api-key/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="topbar"></div>
+    <main style="padding: 1.5rem 2rem; max-width: 800px; margin: 0 auto;">
+      <p style="margin-bottom: 1rem;">
+        <a href="/">← Back to Teeline</a>
+      </p>
+
+      <h1>Get an API key</h1>
+      <p>
+        The <a href="https://api.tspsolver.com/docs" target="_blank" rel="noopener">Teeline REST API</a>
+        requires a personal API key for every endpoint except <code>/api/v1/health</code>.
+        Getting one takes about a minute — no separate Teeline account or password to create,
+        and no request to us.
+      </p>
+
+      <h2>1. Sign in</h2>
+      <p>
+        Go to <a href="https://accounts.tspsolver.com/sign-in" target="_blank" rel="noopener">accounts.tspsolver.com/sign-in</a>
+        and continue with GitHub, GitLab, Google, or an email address — whichever's easiest.
+        There's nothing to install and no separate signup form.
+      </p>
+
+      <h2>2. Create a key</h2>
+      <p>
+        Signing in takes you straight to the <strong>API keys</strong> page. From there:
+      </p>
+      <ol>
+        <li>Click <strong>Add new key</strong>.</li>
+        <li>
+          Give it a name you'll recognize later — e.g. <code>my-laptop</code> or
+          <code>ci-pipeline</code>. An expiration date is optional; leave it blank for a
+          key that never expires.
+        </li>
+        <li>Click <strong>Create key</strong>.</li>
+      </ol>
+
+      <h2>3. Save it now — it's shown once</h2>
+      <p>
+        Your new key (it looks like <code>ak_&hellip;</code>) is revealed exactly once,
+        immediately after you create it. Clerk (the identity provider we use) cannot show it
+        to you again.
+      </p>
+      <p>
+        <strong>Copy it straight into a password manager</strong> (1Password, Bitwarden, or
+        similar) before you navigate away. If you lose it, there's no way to recover it — you'll
+        need to revoke it from the same page and create a new one.
+      </p>
+
+      <h2>4. Use it</h2>
+      <p>Send it as a bearer token on every request:</p>
+      <pre><code>curl -H "Authorization: Bearer ak_your_key_here" \
+  https://api.tspsolver.com/api/v1/solvers</code></pre>
+      <p>
+        An <code>X-Api-Key</code> header works the same way, if that fits your tooling better:
+      </p>
+      <pre><code>curl -H "X-Api-Key: ak_your_key_here" \
+  https://api.tspsolver.com/api/v1/solvers</code></pre>
+
+      <h2>Managing or revoking a key</h2>
+      <p>
+        Sign back in at the same
+        <a href="https://accounts.tspsolver.com/sign-in" target="_blank" rel="noopener">sign-in link</a> any
+        time — you'll land on the API keys page, where you can add more keys or revoke ones
+        you no longer use.
+      </p>
+
+      <p>
+        For the full list of endpoints, request/response shapes, and to try requests
+        directly in the browser, see the
+        <a href="https://api.tspsolver.com/docs" target="_blank" rel="noopener">API reference (Scalar docs)</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/teeline-web/src/feature-cards.mjs
+++ b/teeline-web/src/feature-cards.mjs
@@ -16,7 +16,7 @@ const FEATURES = [
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 5 L2.5 10 L7 15"/><path d="M13 5 L17.5 10 L13 15"/></svg>',
     links: [
       { href: 'https://api.tspsolver.com/docs', text: 'View API docs ↗', external: true },
-      { href: 'https://accounts.tspsolver.com/sign-in', text: 'Get your API key ↗', external: true },
+      { href: '/api-key/', text: 'Get your API key' },
     ],
   },
   {

--- a/teeline-web/vite.config.ts
+++ b/teeline-web/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
         main: 'index.html',
         webmcp: 'webmcp/index.html',
         tsp: 'tsp/index.html',
+        apiKey: 'api-key/index.html',
         ...algoPages,
         ...explainerPages,
       },
@@ -119,14 +120,14 @@ export default defineConfig({
       },
     },
     // Make CSS non-blocking on the main SPA page.
-    // Static content pages (algorithm docs, webmcp, tsp) keep blocking CSS since
-    // they need immediate styling and have no heavy SPA bundle to defer for.
+    // Static content pages (algorithm docs, webmcp, tsp, api-key) keep blocking CSS
+    // since they need immediate styling and have no heavy SPA bundle to defer for.
     {
       name: 'async-css-main',
       transformIndexHtml: {
         order: 'post' as const,
         handler(html: string, ctx: { filename: string }) {
-          if (ctx.filename.includes('/algorithms/') || ctx.filename.includes('/webmcp/') || ctx.filename.includes('/tsp/')) return html
+          if (ctx.filename.includes('/algorithms/') || ctx.filename.includes('/webmcp/') || ctx.filename.includes('/tsp/') || ctx.filename.includes('/api-key/')) return html
           return html.replace(
             /<link rel="stylesheet" crossorigin href="([^"]+)">/g,
             `<link rel="preload" as="style" crossorigin href="$1" onload="this.onload=null;this.rel='stylesheet'">` +


### PR DESCRIPTION
## Summary
- New page `teeline-web/api-key/index.html` — a step-by-step guide (sign in → create key → **save it to a password manager immediately, it's shown once** → use it with curl) documenting the exact flow verified manually against production
- Homepage's "API" card now links to this guide (`/api-key/`) instead of dropping users straight into the Clerk Account Portal with no context
- Scalar docs page (`api.tspsolver.com/docs`) now shows a "Sign in to get one" + "full guide" link right under the title, via OpenAPI's `info.description` (Scalar renders it as markdown)

## Test plan
- [x] `cargo test -p teeline-api`: 31 unit + 26 integration, all passing
- [x] `cargo clippy -p teeline -p teeline-cli -p teeline-api -- -D warnings`: clean
- [x] `npm test` (teeline-web): 198/198 passing
- [x] `npm run build:check`: new `/api-key/` page builds with topbar; homepage links to it
- [x] Manually verified locally: `/openapi.json`'s `info.description` includes the new links; Scalar renders both as clickable markdown links under the title