### PR TITLE
perf(fourier): replace brute-force nearest-sample scan with a KD-tree

### DIFF
--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -121,6 +121,10 @@ teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp
   from the current curve samples each step, rather than a linear scan. The KD-tree module
   stores coordinates as `f32`, so the *which-sample-is-nearest* decision is made at `f32`
   precision; the gradient and decode math around the returned index still run in `f64`.
+  The query point is tagged with a sentinel id (`usize::MAX`) that can never collide with a
+  real curve-sample id, since the KD-tree's self-exclusion guard (designed for querying a
+  point against the same id space it came from, as in `nearest_neighbor.rs`) would otherwise
+  make curve sample 0 permanently unselectable whenever the query's id defaulted to `0`.
 - **WASM-compatible**: uses `num-complex = "0.4"` (no_std-compatible, no libm dependency).
 
 ## Relationship to the Elastic Net

--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -12,7 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `fourier` |
 | **Type** | Heuristic — constructive |
-| **Complexity** | O(K_max · epochs · n · M) per run |
+| **Complexity** | O(K_max · epochs · (n + M) log M) per run |
 
 ## Description
 
@@ -116,6 +116,11 @@ teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp
   benefit from a seed tour; the `--init-tour` pipeline option has no effect on this solver.
 - **f64 internally**: all gradient computation uses `f64` for numerical stability; coordinates
   are converted from `f32` at input and the final tour is `Vec<usize>` city IDs.
+- **Nearest-sample lookup uses a KD-tree**: finding each city's nearest point on the curve
+  (used in both the attraction gradient and the final decode) queries a KD-tree built fresh
+  from the current curve samples each step, rather than a linear scan. The KD-tree module
+  stores coordinates as `f32`, so the *which-sample-is-nearest* decision is made at `f32`
+  precision; the gradient and decode math around the returned index still run in `f64`.
 - **WASM-compatible**: uses `num-complex = "0.4"` (no_std-compatible, no libm dependency).
 
 ## Relationship to the Elastic Net

--- a/src/tsp/fourier.rs
+++ b/src/tsp/fourier.rs
@@ -83,8 +83,14 @@ fn build_gamma_tree(gamma: &[Complex<f64>]) -> KDTree {
     kdtree::from_cities(&points)
 }
 
+/// `NearestResult::add` skips any tree point whose `id` matches the query point's
+/// `id`, a self-match guard designed for same-id-space queries (e.g. `nearest_neighbor.rs`
+/// querying a city against the same city set). Here the query is a city and the tree is
+/// curve samples, two unrelated id spaces, so an unqualified `KDPoint::new` (which
+/// defaults `id` to `0`) would collide with curve sample 0's real id and make it
+/// permanently unselectable. `usize::MAX` can never collide with a real sample index.
 fn nearest_sample(tree: &KDTree, city: Complex<f64>) -> usize {
-    let target = KDPoint::new(&[city.re as f32, city.im as f32]);
+    let target = KDPoint::new_with_id(usize::MAX, &[city.re as f32, city.im as f32]);
     tree.nearest(&target, 1).point.id
 }
 

--- a/src/tsp/fourier.rs
+++ b/src/tsp/fourier.rs
@@ -1,5 +1,8 @@
 use crate::tsp::progress::ProgressMessage;
-use crate::tsp::{FourierOptions, Solution, TspProblem, kdtree::KDPoint};
+use crate::tsp::{
+    FourierOptions, Solution, TspProblem,
+    kdtree::{self, KDPoint, KDTree},
+};
 use num_complex::Complex;
 use std::f64::consts::PI;
 use std::sync::mpsc;
@@ -66,24 +69,30 @@ fn eval_curve(c: &[Complex<f64>], ks: &[i64], m: usize) -> Vec<Complex<f64>> {
         .collect()
 }
 
