### PR TITLE
feat(api): POST /api/v1/pipeline solver-chaining endpoint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,6 +48,7 @@ tasks:
     vars:
       API_KEY: '{{.API_KEY | default ""}}'
       RATE_LIMIT_RPM: '{{.RATE_LIMIT_RPM | default ""}}'
+      PORT: '{{.PORT | default "8080"}}'
     # Values are threaded through as opaque env vars (never interpolated
     # into the bash -c string itself) so a token containing a quote or
     # `$(...)` can't break out and inject commands — same reasoning as the
@@ -55,16 +56,22 @@ tasks:
     env:
       TASK_API_KEY: '{{.API_KEY}}'
       TASK_RATE_LIMIT_RPM: '{{.RATE_LIMIT_RPM}}'
+      TASK_PORT: '{{.PORT}}'
     cmds:
       # go-task's bundled shell interpreter doesn't preserve backgrounded
       # processes past the end of the task run, and mis-captures $!.
       # bash -c ... & disown bypasses it so the server actually survives.
-      - bash -c 'API_KEY="$TASK_API_KEY" RATE_LIMIT_RPM="$TASK_RATE_LIMIT_RPM" nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
+      - bash -c 'API_KEY="$TASK_API_KEY" RATE_LIMIT_RPM="$TASK_RATE_LIMIT_RPM" PORT="$TASK_PORT" nohup ./target/debug/teeline-api >/tmp/teeline-api.log 2>&1 & echo $! > /tmp/teeline-api.pid; disown'
+      - 'echo "teeline-api starting on http://127.0.0.1:{{.PORT}} (PID $(cat /tmp/teeline-api.pid)); logs: /tmp/teeline-api.log"'
 
   api:serve:
-    desc: Start teeline-api server in background (writes PID to /tmp/teeline-api.pid)
+    desc: Start teeline-api server in background (writes PID to /tmp/teeline-api.pid). Override port with PORT=<n>.
+    vars:
+      PORT: '{{.PORT | default "8080"}}'
     cmds:
       - task: api:_launch
+        vars:
+          PORT: "{{.PORT}}"
 
   # NOTE: api:serve, test:e2e:api, and test:e2e:auth all share the single
   # /tmp/teeline-api.pid file. This is only safe because they're never run
@@ -78,9 +85,11 @@ tasks:
       - pkill -f target/debug/teeline-api 2>/dev/null || true
 
   api:wait:
-    desc: Poll until teeline-api health endpoint is ready (max 10s)
+    desc: Poll until teeline-api health endpoint is ready (max 10s). Override port with PORT=<n>.
+    vars:
+      PORT: '{{.PORT | default "8080"}}'
     cmds:
-      - for i in $(seq 10); do curl -sf http://127.0.0.1:8080/api/v1/health && break || sleep 1; done
+      - for i in $(seq 10); do curl -sf http://127.0.0.1:{{.PORT}}/api/v1/health && break || sleep 1; done
 
   api:release:
     desc: Deploy teeline-api to Fly.io (requires flyctl auth; app must exist, see fly.toml)

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -98,11 +98,23 @@ pub fn stage_warnings(solvers: &[Solvers]) -> Vec<String> {
                 "nn at stage {i} discards the warm-start seed from the previous stage"
             ));
         }
-        if i != last && matches!(solver, Solvers::BellmanKarp | Solvers::BranchBound) {
-            warnings.push(format!(
-                "{solver:?} at stage {i} does not consume a warm-start seed and its result \
-                 will be discarded by later stages"
-            ));
+        if i != last {
+            match solver {
+                Solvers::BellmanKarp => warnings.push(format!(
+                    "BellmanKarp at stage {i} ignores the warm-start seed entirely (the exact \
+                     DP has no use for a partial/seed tour) and its optimal result will be \
+                     superseded by later stages"
+                )),
+                // Unlike BellmanKarp, BranchBound *does* consume the warm-start seed — it uses
+                // it to prime the pruning upper bound (see branch_bound::solve) — so the warning
+                // wording must not claim it ignores the seed the way BellmanKarp does.
+                Solvers::BranchBound => warnings.push(format!(
+                    "BranchBound at stage {i} only uses the warm-start seed to prime its \
+                     pruning bound, not as a tour to refine, and its optimal result will be \
+                     superseded by later stages"
+                )),
+                _ => {}
+            }
         }
     }
     warnings

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -1,7 +1,17 @@
 use std::sync::mpsc;
+use std::time::Instant;
 
 use super::progress::ProgressMessage;
 use super::{AppOptions, Solution, Solvers, TspProblem, validate_tour};
+
+/// One stage's result within a pipeline run: the solved tour plus the wall-clock
+/// time that stage took. Lives alongside `PipelineStage` (the stage's inputs) —
+/// no `solver` field here, since callers already know which stage produced which
+/// outcome by index/zip with the input stage list.
+pub struct StageOutcome {
+    pub solution: Solution,
+    pub duration_ms: u64,
+}
 
 pub struct PipelineStage {
     pub solver: Solvers,
@@ -36,11 +46,16 @@ impl PipelineStage {
     }
 }
 
-pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
+/// Runs `stages` in order, warm-starting each stage from the previous stage's
+/// tour, and returns every stage's outcome (solved tour + wall-clock duration).
+/// Shared by `run_pipeline` (below) and any caller that needs per-stage detail
+/// (e.g. the API's pipeline endpoint).
+pub fn run_pipeline_stages(stages: &[PipelineStage]) -> Result<Vec<StageOutcome>, String> {
     if stages.is_empty() {
         return Err("pipeline has no stages".into());
     }
     let mut seed: Option<Vec<usize>> = None;
+    let mut outcomes = Vec::with_capacity(stages.len());
     for stage in stages {
         if let Some(ref t) = seed
             && let Err(e) = validate_tour(t, &stage.problem.cities)
@@ -49,16 +64,48 @@ pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
             seed = None;
         }
         tracing::info!(solver = ?stage.solver, "pipeline: stage starting");
+        let start = Instant::now();
         let solution = stage.solve(seed.as_deref())?;
+        let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         validate_tour(solution.route(), &stage.problem.cities)
             .map_err(|e| format!("stage {:?} invalid tour: {e}", stage.solver))?;
         tracing::info!(cost = solution.total, "pipeline: stage complete");
         seed = Some(solution.route().to_vec());
+        outcomes.push(StageOutcome {
+            solution,
+            duration_ms,
+        });
     }
