### PR TITLE
ci: split rust.yml build-wasm and build-qt into standalone workflows

### DIFF
--- a/.github/workflows/build-qt-ci.yml
+++ b/.github/workflows/build-qt-ci.yml
@@ -1,0 +1,39 @@
+name: build-qt-ci
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - 'teeline-qt/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/build-qt-ci.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'teeline-qt/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/build-qt-ci.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-qt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install build dependencies
+        run: sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev
+      - name: Install Qt 6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.*'
+          cache: true
+      - name: Build teeline-qt
+        run: cargo build --manifest-path teeline-qt/Cargo.toml 2>&1
+        env:
+          RUST_LOG: debug

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,45 @@
+name: build-wasm
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - 'teeline-wasm/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/build-wasm.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'teeline-wasm/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/build-wasm.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install cargo-component
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-component
+      - name: Add wasm32-wasip2 target
+        run: rustup target add wasm32-wasip2
+      - name: Build WASM component
+        run: cd teeline-wasm && cargo component build --target wasm32-wasip2
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: teeline-wasm-debug
+          path: teeline-wasm/target/wasm32-wasip2/debug/teeline_wasm.wasm
+      - name: Run wasm_component integration tests
+        run: cd teeline-wasm && cargo test --test wasm_component --target x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,11 +6,15 @@ name: Rust
     paths-ignore:
       - 'teeline-web/**'
       - 'teeline-api/**'
+      - 'teeline-qt/**'
+      - 'teeline-wasm/**'
   pull_request:
     branches: [master]
     paths-ignore:
       - 'teeline-web/**'
       - 'teeline-api/**'
+      - 'teeline-qt/**'
+      - 'teeline-wasm/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,41 +46,3 @@ jobs:
           flags: core
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  build-wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install cargo-component
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-component
-      - name: Add wasm32-wasip2 target
-        run: rustup target add wasm32-wasip2
-      - name: Build WASM component
-        run: cd teeline-wasm && cargo component build --target wasm32-wasip2
-      - name: Upload WASM artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: teeline-wasm-debug
-          path: teeline-wasm/target/wasm32-wasip2/debug/teeline_wasm.wasm
-      - name: Run wasm_component integration tests
-        run: cd teeline-wasm && cargo test --test wasm_component --target x86_64-unknown-linux-gnu
-
-  build-qt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install build dependencies
-        run: sudo apt-get install -y libgl1-mesa-dev libglib2.0-dev
-      - name: Install Qt 6
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.11.*'
-          cache: true
-      - name: Build teeline-qt
-        run: cargo build --manifest-path teeline-qt/Cargo.toml 2>&1
-        env:
-          RUST_LOG: debug


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-wasm.yml`: standalone workflow, job body copied verbatim from `rust.yml`'s current `build-wasm` job, triggered on `teeline-wasm/**` + core paths (`src/**`, `Cargo.toml`, `Cargo.lock`).
- Adds `.github/workflows/build-qt-ci.yml` (named `-ci` to avoid colliding with the existing `build-qt.yml` manual pre-release packaging workflow, which has different job names and no push/PR trigger), job body copied verbatim from `rust.yml`'s current `build-qt` job, same trigger pattern scoped to `teeline-qt/**`.
- Removes the `build-wasm`/`build-qt` jobs from `rust.yml`, and adds `teeline-qt/**`/`teeline-wasm/**` to its `paths-ignore` (alongside the existing `teeline-web/**`/`teeline-api/**` from #308) since the core `build` job doesn't depend on either.

Both `teeline-wasm/Cargo.toml` and `teeline-qt/Cargo.toml` declare their own independent `[workspace]` and only path-depend on the root `teeline` lib — no shared dependency on each other or `teeline-cli` — so this split has no behavioral risk. No branch protection is configured on `master` today, and no docs reference the old job names, so no additional cleanup was needed.

**Deliberately out of scope** (per plan discussion): not switching either workflow to call `task build:wasm`/`task qt:build` (would introduce bugs — missing test step / hardcoded Qt path mismatch), and not adding `src/**` to `teeline-web.yml`'s trigger (a real, separate gap — teeline-web.yml builds teeline-wasm from source but doesn't watch `src/**` — left for a follow-up issue).

## Test plan
- [x] `yamllint` on all three touched workflow files — clean
- [x] `cd teeline-wasm && cargo component build --target wasm32-wasip2` standalone — succeeds, artifact lands at the path `build-wasm.yml` uploads
- [x] `cargo test --test wasm_component --target x86_64-unknown-linux-gnu` standalone — 58/58 pass
- [x] `cargo build --manifest-path teeline-qt/Cargo.toml` standalone (with local Qt 6.11.1) — succeeds
- [x] Confirm on GitHub Actions: a `teeline-qt/**`-only PR triggers `build-qt-ci` but not `build-wasm`/`rust.yml`; a `teeline-wasm/**`-only PR triggers `build-wasm` but not `build-qt-ci`/`rust.yml`; a `src/**`-only PR triggers all of `rust.yml`, `build-wasm.yml`, `build-qt-ci.yml`, `build-api.yml`

Closes #182