-fn nearest_sample(gamma: &[Complex<f64>], city: Complex<f64>) -> usize {
-    gamma
+/// Builds a KD-tree over the curve samples so `nearest_sample` is a tree query
+/// instead of a linear scan. Coordinates are cast to `f32` (the KD-tree module's
+/// native precision); the gradient/decode math around the returned index still
+/// runs in `f64`, so this only affects which-sample-is-nearest tie-breaking at
+/// the f32 ULP level, not the numerical stability of the optimisation itself.
+fn build_gamma_tree(gamma: &[Complex<f64>]) -> KDTree {
+    let points: Vec<KDPoint> = gamma
         .iter()
         .enumerate()
-        .min_by(|&(_, a), &(_, b)| {
-            (*a - city)
-                .norm_sqr()
-                .partial_cmp(&(*b - city).norm_sqr())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .map(|(i, _)| i)
-        .unwrap_or(0)
+        .map(|(j, g)| KDPoint::new_with_id(j, &[g.re as f32, g.im as f32]))
+        .collect();
+    kdtree::from_cities(&points)
+}
+
+fn nearest_sample(tree: &KDTree, city: Complex<f64>) -> usize {
+    let target = KDPoint::new(&[city.re as f32, city.im as f32]);
+    tree.nearest(&target, 1).point.id
 }
 
 fn decode_tour(gamma: &[Complex<f64>], cities: &[KDPoint]) -> Vec<usize> {
+    let tree = build_gamma_tree(gamma);
     let sample_indices: Vec<usize> = cities
         .iter()
-        .map(|c| nearest_sample(gamma, Complex::new(c.coords[0] as f64, c.coords[1] as f64)))
+        .map(|c| nearest_sample(&tree, Complex::new(c.coords[0] as f64, c.coords[1] as f64)))
         .collect();
     let mut order: Vec<usize> = (0..cities.len()).collect();
     order.sort_by_key(|&i| sample_indices[i]);
@@ -268,10 +277,11 @@ fn gradient_step(
     let gamma = eval_curve(c, ks, m);
     let n = cities.len() as f64;
     let mut grad = vec![Complex::new(0.0, 0.0); c.len()];
+    let tree = build_gamma_tree(&gamma);
 
     // attraction gradient
     for &city in cities {
-        let j = nearest_sample(&gamma, city);
+        let j = nearest_sample(&tree, city);
         let err = gamma[j] - city;
         for (ki, gk) in grad.iter_mut().enumerate() {
             *gk += err * basis[ki][j].conj();


### PR DESCRIPTION
## Summary
- `nearest_sample` (finding each city's nearest point on the Fourier curve) was a linear scan over all `M` curve samples, called once per city per gradient step and once per city in the final decode
- Replaced with a KD-tree query, reusing the existing `src/tsp/kdtree.rs` module already used by `nearest_neighbor.rs` rather than writing a new spatial structure. The tree is rebuilt once per call site (once per `gradient_step` call, once in `decode_tour`), not once per query
- Pure internal optimization: `FourierOptions`, the public `solve()` signature, CLI/API surface, and defaults are all unchanged

## Why
Investigated while benchmarking for the Fourier blog post (#369) — quality degrades badly on larger instances (a280: +103% gap vs berlin52's +13%), and one contributing factor is that scaling the curve resolution `m` to compensate is extremely expensive with the brute-force search (25-65x slower). This is step one of making that scaling practical; full experiment write-up in the KB task `tasks/fourier-scaling-optimizer-experiments`.

Measured on a280 (280 cities, used here purely to stress-test):

| Config | Brute force | KD-tree | Speedup | Gap (brute / kdtree) |
| --- | ---: | ---: | ---: | --- |
| k_max=4, m=200 (shipped default) | 706ms | 187ms | 3.8x | +103.4% / +104.5% |
| k_max=32, m=200 | 8.52s | 4.25s | 2.0x | +24.6% / +25.0% |
| k_max=32, m=1120 (4n) | 45.3s | 19.2s | 2.4x | +15.9% / +15.8% |

The KD-tree stores coordinates as `f32` (vs. the solver's `f64` gradient/decode math), so tiny gap deltas above are `f32` tie-breaking noise, not a systematic quality regression. Documented this precision detail in `docs/algorithms/fourier.md`.

## Test plan
- [x] All existing `fourier` unit tests pass unmodified (`cargo test --release --lib tsp::fourier`)
- [x] Integration tests pass, including the `#[ignore]`d quality threshold check (`cargo test --release --test fourier_test -- --include-ignored`)
- [x] Full workspace test suite passes (`cargo test --release -p teeline`, 288+ tests, 0 failures)
- [x] `cargo clippy -p teeline -p teeline-cli -- -D warnings` clean (matches CI's exact invocation)
- [x] `docs/algorithms/fourier.md` complexity note and precision note updated