+    Ok(outcomes)
+}
 
-    let last = stages.last().unwrap();
-    let route = seed.unwrap();
-    Ok(Solution::new(&route, &last.problem))
+pub fn run_pipeline(stages: &[PipelineStage]) -> Result<Solution, String> {
+    Ok(run_pipeline_stages(stages)?
+        .pop()
+        .expect("run_pipeline_stages errors on empty input")
+        .solution)
+}
+
+/// Non-fatal composition warnings for a pipeline's solver sequence (issue #66's
+/// original design table). Purely a static lint over `solvers` — derivable from
+/// the request alone, never depends on how a stage actually solves.
+pub fn stage_warnings(solvers: &[Solvers]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let last = solvers.len().saturating_sub(1);
+    for (i, solver) in solvers.iter().enumerate() {
+        if i > 0 && *solver == Solvers::NearestNeighbor {
+            warnings.push(format!(
+                "nn at stage {i} discards the warm-start seed from the previous stage"
+            ));
+        }
+        if i != last && matches!(solver, Solvers::BellmanKarp | Solvers::BranchBound) {
+            warnings.push(format!(
+                "{solver:?} at stage {i} does not consume a warm-start seed and its result \
+                 will be discarded by later stages"
+            ));
+        }
+    }
+    warnings
 }
 
 #[cfg(test)]
@@ -130,5 +177,72 @@ mod tests {
 
         let result = run_pipeline(&stages);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_run_pipeline_stages_matches_run_pipeline_final_cost() {
+        let cities = small_cities();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
+
+        let stages = [
+            make_stage(Solvers::NearestNeighbor, problem.clone()),
+            make_stage(Solvers::TwoOpt, problem.clone()),
+        ];
+        let outcomes = run_pipeline_stages(&stages).unwrap();
+        assert_eq!(outcomes.len(), stages.len());
+
+        let stages_again = [
+            make_stage(Solvers::NearestNeighbor, problem.clone()),
+            make_stage(Solvers::TwoOpt, problem),
+        ];
+        let final_solution = run_pipeline(&stages_again).unwrap();
+
+        assert_eq!(
+            outcomes.last().unwrap().solution.total,
+            final_solution.total
+        );
+    }
+
+    #[test]
+    fn test_run_pipeline_stages_errors_on_stage_failure() {
+        let cities = small_cities();
+        let dm = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities, dm);
+        let stages = [make_stage(Solvers::Unspecified, problem)];
+
+        assert!(run_pipeline_stages(&stages).is_err());
+        assert!(run_pipeline(&stages).is_err());
+    }
+
+    #[test]
+    fn test_stage_warnings_flags_nn_mid_pipeline() {
+        let warnings =
+            stage_warnings(&[Solvers::TwoOpt, Solvers::NearestNeighbor, Solvers::TwoOpt]);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("nn at stage 1"));
+    }
+
+    #[test]
+    fn test_stage_warnings_flags_exact_solver_non_terminal() {
+        let warnings = stage_warnings(&[Solvers::BranchBound, Solvers::TwoOpt]);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("stage 0"));
+    }
+
+    #[test]
+    fn test_stage_warnings_empty_for_well_formed_pipeline() {
+        let warnings = stage_warnings(&[
+            Solvers::NearestNeighbor,
+            Solvers::TwoOpt,
+            Solvers::SimulatedAnnealing,
+        ]);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_stage_warnings_exact_solver_in_terminal_position_is_fine() {
+        let warnings = stage_warnings(&[Solvers::NearestNeighbor, Solvers::BranchBound]);
+        assert!(warnings.is_empty());
     }
 }

--- a/teeline-api/src/error.rs
+++ b/teeline-api/src/error.rs
@@ -12,6 +12,22 @@ pub enum ApiError {
     Unauthorized,
 }
 
