### PR TITLE
feat(fourier): expose k_max/m as CLI flags and pipeline TOML options

### DIFF
--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -86,16 +86,48 @@ procedure FourierSolver(cities):
 
 ## Options
 
-| Field | Default | Range | Description |
-| ------- | --------- | ------- | ------------- |
-| `k_max` | 4 | ≥ 1 | Maximum Fourier mode (number of frequency stages) |
-| `m` | 200 | ≥ 2 | Curve sampling resolution (points on γ) |
-| `lambda` | 0.05 | > 0 | Initial tension weight |
-| `lambda_decay` | 0.5 | (0, 1) | Tension multiplier applied at each stage |
-| `lr` | 0.05 | > 0 | Gradient descent learning rate |
-| `epochs` | 400 | ≥ 1 | Gradient steps per k_active stage |
+| Field | CLI flag | Default | Range | Description |
+| ------- | ------- | --------- | ------- | ------------- |
+| `k_max` | `--k-max` | 4 | ≥ 1 | Maximum Fourier mode (number of frequency stages) |
+| `m` | `--m` | 200 | ≥ 2 | Curve sampling resolution (points on γ) |
+| `lambda` | — | 0.05 | > 0 | Initial tension weight |
+| `lambda_decay` | — | 0.5 | (0, 1) | Tension multiplier applied at each stage |
+| `lr` | — | 0.05 | > 0 | Gradient descent learning rate |
+| `epochs` | `--epochs` | 400 | ≥ 1 | Gradient steps per k_active stage |
 
