### PR TITLE
feat(wasm): add tour-distance export for measuring a given route's cost

### DIFF
--- a/teeline-wasm/js-bindings/teeline_wasm.js
+++ b/teeline-wasm/js-bindings/teeline_wasm.js
@@ -1,9 +1,8 @@
 "use components";
-import { environment, exit as exit$1, stderr, stdin, stdout } from '@bytecodealliance/preview2-shim/cli';
+import { environment, exit as exit$1, stderr, stdin, stdout, terminalInput, terminalOutput, terminalStderr, terminalStdin, terminalStdout } from '@bytecodealliance/preview2-shim/cli';
 import { monotonicClock, wallClock } from '@bytecodealliance/preview2-shim/clocks';
-import { preopens, types } from '@bytecodealliance/preview2-shim/filesystem';
-import { error, streams } from '@bytecodealliance/preview2-shim/io';
-import { random } from '@bytecodealliance/preview2-shim/random';
+import { error, poll, streams } from '@bytecodealliance/preview2-shim/io';
+import { insecureSeed as insecureSeed$1, random } from '@bytecodealliance/preview2-shim/random';
 const { getEnvironment } = environment;
 
 if (getEnvironment=== undefined) {
@@ -44,6 +43,46 @@ if (getStdout=== undefined) {
   throw err;
 }
 
+const { TerminalInput } = terminalInput;
+
+if (TerminalInput=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'TerminalInput', was 'TerminalInput' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { TerminalOutput } = terminalOutput;
+
+if (TerminalOutput=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'TerminalOutput', was 'TerminalOutput' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStderr } = terminalStderr;
+
+if (getTerminalStderr=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStderr', was 'getTerminalStderr' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStdin } = terminalStdin;
+
+if (getTerminalStdin=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStdin', was 'getTerminalStdin' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getTerminalStdout } = terminalStdout;
+
+if (getTerminalStdout=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getTerminalStdout', was 'getTerminalStdout' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
 const { now } = monotonicClock;
 
 if (now=== undefined) {
@@ -60,34 +99,18 @@ if (now$1=== undefined) {
   throw err;
 }
 
-const { getDirectories } = preopens;
-
-if (getDirectories=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'getDirectories', was 'getDirectories' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
-const { Descriptor,
-  filesystemErrorCode } = types;
-
-if (Descriptor=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'Descriptor', was 'Descriptor' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
-
-if (filesystemErrorCode=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'filesystemErrorCode', was 'filesystemErrorCode' available at instantiation?");
-  console.error("ERROR:", err.toString());
-  throw err;
-}
-
 const { Error: Error$1 } = error;
 
 if (Error$1=== undefined) {
   const err = new Error("unexpectedly undefined local import 'Error$1', was 'Error' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { Pollable } = poll;
+
+if (Pollable=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'Pollable', was 'Pollable' available at instantiation?");
   console.error("ERROR:", err.toString());
   throw err;
 }
@@ -108,10 +131,18 @@ if (OutputStream=== undefined) {
   throw err;
 }
 
-const { getRandomBytes } = random;
+const { insecureSeed } = insecureSeed$1;
 
-if (getRandomBytes=== undefined) {
-  const err = new Error("unexpectedly undefined local import 'getRandomBytes', was 'getRandomBytes' available at instantiation?");
+if (insecureSeed=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'insecureSeed', was 'insecureSeed' available at instantiation?");
+  console.error("ERROR:", err.toString());
+  throw err;
+}
+
+const { getRandomU64 } = random;
+
+if (getRandomU64=== undefined) {
+  const err = new Error("unexpectedly undefined local import 'getRandomU64', was 'getRandomU64' available at instantiation?");
   console.error("ERROR:", err.toString());
   throw err;
 }
@@ -2357,30 +2388,6 @@ function _lowerImportBackwardsCompat(args) {
   }
   
   
-  function _liftFlatU64(ctx) {
-    _debugLog('[_liftFlatU64()] args', { ctx });
-    let val;
-    
-    if (ctx.useDirectParams) {
-      if (ctx.params.length === 0) { throw new Error('expected at least one single i64 argument'); }
-      if (typeof ctx.params[0] !== 'bigint') { throw new Error('expected bigint'); }
-      val = ctx.params[0];
-      ctx.params = ctx.params.slice(1);
-      return [val, ctx];
-    }
-    
-    if (ctx.storageLen !== undefined && ctx.storageLen < 8) {
-      throw new Error(`insufficient storage ([${ctx.storageLen}] bytes) for lift (u64 requires 8 bytes)`);
-    }
-    
-    val = new DataView(ctx.memory.buffer).getBigUint64(ctx.storagePtr, true);
-    ctx.storagePtr += 8;
-    if (ctx.storageLen !== undefined) { ctx.storageLen -= 8; }
-    
-    return [val, ctx];
-  }
-  
-  
   function _liftFlatVariant(casesAndLiftFns) {
     return function _liftFlatVariantInner(ctx) {
       _debugLog('[_liftFlatVariant()] args', { ctx });
@@ -2878,22 +2885,6 @@ function _lowerFlatTuple(meta) {
     if (rem !== 0) {
       ctx.storagePtr += tupleAlign32 - rem;
     }
-  }
-}
-
-function _lowerFlatEnum(lowerMetas) {
-  return function _lowerFlatEnumInner(ctx) {
-    _debugLog('[_lowerFlatEnum()] args', { ctx });
-    
-    const v = ctx.vals[0];
-    const isNotEnumObject = typeof v !== 'object'
-    || Object.keys(v).length !== 2
-    || !('tag' in v);
-    if (isNotEnumObject) {
-      ctx.vals[0] = { tag: v };
-    }
-    
-    _lowerFlatVariant(lowerMetas)(ctx);
   }
 }
 
@@ -3704,10 +3695,9 @@ const instantiateCore = WebAssembly.instantiate;
 
 
 let exports0;
-let exports1;
 
 const _trampoline0 = function() {
-  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.3", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+  _debugLog('[iface="wasi:random/random@0.2.6", function="get-random-u64"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3718,7 +3708,7 @@ const _trampoline0 = function() {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'now',
+      entryFnName: 'getRandomU64',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -3757,7 +3747,7 @@ const _trampoline0 = function() {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => now(),
+      fn: () => getRandomU64(),
     })
     ;
   } catch (err) {
@@ -3769,8 +3759,8 @@ const _trampoline0 = function() {
     
   }
   
-  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.3", function="now"][Instruction::Return]', {
-    funcName: 'now',
+  _debugLog('[iface="wasi:random/random@0.2.6", function="get-random-u64"][Instruction::Return]', {
+    funcName: 'get-random-u64',
     paramCount: 1,
     async: false,
     postReturn: false
@@ -3779,14 +3769,30 @@ const _trampoline0 = function() {
   task.exit();
   return toUint64(ret);
 }
-_trampoline0.fnName = 'wasi:clocks/monotonic-clock@0.2.3#now';
-const handleTable1 = [T_FLAG, 0];
-const captureTable1= new Map();
-let captureCnt1 = 0;
-handleTables[1] = handleTable1;
+_trampoline0.fnName = 'wasi:random/random@0.2.6#getRandomU64';
 
-const _trampoline5 = function() {
-  _debugLog('[iface="wasi:cli/stderr@0.2.3", function="get-stderr"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline7 = function(arg0) {
+  let variant0;
+  switch (arg0) {
+    case 0: {
+      variant0= {
+        tag: 'ok',
+        val: undefined
+      };
+      break;
+    }
+    case 1: {
+      variant0= {
+        tag: 'err',
+        val: undefined
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  _debugLog('[iface="wasi:cli/exit@0.2.6", function="exit"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3797,7 +3803,189 @@ const _trampoline5 = function() {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'getStderr',
+      entryFnName: 'exit',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => exit(variant0),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  _debugLog('[iface="wasi:cli/exit@0.2.6", function="exit"][Instruction::Return]', {
+    funcName: 'exit',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline7.fnName = 'wasi:cli/exit@0.2.6#exit';
+const handleTable0 = [T_FLAG, 0];
+const captureTable0= new Map();
+let captureCnt0 = 0;
+handleTables[0] = handleTable0;
+
+const _trampoline8 = function(arg0) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable0[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable0.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(Pollable.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/poll@0.2.6", function="[method]pollable.block"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'block',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => rsc0.block(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  for (const rsc of curResourceBorrows) {
+    rsc[symbolRscHandle] = undefined;
+  }
+  curResourceBorrows = [];
+  _debugLog('[iface="wasi:io/poll@0.2.6", function="[method]pollable.block"][Instruction::Return]', {
+    funcName: '[method]pollable.block',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline8.fnName = 'wasi:io/poll@0.2.6#block';
+const handleTable3 = [T_FLAG, 0];
+const captureTable3= new Map();
+let captureCnt3 = 0;
+handleTables[3] = handleTable3;
+
+const _trampoline9 = function(arg0) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(OutputStream.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.subscribe"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'subscribe',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -3836,7 +4024,7 @@ const _trampoline5 = function() {
     ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => getStderr(),
+      fn: () => rsc0.subscribe(),
     })
     ;
   } catch (err) {
@@ -3848,35 +4036,39 @@ const _trampoline5 = function() {
     
   }
   
-  
-  if (!(ret instanceof OutputStream)) {
-    throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+  for (const rsc of curResourceBorrows) {
+    rsc[symbolRscHandle] = undefined;
   }
-  var handle0 = ret[symbolRscHandle];
-  if (!handle0) {
-    const rep = ret[symbolRscRep] || ++captureCnt1;
-    captureTable1.set(rep, ret);
-    handle0 = rscTableCreateOwn(handleTable1, rep);
+  curResourceBorrows = [];
+  
+  if (!(ret instanceof Pollable)) {
+    throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+  }
+  var handle3 = ret[symbolRscHandle];
+  if (!handle3) {
+    const rep = ret[symbolRscRep] || ++captureCnt0;
+    captureTable0.set(rep, ret);
+    handle3 = rscTableCreateOwn(handleTable0, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stderr@0.2.3", function="get-stderr"][Instruction::Return]', {
-    funcName: 'get-stderr',
+  _debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.subscribe"][Instruction::Return]', {
+    funcName: '[method]output-stream.subscribe',
     paramCount: 1,
     async: false,
     postReturn: false
   });
-  task.resolve([handle0]);
+  task.resolve([handle3]);
   task.exit();
-  return handle0;
+  return handle3;
 }
-_trampoline5.fnName = 'wasi:cli/stderr@0.2.3#getStderr';
+_trampoline9.fnName = 'wasi:io/streams@0.2.6#subscribe';
 const handleTable2 = [T_FLAG, 0];
 const captureTable2= new Map();
 let captureCnt2 = 0;
 handleTables[2] = handleTable2;
 
-const _trampoline6 = function() {
-  _debugLog('[iface="wasi:cli/stdin@0.2.3", function="get-stdin"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline10 = function() {
+  _debugLog('[iface="wasi:cli/stdin@0.2.6", function="get-stdin"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -3949,7 +4141,7 @@ const _trampoline6 = function() {
     handle0 = rscTableCreateOwn(handleTable2, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stdin@0.2.3", function="get-stdin"][Instruction::Return]', {
+  _debugLog('[iface="wasi:cli/stdin@0.2.6", function="get-stdin"][Instruction::Return]', {
     funcName: 'get-stdin',
     paramCount: 1,
     async: false,
@@ -3959,10 +4151,10 @@ const _trampoline6 = function() {
   task.exit();
   return handle0;
 }
-_trampoline6.fnName = 'wasi:cli/stdin@0.2.3#getStdin';
+_trampoline10.fnName = 'wasi:cli/stdin@0.2.6#getStdin';
 
-const _trampoline7 = function() {
-  _debugLog('[iface="wasi:cli/stdout@0.2.3", function="get-stdout"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline11 = function() {
+  _debugLog('[iface="wasi:cli/stdout@0.2.6", function="get-stdout"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4030,12 +4222,12 @@ const _trampoline7 = function() {
   }
   var handle0 = ret[symbolRscHandle];
   if (!handle0) {
-    const rep = ret[symbolRscRep] || ++captureCnt1;
-    captureTable1.set(rep, ret);
-    handle0 = rscTableCreateOwn(handleTable1, rep);
+    const rep = ret[symbolRscRep] || ++captureCnt3;
+    captureTable3.set(rep, ret);
+    handle0 = rscTableCreateOwn(handleTable3, rep);
   }
   
-  _debugLog('[iface="wasi:cli/stdout@0.2.3", function="get-stdout"][Instruction::Return]', {
+  _debugLog('[iface="wasi:cli/stdout@0.2.6", function="get-stdout"][Instruction::Return]', {
     funcName: 'get-stdout',
     paramCount: 1,
     async: false,
@@ -4045,30 +4237,10 @@ const _trampoline7 = function() {
   task.exit();
   return handle0;
 }
-_trampoline7.fnName = 'wasi:cli/stdout@0.2.3#getStdout';
+_trampoline11.fnName = 'wasi:cli/stdout@0.2.6#getStdout';
 
-const _trampoline8 = function(arg0) {
-  let variant0;
-  switch (arg0) {
-    case 0: {
-      variant0= {
-        tag: 'ok',
-        val: undefined
-      };
-      break;
-    }
-    case 1: {
-      variant0= {
-        tag: 'err',
-        val: undefined
-      };
-      break;
-    }
-    default: {
-      throw new TypeError('invalid variant discriminant for expected');
-    }
-  }
-  _debugLog('[iface="wasi:cli/exit@0.2.3", function="exit"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline12 = function() {
+  _debugLog('[iface="wasi:cli/stderr@0.2.6", function="get-stderr"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4079,7 +4251,7 @@ const _trampoline8 = function(arg0) {
     const results = createNewCurrentTask({
       componentIdx: -1,
       isAsync: false,
-      entryFnName: 'exit',
+      entryFnName: 'getStderr',
       getCallbackFn: () => null,
       callbackFnName: null,
       errHandling: 'none',
@@ -4115,10 +4287,10 @@ const _trampoline8 = function(arg0) {
   let ret;
   
   try {
-    _withGlobalCurrentTaskMeta({
+    ret = _withGlobalCurrentTaskMeta({
       componentIdx: task.componentIdx(),
       taskID: task.id(),
-      fn: () => exit(variant0),
+      fn: () => getStderr(),
     })
     ;
   } catch (err) {
@@ -4130,8 +4302,176 @@ const _trampoline8 = function(arg0) {
     
   }
   
-  _debugLog('[iface="wasi:cli/exit@0.2.3", function="exit"][Instruction::Return]', {
-    funcName: 'exit',
+  
+  if (!(ret instanceof OutputStream)) {
+    throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+  }
+  var handle0 = ret[symbolRscHandle];
+  if (!handle0) {
+    const rep = ret[symbolRscRep] || ++captureCnt3;
+    captureTable3.set(rep, ret);
+    handle0 = rscTableCreateOwn(handleTable3, rep);
+  }
+  
+  _debugLog('[iface="wasi:cli/stderr@0.2.6", function="get-stderr"][Instruction::Return]', {
+    funcName: 'get-stderr',
+    paramCount: 1,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([handle0]);
+  task.exit();
+  return handle0;
+}
+_trampoline12.fnName = 'wasi:cli/stderr@0.2.6#getStderr';
+
+const _trampoline13 = function() {
+  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.6", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'now',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => now(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  _debugLog('[iface="wasi:clocks/monotonic-clock@0.2.6", function="now"][Instruction::Return]', {
+    funcName: 'now',
+    paramCount: 1,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([toUint64(ret)]);
+  task.exit();
+  return toUint64(ret);
+}
+_trampoline13.fnName = 'wasi:clocks/monotonic-clock@0.2.6#now';
+let exports1;
+let memory0;
+let realloc0;
+let realloc0Async;
+
+const _trampoline14 = function(arg0) {
+  _debugLog('[iface="wasi:random/insecure-seed@0.2.6", function="insecure-seed"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'insecureSeed',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => insecureSeed(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var [tuple0_0, tuple0_1] = ret;
+  dataView(memory0).setBigInt64(arg0 + 0, toUint64(tuple0_0), true);
+  dataView(memory0).setBigInt64(arg0 + 8, toUint64(tuple0_1), true);
+  _debugLog('[iface="wasi:random/insecure-seed@0.2.6", function="insecure-seed"][Instruction::Return]', {
+    funcName: 'insecure-seed',
     paramCount: 0,
     async: false,
     postReturn: false
@@ -4139,14 +4479,405 @@ const _trampoline8 = function(arg0) {
   task.resolve([ret]);
   task.exit();
 }
-_trampoline8.fnName = 'wasi:cli/exit@0.2.3#exit';
-let exports2;
-let memory0;
-let realloc0;
-let realloc0Async;
+_trampoline14.fnName = 'wasi:random/insecure-seed@0.2.6#insecureSeed';
+const handleTable1 = [T_FLAG, 0];
+const captureTable1= new Map();
+let captureCnt1 = 0;
+handleTables[1] = handleTable1;
 
-const _trampoline9 = function(arg0) {
-  _debugLog('[iface="wasi:cli/environment@0.2.3", function="get-environment"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline15 = function(arg0, arg1) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(OutputStream.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.check-write"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'checkWrite',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'result-catch-handler',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  try {
+    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => rsc0.checkWrite(),
+    })
+  };
+} catch (e) {
+  ret = { tag: 'err', val: getErrorPayload(e) };
+}
+
+for (const rsc of curResourceBorrows) {
+  rsc[symbolRscHandle] = undefined;
+}
+curResourceBorrows = [];
+var variant5 = ret;
+switch (variant5.tag) {
+  case 'ok': {
+    const e = variant5.val;
+    dataView(memory0).setInt8(arg1 + 0, 0, true);
+    dataView(memory0).setBigInt64(arg1 + 8, toUint64(e), true);
+    
+    break;
+  }
+  case 'err': {
+    const e = variant5.val;
+    dataView(memory0).setInt8(arg1 + 0, 1, true);
+    var variant4 = e;
+    switch (variant4.tag) {
+      case 'last-operation-failed': {
+        const e = variant4.val;
+        dataView(memory0).setInt8(arg1 + 8, 0, true);
+        
+        if (!(e instanceof Error$1)) {
+          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
+        }
+        var handle3 = e[symbolRscHandle];
+        if (!handle3) {
+          const rep = e[symbolRscRep] || ++captureCnt1;
+          captureTable1.set(rep, e);
+          handle3 = rscTableCreateOwn(handleTable1, rep);
+        }
+        
+        dataView(memory0).setInt32(arg1 + 12, handle3, true);
+        break;
+      }
+      case 'closed': {
+        dataView(memory0).setInt8(arg1 + 8, 1, true);
+        break;
+      }
+      default: {
+        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant4.tag)}\` (received \`${variant4}\`) specified for \`StreamError\``);
+      }
+    }
+    
+    break;
+  }
+  default: {
+    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
+    throw new TypeError('invalid variant specified for result');
+  }
+}
+_debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.check-write"][Instruction::Return]', {
+  funcName: '[method]output-stream.check-write',
+  paramCount: 0,
+  async: false,
+  postReturn: false
+});
+task.resolve([ret]);
+task.exit();
+}
+_trampoline15.fnName = 'wasi:io/streams@0.2.6#checkWrite';
+
+const _trampoline16 = function(arg0, arg1, arg2, arg3) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(OutputStream.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  var ptr3 = arg1;
+  var len3 = arg2;
+  var result3 = new Uint8Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 1));
+  _debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.write"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'write',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'result-catch-handler',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  try {
+    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => rsc0.write(result3),
+    })
+  };
+} catch (e) {
+  ret = { tag: 'err', val: getErrorPayload(e) };
+}
+
+for (const rsc of curResourceBorrows) {
+  rsc[symbolRscHandle] = undefined;
+}
+curResourceBorrows = [];
+var variant6 = ret;
+switch (variant6.tag) {
+  case 'ok': {
+    const e = variant6.val;
+    dataView(memory0).setInt8(arg3 + 0, 0, true);
+    
+    break;
+  }
+  case 'err': {
+    const e = variant6.val;
+    dataView(memory0).setInt8(arg3 + 0, 1, true);
+    var variant5 = e;
+    switch (variant5.tag) {
+      case 'last-operation-failed': {
+        const e = variant5.val;
+        dataView(memory0).setInt8(arg3 + 4, 0, true);
+        
+        if (!(e instanceof Error$1)) {
+          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
+        }
+        var handle4 = e[symbolRscHandle];
+        if (!handle4) {
+          const rep = e[symbolRscRep] || ++captureCnt1;
+          captureTable1.set(rep, e);
+          handle4 = rscTableCreateOwn(handleTable1, rep);
+        }
+        
+        dataView(memory0).setInt32(arg3 + 8, handle4, true);
+        break;
+      }
+      case 'closed': {
+        dataView(memory0).setInt8(arg3 + 4, 1, true);
+        break;
+      }
+      default: {
+        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant5.tag)}\` (received \`${variant5}\`) specified for \`StreamError\``);
+      }
+    }
+    
+    break;
+  }
+  default: {
+    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant6, valueType: typeof variant6});
+    throw new TypeError('invalid variant specified for result');
+  }
+}
+_debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.write"][Instruction::Return]', {
+  funcName: '[method]output-stream.write',
+  paramCount: 0,
+  async: false,
+  postReturn: false
+});
+task.resolve([ret]);
+task.exit();
+}
+_trampoline16.fnName = 'wasi:io/streams@0.2.6#write';
+
+const _trampoline17 = function(arg0, arg1) {
+  var handle1 = arg0;
+  
+  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
+  var rsc0 = captureTable3.get(rep2);
+  if (!rsc0) {
+    rsc0 = Object.create(OutputStream.prototype);
+    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
+    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
+  }
+  
+  curResourceBorrows.push(rsc0);
+  _debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.blocking-flush"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'blockingFlush',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'result-catch-handler',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  try {
+    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => rsc0.blockingFlush(),
+    })
+  };
+} catch (e) {
+  ret = { tag: 'err', val: getErrorPayload(e) };
+}
+
+for (const rsc of curResourceBorrows) {
+  rsc[symbolRscHandle] = undefined;
+}
+curResourceBorrows = [];
+var variant5 = ret;
+switch (variant5.tag) {
+  case 'ok': {
+    const e = variant5.val;
+    dataView(memory0).setInt8(arg1 + 0, 0, true);
+    
+    break;
+  }
+  case 'err': {
+    const e = variant5.val;
+    dataView(memory0).setInt8(arg1 + 0, 1, true);
+    var variant4 = e;
+    switch (variant4.tag) {
+      case 'last-operation-failed': {
+        const e = variant4.val;
+        dataView(memory0).setInt8(arg1 + 4, 0, true);
+        
+        if (!(e instanceof Error$1)) {
+          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
+        }
+        var handle3 = e[symbolRscHandle];
+        if (!handle3) {
+          const rep = e[symbolRscRep] || ++captureCnt1;
+          captureTable1.set(rep, e);
+          handle3 = rscTableCreateOwn(handleTable1, rep);
+        }
+        
+        dataView(memory0).setInt32(arg1 + 8, handle3, true);
+        break;
+      }
+      case 'closed': {
+        dataView(memory0).setInt8(arg1 + 4, 1, true);
+        break;
+      }
+      default: {
+        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant4.tag)}\` (received \`${variant4}\`) specified for \`StreamError\``);
+      }
+    }
+    
+    break;
+  }
+  default: {
+    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
+    throw new TypeError('invalid variant specified for result');
+  }
+}
+_debugLog('[iface="wasi:io/streams@0.2.6", function="[method]output-stream.blocking-flush"][Instruction::Return]', {
+  funcName: '[method]output-stream.blocking-flush',
+  paramCount: 0,
+  async: false,
+  postReturn: false
+});
+task.resolve([ret]);
+task.exit();
+}
+_trampoline17.fnName = 'wasi:io/streams@0.2.6#blockingFlush';
+
+const _trampoline18 = function(arg0) {
+  _debugLog('[iface="wasi:cli/environment@0.2.6", function="get-environment"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4231,7 +4962,7 @@ const _trampoline9 = function(arg0) {
   }
   dataView(memory0).setUint32(arg0 + 4, len3, true);
   dataView(memory0).setUint32(arg0 + 0, result3, true);
-  _debugLog('[iface="wasi:cli/environment@0.2.3", function="get-environment"][Instruction::Return]', {
+  _debugLog('[iface="wasi:cli/environment@0.2.6", function="get-environment"][Instruction::Return]', {
     funcName: 'get-environment',
     paramCount: 0,
     async: false,
@@ -4240,10 +4971,297 @@ const _trampoline9 = function(arg0) {
   task.resolve([ret]);
   task.exit();
 }
-_trampoline9.fnName = 'wasi:cli/environment@0.2.3#getEnvironment';
+_trampoline18.fnName = 'wasi:cli/environment@0.2.6#getEnvironment';
+const handleTable4 = [T_FLAG, 0];
+const captureTable4= new Map();
+let captureCnt4 = 0;
+handleTables[4] = handleTable4;
 
-const _trampoline10 = function(arg0) {
-  _debugLog('[iface="wasi:clocks/wall-clock@0.2.3", function="now"] [Instruction::CallInterface] (sync, @ enter)');
+const _trampoline19 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stdin@0.2.6", function="get-terminal-stdin"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStdin',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStdin(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalInput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt4;
+      captureTable4.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable4, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stdin@0.2.6", function="get-terminal-stdin"][Instruction::Return]', {
+    funcName: 'get-terminal-stdin',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline19.fnName = 'wasi:cli/terminal-stdin@0.2.6#getTerminalStdin';
+const handleTable5 = [T_FLAG, 0];
+const captureTable5= new Map();
+let captureCnt5 = 0;
+handleTables[5] = handleTable5;
+
+const _trampoline20 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stdout@0.2.6", function="get-terminal-stdout"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStdout',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStdout(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalOutput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt5;
+      captureTable5.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable5, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stdout@0.2.6", function="get-terminal-stdout"][Instruction::Return]', {
+    funcName: 'get-terminal-stdout',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline20.fnName = 'wasi:cli/terminal-stdout@0.2.6#getTerminalStdout';
+
+const _trampoline21 = function(arg0) {
+  _debugLog('[iface="wasi:cli/terminal-stderr@0.2.6", function="get-terminal-stderr"] [Instruction::CallInterface] (sync, @ enter)');
+  let hostProvided = true;
+  
+  let parentTask;
+  let task;
+  let subtask;
+  
+  const createTask = () => {
+    const results = createNewCurrentTask({
+      componentIdx: -1,
+      isAsync: false,
+      entryFnName: 'getTerminalStderr',
+      getCallbackFn: () => null,
+      callbackFnName: null,
+      errHandling: 'none',
+      callingWasmExport: false,
+    });
+    task = results[0];
+  };
+  
+  taskCreation: {
+    parentTask = getCurrentTask(
+    0,
+    _getGlobalCurrentTaskMeta(0)?.taskID,
+    )?.task;
+    
+    if (!parentTask) {
+      createTask();
+      break taskCreation;
+    }
+    
+    createTask();
+    
+    if (hostProvided) {
+      subtask = parentTask.getLatestSubtask();
+      if (!subtask) {
+        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
+      }
+      task.setParentSubtask(subtask);
+    }
+  }
+  
+  const started = task.enterSync();
+  
+  let ret;
+  
+  try {
+    ret = _withGlobalCurrentTaskMeta({
+      componentIdx: task.componentIdx(),
+      taskID: task.id(),
+      fn: () => getTerminalStderr(),
+    })
+    ;
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  var variant1 = ret;
+  if (variant1 === null || variant1=== undefined) {
+    dataView(memory0).setInt8(arg0 + 0, 0, true);
+  } else {
+    const e = variant1;
+    dataView(memory0).setInt8(arg0 + 0, 1, true);
+    
+    if (!(e instanceof TerminalOutput)) {
+      throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+    }
+    var handle0 = e[symbolRscHandle];
+    if (!handle0) {
+      const rep = e[symbolRscRep] || ++captureCnt5;
+      captureTable5.set(rep, e);
+      handle0 = rscTableCreateOwn(handleTable5, rep);
+    }
+    
+    dataView(memory0).setInt32(arg0 + 4, handle0, true);
+  }
+  _debugLog('[iface="wasi:cli/terminal-stderr@0.2.6", function="get-terminal-stderr"][Instruction::Return]', {
+    funcName: 'get-terminal-stderr',
+    paramCount: 0,
+    async: false,
+    postReturn: false
+  });
+  task.resolve([ret]);
+  task.exit();
+}
+_trampoline21.fnName = 'wasi:cli/terminal-stderr@0.2.6#getTerminalStderr';
+
+const _trampoline22 = function(arg0) {
+  _debugLog('[iface="wasi:clocks/wall-clock@0.2.6", function="now"] [Instruction::CallInterface] (sync, @ enter)');
   let hostProvided = true;
   
   let parentTask;
@@ -4308,7 +5326,7 @@ const _trampoline10 = function(arg0) {
   var {seconds: v0_0, nanoseconds: v0_1 } = ret;
   dataView(memory0).setBigInt64(arg0 + 0, toUint64(v0_0), true);
   dataView(memory0).setInt32(arg0 + 8, toUint32(v0_1), true);
-  _debugLog('[iface="wasi:clocks/wall-clock@0.2.3", function="now"][Instruction::Return]', {
+  _debugLog('[iface="wasi:clocks/wall-clock@0.2.6", function="now"][Instruction::Return]', {
     funcName: 'now',
     paramCount: 0,
     async: false,
@@ -4317,2190 +5335,8 @@ const _trampoline10 = function(arg0) {
   task.resolve([ret]);
   task.exit();
 }
-_trampoline10.fnName = 'wasi:clocks/wall-clock@0.2.3#now$1';
-const handleTable0 = [T_FLAG, 0];
-const captureTable0= new Map();
-let captureCnt0 = 0;
-handleTables[0] = handleTable0;
-
-const _trampoline11 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable0[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable0.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Error$1.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="filesystem-error-code"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'filesystemErrorCode',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => filesystemErrorCode(rsc0),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  for (const rsc of curResourceBorrows) {
-    rsc[symbolRscHandle] = undefined;
-  }
-  curResourceBorrows = [];
-  var variant4 = ret;
-  if (variant4 === null || variant4=== undefined) {
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-  } else {
-    const e = variant4;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val3 = e;
-    let enum3;
-    switch (val3) {
-      case 'access': {
-        enum3 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum3 = 1;
-        break;
-      }
-      case 'already': {
-        enum3 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum3 = 3;
-        break;
-      }
-      case 'busy': {
-        enum3 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum3 = 5;
-        break;
-      }
-      case 'quota': {
-        enum3 = 6;
-        break;
-      }
-      case 'exist': {
-        enum3 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum3 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum3 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum3 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum3 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum3 = 12;
-        break;
-      }
-      case 'io': {
-        enum3 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum3 = 14;
-        break;
-      }
-      case 'loop': {
-        enum3 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum3 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum3 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum3 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum3 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum3 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum3 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum3 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum3 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum3 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum3 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum3 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum3 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum3 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum3 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum3 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum3 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum3 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum3 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum3 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum3 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum3 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val3}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum3, true);
-  }
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="filesystem-error-code"][Instruction::Return]', {
-    funcName: 'filesystem-error-code',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline11.fnName = 'wasi:filesystem/types@0.2.3#filesystemErrorCode';
-const handleTable3 = [T_FLAG, 0];
-const captureTable3= new Map();
-let captureCnt3 = 0;
-handleTables[3] = handleTable3;
-
-const _trampoline12 = function(arg0, arg1, arg2) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.write-via-stream"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'writeViaStream',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.writeViaStream(BigInt.asUintN(64, BigInt(arg1))),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg2 + 0, 0, true);
-    
-    if (!(e instanceof OutputStream)) {
-      throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-    }
-    var handle3 = e[symbolRscHandle];
-    if (!handle3) {
-      const rep = e[symbolRscRep] || ++captureCnt1;
-      captureTable1.set(rep, e);
-      handle3 = rscTableCreateOwn(handleTable1, rep);
-    }
-    
-    dataView(memory0).setInt32(arg2 + 4, handle3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg2 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg2 + 4, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.write-via-stream"][Instruction::Return]', {
-  funcName: '[method]descriptor.write-via-stream',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline12.fnName = 'wasi:filesystem/types@0.2.3#writeViaStream';
-
-const _trampoline13 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.append-via-stream"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'appendViaStream',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.appendViaStream(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    
-    if (!(e instanceof OutputStream)) {
-      throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-    }
-    var handle3 = e[symbolRscHandle];
-    if (!handle3) {
-      const rep = e[symbolRscRep] || ++captureCnt1;
-      captureTable1.set(rep, e);
-      handle3 = rscTableCreateOwn(handleTable1, rep);
-    }
-    
-    dataView(memory0).setInt32(arg1 + 4, handle3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 4, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.append-via-stream"][Instruction::Return]', {
-  funcName: '[method]descriptor.append-via-stream',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline13.fnName = 'wasi:filesystem/types@0.2.3#appendViaStream';
-
-const _trampoline14 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.get-type"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getType',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.getType(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    var val3 = e;
-    let enum3;
-    switch (val3) {
-      case 'unknown': {
-        enum3 = 0;
-        break;
-      }
-      case 'block-device': {
-        enum3 = 1;
-        break;
-      }
-      case 'character-device': {
-        enum3 = 2;
-        break;
-      }
-      case 'directory': {
-        enum3 = 3;
-        break;
-      }
-      case 'fifo': {
-        enum3 = 4;
-        break;
-      }
-      case 'symbolic-link': {
-        enum3 = 5;
-        break;
-      }
-      case 'regular-file': {
-        enum3 = 6;
-        break;
-      }
-      case 'socket': {
-        enum3 = 7;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val3}" is not one of the cases of descriptor-type`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum3, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val4 = e;
-    let enum4;
-    switch (val4) {
-      case 'access': {
-        enum4 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum4 = 1;
-        break;
-      }
-      case 'already': {
-        enum4 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum4 = 3;
-        break;
-      }
-      case 'busy': {
-        enum4 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum4 = 5;
-        break;
-      }
-      case 'quota': {
-        enum4 = 6;
-        break;
-      }
-      case 'exist': {
-        enum4 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum4 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum4 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum4 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum4 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum4 = 12;
-        break;
-      }
-      case 'io': {
-        enum4 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum4 = 14;
-        break;
-      }
-      case 'loop': {
-        enum4 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum4 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum4 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum4 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum4 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum4 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum4 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum4 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum4 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum4 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum4 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum4 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum4 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum4 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum4 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum4 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum4 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum4 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum4 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum4 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum4 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum4 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 1, enum4, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.get-type"][Instruction::Return]', {
-  funcName: '[method]descriptor.get-type',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline14.fnName = 'wasi:filesystem/types@0.2.3#getType';
-
-const _trampoline15 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable3[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable3.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(Descriptor.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.stat"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'stat',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.stat(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant12 = ret;
-switch (variant12.tag) {
-  case 'ok': {
-    const e = variant12.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    var {type: v3_0, linkCount: v3_1, size: v3_2, dataAccessTimestamp: v3_3, dataModificationTimestamp: v3_4, statusChangeTimestamp: v3_5 } = e;
-    var val4 = v3_0;
-    let enum4;
-    switch (val4) {
-      case 'unknown': {
-        enum4 = 0;
-        break;
-      }
-      case 'block-device': {
-        enum4 = 1;
-        break;
-      }
-      case 'character-device': {
-        enum4 = 2;
-        break;
-      }
-      case 'directory': {
-        enum4 = 3;
-        break;
-      }
-      case 'fifo': {
-        enum4 = 4;
-        break;
-      }
-      case 'symbolic-link': {
-        enum4 = 5;
-        break;
-      }
-      case 'regular-file': {
-        enum4 = 6;
-        break;
-      }
-      case 'socket': {
-        enum4 = 7;
-        break;
-      }
-      default: {
-        if ((v3_0) instanceof Error) {
-          console.error(v3_0);
-        }
-        
-        throw new TypeError(`"${val4}" is not one of the cases of descriptor-type`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 8, enum4, true);
-    dataView(memory0).setBigInt64(arg1 + 16, toUint64(v3_1), true);
-    dataView(memory0).setBigInt64(arg1 + 24, toUint64(v3_2), true);
-    var variant6 = v3_3;
-    if (variant6 === null || variant6=== undefined) {
-      dataView(memory0).setInt8(arg1 + 32, 0, true);
-    } else {
-      const e = variant6;
-      dataView(memory0).setInt8(arg1 + 32, 1, true);
-      var {seconds: v5_0, nanoseconds: v5_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 40, toUint64(v5_0), true);
-      dataView(memory0).setInt32(arg1 + 48, toUint32(v5_1), true);
-    }
-    var variant8 = v3_4;
-    if (variant8 === null || variant8=== undefined) {
-      dataView(memory0).setInt8(arg1 + 56, 0, true);
-    } else {
-      const e = variant8;
-      dataView(memory0).setInt8(arg1 + 56, 1, true);
-      var {seconds: v7_0, nanoseconds: v7_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 64, toUint64(v7_0), true);
-      dataView(memory0).setInt32(arg1 + 72, toUint32(v7_1), true);
-    }
-    var variant10 = v3_5;
-    if (variant10 === null || variant10=== undefined) {
-      dataView(memory0).setInt8(arg1 + 80, 0, true);
-    } else {
-      const e = variant10;
-      dataView(memory0).setInt8(arg1 + 80, 1, true);
-      var {seconds: v9_0, nanoseconds: v9_1 } = e;
-      dataView(memory0).setBigInt64(arg1 + 88, toUint64(v9_0), true);
-      dataView(memory0).setInt32(arg1 + 96, toUint32(v9_1), true);
-    }
-    
-    break;
-  }
-  case 'err': {
-    const e = variant12.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var val11 = e;
-    let enum11;
-    switch (val11) {
-      case 'access': {
-        enum11 = 0;
-        break;
-      }
-      case 'would-block': {
-        enum11 = 1;
-        break;
-      }
-      case 'already': {
-        enum11 = 2;
-        break;
-      }
-      case 'bad-descriptor': {
-        enum11 = 3;
-        break;
-      }
-      case 'busy': {
-        enum11 = 4;
-        break;
-      }
-      case 'deadlock': {
-        enum11 = 5;
-        break;
-      }
-      case 'quota': {
-        enum11 = 6;
-        break;
-      }
-      case 'exist': {
-        enum11 = 7;
-        break;
-      }
-      case 'file-too-large': {
-        enum11 = 8;
-        break;
-      }
-      case 'illegal-byte-sequence': {
-        enum11 = 9;
-        break;
-      }
-      case 'in-progress': {
-        enum11 = 10;
-        break;
-      }
-      case 'interrupted': {
-        enum11 = 11;
-        break;
-      }
-      case 'invalid': {
-        enum11 = 12;
-        break;
-      }
-      case 'io': {
-        enum11 = 13;
-        break;
-      }
-      case 'is-directory': {
-        enum11 = 14;
-        break;
-      }
-      case 'loop': {
-        enum11 = 15;
-        break;
-      }
-      case 'too-many-links': {
-        enum11 = 16;
-        break;
-      }
-      case 'message-size': {
-        enum11 = 17;
-        break;
-      }
-      case 'name-too-long': {
-        enum11 = 18;
-        break;
-      }
-      case 'no-device': {
-        enum11 = 19;
-        break;
-      }
-      case 'no-entry': {
-        enum11 = 20;
-        break;
-      }
-      case 'no-lock': {
-        enum11 = 21;
-        break;
-      }
-      case 'insufficient-memory': {
-        enum11 = 22;
-        break;
-      }
-      case 'insufficient-space': {
-        enum11 = 23;
-        break;
-      }
-      case 'not-directory': {
-        enum11 = 24;
-        break;
-      }
-      case 'not-empty': {
-        enum11 = 25;
-        break;
-      }
-      case 'not-recoverable': {
-        enum11 = 26;
-        break;
-      }
-      case 'unsupported': {
-        enum11 = 27;
-        break;
-      }
-      case 'no-tty': {
-        enum11 = 28;
-        break;
-      }
-      case 'no-such-device': {
-        enum11 = 29;
-        break;
-      }
-      case 'overflow': {
-        enum11 = 30;
-        break;
-      }
-      case 'not-permitted': {
-        enum11 = 31;
-        break;
-      }
-      case 'pipe': {
-        enum11 = 32;
-        break;
-      }
-      case 'read-only': {
-        enum11 = 33;
-        break;
-      }
-      case 'invalid-seek': {
-        enum11 = 34;
-        break;
-      }
-      case 'text-file-busy': {
-        enum11 = 35;
-        break;
-      }
-      case 'cross-device': {
-        enum11 = 36;
-        break;
-      }
-      default: {
-        if ((e) instanceof Error) {
-          console.error(e);
-        }
-        
-        throw new TypeError(`"${val11}" is not one of the cases of error-code`);
-      }
-    }
-    dataView(memory0).setInt8(arg1 + 8, enum11, true);
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant12, valueType: typeof variant12});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:filesystem/types@0.2.3", function="[method]descriptor.stat"][Instruction::Return]', {
-  funcName: '[method]descriptor.stat',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline15.fnName = 'wasi:filesystem/types@0.2.3#stat';
-
-const _trampoline16 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(OutputStream.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.check-write"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'checkWrite',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.checkWrite(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    dataView(memory0).setBigInt64(arg1 + 8, toUint64(e), true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var variant4 = e;
-    switch (variant4.tag) {
-      case 'last-operation-failed': {
-        const e = variant4.val;
-        dataView(memory0).setInt8(arg1 + 8, 0, true);
-        
-        if (!(e instanceof Error$1)) {
-          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
-        }
-        var handle3 = e[symbolRscHandle];
-        if (!handle3) {
-          const rep = e[symbolRscRep] || ++captureCnt0;
-          captureTable0.set(rep, e);
-          handle3 = rscTableCreateOwn(handleTable0, rep);
-        }
-        
-        dataView(memory0).setInt32(arg1 + 12, handle3, true);
-        break;
-      }
-      case 'closed': {
-        dataView(memory0).setInt8(arg1 + 8, 1, true);
-        break;
-      }
-      default: {
-        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant4.tag)}\` (received \`${variant4}\`) specified for \`StreamError\``);
-      }
-    }
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.check-write"][Instruction::Return]', {
-  funcName: '[method]output-stream.check-write',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline16.fnName = 'wasi:io/streams@0.2.3#checkWrite';
-
-const _trampoline17 = function(arg0, arg1, arg2, arg3) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(OutputStream.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  var ptr3 = arg1;
-  var len3 = arg2;
-  var result3 = new Uint8Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 1));
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.write"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'write',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.write(result3),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant6 = ret;
-switch (variant6.tag) {
-  case 'ok': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 0, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 1, true);
-    var variant5 = e;
-    switch (variant5.tag) {
-      case 'last-operation-failed': {
-        const e = variant5.val;
-        dataView(memory0).setInt8(arg3 + 4, 0, true);
-        
-        if (!(e instanceof Error$1)) {
-          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
-        }
-        var handle4 = e[symbolRscHandle];
-        if (!handle4) {
-          const rep = e[symbolRscRep] || ++captureCnt0;
-          captureTable0.set(rep, e);
-          handle4 = rscTableCreateOwn(handleTable0, rep);
-        }
-        
-        dataView(memory0).setInt32(arg3 + 8, handle4, true);
-        break;
-      }
-      case 'closed': {
-        dataView(memory0).setInt8(arg3 + 4, 1, true);
-        break;
-      }
-      default: {
-        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant5.tag)}\` (received \`${variant5}\`) specified for \`StreamError\``);
-      }
-    }
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant6, valueType: typeof variant6});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.write"][Instruction::Return]', {
-  funcName: '[method]output-stream.write',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline17.fnName = 'wasi:io/streams@0.2.3#write';
-
-const _trampoline18 = function(arg0, arg1) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(OutputStream.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-flush"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'blockingFlush',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.blockingFlush(),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant5 = ret;
-switch (variant5.tag) {
-  case 'ok': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 0, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant5.val;
-    dataView(memory0).setInt8(arg1 + 0, 1, true);
-    var variant4 = e;
-    switch (variant4.tag) {
-      case 'last-operation-failed': {
-        const e = variant4.val;
-        dataView(memory0).setInt8(arg1 + 4, 0, true);
-        
-        if (!(e instanceof Error$1)) {
-          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
-        }
-        var handle3 = e[symbolRscHandle];
-        if (!handle3) {
-          const rep = e[symbolRscRep] || ++captureCnt0;
-          captureTable0.set(rep, e);
-          handle3 = rscTableCreateOwn(handleTable0, rep);
-        }
-        
-        dataView(memory0).setInt32(arg1 + 8, handle3, true);
-        break;
-      }
-      case 'closed': {
-        dataView(memory0).setInt8(arg1 + 4, 1, true);
-        break;
-      }
-      default: {
-        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant4.tag)}\` (received \`${variant4}\`) specified for \`StreamError\``);
-      }
-    }
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant5, valueType: typeof variant5});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-flush"][Instruction::Return]', {
-  funcName: '[method]output-stream.blocking-flush',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline18.fnName = 'wasi:io/streams@0.2.3#blockingFlush';
-
-const _trampoline19 = function(arg0, arg1, arg2, arg3) {
-  var handle1 = arg0;
-  
-  var rep2 = handleTable1[(handle1 << 1) + 1] & ~T_FLAG;
-  var rsc0 = captureTable1.get(rep2);
-  if (!rsc0) {
-    rsc0 = Object.create(OutputStream.prototype);
-    Object.defineProperty(rsc0, symbolRscHandle, { writable: true, value: handle1});
-    Object.defineProperty(rsc0, symbolRscRep, { writable: true, value: rep2});
-  }
-  
-  curResourceBorrows.push(rsc0);
-  var ptr3 = arg1;
-  var len3 = arg2;
-  var result3 = new Uint8Array(memory0.buffer.slice(ptr3, ptr3 + len3 * 1));
-  _debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-write-and-flush"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'blockingWriteAndFlush',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'result-catch-handler',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  try {
-    ret = { tag: 'ok', val: _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => rsc0.blockingWriteAndFlush(result3),
-    })
-  };
-} catch (e) {
-  ret = { tag: 'err', val: getErrorPayload(e) };
-}
-
-for (const rsc of curResourceBorrows) {
-  rsc[symbolRscHandle] = undefined;
-}
-curResourceBorrows = [];
-var variant6 = ret;
-switch (variant6.tag) {
-  case 'ok': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 0, true);
-    
-    break;
-  }
-  case 'err': {
-    const e = variant6.val;
-    dataView(memory0).setInt8(arg3 + 0, 1, true);
-    var variant5 = e;
-    switch (variant5.tag) {
-      case 'last-operation-failed': {
-        const e = variant5.val;
-        dataView(memory0).setInt8(arg3 + 4, 0, true);
-        
-        if (!(e instanceof Error$1)) {
-          throw new TypeError('Resource error: Not a valid \"Error\" resource.');
-        }
-        var handle4 = e[symbolRscHandle];
-        if (!handle4) {
-          const rep = e[symbolRscRep] || ++captureCnt0;
-          captureTable0.set(rep, e);
-          handle4 = rscTableCreateOwn(handleTable0, rep);
-        }
-        
-        dataView(memory0).setInt32(arg3 + 8, handle4, true);
-        break;
-      }
-      case 'closed': {
-        dataView(memory0).setInt8(arg3 + 4, 1, true);
-        break;
-      }
-      default: {
-        throw new TypeError(`invalid variant tag value \`${JSON.stringify(variant5.tag)}\` (received \`${variant5}\`) specified for \`StreamError\``);
-      }
-    }
-    
-    break;
-  }
-  default: {
-    _debugLog("ERROR: invalid value (expected result as object with 'tag' member)", { value: variant6, valueType: typeof variant6});
-    throw new TypeError('invalid variant specified for result');
-  }
-}
-_debugLog('[iface="wasi:io/streams@0.2.3", function="[method]output-stream.blocking-write-and-flush"][Instruction::Return]', {
-  funcName: '[method]output-stream.blocking-write-and-flush',
-  paramCount: 0,
-  async: false,
-  postReturn: false
-});
-task.resolve([ret]);
-task.exit();
-}
-_trampoline19.fnName = 'wasi:io/streams@0.2.3#blockingWriteAndFlush';
-
-const _trampoline20 = function(arg0, arg1) {
-  _debugLog('[iface="wasi:random/random@0.2.3", function="get-random-bytes"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getRandomBytes',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => getRandomBytes(BigInt.asUintN(64, BigInt(arg0))),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  var val0 = ret;
-  var len0 = Array.isArray(val0) ? val0.length : val0.byteLength;
-  var ptr0 = realloc0(0, 0, 1, len0 * 1);
-  
-  let valData0;
-  const valLenBytes0 = len0 * 1;
-  if (Array.isArray(val0)) {
-    // Regular array likely containing numbers, write values to memory
-    let offset = 0;
-    const dv0 = new DataView(memory0.buffer);
-    for (const v of val0) {
-      _requireValidNumericPrimitive.bind(null, 'u8')(v);
-      dv0.setUint8(ptr0+ offset, v, true);
-      offset += 1;
-    }
-  } else {
-    // TypedArray / ArrayBuffer-like, direct copy
-    valData0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, valLenBytes0);
-    const out0 = new Uint8Array(memory0.buffer, ptr0, valLenBytes0);
-    out0.set(valData0);
-  }
-  
-  dataView(memory0).setUint32(arg1 + 4, len0, true);
-  dataView(memory0).setUint32(arg1 + 0, ptr0, true);
-  _debugLog('[iface="wasi:random/random@0.2.3", function="get-random-bytes"][Instruction::Return]', {
-    funcName: 'get-random-bytes',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline20.fnName = 'wasi:random/random@0.2.3#getRandomBytes';
-
-const _trampoline21 = function(arg0) {
-  _debugLog('[iface="wasi:filesystem/preopens@0.2.3", function="get-directories"] [Instruction::CallInterface] (sync, @ enter)');
-  let hostProvided = true;
-  
-  let parentTask;
-  let task;
-  let subtask;
-  
-  const createTask = () => {
-    const results = createNewCurrentTask({
-      componentIdx: -1,
-      isAsync: false,
-      entryFnName: 'getDirectories',
-      getCallbackFn: () => null,
-      callbackFnName: null,
-      errHandling: 'none',
-      callingWasmExport: false,
-    });
-    task = results[0];
-  };
-  
-  taskCreation: {
-    parentTask = getCurrentTask(
-    0,
-    _getGlobalCurrentTaskMeta(0)?.taskID,
-    )?.task;
-    
-    if (!parentTask) {
-      createTask();
-      break taskCreation;
-    }
-    
-    createTask();
-    
-    if (hostProvided) {
-      subtask = parentTask.getLatestSubtask();
-      if (!subtask) {
-        throw new Error(`Missing subtask (in parent task [${parentTask.id()}]) for host import, has the import been lowered? (ensure asyncImports are set properly)`);
-      }
-      task.setParentSubtask(subtask);
-    }
-  }
-  
-  const started = task.enterSync();
-  
-  let ret;
-  
-  try {
-    ret = _withGlobalCurrentTaskMeta({
-      componentIdx: task.componentIdx(),
-      taskID: task.id(),
-      fn: () => getDirectories(),
-    })
-    ;
-  } catch (err) {
-    
-    task.setErrored(err);
-    task.reject(err);
-    task.exit();
-    throw err;
-    
-  }
-  
-  var vec3 = ret;
-  var len3 = vec3.length;
-  var result3 = realloc0(0, 0, 4, len3 * 12);
-  for (let i = 0; i < vec3.length; i++) {
-    const e = vec3[i];
-    const base = result3 + i * 12;var [tuple0_0, tuple0_1] = e;
-    
-    if (!(tuple0_0 instanceof Descriptor)) {
-      throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-    }
-    var handle1 = tuple0_0[symbolRscHandle];
-    if (!handle1) {
-      const rep = tuple0_0[symbolRscRep] || ++captureCnt3;
-      captureTable3.set(rep, tuple0_0);
-      handle1 = rscTableCreateOwn(handleTable3, rep);
-    }
-    
-    dataView(memory0).setInt32(base + 0, handle1, true);
-    
-    var encodeRes = _utf8AllocateAndEncode(tuple0_1, realloc0, memory0);
-    var ptr2= encodeRes.ptr;
-    var len2 = encodeRes.len;
-    
-    dataView(memory0).setUint32(base + 8, len2, true);
-    dataView(memory0).setUint32(base + 4, ptr2, true);
-  }
-  dataView(memory0).setUint32(arg0 + 4, len3, true);
-  dataView(memory0).setUint32(arg0 + 0, result3, true);
-  _debugLog('[iface="wasi:filesystem/preopens@0.2.3", function="get-directories"][Instruction::Return]', {
-    funcName: 'get-directories',
-    paramCount: 0,
-    async: false,
-    postReturn: false
-  });
-  task.resolve([ret]);
-  task.exit();
-}
-_trampoline21.fnName = 'wasi:filesystem/preopens@0.2.3#getDirectories';
-let exports3;
-let realloc1;
-let realloc1Async;
+_trampoline22.fnName = 'wasi:clocks/wall-clock@0.2.6#now$1';
+let exports2;
 let postReturn0;
 let postReturn0Async;
 let postReturn1;
@@ -6513,19 +5349,17 @@ let postReturn4;
 let postReturn4Async;
 let postReturn5;
 let postReturn5Async;
-let postReturn6;
-let postReturn6Async;
 let exports1Solve;
 
 function solve(arg0, arg1, arg2) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
   var vec2 = arg1;
   var len2 = vec2.length;
-  var result2 = realloc1(0, 0, 4, len2 * 12);
+  var result2 = realloc0(0, 0, 4, len2 * 12);
   for (let i = 0; i < vec2.length; i++) {
     const e = vec2[i];
     const base = result2 + i * 12;var {id: v1_0, x: v1_1, y: v1_2 } = e;
@@ -6635,12 +5469,12 @@ let exports1ParseAndSolve;
 
 function parseAndSolve(arg0, arg1, arg2) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
   
-  var encodeRes = _utf8AllocateAndEncode(arg1, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg1, realloc0, memory0);
   var ptr1= encodeRes.ptr;
   var len1 = encodeRes.len;
   
@@ -6730,7 +5564,7 @@ function parseAndSolve(arg0, arg1, arg2) {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn1(ret);
+  postReturn0(ret);
   cstate.mayLeave = true;
   task.exit();
   
@@ -6746,7 +5580,7 @@ let exports1Parse;
 
 function parse(arg0) {
   
-  var encodeRes = _utf8AllocateAndEncode(arg0, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg0, realloc0, memory0);
   var ptr0= encodeRes.ptr;
   var len0 = encodeRes.len;
   
@@ -6853,7 +5687,7 @@ function parse(arg0) {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn2(ret);
+  postReturn1(ret);
   cstate.mayLeave = true;
   task.exit();
   
@@ -7021,7 +5855,7 @@ function listAlgorithms() {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn3(ret);
+  postReturn2(ret);
   cstate.mayLeave = true;
   task.exit();
   return retCopy;
@@ -7088,7 +5922,7 @@ function getVersion() {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn4(ret);
+  postReturn3(ret);
   cstate.mayLeave = true;
   task.exit();
   return retCopy;
@@ -7099,11 +5933,11 @@ let exports1Compare;
 function compare(arg0, arg1, arg2) {
   var vec1 = arg0;
   var len1 = vec1.length;
-  var result1 = realloc1(0, 0, 4, len1 * 8);
+  var result1 = realloc0(0, 0, 4, len1 * 8);
   for (let i = 0; i < vec1.length; i++) {
     const e = vec1[i];
     const base = result1 + i * 8;
-    var encodeRes = _utf8AllocateAndEncode(e, realloc1, memory0);
+    var encodeRes = _utf8AllocateAndEncode(e, realloc0, memory0);
     var ptr0= encodeRes.ptr;
     var len0 = encodeRes.len;
     
@@ -7111,7 +5945,7 @@ function compare(arg0, arg1, arg2) {
     dataView(memory0).setUint32(base + 0, ptr0, true);
   }
   
-  var encodeRes = _utf8AllocateAndEncode(arg1, realloc1, memory0);
+  var encodeRes = _utf8AllocateAndEncode(arg1, realloc0, memory0);
   var ptr2= encodeRes.ptr;
   var len2 = encodeRes.len;
   
@@ -7214,7 +6048,7 @@ function compare(arg0, arg1, arg2) {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn5(ret);
+  postReturn4(ret);
   cstate.mayLeave = true;
   task.exit();
   return retCopy;
@@ -7225,7 +6059,7 @@ let exports1CompareTours;
 function compareTours(arg0, arg1, arg2) {
   var val0 = arg0;
   var len0 = val0.length;
-  var ptr0 = realloc1(0, 0, 4, len0 * 4);
+  var ptr0 = realloc0(0, 0, 4, len0 * 4);
   
   let valData0;
   const valLenBytes0 = len0 * 4;
@@ -7247,7 +6081,7 @@ function compareTours(arg0, arg1, arg2) {
   
   var val1 = arg1;
   var len1 = val1.length;
-  var ptr1 = realloc1(0, 0, 4, len1 * 4);
+  var ptr1 = realloc0(0, 0, 4, len1 * 4);
   
   let valData1;
   const valLenBytes1 = len1 * 4;
@@ -7269,7 +6103,7 @@ function compareTours(arg0, arg1, arg2) {
   
   var vec3 = arg2;
   var len3 = vec3.length;
-  var result3 = realloc1(0, 0, 4, len3 * 12);
+  var result3 = realloc0(0, 0, 4, len3 * 12);
   for (let i = 0; i < vec3.length; i++) {
     const e = vec3[i];
     const base = result3 + i * 12;var {id: v2_0, x: v2_1, y: v2_2 } = e;
@@ -7362,7 +6196,132 @@ function compareTours(arg0, arg1, arg2) {
   
   let cstate = getOrCreateAsyncState(0);
   cstate.mayLeave = false;
-  postReturn6(ret);
+  postReturn5(ret);
+  cstate.mayLeave = true;
+  task.exit();
+  
+  
+  
+  if (typeof retCopy === 'object' && retCopy.tag === 'err') {
+    throw new ComponentError(retCopy.val);
+  }
+  return retCopy.val;
+  
+}
+let exports1TourDistance;
+
+function tourDistance(arg0, arg1) {
+  var val0 = arg0;
+  var len0 = val0.length;
+  var ptr0 = realloc0(0, 0, 4, len0 * 4);
+  
+  let valData0;
+  const valLenBytes0 = len0 * 4;
+  if (Array.isArray(val0)) {
+    // Regular array likely containing numbers, write values to memory
+    let offset = 0;
+    const dv0 = new DataView(memory0.buffer);
+    for (const v of val0) {
+      _requireValidNumericPrimitive.bind(null, 'u32')(v);
+      dv0.setUint32(ptr0+ offset, v, true);
+      offset += 4;
+    }
+  } else {
+    // TypedArray / ArrayBuffer-like, direct copy
+    valData0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, valLenBytes0);
+    const out0 = new Uint8Array(memory0.buffer, ptr0, valLenBytes0);
+    out0.set(valData0);
+  }
+  
+  var vec2 = arg1;
+  var len2 = vec2.length;
+  var result2 = realloc0(0, 0, 4, len2 * 12);
+  for (let i = 0; i < vec2.length; i++) {
+    const e = vec2[i];
+    const base = result2 + i * 12;var {id: v1_0, x: v1_1, y: v1_2 } = e;
+    dataView(memory0).setInt32(base + 0, toUint32(v1_0), true);
+    dataView(memory0).setFloat32(base + 4, +v1_1, true);
+    dataView(memory0).setFloat32(base + 8, +v1_2, true);
+  }
+  _debugLog('[iface="tour-distance", function="tour-distance"][Instruction::CallWasm] enter', {
+    funcName: 'tour-distance',
+    paramCount: 4,
+    async: false,
+    postReturn: true,
+  });
+  const hostProvided = false;
+  
+  const [task, _wasm_call_currentTaskID] = createNewCurrentTask({
+    componentIdx: 0,
+    isAsync: false,
+    isManualAsync: false,
+    entryFnName: 'exports1TourDistance',
+    getCallbackFn: () => null,
+    callbackFnName: null,
+    errHandling: 'throw-result-err',
+    callingWasmExport: true,
+  });
+  
+  const started = task.enterSync();
+  
+  if (0!== null) {
+    task.setReturnMemoryIdx(0);
+    task.setReturnMemory(() => memory0());
+  }
+  
+  
+  let ret;
+  
+  try {
+    ret =   _withGlobalCurrentTaskMeta({
+      taskID: task.id(),
+      componentIdx: task.componentIdx(),
+      fn: () => exports1TourDistance(ptr0, len0, result2, len2),
+    });
+  } catch (err) {
+    
+    task.setErrored(err);
+    task.reject(err);
+    task.exit();
+    throw err;
+    
+  }
+  
+  let variant4;
+  switch (dataView(memory0).getUint8(ret + 0, true)) {
+    case 0: {
+      variant4= {
+        tag: 'ok',
+        val: dataView(memory0).getFloat32(ret + 4, true)
+      };
+      break;
+    }
+    case 1: {
+      var ptr3 = dataView(memory0).getUint32(ret + 4, true);
+      var len3 = dataView(memory0).getUint32(ret + 8, true);
+      var result3 = TEXT_DECODER_UTF8.decode(new Uint8Array(memory0.buffer, ptr3, len3));
+      variant4= {
+        tag: 'err',
+        val: result3
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  _debugLog('[iface="tour-distance", function="tour-distance"][Instruction::Return]', {
+    funcName: 'tour-distance',
+    paramCount: 1,
+    async: false,
+    postReturn: true
+  });
+  const retCopy = variant4;
+  task.resolve([retCopy.val]);
+  
+  let cstate = getOrCreateAsyncState(0);
+  cstate.mayLeave = false;
+  postReturn5(ret);
   cstate.mayLeave = true;
   task.exit();
   
@@ -7416,19 +6375,6 @@ null,
 },
 );
 function trampoline1(handle) {
-  const handleEntry = rscTableRemove(handleTable3, handle);
-  if (handleEntry.own) {
-    
-    const rsc = captureTable3.get(handleEntry.rep);
-    if (rsc) {
-      if (rsc[symbolDispose]) rsc[symbolDispose]();
-      captureTable3.delete(handleEntry.rep);
-    } else if (Descriptor[symbolCabiDispose]) {
-      Descriptor[symbolCabiDispose](handleEntry.rep);
-    }
-  }
-}
-function trampoline2(handle) {
   const handleEntry = rscTableRemove(handleTable1, handle);
   if (handleEntry.own) {
     
@@ -7436,12 +6382,12 @@ function trampoline2(handle) {
     if (rsc) {
       if (rsc[symbolDispose]) rsc[symbolDispose]();
       captureTable1.delete(handleEntry.rep);
-    } else if (OutputStream[symbolCabiDispose]) {
-      OutputStream[symbolCabiDispose](handleEntry.rep);
+    } else if (Error$1[symbolCabiDispose]) {
+      Error$1[symbolCabiDispose](handleEntry.rep);
     }
   }
 }
-function trampoline3(handle) {
+function trampoline2(handle) {
   const handleEntry = rscTableRemove(handleTable0, handle);
   if (handleEntry.own) {
     
@@ -7449,12 +6395,12 @@ function trampoline3(handle) {
     if (rsc) {
       if (rsc[symbolDispose]) rsc[symbolDispose]();
       captureTable0.delete(handleEntry.rep);
-    } else if (Error$1[symbolCabiDispose]) {
-      Error$1[symbolCabiDispose](handleEntry.rep);
+    } else if (Pollable[symbolCabiDispose]) {
+      Pollable[symbolCabiDispose](handleEntry.rep);
     }
   }
 }
-function trampoline4(handle) {
+function trampoline3(handle) {
   const handleEntry = rscTableRemove(handleTable2, handle);
   if (handleEntry.own) {
     
@@ -7467,152 +6413,45 @@ function trampoline4(handle) {
     }
   }
 }
-let trampoline5 = _trampoline5.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 5,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline5.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
+function trampoline4(handle) {
+  const handleEntry = rscTableRemove(handleTable3, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable3.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable3.delete(handleEntry.rep);
+    } else if (OutputStream[symbolCabiDispose]) {
+      OutputStream[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline5,
-},
-)) : _lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 5,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline5.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
+  }
+}
+function trampoline5(handle) {
+  const handleEntry = rscTableRemove(handleTable4, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable4.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable4.delete(handleEntry.rep);
+    } else if (TerminalInput[symbolCabiDispose]) {
+      TerminalInput[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline5,
-},
-);
-let trampoline6 = _trampoline6.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 6,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline6.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_InputStream(obj) {
-      if (!(obj instanceof InputStream)) {
-        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt2;
-        captureTable2.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable2, rep);
-      }
-      return handle;
+  }
+}
+function trampoline6(handle) {
+  const handleEntry = rscTableRemove(handleTable5, handle);
+  if (handleEntry.own) {
+    
+    const rsc = captureTable5.get(handleEntry.rep);
+    if (rsc) {
+      if (rsc[symbolDispose]) rsc[symbolDispose]();
+      captureTable5.delete(handleEntry.rep);
+    } else if (TerminalOutput[symbolCabiDispose]) {
+      TerminalOutput[symbolCabiDispose](handleEntry.rep);
     }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline6,
-},
-)) : _lowerImportBackwardsCompat.bind(
-null,
-{
-  trampolineIdx: 6,
-  componentIdx: 0,
-  isAsync: false,
-  isManualAsync: _trampoline6.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_InputStream(obj) {
-      if (!(obj instanceof InputStream)) {
-        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt2;
-        captureTable2.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable2, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
-  hasResultPointer: false,
-  funcTypeIsAsync: false,
-  getCallbackFn: () => null,
-  getPostReturnFn: () => null,
-  isCancellable: false,
-  memoryIdx: null,
-  stringEncoding: 'utf8',
-  getMemoryFn: () => null,
-  getReallocFn: undefined,
-  importFn: _trampoline6,
-},
-);
+  }
+}
 let trampoline7 = _trampoline7.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
 null,
 {
@@ -7620,24 +6459,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline7.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
+  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7656,24 +6479,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline7.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  })],
+  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -7693,7 +6500,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline8.manuallyAsync,
-  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
   resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
@@ -7713,7 +6520,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline8.manuallyAsync,
-  paramLiftFns: [_liftFlatResult([['ok', null, 1, 1, 1, 0, 1],['err', null, 1, 1, 1, 0, 1],])],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
   resultLowerFns: [],
   hasResultPointer: false,
   funcTypeIsAsync: false,
@@ -7734,21 +6541,33 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline9.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
-    elemSize32: 16,
-    elemAlign32: 4,
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Pollable(obj) {
+      if (!(obj instanceof Pollable)) {
+        throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt0;
+        captureTable0.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable0, rep);
+      }
+      return handle;
+    }
+    ,
   })],
-  hasResultPointer: true,
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getMemoryFn: () => null,
+  getReallocFn: undefined,
   importFn: _trampoline9,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -7758,21 +6577,33 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline9.manuallyAsync,
-  paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
-    elemSize32: 16,
-    elemAlign32: 4,
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Pollable(obj) {
+      if (!(obj instanceof Pollable)) {
+        throw new TypeError('Resource error: Not a valid \"Pollable\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt0;
+        captureTable0.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable0, rep);
+      }
+      return handle;
+    }
+    ,
   })],
-  hasResultPointer: true,
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getMemoryFn: () => null,
+  getReallocFn: undefined,
   importFn: _trampoline9,
 },
 );
@@ -7784,15 +6615,31 @@ null,
   isAsync: false,
   isManualAsync: _trampoline10.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
-  hasResultPointer: true,
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_InputStream(obj) {
+      if (!(obj instanceof InputStream)) {
+        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt2;
+        captureTable2.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable2, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline10,
 },
@@ -7804,15 +6651,31 @@ null,
   isAsync: false,
   isManualAsync: _trampoline10.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
-  hasResultPointer: true,
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_InputStream(obj) {
+      if (!(obj instanceof InputStream)) {
+        throw new TypeError('Resource error: Not a valid \"InputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt2;
+        captureTable2.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable2, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline10,
 },
@@ -7824,20 +6687,32 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline11.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
-  resultLowerFns: [_lowerFlatOption([
-  [ 'none', null, 2, 1, 1 ],
-  [ 'some', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_OutputStream(obj) {
+      if (!(obj instanceof OutputStream)) {
+        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline11,
 },
@@ -7848,20 +6723,32 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline11.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 0)],
-  resultLowerFns: [_lowerFlatOption([
-  [ 'none', null, 2, 1, 1 ],
-  [ 'some', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_OutputStream(obj) {
+      if (!(obj instanceof OutputStream)) {
+        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
+      }
+      return handle;
+    }
+    ,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline11,
 },
@@ -7873,9 +6760,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline12.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatU64],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
     function lowerImportedOwnedHost_OutputStream(obj) {
@@ -7884,25 +6770,22 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline12,
 },
@@ -7913,9 +6796,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline12.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatU64],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
     function lowerImportedOwnedHost_OutputStream(obj) {
@@ -7924,25 +6806,22 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt3;
+        captureTable3.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable3, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  })],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline12,
 },
@@ -7954,36 +6833,16 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline13.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatU64],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline13,
 },
@@ -7994,36 +6853,16 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline13.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_OutputStream(obj) {
-      if (!(obj instanceof OutputStream)) {
-        throw new TypeError('Resource error: Not a valid \"OutputStream\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt1;
-        captureTable1.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable1, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 8, 4, 4 ],
-  ])
-  ],
-  hasResultPointer: true,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatU64],
+  hasResultPointer: false,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
   getPostReturnFn: () => null,
   isCancellable: false,
-  memoryIdx: 0,
+  memoryIdx: null,
   stringEncoding: 'utf8',
-  getMemoryFn: () => memory0,
+  getMemoryFn: () => null,
   getReallocFn: undefined,
   importFn: _trampoline13,
 },
@@ -8035,12 +6874,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline14.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 2, 1, 1 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatTuple({ elemLowerMetas: [[_lowerFlatU64, 8, 8],[_lowerFlatU64, 8, 8],], size32: 16, align32: 8 })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8059,12 +6894,8 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline14.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 2, 1, 1 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 2, 1, 1 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatTuple({ elemLowerMetas: [[_lowerFlatU64, 8, 8],[_lowerFlatU64, 8, 8],], size32: 16, align32: 8 })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8086,20 +6917,24 @@ null,
   isManualAsync: _trampoline15.manuallyAsync,
   paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatRecord({ fieldMetas: [['type', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 1, 1 ],['linkCount', _lowerFlatU64, 8, 8 ],['size', _lowerFlatU64, 8, 8 ],['dataAccessTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['dataModificationTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['statusChangeTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],], size32: 96, align32: 8 }), 104, 8, 8 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 104, 8, 8 ],
+  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Error$1(obj) {
+      if (!(obj instanceof Error$1)) {
+        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
   ])
   ],
   hasResultPointer: true,
@@ -8122,20 +6957,24 @@ null,
   isManualAsync: _trampoline15.manuallyAsync,
   paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatRecord({ fieldMetas: [['type', _lowerFlatEnum([['unknown', null, 1, 1, 1],['block-device', null, 1, 1, 1],['character-device', null, 1, 1, 1],['directory', null, 1, 1, 1],['fifo', null, 1, 1, 1],['symbolic-link', null, 1, 1, 1],['regular-file', null, 1, 1, 1],['socket', null, 1, 1, 1],]), 1, 1 ],['linkCount', _lowerFlatU64, 8, 8 ],['size', _lowerFlatU64, 8, 8 ],['dataAccessTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['dataModificationTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],['statusChangeTimestamp', _lowerFlatOption([
-  [ 'none', null, 24, 8, 8 ],
-  [ 'some', _lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 }), 24, 8, 8 ],
-  ])
-  , 24, 8 ],], size32: 96, align32: 8 }), 104, 8, 8 ],
-  [ 'err', _lowerFlatEnum([['access', null, 1, 1, 1],['would-block', null, 1, 1, 1],['already', null, 1, 1, 1],['bad-descriptor', null, 1, 1, 1],['busy', null, 1, 1, 1],['deadlock', null, 1, 1, 1],['quota', null, 1, 1, 1],['exist', null, 1, 1, 1],['file-too-large', null, 1, 1, 1],['illegal-byte-sequence', null, 1, 1, 1],['in-progress', null, 1, 1, 1],['interrupted', null, 1, 1, 1],['invalid', null, 1, 1, 1],['io', null, 1, 1, 1],['is-directory', null, 1, 1, 1],['loop', null, 1, 1, 1],['too-many-links', null, 1, 1, 1],['message-size', null, 1, 1, 1],['name-too-long', null, 1, 1, 1],['no-device', null, 1, 1, 1],['no-entry', null, 1, 1, 1],['no-lock', null, 1, 1, 1],['insufficient-memory', null, 1, 1, 1],['insufficient-space', null, 1, 1, 1],['not-directory', null, 1, 1, 1],['not-empty', null, 1, 1, 1],['not-recoverable', null, 1, 1, 1],['unsupported', null, 1, 1, 1],['no-tty', null, 1, 1, 1],['no-such-device', null, 1, 1, 1],['overflow', null, 1, 1, 1],['not-permitted', null, 1, 1, 1],['pipe', null, 1, 1, 1],['read-only', null, 1, 1, 1],['invalid-seek', null, 1, 1, 1],['text-file-busy', null, 1, 1, 1],['cross-device', null, 1, 1, 1],]), 104, 8, 8 ],
+  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_Error$1(obj) {
+      if (!(obj instanceof Error$1)) {
+        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
   ])
   ],
   hasResultPointer: true,
@@ -8157,9 +6996,14 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline16.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatList({
+    elemLiftFn: _liftFlatU8,
+    elemAlign32: 1,
+    elemSize32: 1,
+    typedArray: Uint8Array,
+  })],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
@@ -8169,14 +7013,14 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8197,9 +7041,14 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline16.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3),_liftFlatList({
+    elemLiftFn: _liftFlatU8,
+    elemAlign32: 1,
+    elemSize32: 1,
+    typedArray: Uint8Array,
+  })],
   resultLowerFns: [_lowerFlatResult([
-  [ 'ok', _lowerFlatU64, 16, 8, 8 ],
+  [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
@@ -8209,14 +7058,14 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 16, 8, 8 ],
+  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8238,12 +7087,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline17.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
   [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
@@ -8255,9 +7099,9 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
       }
       return handle;
     }
@@ -8283,12 +7127,7 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline17.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
+  paramLiftFns: [_liftFlatBorrow.bind(null, 3)],
   resultLowerFns: [_lowerFlatResult([
   [ 'ok', null, 12, 4, 4 ],
   [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
@@ -8300,9 +7139,9 @@ null,
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt1;
+        captureTable1.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable1, rep);
       }
       return handle;
     }
@@ -8329,28 +7168,12 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline18.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatList({
+    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
+    elemSize32: 16,
+    elemAlign32: 4,
+  })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8359,7 +7182,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: undefined,
+  getReallocFn: () => realloc0,
   importFn: _trampoline18,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8369,28 +7192,12 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline18.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1)],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
-    componentIdx: 0,
-    lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
-      }
-      let handle = obj[symbolRscHandle];
-      if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
-      }
-      return handle;
-    }
-    ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
-  ])
-  ],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatList({
+    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatStringAny, 8, 4],[_lowerFlatStringAny, 8, 4],], size32: 16, align32: 4 }),
+    elemSize32: 16,
+    elemAlign32: 4,
+  })],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8399,7 +7206,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: undefined,
+  getReallocFn: () => realloc0,
   importFn: _trampoline18,
 },
 );
@@ -8410,31 +7217,26 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline19.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+    function lowerImportedOwnedHost_TerminalInput(obj) {
+      if (!(obj instanceof TerminalInput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt4;
+        captureTable4.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable4, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
+  }), 8, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8455,31 +7257,26 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline19.manuallyAsync,
-  paramLiftFns: [_liftFlatBorrow.bind(null, 1),_liftFlatList({
-    elemLiftFn: _liftFlatU8,
-    elemAlign32: 1,
-    elemSize32: 1,
-    typedArray: Uint8Array,
-  })],
-  resultLowerFns: [_lowerFlatResult([
-  [ 'ok', null, 12, 4, 4 ],
-  [ 'err', _lowerFlatVariant([[ 'last-operation-failed', _lowerFlatOwn({
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
     componentIdx: 0,
     lowerFn: 
-    function lowerImportedOwnedHost_Error$1(obj) {
-      if (!(obj instanceof Error$1)) {
-        throw new TypeError('Resource error: Not a valid \"Error$1\" resource.');
+    function lowerImportedOwnedHost_TerminalInput(obj) {
+      if (!(obj instanceof TerminalInput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalInput\" resource.');
       }
       let handle = obj[symbolRscHandle];
       if (!handle) {
-        const rep = obj[symbolRscRep] || ++captureCnt0;
-        captureTable0.set(rep, obj);
-        handle = rscTableCreateOwn(handleTable0, rep);
+        const rep = obj[symbolRscRep] || ++captureCnt4;
+        captureTable4.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable4, rep);
       }
       return handle;
     }
     ,
-  }), 8, 4, 4 ],[ 'closed', null, 8, 4, 4 ],]), 12, 4, 4 ],
+  }), 8, 4, 4 ],
   ])
   ],
   hasResultPointer: true,
@@ -8501,12 +7298,28 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline20.manuallyAsync,
-  paramLiftFns: [_liftFlatU64],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatU8,
-    elemSize32: 1,
-    elemAlign32: 1,
-  })],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8515,7 +7328,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline20,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8525,12 +7338,28 @@ null,
   componentIdx: 0,
   isAsync: false,
   isManualAsync: _trampoline20.manuallyAsync,
-  paramLiftFns: [_liftFlatU64],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatU8,
-    elemSize32: 1,
-    elemAlign32: 1,
-  })],
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
+      }
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8539,7 +7368,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline20,
 },
 );
@@ -8551,27 +7380,27 @@ null,
   isAsync: false,
   isManualAsync: _trampoline21.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatOwn({
-      componentIdx: 0,
-      lowerFn: 
-      function lowerImportedOwnedHost_Descriptor(obj) {
-        if (!(obj instanceof Descriptor)) {
-          throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-        }
-        let handle = obj[symbolRscHandle];
-        if (!handle) {
-          const rep = obj[symbolRscRep] || ++captureCnt3;
-          captureTable3.set(rep, obj);
-          handle = rscTableCreateOwn(handleTable3, rep);
-        }
-        return handle;
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
       }
-      ,
-    }), 4, 4],[_lowerFlatStringAny, 8, 4],], size32: 12, align32: 4 }),
-    elemSize32: 12,
-    elemAlign32: 4,
-  })],
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8580,7 +7409,7 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline21,
 },
 )) : _lowerImportBackwardsCompat.bind(
@@ -8591,27 +7420,27 @@ null,
   isAsync: false,
   isManualAsync: _trampoline21.manuallyAsync,
   paramLiftFns: [],
-  resultLowerFns: [_lowerFlatList({
-    elemLowerFn: _lowerFlatTuple({ elemLowerMetas: [[_lowerFlatOwn({
-      componentIdx: 0,
-      lowerFn: 
-      function lowerImportedOwnedHost_Descriptor(obj) {
-        if (!(obj instanceof Descriptor)) {
-          throw new TypeError('Resource error: Not a valid \"Descriptor\" resource.');
-        }
-        let handle = obj[symbolRscHandle];
-        if (!handle) {
-          const rep = obj[symbolRscRep] || ++captureCnt3;
-          captureTable3.set(rep, obj);
-          handle = rscTableCreateOwn(handleTable3, rep);
-        }
-        return handle;
+  resultLowerFns: [_lowerFlatOption([
+  [ 'none', null, 8, 4, 4 ],
+  [ 'some', _lowerFlatOwn({
+    componentIdx: 0,
+    lowerFn: 
+    function lowerImportedOwnedHost_TerminalOutput(obj) {
+      if (!(obj instanceof TerminalOutput)) {
+        throw new TypeError('Resource error: Not a valid \"TerminalOutput\" resource.');
       }
-      ,
-    }), 4, 4],[_lowerFlatStringAny, 8, 4],], size32: 12, align32: 4 }),
-    elemSize32: 12,
-    elemAlign32: 4,
-  })],
+      let handle = obj[symbolRscHandle];
+      if (!handle) {
+        const rep = obj[symbolRscRep] || ++captureCnt5;
+        captureTable5.set(rep, obj);
+        handle = rscTableCreateOwn(handleTable5, rep);
+      }
+      return handle;
+    }
+    ,
+  }), 8, 4, 4 ],
+  ])
+  ],
   hasResultPointer: true,
   funcTypeIsAsync: false,
   getCallbackFn: () => null,
@@ -8620,179 +7449,186 @@ null,
   memoryIdx: 0,
   stringEncoding: 'utf8',
   getMemoryFn: () => memory0,
-  getReallocFn: () => realloc0,
+  getReallocFn: undefined,
   importFn: _trampoline21,
+},
+);
+let trampoline22 = _trampoline22.manuallyAsync ? new WebAssembly.Suspending(_lowerImportBackwardsCompat.bind(
+null,
+{
+  trampolineIdx: 22,
+  componentIdx: 0,
+  isAsync: false,
+  isManualAsync: _trampoline22.manuallyAsync,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
+  hasResultPointer: true,
+  funcTypeIsAsync: false,
+  getCallbackFn: () => null,
+  getPostReturnFn: () => null,
+  isCancellable: false,
+  memoryIdx: 0,
+  stringEncoding: 'utf8',
+  getMemoryFn: () => memory0,
+  getReallocFn: undefined,
+  importFn: _trampoline22,
+},
+)) : _lowerImportBackwardsCompat.bind(
+null,
+{
+  trampolineIdx: 22,
+  componentIdx: 0,
+  isAsync: false,
+  isManualAsync: _trampoline22.manuallyAsync,
+  paramLiftFns: [],
+  resultLowerFns: [_lowerFlatRecord({ fieldMetas: [['seconds', _lowerFlatU64, 8, 8 ],['nanoseconds', _lowerFlatU32, 4, 4 ],], size32: 16, align32: 8 })],
+  hasResultPointer: true,
+  funcTypeIsAsync: false,
+  getCallbackFn: () => null,
+  getPostReturnFn: () => null,
+  isCancellable: false,
+  memoryIdx: 0,
+  stringEncoding: 'utf8',
+  getMemoryFn: () => memory0,
+  getReallocFn: undefined,
+  importFn: _trampoline22,
 },
 );
 
 const $init = (() => {
   let gen = (function* _initGenerator () {
     const module0 = fetchCompile(new URL('./teeline_wasm.core.wasm', import.meta.url));
-    const module1 = fetchCompile(new URL('./teeline_wasm.core2.wasm', import.meta.url));
-    const module2 = base64Compile('AGFzbQEAAAABOQpgAn9/AX9gA39+fwF/YAR/f39/AX9gAX8AYAABf2ABfwBgAn9/AGADf35/AGAEf39/fwBgAn5/AAMVFAAAAAECAwQFBQYHBgYGBggGCAkFBAUBcAEUFAdmFQEwAAABMQABATIAAgEzAAMBNAAEATUABQE2AAYBNwAHATgACAE5AAkCMTAACgIxMQALAjEyAAwCMTMADQIxNAAOAjE1AA8CMTYAEAIxNwARAjE4ABICMTkAEwgkaW1wb3J0cwEACvUBFAsAIAAgAUEAEQAACwsAIAAgAUEBEQAACwsAIAAgAUECEQAACw0AIAAgASACQQMRAQALDwAgACABIAIgA0EEEQIACwkAIABBBREDAAsHAEEGEQQACwkAIABBBxEFAAsJACAAQQgRBQALCwAgACABQQkRBgALDQAgACABIAJBChEHAAsLACAAIAFBCxEGAAsLACAAIAFBDBEGAAsLACAAIAFBDREGAAsLACAAIAFBDhEGAAsPACAAIAEgAiADQQ8RCAALCwAgACABQRARBgALDwAgACABIAIgA0EREQgACwsAIAAgAUESEQkACwkAIABBExEFAAsALwlwcm9kdWNlcnMBDHByb2Nlc3NlZC1ieQENd2l0LWNvbXBvbmVudAcwLjIyNy4xAPcIBG5hbWUAExJ3aXQtY29tcG9uZW50OnNoaW0B2ggUACdhZGFwdC13YXNpX3NuYXBzaG90X3ByZXZpZXcxLXJhbmRvbV9nZXQBKGFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZW52aXJvbl9nZXQCLmFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZW52aXJvbl9zaXplc19nZXQDK2FkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtY2xvY2tfdGltZV9nZXQEJWFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtZmRfd3JpdGUFJmFkYXB0LXdhc2lfc25hcHNob3RfcHJldmlldzEtcHJvY19leGl0BihhZGFwdC13YXNpX3NuYXBzaG90X3ByZXZpZXcxLXNjaGVkX3lpZWxkBzNpbmRpcmVjdC13YXNpOmNsaS9lbnZpcm9ubWVudEAwLjIuMy1nZXQtZW52aXJvbm1lbnQIKWluZGlyZWN0LXdhc2k6Y2xvY2tzL3dhbGwtY2xvY2tAMC4yLjMtbm93CTppbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vdHlwZXNAMC4yLjMtZmlsZXN5c3RlbS1lcnJvci1jb2RlCkhpbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vdHlwZXNAMC4yLjMtW21ldGhvZF1kZXNjcmlwdG9yLndyaXRlLXZpYS1zdHJlYW0LSWluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3IuYXBwZW5kLXZpYS1zdHJlYW0MQGluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3IuZ2V0LXR5cGUNPGluZGlyZWN0LXdhc2k6ZmlsZXN5c3RlbS90eXBlc0AwLjIuMy1bbWV0aG9kXWRlc2NyaXB0b3Iuc3RhdA5AaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5jaGVjay13cml0ZQ86aW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS53cml0ZRBDaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5ibG9ja2luZy1mbHVzaBFNaW5kaXJlY3Qtd2FzaTppby9zdHJlYW1zQDAuMi4zLVttZXRob2Rdb3V0cHV0LXN0cmVhbS5ibG9ja2luZy13cml0ZS1hbmQtZmx1c2gSMmluZGlyZWN0LXdhc2k6cmFuZG9tL3JhbmRvbUAwLjIuMy1nZXQtcmFuZG9tLWJ5dGVzEzdpbmRpcmVjdC13YXNpOmZpbGVzeXN0ZW0vcHJlb3BlbnNAMC4yLjItZ2V0LWRpcmVjdG9yaWVz');
-    const module3 = base64Compile('AGFzbQEAAAABOQpgAn9/AX9gA39+fwF/YAR/f39/AX9gAX8AYAABf2ABfwBgAn9/AGADf35/AGAEf39/fwBgAn5/AAJ+FQABMAAAAAExAAAAATIAAAABMwABAAE0AAIAATUAAwABNgAEAAE3AAUAATgABQABOQAGAAIxMAAHAAIxMQAGAAIxMgAGAAIxMwAGAAIxNAAGAAIxNQAIAAIxNgAGAAIxNwAIAAIxOAAJAAIxOQAFAAgkaW1wb3J0cwFwARQUCRoBAEEACxQAAQIDBAUGBwgJCgsMDQ4PEBESEwAvCXByb2R1Y2VycwEMcHJvY2Vzc2VkLWJ5AQ13aXQtY29tcG9uZW50BzAuMjI3LjEAHARuYW1lABUUd2l0LWNvbXBvbmVudDpmaXh1cHM');
-    ({ exports: exports0 } = yield instantiateCore(yield module2));
+    const module1 = base64Compile('AGFzbQEAAAABEQNgAX8AYAJ/fwBgBH9/f38AAwoJAAECAQAAAAAABAUBcAEJCQcwCgEwAAABMQABATIAAgEzAAMBNAAEATUABQE2AAYBNwAHATgACAgkaW1wb3J0cwEACmUJCQAgAEEAEQAACwsAIAAgAUEBEQEACw8AIAAgASACIANBAhECAAsLACAAIAFBAxEBAAsJACAAQQQRAAALCQAgAEEFEQAACwkAIABBBhEAAAsJACAAQQcRAAALCQAgAEEIEQAACwAvCXByb2R1Y2VycwEMcHJvY2Vzc2VkLWJ5AQ13aXQtY29tcG9uZW50BzAuMjQ2LjI');
+    const module2 = base64Compile('AGFzbQEAAAABEQNgAX8AYAJ/fwBgBH9/f38AAj0KAAEwAAAAATEAAQABMgACAAEzAAEAATQAAAABNQAAAAE2AAAAATcAAAABOAAAAAgkaW1wb3J0cwFwAQkJCQ8BAEEACwkAAQIDBAUGBwgALwlwcm9kdWNlcnMBDHByb2Nlc3NlZC1ieQENd2l0LWNvbXBvbmVudAcwLjI0Ni4y');
+    ({ exports: exports0 } = yield instantiateCore(yield module1));
     ({ exports: exports1 } = yield instantiateCore(yield module0, {
-      wasi_snapshot_preview1: {
-        clock_time_get: exports0['3'],
-        environ_get: exports0['1'],
-        environ_sizes_get: exports0['2'],
-        fd_write: exports0['4'],
-        proc_exit: exports0['5'],
-        random_get: exports0['0'],
-        sched_yield: exports0['6'],
+      'wasi:cli/environment@0.2.0': {
+        'get-environment': exports0['4'],
       },
-    }));
-    ({ exports: exports2 } = yield instantiateCore(yield module1, {
-      __main_module__: {
-        cabi_realloc: exports1.cabi_realloc,
+      'wasi:cli/exit@0.2.0': {
+        exit: trampoline7,
       },
-      env: {
-        memory: exports1.memory,
+      'wasi:cli/stderr@0.2.0': {
+        'get-stderr': trampoline12,
       },
-      'wasi:cli/environment@0.2.3': {
-        'get-environment': exports0['7'],
+      'wasi:cli/stdin@0.2.0': {
+        'get-stdin': trampoline10,
       },
-      'wasi:cli/exit@0.2.3': {
-        exit: trampoline8,
+      'wasi:cli/stdout@0.2.0': {
+        'get-stdout': trampoline11,
       },
-      'wasi:cli/stderr@0.2.3': {
-        'get-stderr': trampoline5,
+      'wasi:cli/terminal-input@0.2.0': {
+        '[resource-drop]terminal-input': trampoline5,
       },
-      'wasi:cli/stdin@0.2.3': {
-        'get-stdin': trampoline6,
+      'wasi:cli/terminal-output@0.2.0': {
+        '[resource-drop]terminal-output': trampoline6,
       },
-      'wasi:cli/stdout@0.2.3': {
-        'get-stdout': trampoline7,
+      'wasi:cli/terminal-stderr@0.2.0': {
+        'get-terminal-stderr': exports0['7'],
       },
-      'wasi:clocks/monotonic-clock@0.2.3': {
-        now: trampoline0,
+      'wasi:cli/terminal-stdin@0.2.0': {
+        'get-terminal-stdin': exports0['5'],
       },
-      'wasi:clocks/wall-clock@0.2.3': {
+      'wasi:cli/terminal-stdout@0.2.0': {
+        'get-terminal-stdout': exports0['6'],
+      },
+      'wasi:clocks/monotonic-clock@0.2.0': {
+        now: trampoline13,
+      },
+      'wasi:clocks/wall-clock@0.2.0': {
         now: exports0['8'],
       },
-      'wasi:filesystem/preopens@0.2.2': {
-        'get-directories': exports0['19'],
+      'wasi:io/error@0.2.0': {
+        '[resource-drop]error': trampoline1,
       },
-      'wasi:filesystem/types@0.2.3': {
-        '[method]descriptor.append-via-stream': exports0['11'],
-        '[method]descriptor.get-type': exports0['12'],
-        '[method]descriptor.stat': exports0['13'],
-        '[method]descriptor.write-via-stream': exports0['10'],
-        '[resource-drop]descriptor': trampoline1,
-        'filesystem-error-code': exports0['9'],
+      'wasi:io/poll@0.2.0': {
+        '[method]pollable.block': trampoline8,
+        '[resource-drop]pollable': trampoline2,
       },
-      'wasi:io/error@0.2.3': {
-        '[resource-drop]error': trampoline3,
+      'wasi:io/streams@0.2.0': {
+        '[method]output-stream.blocking-flush': exports0['3'],
+        '[method]output-stream.check-write': exports0['1'],
+        '[method]output-stream.subscribe': trampoline9,
+        '[method]output-stream.write': exports0['2'],
+        '[resource-drop]input-stream': trampoline3,
+        '[resource-drop]output-stream': trampoline4,
       },
-      'wasi:io/streams@0.2.3': {
-        '[method]output-stream.blocking-flush': exports0['16'],
-        '[method]output-stream.blocking-write-and-flush': exports0['17'],
-        '[method]output-stream.check-write': exports0['14'],
-        '[method]output-stream.write': exports0['15'],
-        '[resource-drop]input-stream': trampoline4,
-        '[resource-drop]output-stream': trampoline2,
+      'wasi:random/insecure-seed@0.2.4': {
+        'insecure-seed': exports0['0'],
       },
-      'wasi:random/random@0.2.3': {
-        'get-random-bytes': exports0['18'],
+      'wasi:random/random@0.2.0': {
+        'get-random-u64': trampoline0,
       },
     }));
     memory0 = exports1.memory;
-    realloc0 = exports2.cabi_import_realloc;
+    realloc0 = exports1.cabi_realloc;
     
     try {
-      realloc0Async = WebAssembly.promising(exports2.cabi_import_realloc);
+      realloc0Async = WebAssembly.promising(exports1.cabi_realloc);
     } catch(err) {
-      realloc0Async = exports2.cabi_import_realloc;
+      realloc0Async = exports1.cabi_realloc;
     }
     
-    ({ exports: exports3 } = yield instantiateCore(yield module3, {
+    ({ exports: exports2 } = yield instantiateCore(yield module2, {
       '': {
         $imports: exports0.$imports,
-        '0': exports2.random_get,
-        '1': exports2.environ_get,
-        '10': trampoline12,
-        '11': trampoline13,
-        '12': trampoline14,
-        '13': trampoline15,
-        '14': trampoline16,
-        '15': trampoline17,
-        '16': trampoline18,
-        '17': trampoline19,
-        '18': trampoline20,
-        '19': trampoline21,
-        '2': exports2.environ_sizes_get,
-        '3': exports2.clock_time_get,
-        '4': exports2.fd_write,
-        '5': exports2.proc_exit,
-        '6': exports2.sched_yield,
-        '7': trampoline9,
-        '8': trampoline10,
-        '9': trampoline11,
+        '0': trampoline14,
+        '1': trampoline15,
+        '2': trampoline16,
+        '3': trampoline17,
+        '4': trampoline18,
+        '5': trampoline19,
+        '6': trampoline20,
+        '7': trampoline21,
+        '8': trampoline22,
       },
     }));
-    realloc1 = exports1.cabi_realloc;
+    postReturn0 = exports1['cabi_post_parse-and-solve'];
     
     try {
-      realloc1Async = WebAssembly.promising(exports1.cabi_realloc);
+      postReturn0Async = WebAssembly.promising(exports1['cabi_post_parse-and-solve']);
     } catch(err) {
-      realloc1Async = exports1.cabi_realloc;
+      postReturn0Async = exports1['cabi_post_parse-and-solve'];
     }
     
-    postReturn0 = exports1.cabi_post_solve;
+    postReturn1 = exports1.cabi_post_parse;
     
     try {
-      postReturn0Async = WebAssembly.promising(exports1.cabi_post_solve);
+      postReturn1Async = WebAssembly.promising(exports1.cabi_post_parse);
     } catch(err) {
-      postReturn0Async = exports1.cabi_post_solve;
+      postReturn1Async = exports1.cabi_post_parse;
     }
     
-    postReturn1 = exports1['cabi_post_parse-and-solve'];
+    postReturn2 = exports1['cabi_post_list-algorithms'];
     
     try {
-      postReturn1Async = WebAssembly.promising(exports1['cabi_post_parse-and-solve']);
+      postReturn2Async = WebAssembly.promising(exports1['cabi_post_list-algorithms']);
     } catch(err) {
-      postReturn1Async = exports1['cabi_post_parse-and-solve'];
+      postReturn2Async = exports1['cabi_post_list-algorithms'];
     }
     
-    postReturn2 = exports1.cabi_post_parse;
+    postReturn3 = exports1['cabi_post_get-version'];
     
     try {
-      postReturn2Async = WebAssembly.promising(exports1.cabi_post_parse);
+      postReturn3Async = WebAssembly.promising(exports1['cabi_post_get-version']);
     } catch(err) {
-      postReturn2Async = exports1.cabi_post_parse;
+      postReturn3Async = exports1['cabi_post_get-version'];
     }
     
-    postReturn3 = exports1['cabi_post_list-algorithms'];
+    postReturn4 = exports1.cabi_post_compare;
     
     try {
-      postReturn3Async = WebAssembly.promising(exports1['cabi_post_list-algorithms']);
+      postReturn4Async = WebAssembly.promising(exports1.cabi_post_compare);
     } catch(err) {
-      postReturn3Async = exports1['cabi_post_list-algorithms'];
+      postReturn4Async = exports1.cabi_post_compare;
     }
     
-    postReturn4 = exports1['cabi_post_get-version'];
+    postReturn5 = exports1['cabi_post_compare-tours'];
     
     try {
-      postReturn4Async = WebAssembly.promising(exports1['cabi_post_get-version']);
+      postReturn5Async = WebAssembly.promising(exports1['cabi_post_compare-tours']);
     } catch(err) {
-      postReturn4Async = exports1['cabi_post_get-version'];
-    }
-    
-    postReturn5 = exports1.cabi_post_compare;
-    
-    try {
-      postReturn5Async = WebAssembly.promising(exports1.cabi_post_compare);
-    } catch(err) {
-      postReturn5Async = exports1.cabi_post_compare;
-    }
-    
-    postReturn6 = exports1['cabi_post_compare-tours'];
-    
-    try {
-      postReturn6Async = WebAssembly.promising(exports1['cabi_post_compare-tours']);
-    } catch(err) {
-      postReturn6Async = exports1['cabi_post_compare-tours'];
+      postReturn5Async = exports1['cabi_post_compare-tours'];
     }
     
     exports1Solve = exports1.solve;
@@ -8802,6 +7638,7 @@ const $init = (() => {
     exports1GetVersion = exports1['get-version'];
     exports1Compare = exports1.compare;
     exports1CompareTours = exports1['compare-tours'];
+    exports1TourDistance = exports1['tour-distance'];
   })();
   let promise, resolve, reject;
   function runNext (value) {
@@ -8828,4 +7665,4 @@ const $init = (() => {
 
 await $init;
 
-export { compare, compareTours, getVersion, listAlgorithms, parse, parseAndSolve, solve,  }
+export { compare, compareTours, getVersion, listAlgorithms, parse, parseAndSolve, solve, tourDistance,  }

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -382,6 +382,42 @@ impl Guest for Component {
             optimal_only_edges: stats.optimal_only_edges as u32,
         })
     }
+
+    fn tour_distance(route: Vec<u32>, cities: Vec<City>) -> Result<f32, String> {
+        // tour_cost computes route[(i+1) % n], so a route of 0 or 1 silently
+        // produces a meaningless (0.0) result rather than an error — reject
+        // it explicitly rather than returning a wrong-looking answer.
+        if route.len() < 2 {
+            return Err("route must contain at least 2 city ids".to_string());
+        }
+
+        // Convert WIT City -> KDPoint
+        let kd_cities: Vec<KDPoint> = cities
+            .iter()
+            .map(|c| KDPoint::new_with_id(c.id as usize, &[c.x, c.y]))
+            .collect();
+
+        // Build city ID set for membership validation. tour_cost's HashMap
+        // build silently collapses duplicate ids (last write wins), which
+        // would compute against the wrong coordinate with no error — reject
+        // duplicates instead of letting that happen quietly.
+        let city_ids: std::collections::HashSet<usize> = kd_cities.iter().map(|c| c.id).collect();
+        if city_ids.len() != kd_cities.len() {
+            return Err("cities list contains duplicate city ids".to_string());
+        }
+
+        // Validate that every route id exists in the cities list — tour_cost
+        // does a raw HashMap index with no bounds check, so an unknown id
+        // would panic across the WASM boundary instead of erroring cleanly.
+        for &id in route.iter() {
+            if !city_ids.contains(&(id as usize)) {
+                return Err(format!("unknown city id {id} in route"));
+            }
+        }
+
+        let route: Vec<usize> = route.iter().map(|&x| x as usize).collect();
+        Ok(comparison::tour_cost(&route, &kd_cities))
+    }
 }
 
 bindings::export!(Component with_types_in bindings);

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -198,6 +198,43 @@ fn run_compare_tours(
         .unwrap()
 }
 
+fn run_tour_distance(
+    route: &[u32],
+    cities: &[crate::teeline::solver::types::City],
+) -> Result<f32, String> {
+    let (mut store, instance) = make_instance();
+    instance
+        .call_tour_distance(&mut store, route, cities)
+        .unwrap()
+}
+
+// Unit square, side 10: closed-loop perimeter is exactly 40.0.
+fn square_cities() -> Vec<crate::teeline::solver::types::City> {
+    use crate::teeline::solver::types::City;
+    vec![
+        City {
+            id: 0,
+            x: 0.0,
+            y: 0.0,
+        },
+        City {
+            id: 1,
+            x: 10.0,
+            y: 0.0,
+        },
+        City {
+            id: 2,
+            x: 10.0,
+            y: 10.0,
+        },
+        City {
+            id: 3,
+            x: 0.0,
+            y: 10.0,
+        },
+    ]
+}
+
 // ── solve tests ───────────────────────────────────────────────────────────────
 
 #[test]
@@ -836,4 +873,63 @@ fn test_list_algorithms_ga_params() {
     assert!(keys.contains(&"nElite"), "ga must have nElite");
     let n_elite = ga.params.iter().find(|p| p.key == "nElite").unwrap();
     assert_eq!(n_elite.value_type, "int", "nElite must be int type");
+}
+
+// ── tour_distance tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_tour_distance_square_perimeter() {
+    let cities = square_cities();
+    let route: Vec<u32> = cities.iter().map(|c| c.id).collect();
+    let distance = run_tour_distance(&route, &cities).expect("square perimeter must succeed");
+    assert!(
+        (distance - 40.0).abs() < 0.001,
+        "expected closed-loop perimeter of 40.0, got {distance}"
+    );
+}
+
+#[test]
+fn test_tour_distance_unknown_city_id_returns_error() {
+    let cities = square_cities(); // IDs 0..3
+    let bad_route: Vec<u32> = vec![0, 1, 2, 100]; // 100 doesn't exist
+    let result = run_tour_distance(&bad_route, &cities);
+    assert!(result.is_err(), "unknown city id must return Err");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("unknown city"),
+        "error must mention 'unknown city', got: {msg}"
+    );
+}
+
+#[test]
+fn test_tour_distance_empty_route_returns_error() {
+    let cities = square_cities();
+    let result = run_tour_distance(&[], &cities);
+    assert!(result.is_err(), "empty route must return Err");
+}
+
+#[test]
+fn test_tour_distance_single_city_route_returns_error() {
+    let cities = square_cities();
+    let result = run_tour_distance(&[0], &cities);
+    assert!(result.is_err(), "single-city route must return Err");
+}
+
+#[test]
+fn test_tour_distance_duplicate_city_id_returns_error() {
+    use crate::teeline::solver::types::City;
+    let mut cities = square_cities();
+    cities.push(City {
+        id: 0, // duplicate of the first city's id
+        x: 999.0,
+        y: 999.0,
+    });
+    let route: Vec<u32> = vec![0, 1, 2, 3];
+    let result = run_tour_distance(&route, &cities);
+    assert!(result.is_err(), "duplicate city id must return Err");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("duplicate"),
+        "error must mention 'duplicate', got: {msg}"
+    );
 }

--- a/teeline-wasm/wit/world.wit
+++ b/teeline-wasm/wit/world.wit
@@ -99,4 +99,11 @@ world solver {
         opt-route:    list<u32>,
         cities:       list<city>,
     ) -> result<comparison-stats, string>;
+
+    // Measures the closed-loop distance of `route` as given — no solving,
+    // no reordering. Every id in `route` must exist in `cities`.
+    export tour-distance: func(
+        route:  list<u32>,
+        cities: list<city>,
+    ) -> result<f32, string>;
 }


### PR DESCRIPTION
## Summary
- Adds a new `tour-distance` WIT export to `teeline-wasm` that measures the closed-loop distance of a route as given — no solving, no reordering.
- This is PR A of the two-PR `teeline-excel` plan: the fully independent, mergeable Rust change. PR B (the Excel add-in scaffold, `TSPSOLVER.DISTANCE_EUC`) builds against this once merged.
- Validates unknown city ids, routes shorter than 2 cities, and duplicate city ids before delegating to `comparison::tour_cost` — that function does a raw `HashMap` index with no bounds checking and would otherwise panic across the WASM boundary (unknown id) or silently return a wrong distance (duplicate id) rather than erroring cleanly.
- Regenerated `teeline-wasm/js-bindings` via the same pinned `jco@1.20.0` command used in CI; verified against `teeline-web`'s full test suite (198 tests) and production build, which consume these bindings via `file:../teeline-wasm/js-bindings`.

## Test plan
- [x] `cargo test --manifest-path teeline-wasm/Cargo.toml --test wasm_component` — 5 new tests (unknown id, empty route, single-city route, duplicate city id, happy-path square perimeter) all pass alongside the existing 53
- [x] `cargo component build --manifest-path teeline-wasm/Cargo.toml --target wasm32-wasip2 --release` — new export compiles
- [x] Regenerated bindings pass `teeline-wasm/js-bindings/smoke.mjs`
- [x] `cargo clippy -p teeline -p teeline-cli -p teeline-api -- -D warnings` (matches CI) — clean
- [x] `cd teeline-web && npm test` — 198/198 pass against regenerated bindings
- [x] `cd teeline-web && npm run build` — production build succeeds