+impl ApiError {
+    /// Maps a service-layer error string to the right HTTP status: solver
+    /// panics (surfaced from `tokio::task::spawn_blocking`'s `JoinError` as
+    /// `format!("task panic: {e}")`) are a server-side fault, everything else
+    /// (validation failures, unknown solver names) is a client error. Shared
+    /// by `routes::solve::solve` and `routes::pipeline::pipeline`, which both
+    /// call solver-service methods with this exact error convention.
+    pub fn from_solver_error(e: String) -> Self {
+        if e.starts_with("task panic:") {
+            ApiError::Internal(e)
+        } else {
+            ApiError::BadRequest(e)
+        }
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         // RFC 7235 §3.1: a 401 response must include WWW-Authenticate

--- a/teeline-api/src/lib.rs
+++ b/teeline-api/src/lib.rs
@@ -28,6 +28,7 @@ pub fn build_api_router() -> axum::Router<AppState> {
         .route("/api/v1/solvers", get(routes::solvers::list_solvers))
         .route("/api/v1/parse", post(routes::parse::parse))
         .route("/api/v1/solve", post(routes::solve::solve))
+        .route("/api/v1/pipeline", post(routes::pipeline::pipeline))
 }
 
 /// Full router with MetricsLayer applied. `api` is the already-assembled

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -251,6 +251,17 @@ pub struct PipelineStageRequest {
     pub configs: Option<SolverConfigs>,
 }
 
+/// Upper bound on the number of stages a single pipeline request may chain.
+/// Each stage is a full solver run (potentially an exact, exponential-time
+/// solver per CLAUDE.md's guidance on `bellman_karp`/`branch_bound`), and
+/// `run_pipeline_stages` runs them strictly sequentially inside one
+/// `spawn_blocking` task — with no per-stage or per-request timeout elsewhere
+/// in teeline-api, an unbounded `stages` array is an unmetered compute-cost
+/// amplifier for a single HTTP request. 20 comfortably covers every
+/// documented/realistic pipeline (the docs' examples top out at 3 stages)
+/// while capping worst-case cost.
+pub const MAX_PIPELINE_STAGES: usize = 20;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct PipelineRequest {
     pub input: TspInput,
@@ -262,6 +273,11 @@ impl PipelineRequest {
         self.input.validate()?;
         if self.stages.len() < 2 {
             return Err("`stages` must contain at least 2 solver stages".to_string());
+        }
+        if self.stages.len() > MAX_PIPELINE_STAGES {
+            return Err(format!(
+                "`stages` must contain at most {MAX_PIPELINE_STAGES} solver stages"
+            ));
         }
         if self.stages.iter().any(|s| s.solver.trim().is_empty()) {
             return Err("`solver` must not be empty".to_string());
@@ -526,6 +542,34 @@ mod tests {
             }],
         };
         assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn pipeline_request_validate_rejects_too_many_stages() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: (0..=MAX_PIPELINE_STAGES)
+                .map(|_| PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                })
+                .collect(),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn pipeline_request_validate_accepts_max_stages() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: (0..MAX_PIPELINE_STAGES)
+                .map(|_| PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                })
+                .collect(),
+        };
+        assert!(req.validate().is_ok());
     }
 
     #[test]

--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -241,6 +241,35 @@ impl SolveRequest {
     }
 }
 
+/// One stage in a `PipelineRequest`. Named `PipelineStageRequest` (not just
+/// `PipelineStage`) to avoid colliding with `teeline::tsp::pipeline::PipelineStage`,
+/// which is a different, already-resolved type used internally by the service layer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct PipelineStageRequest {
+    pub solver: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configs: Option<SolverConfigs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct PipelineRequest {
+    pub input: TspInput,
+    pub stages: Vec<PipelineStageRequest>,
+}
+
+impl PipelineRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        self.input.validate()?;
+        if self.stages.len() < 2 {
+            return Err("`stages` must contain at least 2 solver stages".to_string());
+        }
+        if self.stages.iter().any(|s| s.solver.trim().is_empty()) {
+            return Err("`solver` must not be empty".to_string());
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,5 +496,118 @@ mod tests {
         use utoipa::ToSchema;
         let name = SolveRequest::name();
         assert_eq!(name, "SolveRequest");
+    }
+
+    fn tiny_cities_input() -> TspInput {
+        TspInput {
+            cities: Some(vec![
+                CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                },
+                CityInput {
+                    id: Some(2),
+                    x: 1.0,
+                    y: 0.0,
+                },
+            ]),
+            tsplib: None,
+        }
+    }
+
+    #[test]
+    fn pipeline_request_validate_rejects_single_stage() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: vec![PipelineStageRequest {
+                solver: "nn".to_string(),
+                configs: None,
+            }],
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn pipeline_request_validate_rejects_blank_solver() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "   ".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn pipeline_request_validate_accepts_valid() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "2opt".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn pipeline_request_round_trip_with_per_stage_configs() {
+        let req = PipelineRequest {
+            input: tiny_cities_input(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "sa".to_string(),
+                    configs: Some(SolverConfigs {
+                        sa: Some(SaConfig {
+                            heuristic: None,
+                            cooling_rate: Some(0.0005),
+                            min_temperature: None,
+                            max_temperature: Some(200.0),
+                        }),
+                        ..SolverConfigs::default()
+                    }),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: PipelineRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.stages.len(), 2);
+        assert_eq!(back.stages[0].configs, None);
+        assert_eq!(
+            back.stages[1]
+                .configs
+                .as_ref()
+                .unwrap()
+                .sa
+                .as_ref()
+                .unwrap()
+                .cooling_rate,
+            Some(0.0005)
+        );
+    }
+
+    #[test]
+    fn pipeline_request_schema_builds() {
+        use utoipa::ToSchema;
+        assert_eq!(PipelineRequest::name(), "PipelineRequest");
+        assert_eq!(PipelineStageRequest::name(), "PipelineStageRequest");
     }
 }

--- a/teeline-api/src/models/response.rs
+++ b/teeline-api/src/models/response.rs
@@ -45,6 +45,29 @@ pub struct SolveResponse {
     pub duration_ms: u64,
 }
 