-`epochs` follows the same vocabulary as all other solvers in this codebase.
+`epochs` follows the same vocabulary as all other solvers in this codebase, with one
+exception: unlike `HeuristicOptions.epochs` elsewhere, `epochs=0` is **not** a
+"run forever" sentinel here — it's rejected by validation, since it counts gradient
+steps per k_active stage, not outer solver iterations.
+
+Only `k_max` and `m` have CLI flags; `lambda`, `lambda_decay`, and `lr` are reachable
+only via the REST API's `configs.fourier` or a `[fourier]`/`[stage.fourier]` TOML table
+(field names match the table above).
+
+## Tuning for larger instances
+
+`k_max` (coefficient count) is the dominant quality lever, not `m` (curve resolution).
+On a280 (280 cities), scaling `k_max` alone took the standalone gap from **+103.4%** at
+the shipped default (`k_max=4`) down to **+24.6%** at `k_max=32` (further down to
+**+7.6%** after piping into a 2-opt polish pass, which is the more relevant number since
+Fourier is typically used as a warm-start). Scaling `m` alone, without more
+coefficients, made quality *worse*.
+
+| Config | Standalone gap | +2-opt gap | Wall time |
+| --- | ---: | ---: | ---: |
+| `k_max=4, m=200` (default) | +103.4% | — | 0.19s |
+| `k_max=32, m=200` | +24.6% | **+7.6%** | 4.25s |
+| `k_max=32, m=1120` (4n) | +15.9% | +15.8% | 19.2s |
+
+(a280, 280 cities; wall times measured after the KD-tree nearest-sample optimization
+that shipped in #370.)
+
+Cost scales as `k_max × epochs` gradient steps total, with no upper bound enforced by
+`validate()` — there's no instance-size-aware guard, so an oversized `--k-max` on a
+large instance will simply run for a long time (or, at extreme values, effectively
+hang) rather than error out. Start by scaling `k_max` alone before touching `m`; `m`
+scaling is comparatively expensive and, per the table above, doesn't reliably help
+quality on its own.
 
 ## Usage
 
@@ -108,6 +140,20 @@ teeline pipeline --steps=fourier,2opt -i ./data/tsplib/berlin52.tsp
 
 # as warm-start for LK
 teeline pipeline --steps=fourier,lk -i ./data/tsplib/berlin52.tsp
+
+# tuning k_max for a larger instance
+teeline solve fourier -i ./data/tsplib/a280.tsp --k-max 32
+```
+
+Per-stage TOML config (via `pipeline --config`):
+
+```toml
+[[stage]]
+solver = "fourier"
+
+[stage.fourier]
+k_max = 32
+m     = 200
 ```
 
 ## Notes

--- a/docs/algorithms/fourier.md
+++ b/docs/algorithms/fourier.md
@@ -100,9 +100,9 @@ exception: unlike `HeuristicOptions.epochs` elsewhere, `epochs=0` is **not** a
 "run forever" sentinel here — it's rejected by validation, since it counts gradient
 steps per k_active stage, not outer solver iterations.
 
-Only `k_max` and `m` have CLI flags; `lambda`, `lambda_decay`, and `lr` are reachable
-only via the REST API's `configs.fourier` or a `[fourier]`/`[stage.fourier]` TOML table
-(field names match the table above).
+Only `k_max`, `m`, and `epochs` have CLI flags; `lambda`, `lambda_decay`, and `lr` are
+reachable only via the REST API's `configs.fourier` or a `[fourier]`/`[stage.fourier]`
+TOML table (field names match the table above).
 
 ## Tuning for larger instances
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -55,6 +55,14 @@ representative, not as a guarantee.
 
 *Wall time* = elapsed wall-clock time. *CPU* = percentage of one core used (>100% would indicate parallelism). *Peak RSS* = maximum resident set size reported by GNU `time -v`.
 
+**Fourier on larger instances**: the `k_max`/`m` defaults above are tuned for
+berlin52-scale instances. On a280 (280 cities), Fourier's gap grows sharply at the
+default `k_max=4` (+103.4%), but `k_max` — not `m` — is the lever that fixes it
+(`k_max=32` brings it down to +24.6% standalone, +7.6% after a 2-opt polish). This
+table doesn't include an a280 row because it wasn't measured under this doc's exact
+methodology (release build, `GNU time -v` for CPU/RSS); see the "Tuning for larger
+instances" section in `docs/algorithms/fourier.md` for the full scaling data.
+
 ---
 
 ## How to reproduce

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::tsp::{
-    AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions, Solvers,
+    AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, SAOptions,
+    Solvers,
 };
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
@@ -12,7 +13,7 @@ pub trait AppOptionsProvider {
 }
 
 /// Applies recognised sub-tables from a `toml::Table` to the base `AppOptions`.
-/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, and `heuristic` are valid top-level keys.
+/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, `fourier`, and `heuristic` are valid top-level keys.
 /// Returns `Err` on unknown keys or mis-typed sub-tables.
 pub struct TomlTableProvider<'a>(pub &'a toml::Table);
 
@@ -37,6 +38,12 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                     let t = value.as_table().ok_or("config: `fpa` must be a table")?;
                     base.fpa = Some(FPAOptions::from_toml(t)?);
                 }
+                "fourier" => {
+                    let t = value
+                        .as_table()
+                        .ok_or("config: `fourier` must be a table")?;
+                    base.fourier = Some(FourierOptions::from_toml(t)?);
+                }
                 "heuristic" => {
                     let t = value
                         .as_table()
@@ -45,7 +52,7 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                 }
                 other => {
                     return Err(format!(
-                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, heuristic"
+                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, fourier, heuristic"
                     ));
                 }
             }
@@ -100,6 +107,7 @@ pub fn load_pipeline_config(
             ("ga", matches!(solver, Solvers::GeneticAlgorithm)),
             ("cs", matches!(solver, Solvers::CuckooSearch)),
             ("fpa", matches!(solver, Solvers::FlowerPollination)),
+            ("fourier", matches!(solver, Solvers::Fourier)),
             (
                 "heuristic",
                 !matches!(
@@ -108,6 +116,7 @@ pub fn load_pipeline_config(
                         | Solvers::GeneticAlgorithm
                         | Solvers::CuckooSearch
                         | Solvers::FlowerPollination
+                        | Solvers::Fourier
                 ),
             ),
         ] {
@@ -218,6 +227,18 @@ mod tests {
     }
 
     #[test]
+    fn test_toml_provider_fourier_sub_table_works() {
+        let table: toml::Table =
+            toml::from_str("solver = \"fourier\"\n[fourier]\nk_max = 32\nm = 1120").unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
+        let fourier = opts.fourier.unwrap();
+        assert_eq!(fourier.k_max, 32);
+        assert_eq!(fourier.m, 1120);
+    }
+
+    #[test]
     fn test_toml_provider_heuristic_sub_table_works() {
         let table: toml::Table =
             toml::from_str("solver = \"2opt\"\n[heuristic]\nepochs = 500").unwrap();
@@ -319,6 +340,22 @@ mod tests {
         let toml = "[[stage]]\nsolver = \"sa\"\n\n[stage.sa]\ncooling_rate = 0.001\nmax_temperature = 100.0\nmin_temperature = 0.001\n\n[stage.heuristic]\nepochs = 5000\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("heuristic"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_heuristic_sub_table_on_fourier_errors() {
+        // Fourier reads only opts.fourier at solve time, never opts.heuristic —
+        // [stage.heuristic] on a fourier stage is a silent no-op unless rejected here.
+        let toml = "[[stage]]\nsolver = \"fourier\"\n\n[stage.fourier]\nk_max = 32\n\n[stage.heuristic]\nepochs = 500\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("heuristic"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_fourier_sub_table_on_nn_errors() {
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.fourier]\nk_max = 32\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("fourier"), "got: {err}");
     }
 
     #[test]

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1202,6 +1202,16 @@ impl FourierOptions {
                 .parse::<usize>()
                 .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
         }
+        if let Some(v) = args.get_one::<String>("k_max") {
+            f.k_max = v
+                .parse::<usize>()
+                .map_err(|_| format!("--k-max: invalid integer `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("m") {
+            f.m = v
+                .parse::<usize>()
+                .map_err(|_| format!("--m: invalid integer `{v}`"))?;
+        }
         f.validate()?;
         Ok(f)
     }
