### PR TITLE
perf(web): remove deferred-CSS trick on the homepage — it caused CLS 0.67

### DIFF
--- a/teeline-web/vite.config.ts
+++ b/teeline-web/vite.config.ts
@@ -119,22 +119,5 @@ export default defineConfig({
         },
       },
     },
-    // Make CSS non-blocking on the main SPA page.
-    // Static content pages (algorithm docs, webmcp, tsp, api-key) keep blocking CSS
-    // since they need immediate styling and have no heavy SPA bundle to defer for.
-    {
-      name: 'async-css-main',
-      transformIndexHtml: {
-        order: 'post' as const,
-        handler(html: string, ctx: { filename: string }) {
-          if (ctx.filename.includes('/algorithms/') || ctx.filename.includes('/webmcp/') || ctx.filename.includes('/tsp/') || ctx.filename.includes('/api-key/')) return html
-          return html.replace(
-            /<link rel="stylesheet" crossorigin href="([^"]+)">/g,
-            `<link rel="preload" as="style" crossorigin href="$1" onload="this.onload=null;this.rel='stylesheet'">` +
-            `<noscript><link rel="stylesheet" crossorigin href="$1"></noscript>`
-          )
-        },
-      },
-    },
   ],
 })


### PR DESCRIPTION
## Summary
The `async-css-main` Vite plugin deferred `main.css`/`topbar.css` on the homepage specifically (via `rel=preload` + swap-on-load), so the page rendered fully unstyled first and then snapped into the Pico-styled layout once the stylesheets finished loading — a severe layout-shift burst.

Measured with a Chrome DevTools performance trace against the live site:
- **Before**: LCP 175ms, **CLS 0.672** ("bad" — anything over 0.25 is bad per Core Web Vitals)
- CLS burst spanned ~153ms–1153ms — a full second of visual "settling," which is almost certainly what read as "slow to render" even though raw paint timing was fast

Then measured the actual cost of just blocking on the CSS instead of deferring it:
- Both files combined download in ~30ms
- Chrome DevTools' own `RenderBlocking` insight: **"estimated savings: FCP 0 ms, LCP 0 ms"**

So the deferral was trading a severe, real CLS regression for a "render-blocking optimization" that had zero measurable benefit. Removed it — the homepage now loads CSS the same way every other page in this project (`tsp/`, `webmcp/`, `api-key/`) already does.

**After**: LCP 154ms, **CLS 0.00**

## Test plan
- [x] `npm test`: 198/198 passing
- [x] `npx tsc --noEmit`: clean
- [x] `npm run build:check`: homepage now emits blocking `<link rel="stylesheet">` tags
- [x] Re-ran the Chrome DevTools performance trace against the built output locally: LCP 154ms, CLS 0.00 (down from 0.672)