+/// One stage's result within a `PipelineResponse`. Named `PipelineStageResult` to
+/// avoid colliding with `teeline::tsp::pipeline::PipelineStage` (the lib's
+/// stage-input type) and with `pipeline::StageOutcome` (the lib's own output type,
+/// which has no `solver` field — this DTO's `solver` is echoed straight from the
+/// request, same convention as `SolveResponse.solver`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct PipelineStageResult {
+    pub solver: String,
+    pub cost: f32,
+    pub tour: Vec<usize>,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct PipelineResponse {
+    pub stages: Vec<PipelineStageResult>,
+    pub final_cost: f32,
+    pub final_tour: Vec<usize>,
+    /// Non-fatal composition warnings, e.g. an `nn` stage discarding the
+    /// warm-start seed, or an exact solver in a non-terminal position.
+    pub warnings: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +142,42 @@ mod tests {
         use utoipa::ToSchema;
         let name = SolveResponse::name();
         assert_eq!(name, "SolveResponse");
+    }
+
+    #[test]
+    fn pipeline_response_round_trip() {
+        let resp = PipelineResponse {
+            stages: vec![
+                PipelineStageResult {
+                    solver: "nn".to_string(),
+                    cost: 2000.0,
+                    tour: vec![1, 2, 3],
+                    duration_ms: 1,
+                },
+                PipelineStageResult {
+                    solver: "2opt".to_string(),
+                    cost: 1500.0,
+                    tour: vec![1, 3, 2],
+                    duration_ms: 5,
+                },
+            ],
+            final_cost: 1500.0,
+            final_tour: vec![1, 3, 2],
+            warnings: vec![],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: PipelineResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.stages.len(), 2);
+        assert_eq!(back.stages[0].solver, "nn");
+        assert_eq!(back.final_cost, 1500.0_f32);
+        assert_eq!(back.final_tour, vec![1, 3, 2]);
+        assert!(back.warnings.is_empty());
+    }
+
+    #[test]
+    fn pipeline_response_schema_builds() {
+        use utoipa::ToSchema;
+        assert_eq!(PipelineResponse::name(), "PipelineResponse");
+        assert_eq!(PipelineStageResult::name(), "PipelineStageResult");
     }
 }

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -41,6 +41,7 @@ impl Modify for SecurityAddon {
         routes::solvers::list_solvers,
         routes::parse::parse,
         routes::solve::solve,
+        routes::pipeline::pipeline,
     ),
     components(schemas(
         routes::index::IndexResponse,
@@ -66,10 +67,14 @@ impl Modify for SecurityAddon {
         request::TspInput,
         request::ParseRequest,
         request::SolveRequest,
+        request::PipelineStageRequest,
+        request::PipelineRequest,
         response::AlgorithmInfo,
         response::CityDto,
         response::ParseResponse,
         response::SolveResponse,
+        response::PipelineStageResult,
+        response::PipelineResponse,
     )),
     tags(
         (name = "tsp", description = "Traveling Salesman Problem solver endpoints")

--- a/teeline-api/src/routes/index.rs
+++ b/teeline-api/src/routes/index.rs
@@ -9,6 +9,7 @@ const ROUTES: &[&str] = &[
     "GET /api/v1/solvers",
     "POST /api/v1/parse",
     "POST /api/v1/solve",
+    "POST /api/v1/pipeline",
     "GET /openapi.json",
     "GET /docs",
 ];

--- a/teeline-api/src/routes/mod.rs
+++ b/teeline-api/src/routes/mod.rs
@@ -2,5 +2,6 @@ pub mod health;
 pub mod index;
 pub mod metrics;
 pub mod parse;
+pub mod pipeline;
 pub mod solve;
 pub mod solvers;

--- a/teeline-api/src/routes/pipeline.rs
+++ b/teeline-api/src/routes/pipeline.rs
@@ -1,0 +1,97 @@
+use axum::{Json, extract::State};
+
+use crate::{
+    AppState,
+    error::{ApiError, ApiResult},
+    models::{request::PipelineRequest, response::PipelineResponse},
+};
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/pipeline",
+    security(
+        ("bearer_token" = []),
+        ("api_key" = [])
+    ),
+    request_body(
+        content = PipelineRequest,
+        examples(
+            ("Constructive then local search" = (
+                summary = "Nearest neighbor seeds a 2-opt cleanup pass",
+                value = json!({
+                    "input": {
+                        "cities": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 1.0, "y": 0.0},
+                            {"x": 1.0, "y": 1.0},
+                            {"x": 0.0, "y": 1.0}
+                        ]
+                    },
+                    "stages": [
+                        {"solver": "nn"},
+                        {"solver": "2opt"}
+                    ]
+                })
+            )),
+            ("Per-stage tuned metaheuristic" = (
+                summary = "2-opt cleanup, then SA tuned for a lower starting temperature",
+                value = json!({
+                    "input": {
+                        "cities": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 1.0, "y": 0.0},
+                            {"x": 1.0, "y": 1.0},
+                            {"x": 0.0, "y": 1.0}
+                        ]
+                    },
+                    "stages": [
+                        {"solver": "2opt"},
+                        {"solver": "sa", "configs": {"sa": {"max_temperature": 200.0}}}
+                    ]
+                })
+            )),
+            ("Classic three-stage pipeline" = (
+                summary = "nn -> 2opt -> sa: the standard constructor -> local search -> metaheuristic chain",
+                value = json!({
+                    "input": {
+                        "cities": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 1.0, "y": 0.0},
+                            {"x": 1.0, "y": 1.0},
+                            {"x": 0.0, "y": 1.0},
+                            {"x": 0.5, "y": 0.5}
+                        ]
+                    },
+                    "stages": [
+                        {"solver": "nn"},
+                        {"solver": "2opt"},
+                        {"solver": "sa"}
+                    ]
+                })
+            ))
+        )
+    ),
+    responses(
+        (status = 200, description = "Pipeline result", body = PipelineResponse),
+        (status = 400, description = "Invalid input, unknown solver, or fewer than 2 stages"),
+        (status = 401, description = "Missing or invalid API key"),
+        (status = 500, description = "Solver failure")
+    )
+)]
+pub async fn pipeline(
+    State(state): State<AppState>,
+    Json(req): Json<PipelineRequest>,
+) -> ApiResult<Json<PipelineResponse>> {
+    state
+        .solver_service
+        .pipeline(&req)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            if e.starts_with("task panic:") {
+                ApiError::Internal(e)
+            } else {
+                ApiError::BadRequest(e)
+            }
+        })
+}

--- a/teeline-api/src/routes/pipeline.rs
+++ b/teeline-api/src/routes/pipeline.rs
@@ -3,6 +3,7 @@ use axum::{Json, extract::State};
 use crate::{
     AppState,
     error::{ApiError, ApiResult},
+    metrics::{SolverDurationLabels, SolverLabels},
     models::{request::PipelineRequest, response::PipelineResponse},
 };
 
@@ -73,7 +74,7 @@ use crate::{
     ),
     responses(
         (status = 200, description = "Pipeline result", body = PipelineResponse),
-        (status = 400, description = "Invalid input, unknown solver, or fewer than 2 stages"),
+        (status = 400, description = "Invalid input, unknown solver, or stage count outside [2, 20]"),
         (status = 401, description = "Missing or invalid API key"),
         (status = 500, description = "Solver failure")
     )
