### PR TITLE
chore(release): bump to 1.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "teeline"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "clap",
  "num-complex",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "teeline-cli"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "clap",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [package]
 name = "teeline"
-version = "1.0.10"
+version = "1.0.11"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/timgluz/teeline"

--- a/teeline-cli/Cargo.toml
+++ b/teeline-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teeline-cli"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 repository = "https://github.com/timgluz/teeline"

--- a/teeline-wasm/Cargo.toml
+++ b/teeline-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "teeline-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Summary
- Bumps `teeline`/`teeline-cli` from 1.0.10 to 1.0.11, and `teeline-wasm` from 0.2.0 to 0.2.1.
- Needed to cut a new release: `teeline-wasm`'s `tour-distance` export (#321) merged into master, but `deploy-web.yml` downloads `teeline-solver.wasm` from the *latest GitHub Release*, which predates that export. Per the release pipeline's own lesson (learned during the compareTours rollout): a new tag must be pushed before any consumer that fetches the release asset sees the new export.
- Once this merges, pushing tag `v1.0.11` triggers `release.yml`, which rebuilds `teeline-wasm` from source at that tag and attaches a fresh `teeline-solver.wasm` to the release — unblocking `teeline-excel` (PR B of the Excel add-in plan) from needing `DISTANCE_EUC`.

## Test plan
- [x] `cargo check -p teeline -p teeline-cli -p teeline-api`
- [x] `cargo test -p teeline`