### PR TITLE
fix(web): make WebMCP card's link text descriptive for SEO

### DIFF
--- a/teeline-web/src/feature-cards.mjs
+++ b/teeline-web/src/feature-cards.mjs
@@ -7,7 +7,7 @@ const FEATURES = [
     title: 'WebMCP',
     description: 'Solve TSP problems directly from an AI agent in the browser — no server, no API key, just a page an agent can call.',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="10" cy="5" r="2"/><circle cx="4.5" cy="15.5" r="2"/><circle cx="15.5" cy="15.5" r="2"/><path d="M8.6 6.8 L5.9 13.7"/><path d="M11.4 6.8 L14.1 13.7"/></svg>',
-    links: [{ href: '/webmcp/', text: 'Learn more' }],
+    links: [{ href: '/webmcp/', text: 'Learn about AI agent access' }],
   },
   {
     slug: 'api',


### PR DESCRIPTION
## Summary
Lighthouse's SEO audit flagged the homepage's WebMCP feature card link — text was just "Learn more", which search engines and screen readers see repeated identically across many unrelated links/sites with no context. Changed to "Learn about AI agent access". Grepped the rest of the site for the same generic pattern ("Learn more", "click here", "read more") — this was the only instance.

## Test plan
- [x] `npm test`: 198/198 passing
- [x] `npm run build:check`: confirmed new link text present in built `index.html`