@@ -82,16 +83,47 @@ pub async fn pipeline(
     State(state): State<AppState>,
     Json(req): Json<PipelineRequest>,
 ) -> ApiResult<Json<PipelineResponse>> {
-    state
-        .solver_service
-        .pipeline(&req)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            if e.starts_with("task panic:") {
-                ApiError::Internal(e)
-            } else {
-                ApiError::BadRequest(e)
-            }
-        })
+    let result = state.solver_service.pipeline(&req).await;
+
+    // Same cardinality guard as /api/v1/solve: only record metrics for known
+    // aliases, since an unknown solver name is arbitrary client-controlled
+    // input and would otherwise let a caller mint unbounded label values.
+    // Unlike solve() (one solver per request), a pipeline chains several
+    // stages, so every known-alias stage gets its own counter increment, and
+    // (on success) its own duration observation from that stage's own
+    // measured `duration_ms` — a more precise per-stage timing than solve()'s
+    // single request-wide `Instant::now()` delta.
+    let known_aliases: std::collections::HashSet<String> = state
+        .registry_service
+        .list()
+        .into_iter()
+        .map(|s| s.alias)
+        .collect();
+    let status = if result.is_ok() { "success" } else { "error" };
+    for stage in &req.stages {
+        if !known_aliases.contains(&stage.solver) {
+            continue;
+        }
+        state
+            .metrics
+            .solver_requests_total
+            .get_or_create(&SolverLabels {
+                solver: stage.solver.clone(),
+                status: status.into(),
+            })
+            .inc();
+    }
+    if let Ok(resp) = &result {
+        for stage_result in &resp.stages {
+            state
+                .metrics
+                .solver_duration_seconds
+                .get_or_create(&SolverDurationLabels {
+                    solver: stage_result.solver.clone(),
+                })
+                .observe(stage_result.duration_ms as f64 / 1000.0);
+        }
+    }
+
+    result.map(Json).map_err(ApiError::from_solver_error)
 }

--- a/teeline-api/src/routes/solve.rs
+++ b/teeline-api/src/routes/solve.rs
@@ -107,11 +107,5 @@ pub async fn solve(
         }
     }
 
-    result.map(Json).map_err(|e| {
-        if e.starts_with("task panic:") {
-            ApiError::Internal(e)
-        } else {
-            ApiError::BadRequest(e)
-        }
-    })
+    result.map(Json).map_err(ApiError::from_solver_error)
 }

