### PR TITLE
fix(web): stylesheets missing on the api-key guide page

### DIFF
--- a/teeline-web/api-key/index.html
+++ b/teeline-web/api-key/index.html
@@ -84,5 +84,6 @@
         <a href="https://api.tspsolver.com/docs" target="_blank" rel="noopener">API reference (Scalar docs)</a>.
       </p>
     </main>
+    <script type="module" src="/src/api-key-page.ts"></script>
   </body>
 </html>

--- a/teeline-web/src/api-key-page.ts
+++ b/teeline-web/src/api-key-page.ts
@@ -1,0 +1,5 @@
+import '@picocss/pico/css/pico.min.css'
+import './docs.css'
+import { initTopbar } from './topbar'
+
+initTopbar()


### PR DESCRIPTION
## Summary
Root cause: `teeline-web/api-key/index.html` had no `<script type="module">` tag. Vite's HTML transform injects `<link rel="stylesheet">` by tracing CSS imports from a page's JS entry point — with no entry point at all, it had nothing to trace and injected zero stylesheets. Confirmed live at https://tspsolver.com/api-key/ (no CSS requests fired at all, not even a failed one).

Fix: added `teeline-web/src/api-key-page.ts` (Pico CSS + docs.css + `initTopbar()`), matching the exact pattern already used by the sibling `tsp/` and `webmcp/` pages.

## Test plan
- [x] `npm test`: 198/198 passing
- [x] `npx tsc --noEmit`: clean
- [x] `npm run build:check`: confirmed `dist/api-key/index.html` now has `<link rel="stylesheet" ... href="/assets/topbar-*.css">`
- [x] Visually verified via `vite preview` + browser screenshot: topbar nav, typography, and code blocks all render correctly now