@@ -1979,5 +1989,40 @@ mod tests {
         let args = cmd.get_matches_from(["t", "--max-depth", "3"]); // hyphen matches production CLI
         let opts = LKOptions::from_cli(&args).unwrap();
         assert_eq!(opts.max_depth, 3);
+    }
+
+    fn fourier_cli_command() -> clap::Command {
+        use clap::{Arg, ArgAction, Command};
+        Command::new("t")
+            .arg(Arg::new("epochs").long("epochs").action(ArgAction::Set))
+            .arg(Arg::new("k_max").long("k-max").action(ArgAction::Set)) // hyphen matches production CLI
+            .arg(Arg::new("m").long("m").action(ArgAction::Set))
+    }
+
+    #[test]
+    fn test_fourier_from_cli_parses_k_max_and_m() {
+        let cmd = fourier_cli_command();
+        let args = cmd.get_matches_from(["t", "--k-max", "32", "--m", "1120"]);
+        let opts = FourierOptions::from_cli(&args).unwrap();
+        assert_eq!(opts.k_max, 32);
+        assert_eq!(opts.m, 1120);
+    }
+
+    #[test]
+    fn test_fourier_from_cli_errors_on_bad_integer() {
+        let cmd = fourier_cli_command();
+        let args = cmd.get_matches_from(["t", "--k-max", "abc"]);
+        let err = FourierOptions::from_cli(&args).unwrap_err();
+        assert!(err.contains("--k-max"), "got: {err}");
+    }
+
+    #[test]
+    fn test_fourier_from_cli_epochs_zero_errors() {
+        // Unlike HeuristicOptions.epochs (0 = run forever), FourierOptions.epochs is
+        // gradient steps per k_active stage and validate() rejects 0.
+        let cmd = fourier_cli_command();
+        let args = cmd.get_matches_from(["t", "--epochs", "0"]);
+        let err = FourierOptions::from_cli(&args).unwrap_err();
+        assert!(err.contains("epochs"), "got: {err}");
     }
 }

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -301,8 +301,9 @@ fn tuning_args() -> Vec<Arg> {
                 "Fourier: max coefficient count (default 4). Primary quality lever for \
                  larger instances (a280: +103% gap at default → +25% at k_max=32). Total \
                  gradient steps scale as k_max × epochs with no upper bound enforced, so \
-                 large values cost real wall time (measured ~45s vs ~0.7s on a280 at \
-                 k_max=32) or can hang on very large values; see docs/algorithms/fourier.md",
+                 large values cost real wall time (measured ~4.25s vs ~0.19s on a280 at \
+                 k_max=32 vs default, both m=200) or can hang on very large values; see \
+                 docs/algorithms/fourier.md",
             )
             .action(ArgAction::Set)
             .required(false),

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -36,7 +36,8 @@ impl<'a> CliArgsProvider<'a> {
 impl AppOptionsProvider for CliArgsProvider<'_> {
     fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
         use teeline::tsp::{
-            CSOptions, FPAOptions, GAOptions, HeuristicOptions, LKOptions, SAOptions,
+            CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, LKOptions,
+            SAOptions,
         };
         match self.solver {
             Solvers::SimulatedAnnealing => {
@@ -56,6 +57,9 @@ impl AppOptionsProvider for CliArgsProvider<'_> {
             }
             Solvers::KohonenSom => {
                 base.som = Some(SOMOptions::from_cli(self.args)?);
+            }
+            Solvers::Fourier => {
+                base.fourier = Some(FourierOptions::from_cli(self.args)?);
             }
             _ => {
                 base.heuristic = Some(HeuristicOptions::from_cli(self.args)?);
@@ -289,6 +293,28 @@ fn tuning_args() -> Vec<Arg> {
         Arg::new("neuron_multiplier")
             .long("neuron_multiplier")
             .help("SOM: neurons = n_cities × multiplier (default 8)")
+            .required(false),
+        Arg::new("k_max")
+            .long("k-max")
+            .value_name("N")
+            .help(
+                "Fourier: max coefficient count (default 4). Primary quality lever for \
+                 larger instances (a280: +103% gap at default → +25% at k_max=32). Total \
+                 gradient steps scale as k_max × epochs with no upper bound enforced, so \
+                 large values cost real wall time (measured ~45s vs ~0.7s on a280 at \
+                 k_max=32) or can hang on very large values; see docs/algorithms/fourier.md",
+            )
+            .action(ArgAction::Set)
+            .required(false),
+        Arg::new("m")
+            .long("m")
+            .value_name("N")
+            .help(
+                "Fourier: curve sampling resolution (default 200). Scaling m alone \
+                 (without k_max) can worsen quality; k_max is the primary lever, see \
+                 docs/algorithms/fourier.md",
+            )
+            .action(ArgAction::Set)
             .required(false),
     ]
 }
@@ -763,6 +789,15 @@ mod tests {
         let args = options_cmd().get_matches_from(["test", "ga", "--n_elite", "7"]);
         let opts = solver_options_from_args(&args, Solvers::GeneticAlgorithm);
         assert_eq!(opts.ga.unwrap_or_default().n_elite, 7);
+    }
+
+    #[test]
+    fn test_solver_options_k_max_parsed() {
+        // Exercises the CliArgsProvider::provide match arm for Solvers::Fourier —
+        // without it, base.fourier is never populated regardless of flags.
+        let args = options_cmd().get_matches_from(["test", "fourier", "--k-max", "32"]);
+        let opts = solver_options_from_args(&args, Solvers::Fourier);
+        assert_eq!(opts.fourier.unwrap().k_max, 32);
     }
 
     #[test]

--- a/tests/e2e/pipeline.bats
+++ b/tests/e2e/pipeline.bats
@@ -41,6 +41,11 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "pipeline --config with fourier options exits 0" {
+    run "$BIN" pipeline "--config=${FIXTURE_DIR}/pipeline_fourier.toml" -i "$GR17"
+    [ "$status" -eq 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # pipeline subcommand — error cases
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/pipeline_fourier.toml
+++ b/tests/fixtures/pipeline_fourier.toml
@@ -1,0 +1,6 @@
+[[stage]]
+solver = "fourier"
+
+[stage.fourier]
+k_max = 6
+m = 200

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -53,6 +53,23 @@ fn test_pipeline_config_sa_stage_epochs_applied() {
     assert_eq!(solution.route().len(), 52);
 }
 
+#[test]
+fn test_pipeline_config_fourier_stage_k_max_applied() {
+    let p = fixture("pipeline_fourier.toml");
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    // Fourier stage should have k_max=6/m=200 from its [stage.fourier] options
+    let fourier_stage = stage_configs.iter().find(|(s, _)| *s == Solvers::Fourier);
+    assert!(fourier_stage.is_some(), "expected Fourier stage in fixture");
+    let (_, opts) = fourier_stage.unwrap();
+    let fourier_opts = opts.fourier.as_ref().unwrap();
+    assert_eq!(fourier_opts.k_max, 6);
+    assert_eq!(fourier_opts.m, 200);
+    // Also verify it runs to completion
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
+    assert_eq!(solution.route().len(), 52);
+}
+
 // ---------------------------------------------------------------------------
 // Mutual-exclusion errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `--k-max` and `--m` CLI flags for the Fourier solver (`teeline solve fourier` / `teeline pipeline`), wired through `FourierOptions::from_cli`
- Adds `[fourier]` / `[stage.fourier]` TOML table support in pipeline config, mirroring the existing `sa`/`ga`/`cs`/`fpa` pattern in `src/config.rs`
- Documents `k_max` as the dominant quality lever for larger instances (a280: +103.4% gap at default `k_max=4` → +24.6% standalone / +7.6% after a 2-opt polish at `k_max=32`), with a real benchmark table in `docs/algorithms/fourier.md` and a cross-reference note in `docs/benchmarks.md`
- Adds e2e (bats), pipeline-config, and CLI unit test coverage for the new flags/table

Closes #371.

### Follow-up from `/code-review high`

A review pass caught and fixed two documentation-accuracy bugs introduced in the docs update:
- `docs/algorithms/fourier.md` claimed "only k_max and m have CLI flags" directly below a table that also lists `--epochs` as CLI-reachable — corrected.
- The `--k-max` help text in `teeline-cli/src/main.rs` quoted a280 wall times (~45s vs ~0.7s at k_max=32 vs default) that were ~10x off from the actually-measured numbers in the docs table (4.25s vs 0.19s) — corrected to match.

## Test plan

- [x] `cargo build -p teeline-cli -p teeline`
- [x] `cargo test -p teeline fourier` (unit tests incl. new CLI parsing tests)
- [x] `cargo test --test pipeline_config_test` (incl. new `test_pipeline_config_fourier_stage_k_max_applied`)
- [x] New bats e2e case: `pipeline --config with fourier options exits 0`