### PR TITLE
ci: extract teeline-api into a separate build-api workflow

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -1,0 +1,52 @@
+name: build-api
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - 'teeline-api/**'
+      - 'Taskfile.yml'
+      - 'src/**'
+      - '.github/workflows/build-api.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'teeline-api/**'
+      - 'Taskfile.yml'
+      - 'src/**'
+      - '.github/workflows/build-api.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Build
+        run: cargo build -p teeline-api --verbose
+      - name: Run tests
+        run: cargo test -p teeline-api --verbose
+      - name: Install mise tools (hurl)
+        uses: jdx/mise-action@v4
+      - name: Run hurl e2e tests (teeline-api)
+        run: task test:e2e:api
+      - name: Run hurl e2e auth tests (teeline-api)
+        run: task test:e2e:auth
+      - name: Clippy
+        run: cargo clippy -p teeline-api -- -D warnings
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Coverage
+        run: cargo llvm-cov -p teeline-api --lcov --output-path lcov.info
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: api
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,10 +5,12 @@ name: Rust
     branches: [master]
     paths-ignore:
       - 'teeline-web/**'
+      - 'teeline-api/**'
   pull_request:
     branches: [master]
     paths-ignore:
       - 'teeline-web/**'
+      - 'teeline-api/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,27 +24,22 @@ jobs:
         with:
           submodules: true
       - name: Build
-        run: cargo build -p teeline -p teeline-cli -p teeline-api --verbose
+        run: cargo build -p teeline -p teeline-cli --verbose
       - name: Run tests
-        run: cargo test -p teeline -p teeline-cli -p teeline-api --verbose
+        run: cargo test -p teeline -p teeline-cli --verbose
       - name: Run e2e tests (BATS)
         run: ./tests/bats/bin/bats tests/e2e/
-      - name: Install mise tools (hurl)
-        uses: jdx/mise-action@v4
-      - name: Run hurl e2e tests (teeline-api)
-        run: task test:e2e:api
-      - name: Run hurl e2e auth tests (teeline-api)
-        run: task test:e2e:auth
       - name: Clippy
-        run: cargo clippy -p teeline -p teeline-cli -p teeline-api -- -D warnings
+        run: cargo clippy -p teeline -p teeline-cli -- -D warnings
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Coverage
-        run: cargo llvm-cov -p teeline -p teeline-cli -p teeline-api --lcov --output-path lcov.info
+        run: cargo llvm-cov -p teeline -p teeline-cli --lcov --output-path lcov.info
       - name: Upload coverage
         uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          flags: core
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-api.yml`: a standalone, path-scoped workflow (triggers on `teeline-api/**`, `Taskfile.yml`, `src/**`) that builds/tests/lints/covers `teeline-api` and runs both hurl e2e suites (`test:e2e:api`, `test:e2e:auth`), mirroring `teeline-web.yml`'s trigger structure.
- Trims `rust.yml`'s `build` job to `-p teeline -p teeline-cli` only, removes the two hurl e2e steps, and adds `teeline-api/**` to `paths-ignore` so core-lib CI no longer pays the ~20s API e2e cost and API-only changes skip the wasm/qt/core builds.
- Adds Codecov `flags: core` / `flags: api` to the two coverage uploads so they merge cleanly instead of clobbering each other for the same commit (no `codecov.yml` previously existed).

Note: the issue referenced `build-qt.yml`/`build-wasm` as an existing per-crate-workflow-file precedent, but those are actually jobs inside `rust.yml` itself — that split is proposed separately in #182 (still open). `teeline-web.yml` is the real precedent this follows.

## Test plan
- [x] `cargo build -p teeline-api --verbose` standalone — passes
- [x] `cargo test -p teeline-api --verbose` standalone — passes (10 tests)
- [x] `task test:e2e:api` — 7/7 hurl files pass
- [x] `task test:e2e:auth` — 1/1 hurl file (10 requests) pass
- [x] `cargo clippy -p teeline-api -- -D warnings` standalone — clean
- [x] `cargo llvm-cov -p teeline-api` — report generated
- [x] `cargo build/test/clippy -p teeline -p teeline-cli` (trimmed rust.yml core job) — passes
- [x] `yamllint .github/workflows/build-api.yml .github/workflows/rust.yml` — clean
- [x] Confirm on GitHub Actions: a `teeline-api/**`-only PR triggers `build-api` but not `rust.yml`'s jobs; a `src/**`-only PR triggers both

Closes #308