--- a/teeline-api/src/services/mod.rs
+++ b/teeline-api/src/services/mod.rs
@@ -1,14 +1,15 @@
 use async_trait::async_trait;
 
 use crate::models::{
-    request::{ParseRequest, SolveRequest},
-    response::{AlgorithmInfo, ParseResponse, SolveResponse},
+    request::{ParseRequest, PipelineRequest, SolveRequest},
+    response::{AlgorithmInfo, ParseResponse, PipelineResponse, SolveResponse},
 };
 
 #[async_trait]
 pub trait TspSolverService: Send + Sync {
     async fn parse(&self, req: &ParseRequest) -> Result<ParseResponse, String>;
     async fn solve(&self, req: &SolveRequest) -> Result<SolveResponse, String>;
+    async fn pipeline(&self, req: &PipelineRequest) -> Result<PipelineResponse, String>;
 }
 
 pub trait SolverRegistryService: Send + Sync {

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use async_trait::async_trait;
 use teeline::tsp::distance_matrix::DistanceMatrix;
 use teeline::tsp::kdtree::KDPoint;
+use teeline::tsp::pipeline::{PipelineStage, run_pipeline_stages, stage_warnings};
 use teeline::tsp::tsplib;
 use teeline::tsp::{
     AppOptions, CSOptions, DistanceType, FPAOptions, FourierOptions, GAOptions, HeuristicOptions,
@@ -11,8 +12,10 @@ use teeline::tsp::{
 
 use super::TspSolverService;
 use crate::models::{
-    request::{HeuristicConfig, ParseRequest, SolveRequest, SolverConfigs, TspInput},
-    response::{CityDto, ParseResponse, SolveResponse},
+    request::{
+        HeuristicConfig, ParseRequest, PipelineRequest, SolveRequest, SolverConfigs, TspInput,
+    },
+    response::{CityDto, ParseResponse, PipelineResponse, PipelineStageResult, SolveResponse},
 };
 
 pub struct TspService;
@@ -252,6 +255,50 @@ impl TspSolverService for TspService {
             duration_ms,
         })
     }
+
+    async fn pipeline(&self, req: &PipelineRequest) -> Result<PipelineResponse, String> {
+        req.validate()?;
+        let solvers: Vec<Solvers> = req
+            .stages
+            .iter()
+            .map(|s| find_solver(&s.solver))
+            .collect::<Result<_, _>>()?;
+        let problem = input_to_problem(&req.input)?;
+        let warnings = stage_warnings(&solvers);
+
+        let stages: Vec<PipelineStage> = req
+            .stages
+            .iter()
+            .zip(&solvers)
+            .map(|(s, &solver)| {
+                let opts = make_app_options(&s.solver, s.configs.as_ref());
+                PipelineStage::new(solver, opts, problem.clone(), None)
+            })
+            .collect();
+
+        let outcomes = tokio::task::spawn_blocking(move || run_pipeline_stages(&stages))
+            .await
+            .map_err(|e| format!("task panic: {e}"))??;
+
+        let stage_results: Vec<PipelineStageResult> = outcomes
+            .iter()
+            .zip(&req.stages)
+            .map(|(o, s)| PipelineStageResult {
+                solver: s.solver.clone(),
+                cost: o.solution.total,
+                tour: o.solution.route().to_vec(),
+                duration_ms: o.duration_ms,
+            })
+            .collect();
+        let last = outcomes.last().expect("validated >= 2 stages");
+
+        Ok(PipelineResponse {
+            stages: stage_results,
+            final_cost: last.solution.total,
+            final_tour: last.solution.route().to_vec(),
+            warnings,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -261,7 +308,7 @@ impl TspSolverService for TspService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::request::{CityInput, TspInput};
+    use crate::models::request::{CityInput, PipelineStageRequest, TspInput};
 
     const TINY_TSPLIB: &str = "\
 NAME: test
@@ -356,5 +403,118 @@ EOF
         assert_eq!(resp.cities[0].id, 1);
         assert_eq!(resp.cities[1].id, 2);
         assert_eq!(resp.cities[2].id, 3);
+    }
+
+    fn small_pipeline_cities() -> TspInput {
+        TspInput {
+            cities: Some(vec![
+                CityInput {
+                    id: Some(1),
+                    x: 0.0,
+                    y: 0.0,
+                },
+                CityInput {
+                    id: Some(2),
+                    x: 1.0,
+                    y: 0.0,
+                },
+                CityInput {
+                    id: Some(3),
+                    x: 1.0,
+                    y: 1.0,
+                },
+                CityInput {
+                    id: Some(4),
+                    x: 0.0,
+                    y: 1.0,
+                },
+            ]),
+            tsplib: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_two_stages_returns_ordered_results() {
+        let service = TspService;
+        let req = PipelineRequest {
+            input: small_pipeline_cities(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "2opt".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        let resp = service.pipeline(&req).await.unwrap();
+        assert_eq!(resp.stages.len(), 2);
+        assert_eq!(resp.stages[0].solver, "nn");
+        assert_eq!(resp.stages[1].solver, "2opt");
+        assert_eq!(resp.final_cost, resp.stages[1].cost);
+        assert_eq!(resp.final_tour, resp.stages[1].tour);
+        assert!(resp.stages[1].cost <= resp.stages[0].cost * 1.001);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_unknown_solver_errors() {
+        let service = TspService;
+        let req = PipelineRequest {
+            input: small_pipeline_cities(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "does_not_exist".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "2opt".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        assert!(service.pipeline(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_nn_mid_pipeline_produces_warning() {
+        let service = TspService;
+        let req = PipelineRequest {
+            input: small_pipeline_cities(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "2opt".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        let resp = service.pipeline(&req).await.unwrap();
+        assert!(!resp.warnings.is_empty());
+        assert!(resp.warnings[0].contains("nn"));
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_well_formed_has_no_warnings() {
+        let service = TspService;
+        let req = PipelineRequest {
+            input: small_pipeline_cities(),
+            stages: vec![
+                PipelineStageRequest {
+                    solver: "nn".to_string(),
+                    configs: None,
+                },
+                PipelineStageRequest {
+                    solver: "2opt".to_string(),
+                    configs: None,
+                },
+            ],
+        };
+        let resp = service.pipeline(&req).await.unwrap();
+        assert!(resp.warnings.is_empty());
     }
 }

--- a/teeline-api/tests/api_tests.rs
+++ b/teeline-api/tests/api_tests.rs
@@ -10,8 +10,11 @@ use teeline_api::{
     metrics::MetricsState,
     middleware,
     models::{
-        request::{ParseRequest, SolveRequest},
-        response::{AlgorithmInfo, CityDto, ParseResponse, SolveResponse},
+        request::{ParseRequest, PipelineRequest, SolveRequest},
+        response::{
+            AlgorithmInfo, CityDto, ParseResponse, PipelineResponse, PipelineStageResult,
+            SolveResponse,
+        },
     },
     services::{SolverRegistryService, TspSolverService},
 };
@@ -52,6 +55,33 @@ impl TspSolverService for MockSolverService {
                 duration_ms: 0,
             }),
         }
+    }
+
+    async fn pipeline(&self, req: &PipelineRequest) -> Result<PipelineResponse, String> {
+        // Same error-simulation convention as solve(): the first stage's solver
+        // name drives error simulation; full validation is covered by real-service
+        // tests in pipeline.rs.
+        match req.stages.first().map(|s| s.solver.as_str()) {
+            Some("__error__") => return Err("unknown solver: __error__".to_string()),
+            Some("__panic__") => return Err("task panic: simulated".to_string()),
+            _ => {}
+        }
+        let stages: Vec<PipelineStageResult> = req
+            .stages
+            .iter()
+            .map(|s| PipelineStageResult {
+                solver: s.solver.clone(),
+                cost: 1.0,
+                tour: vec![1],
+                duration_ms: 0,
+            })
+            .collect();
+        Ok(PipelineResponse {
+            stages,
+            final_cost: 1.0,
+            final_tour: vec![1],
+            warnings: vec![],
+        })
     }
 }
 

--- a/teeline-api/tests/hurl/pipeline.hurl
+++ b/teeline-api/tests/hurl/pipeline.hurl
@@ -1,0 +1,116 @@
+# POST /api/v1/pipeline — nn seeds a 2-opt cleanup stage
+POST http://127.0.0.1:8080/api/v1/pipeline
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 1.0, "y": 1.0},
+      {"x": 0.0, "y": 1.0}
+    ]
+  },
+  "stages": [
+    {"solver": "nn"},
+    {"solver": "2opt"}
+  ]
+}
+```
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.stages" isCollection
+jsonpath "$.stages" count == 2
+jsonpath "$.stages[0].solver" == "nn"
+jsonpath "$.stages[1].solver" == "2opt"
+jsonpath "$.final_cost" isFloat
+jsonpath "$.final_tour" isCollection
+jsonpath "$.warnings" isCollection
+
+
+# POST /api/v1/pipeline — nn appearing after stage 0 surfaces a warning
+POST http://127.0.0.1:8080/api/v1/pipeline
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 1.0, "y": 1.0},
+      {"x": 0.0, "y": 1.0}
+    ]
+  },
+  "stages": [
+    {"solver": "2opt"},
+    {"solver": "nn"}
+  ]
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.warnings" count >= 1
+
+
+# POST /api/v1/pipeline — fewer than 2 stages returns 400
+POST http://127.0.0.1:8080/api/v1/pipeline
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0}
+    ]
+  },
+  "stages": [
+    {"solver": "nn"}
+  ]
+}
+```
+HTTP 400
+[Asserts]
+jsonpath "$.error" isString
+
+
+# POST /api/v1/pipeline — unknown solver in a later stage still fails the
+# whole request (fail-fast, no partial results)
+POST http://127.0.0.1:8080/api/v1/pipeline
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 1.0, "y": 1.0}
+    ]
+  },
+  "stages": [
+    {"solver": "nn"},
+    {"solver": "does_not_exist"}
+  ]
+}
+```
+HTTP 400
+[Asserts]
+jsonpath "$.error" isString
+
+
+# POST /api/v1/pipeline — both input fields returns 400
+POST http://127.0.0.1:8080/api/v1/pipeline
+Content-Type: application/json
+```json
+{
+  "input": {
+    "cities": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0}],
+    "tsplib": "NAME: x\n"
+  },
+  "stages": [
+    {"solver": "nn"},
+    {"solver": "2opt"}
+  ]
+}
+```
+HTTP 400

--- a/teeline-api/tests/metrics.rs
+++ b/teeline-api/tests/metrics.rs
@@ -37,6 +37,16 @@ fn solve_req(solver: &str) -> Request<Body> {
         .unwrap()
 }
 
+fn pipeline_req() -> Request<Body> {
+    let body = r#"{"input":{"cities":[{"x":0.0,"y":0.0},{"x":1.0,"y":0.0},{"x":1.0,"y":1.0},{"x":0.0,"y":1.0}]},"stages":[{"solver":"nn"},{"solver":"2opt"}]}"#;
+    Request::builder()
+        .method("POST")
+        .uri("/api/v1/pipeline")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap()
+}
+
 async fn body_text(resp: axum::response::Response) -> String {
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
@@ -131,6 +141,29 @@ async fn solver_error_metric_increments_for_known_solver_error() {
     assert!(
         body.contains("teeline_solver_requests_total"),
         "missing teeline_solver_requests_total after failed solve:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn solver_metrics_present_after_successful_pipeline() {
+    let app = make_app();
+    let pipeline_resp = app.clone().oneshot(pipeline_req()).await.unwrap();
+    assert_eq!(
+        pipeline_resp.status(),
+        StatusCode::OK,
+        "pipeline must succeed before solver metrics are populated"
+    );
+    let body = body_text(app.oneshot(metrics_req()).await.unwrap()).await;
+    // Regression check: the pipeline endpoint chains multiple solver stages
+    // and must record per-solver metrics the same way /api/v1/solve does —
+    // it previously recorded none at all.
+    assert!(
+        body.contains("teeline_solver_requests_total"),
+        "missing teeline_solver_requests_total after pipeline:\n{body}"
+    );
+    assert!(
+        body.contains("teeline_solver_duration_seconds"),
+        "missing teeline_solver_duration_seconds after pipeline:\n{body}"
     );
 }
 

--- a/teeline-api/tests/openapi.rs
+++ b/teeline-api/tests/openapi.rs
@@ -50,7 +50,7 @@ async fn openapi_json_is_valid_json() {
 }
 
 #[tokio::test]
-async fn openapi_json_contains_all_four_paths() {
+async fn openapi_json_contains_all_documented_paths() {
     let resp = make_app()
         .oneshot(
             Request::builder()
@@ -75,6 +75,10 @@ async fn openapi_json_contains_all_four_paths() {
     );
     assert!(paths.contains_key("/api/v1/parse"), "missing /api/v1/parse");
     assert!(paths.contains_key("/api/v1/solve"), "missing /api/v1/solve");
+    assert!(
+        paths.contains_key("/api/v1/pipeline"),
+        "missing /api/v1/pipeline"
+    );
 }
 
 #[tokio::test]
@@ -177,6 +181,13 @@ async fn solve_and_parse_request_bodies_have_named_examples() {
     assert!(
         parse_examples.as_object().is_some_and(|o| o.len() >= 2),
         "/api/v1/parse should document at least 2 named examples"
+    );
+
+    let pipeline_examples = &json["paths"]["/api/v1/pipeline"]["post"]["requestBody"]["content"]["application/json"]
+        ["examples"];
+    assert!(
+        pipeline_examples.as_object().is_some_and(|o| o.len() >= 2),
+        "/api/v1/pipeline should document at least 2 named examples"
     );
 }
 

--- a/teeline-api/tests/pipeline.rs
+++ b/teeline-api/tests/pipeline.rs
@@ -1,0 +1,150 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use teeline_api::{
+    AppState,
+    metrics::MetricsState,
+    services::{SolverRegistry, TspService},
+};
+use tower::ServiceExt;
+
+fn make_app() -> axum::Router {
+    let state = AppState {
+        solver_service: Arc::new(TspService),
+        registry_service: Arc::new(SolverRegistry),
+        metrics: Arc::new(MetricsState::new()),
+    };
+    teeline_api::build_router(state, teeline_api::build_api_router())
+}
+
+fn json_body(json: &str) -> Body {
+    Body::from(json.to_owned())
+}
+
+fn post(uri: &str, body: Body) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body)
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+const SQUARE_CITIES: &str =
+    r#"{"cities":[{"x":0.0,"y":0.0},{"x":1.0,"y":0.0},{"x":1.0,"y":1.0},{"x":0.0,"y":1.0}]}"#;
+
+#[tokio::test]
+async fn pipeline_two_stages_returns_ok() {
+    let body =
+        format!(r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"nn"}},{{"solver":"2opt"}}]}}"#);
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn pipeline_returns_ordered_stage_results_and_final_fields() {
+    let body =
+        format!(r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"nn"}},{{"solver":"2opt"}}]}}"#);
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+
+    let stages = json["stages"].as_array().unwrap();
+    assert_eq!(stages.len(), 2);
+    assert_eq!(stages[0]["solver"], "nn");
+    assert_eq!(stages[1]["solver"], "2opt");
+    assert!(stages[0]["duration_ms"].is_u64());
+
+    assert_eq!(json["final_cost"], stages[1]["cost"]);
+    assert_eq!(json["final_tour"], stages[1]["tour"]);
+    assert!(json["warnings"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn pipeline_single_stage_returns_400() {
+    let body = format!(r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"nn"}}]}}"#);
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn pipeline_unknown_solver_in_first_stage_returns_400() {
+    let body = format!(
+        r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"does_not_exist"}},{{"solver":"2opt"}}]}}"#
+    );
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Fail-fast: an unknown solver in a *later* stage still fails the whole
+/// request, even though earlier stages are well-formed — no partial results.
+#[tokio::test]
+async fn pipeline_unknown_solver_in_second_stage_returns_400() {
+    let body = format!(
+        r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"nn"}},{{"solver":"does_not_exist"}}]}}"#
+    );
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp).await;
+    assert!(
+        json.get("stages").is_none(),
+        "no partial results on failure"
+    );
+}
+
+#[tokio::test]
+async fn pipeline_nn_mid_pipeline_returns_warnings() {
+    let body =
+        format!(r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"2opt"}},{{"solver":"nn"}}]}}"#);
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let warnings = json["warnings"].as_array().unwrap();
+    assert!(!warnings.is_empty());
+}
+
+#[tokio::test]
+async fn pipeline_with_per_stage_configs_returns_ok() {
+    let body = format!(
+        r#"{{"input":{SQUARE_CITIES},"stages":[{{"solver":"nn"}},{{"solver":"sa","configs":{{"sa":{{"max_temperature":200.0}}}}}}]}}"#
+    );
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(&body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn pipeline_both_input_fields_returns_400() {
+    let body = r#"{"input":{"cities":[{"x":0.0,"y":0.0},{"x":1.0,"y":0.0}],"tsplib":"NAME: x"},"stages":[{"solver":"nn"},{"solver":"2opt"}]}"#;
+    let resp = make_app()
+        .oneshot(post("/api/v1/pipeline", json_body(body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -12,7 +12,7 @@ use teeline::config::{
 use teeline::tsp::{
     self, AppOptions, SOMOptions, Solution, SolverKind, Solvers, TspProblem, distance_matrix,
     list_solvers,
-    pipeline::{PipelineStage, run_pipeline},
+    pipeline::{PipelineStage, run_pipeline, stage_warnings},
     tsplib,
 };
 use tracing_subscriber::EnvFilter;
@@ -393,10 +393,9 @@ fn run_as_pipeline_stages(
         .with_writer(std::io::stderr)
         .try_init();
 
-    for (i, (solver, _)) in stage_configs.iter().enumerate() {
-        if i > 0 && *solver == Solvers::NearestNeighbor {
-            eprintln!("warning: nn at pipeline stage {i} discards the warm-start seed");
-        }
+    let solvers: Vec<Solvers> = stage_configs.iter().map(|(s, _)| *s).collect();
+    for warning in stage_warnings(&solvers) {
+        eprintln!("warning: {warning}");
     }
 
     let tsp_data = if let Some(input_file_path) = args.get_one::<String>("input") {


### PR DESCRIPTION
## Summary

Implements #287 — a `POST /api/v1/pipeline` endpoint that chains multiple solvers sequentially, warm-starting each stage from the previous stage's tour.

- Reuses the core lib's existing chaining machinery (`teeline::tsp::pipeline`, from #66/#81) instead of duplicating the warm-start/validation loop in `teeline-api`. Added `run_pipeline_stages()`/`StageOutcome` (per-stage cost/tour/duration) and `stage_warnings()` (a shared, non-fatal lint for questionable solver orderings); `run_pipeline()` is now a thin wrapper over the new function with unchanged behavior.
- `teeline-cli` now calls the shared `stage_warnings()` instead of its own inline NN-mid-pipeline check, so the CLI and API report the same warnings (including a new exact-solver-in-non-terminal-position case from #66's original design that the CLI never actually implemented).
- New `PipelineRequest`/`PipelineResponse` DTOs support **per-stage** `SolverConfigs` overrides (e.g. a lower `max_temperature` for an SA stage that follows a 2-opt cleanup).
- A mid-pipeline failure fails the whole request — no partial/tagged results, matching the core lib's fail-fast `run_pipeline` behavior (deliberately not resurrecting the more complex `Ok`/`Error`-tagged shape that was cut from `/api/v1/compare` in #303).
- Route handler stays lean (deserialize → delegate to the service → map `Result` to HTTP), matching `solve.rs`/`parse.rs` conventions. Auth and rate-limiting are inherited automatically from the existing `/api/v1/*` middleware wrapping.
- Three named Scalar/OpenAPI examples ship with the endpoint (constructive→local-search, per-stage-tuned metaheuristic, and the classic `nn → 2opt → sa` chain) so it's easy to try from the docs UI.

## Test plan

- [x] `cargo test -p teeline --lib tsp::pipeline` — new lib tests pass, existing `run_pipeline` tests unchanged
- [x] `cargo test -p teeline-api` — new DTO/service/route/openapi tests pass (26 new/updated assertions across pipeline.rs, api_tests.rs, openapi.rs)
- [x] `cargo test --workspace` — full workspace suite green (288+ lib tests, all crates)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `task test:e2e:api` (hurl) — new `pipeline.hurl` (5 requests) passes against a live binary
- [x] Manual curl smoke test — verified stage ordering, `final_cost`/`final_tour`, and `warnings` population for an `nn`-mid-pipeline case
- [x] Verified all 3 named examples render in `/openapi.json` for Scalar's "Try it" panel