### PR TITLE
feat(config): add [stage.lk]/[stage.som] pipeline TOML support

### DIFF
--- a/docs/algorithms/lin-kernighan.md
+++ b/docs/algorithms/lin-kernighan.md
@@ -36,12 +36,19 @@ procedure LinKernighan(cities, epochs):
 
 ## Options
 
-| Flag | Description | Default |
-| ------ | ------------- | --------- |
-| `--epochs` | Number of ILS restarts | 10 000 |
-| `--platoo_epochs` | Stop after this many non-improving restarts | 500 |
-| `--n_nearest` | Candidate list size (k nearest neighbours per city) | 3 |
-| `--max_depth` | Maximum 2-opt move depth (currently unused in the inner loop) | 5 |
+| Field | CLI flag | Default | Range | Description |
+| ------- | ------- | --------- | ------- | ------------- |
+| `epochs` | `--epochs` | 100 | ≥ 0 (unvalidated) | Number of ILS restarts |
+| `platoo_epochs` | `--platoo_epochs` | 10 | ≥ 0 (unvalidated) | Stop after this many consecutive non-improving restarts |
+| `n_nearest` | `--n_nearest` | 5 | ≥ 1 | Candidate list size (k nearest neighbours per city) |
+| `max_depth` | `--max-depth` | 5 | ≥ 1 | LK chain-search depth; depth-1 ≈ 2-opt, depth-5 enables the full k-opt move space |
+
+`epochs` and `platoo_epochs` aren't rejected by validation at any value, but unlike the
+"0 = run forever" convention some other solvers use, LK's loop doesn't implement that
+convention: `epochs=0` runs zero ILS restarts (only the initial pass), and
+`platoo_epochs=0` stops after the first non-improving restart — the opposite of
+"unlimited". All four fields are also reachable via the REST API's `configs.lk` or a
+`[lk]`/`[stage.lk]` TOML table (field names match the table above).
 
 ## Usage
 
@@ -59,13 +66,28 @@ teeline solve lk --no-seed -i ./data/tsplib/berlin52.tsp
 teeline solve lk -i ./data/tsplib/berlin52.tsp --n_nearest=5 --epochs=50000
 ```
 
+Per-stage TOML config (via `pipeline --config`):
+
+```toml
+[[stage]]
+solver = "lk"
+
+[stage.lk]
+max_depth = 3
+n_nearest = 8
+```
+
 ## Benchmark
 
-| Instance | Optimal | This solver  | Gap   |
-|----------|---------|--------------|-------|
-| berlin52 | 7 542   | ~8 100–8 300 | ~8–9% |
+| Instance | Optimal | This solver (default) | Gap |
+| --- | --- | --- | --- |
+| berlin52 | 7 544.37 | 7 544.37 | 0.0% |
 
-The gap reflects the 2-opt depth of the inner optimizer. True LK moves use sequential edge exchanges of depth ≥ 3, which this implementation approximates with the LK gain criterion applied to 2-opt moves. A depth-3 LK pass would reduce the gap to ≈ 1–2% (tracked in GH #184).
+With the default `max_depth=5` (full LK chain-search depth), this solver finds the
+optimal berlin52 tour. Depth matters: over 10 runs, depth-1 (≈ 2-opt with ILS restarts)
+hits optimal 6/10 times (mean 7595), depth-2 hits 7/10 (mean 7580), and depth-5 hits
+10/10 (mean 7544) — see `docs/benchmarks.md` for the full breakdown. Full sequential
+LK chain search (issue #184) is implemented and shipped, not a future improvement.
 
 ## References
 

--- a/docs/algorithms/som.md
+++ b/docs/algorithms/som.md
@@ -56,12 +56,15 @@ Hamiltonian tour regardless of convergence quality.
 
 ## Options
 
-| Field | Default | Range | Description |
-| ------- | --------- | ------- | ------------- |
-| `epochs` | 100 000 | ≥ 1 | Number of training iterations |
-| `learning_rate` | 0.8 | (0, 1] | Initial learning rate η₀ |
-| `radius_fraction` | 0.1 | (0, 1] | Initial neighbourhood radius as fraction of neuron count |
-| `neuron_multiplier` | 8 | ≥ 1 | Neuron count = n_cities × multiplier; higher reduces dead neurons |
+| Field | CLI flag | Default | Range | Description |
+| ------- | ------- | --------- | ------- | ------------- |
+| `epochs` | `--epochs` | 100 000 | ≥ 1 | Number of training iterations |
+| `learning_rate` | `--learning_rate` | 0.8 | (0, 1] | Initial learning rate η₀ |
+| `radius_fraction` | `--radius_fraction` | 0.1 | (0, 1] | Initial neighbourhood radius as fraction of neuron count |
+| `neuron_multiplier` | `--neuron_multiplier` | 8 | ≥ 1 | Neuron count = n_cities × multiplier; higher reduces dead neurons |
+
+All four fields are also reachable via the REST API's `configs.som` or a
+`[som]`/`[stage.som]` TOML table (field names match the table above).
 
 ## Usage
 
@@ -75,6 +78,17 @@ teeline pipeline --steps=som,sa   -i ./data/tsplib/berlin52.tsp
 
 # custom training schedule
 teeline solve som --epochs=200000 --learning_rate=0.9 -i ./data/tsplib/berlin52.tsp
+```
+
+Per-stage TOML config (via `pipeline --config`):
+
+```toml
+[[stage]]
+solver = "som"
+
+[stage.som]
+epochs        = 50000
+learning_rate = 0.9
 ```
 
 ## Notes

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::tsp::{
-    AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, SAOptions,
-    Solvers,
+    AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, LKOptions,
+    SAOptions, SOMOptions, Solvers,
 };
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
@@ -13,7 +13,8 @@ pub trait AppOptionsProvider {
 }
 
 /// Applies recognised sub-tables from a `toml::Table` to the base `AppOptions`.
-/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, `fourier`, and `heuristic` are valid top-level keys.
+/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, `fourier`, `lk`, `som`, and `heuristic` are
+/// valid top-level keys.
 /// Returns `Err` on unknown keys or mis-typed sub-tables.
 pub struct TomlTableProvider<'a>(pub &'a toml::Table);
 
@@ -44,6 +45,14 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                         .ok_or("config: `fourier` must be a table")?;
                     base.fourier = Some(FourierOptions::from_toml(t)?);
                 }
+                "lk" => {
+                    let t = value.as_table().ok_or("config: `lk` must be a table")?;
+                    base.lk = Some(LKOptions::from_toml(t)?);
+                }
+                "som" => {
+                    let t = value.as_table().ok_or("config: `som` must be a table")?;
+                    base.som = Some(SOMOptions::from_toml(t)?);
+                }
                 "heuristic" => {
                     let t = value
                         .as_table()
@@ -52,7 +61,7 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                 }
                 other => {
                     return Err(format!(
-                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, fourier, heuristic"
+                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, fourier, lk, som, heuristic"
                     ));
                 }
             }
@@ -108,6 +117,8 @@ pub fn load_pipeline_config(
             ("cs", matches!(solver, Solvers::CuckooSearch)),
             ("fpa", matches!(solver, Solvers::FlowerPollination)),
             ("fourier", matches!(solver, Solvers::Fourier)),
+            ("lk", matches!(solver, Solvers::LinKernighan)),
+            ("som", matches!(solver, Solvers::KohonenSom)),
             (
                 "heuristic",
                 !matches!(
@@ -117,6 +128,8 @@ pub fn load_pipeline_config(
                         | Solvers::CuckooSearch
                         | Solvers::FlowerPollination
                         | Solvers::Fourier
+                        | Solvers::LinKernighan
+                        | Solvers::KohonenSom
                 ),
             ),
         ] {
@@ -239,6 +252,24 @@ mod tests {
     }
 
     #[test]
+    fn test_toml_provider_lk_sub_table_works() {
+        let table: toml::Table = toml::from_str("solver = \"lk\"\n[lk]\nmax_depth = 2").unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
+        assert_eq!(opts.lk.unwrap().max_depth, 2);
+    }
+
+    #[test]
+    fn test_toml_provider_som_sub_table_works() {
+        let table: toml::Table = toml::from_str("solver = \"som\"\n[som]\nepochs = 500").unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
+        assert_eq!(opts.som.unwrap().epochs, 500);
+    }
+
+    #[test]
     fn test_toml_provider_heuristic_sub_table_works() {
         let table: toml::Table =
             toml::from_str("solver = \"2opt\"\n[heuristic]\nepochs = 500").unwrap();
@@ -356,6 +387,52 @@ mod tests {
         let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.fourier]\nk_max = 32\n";
         let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
         assert!(err.contains("fourier"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_heuristic_sub_table_on_lk_errors() {
+        // LK reads only opts.lk at solve time, never opts.heuristic —
+        // [stage.heuristic] on an lk stage is a silent no-op unless rejected here.
+        let toml = "[[stage]]\nsolver = \"lk\"\n\n[stage.lk]\nmax_depth = 2\n\n[stage.heuristic]\nepochs = 500\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("heuristic"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_heuristic_sub_table_on_som_errors() {
+        let toml = "[[stage]]\nsolver = \"som\"\n\n[stage.som]\nepochs = 500\n\n[stage.heuristic]\nepochs = 500\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("heuristic"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_lk_sub_table_on_nn_errors() {
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.lk]\nmax_depth = 2\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("lk"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_som_sub_table_on_nn_errors() {
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.som]\nepochs = 500\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("som"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_lk_max_depth_zero_errors() {
+        // Proves validate() actually fires through load_pipeline_config -> from_toml,
+        // not just that the [stage.lk] table parses.
+        let toml = "[[stage]]\nsolver = \"lk\"\n\n[stage.lk]\nmax_depth = 0\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("max_depth"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_som_learning_rate_out_of_range_errors() {
+        let toml = "[[stage]]\nsolver = \"som\"\n\n[stage.som]\nlearning_rate = 1.5\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("learning_rate"), "got: {err}");
     }
 
     #[test]

--- a/tests/e2e/pipeline.bats
+++ b/tests/e2e/pipeline.bats
@@ -46,6 +46,16 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "pipeline --config with lk options exits 0" {
+    run "$BIN" pipeline "--config=${FIXTURE_DIR}/pipeline_lk.toml" -i "$GR17"
+    [ "$status" -eq 0 ]
+}
+
+@test "pipeline --config with som options exits 0" {
+    run "$BIN" pipeline "--config=${FIXTURE_DIR}/pipeline_som.toml" -i "$GR17"
+    [ "$status" -eq 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # pipeline subcommand — error cases
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/pipeline_lk.toml
+++ b/tests/fixtures/pipeline_lk.toml
@@ -1,0 +1,5 @@
+[[stage]]
+solver = "lk"
+
+[stage.lk]
+max_depth = 2

--- a/tests/fixtures/pipeline_som.toml
+++ b/tests/fixtures/pipeline_som.toml
@@ -1,0 +1,5 @@
+[[stage]]
+solver = "som"
+
+[stage.som]
+epochs = 500

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -70,6 +70,40 @@ fn test_pipeline_config_fourier_stage_k_max_applied() {
     assert_eq!(solution.route().len(), 52);
 }
 
+#[test]
+fn test_pipeline_config_lk_stage_max_depth_applied() {
+    let p = fixture("pipeline_lk.toml");
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    // LK stage should have max_depth=2 from its [stage.lk] options
+    let lk_stage = stage_configs
+        .iter()
+        .find(|(s, _)| *s == Solvers::LinKernighan);
+    assert!(lk_stage.is_some(), "expected LK stage in fixture");
+    let (_, opts) = lk_stage.unwrap();
+    assert_eq!(opts.lk.as_ref().unwrap().max_depth, 2);
+    // Also verify it runs to completion
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
+    assert_eq!(solution.route().len(), 52);
+}
+
+#[test]
+fn test_pipeline_config_som_stage_epochs_applied() {
+    let p = fixture("pipeline_som.toml");
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    // SOM stage should have epochs=500 from its [stage.som] options
+    let som_stage = stage_configs
+        .iter()
+        .find(|(s, _)| *s == Solvers::KohonenSom);
+    assert!(som_stage.is_some(), "expected SOM stage in fixture");
+    let (_, opts) = som_stage.unwrap();
+    assert_eq!(opts.som.as_ref().unwrap().epochs, 500);
+    // Also verify it runs to completion
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
+    assert_eq!(solution.route().len(), 52);
+}
+
 // ---------------------------------------------------------------------------
 // Mutual-exclusion errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `"lk"`/`"som"` arms to `TomlTableProvider::provide` (`src/config.rs`), mirroring the `"fourier"` arm from #371 — `LKOptions::from_toml`/`SOMOptions::from_toml` were already fully implemented but unreachable from pipeline TOML config (only `solver`/`sa`/`ga`/`cs`/`fpa`/`fourier`/`heuristic` were recognized top-level keys). Both solvers already have CLI flags, so this was TOML-config-only.
- Adds `lk`/`som` to `load_pipeline_config`'s belongs-check array and the `"heuristic"` exclusion list.
- Restructures `docs/algorithms/lin-kernighan.md`'s Options table to match `fourier.md`'s `Field | CLI flag | Default | Range | Description` style, and adds the same CLI-flag column to `docs/algorithms/som.md`. Both get a `[stage.lk]`/`[stage.som]` TOML usage example.

### Breaking change

`[stage.heuristic]` under an `lk` or `som` stage now hard-errors instead of silently being ignored — neither solver ever reads `opts.heuristic` at solve time (each has its own options struct), so this was previously a silent no-op. Same treatment `fourier` got in #371. Verified zero blast radius: no existing fixture or config in this repo used an `lk`/`som` pipeline TOML stage before this change.

### Doc fixes found along the way

While restructuring `lin-kernighan.md`'s Options table (caught by an independent Opus review pass before implementation started):
- The table documented `HeuristicOptions`' generic defaults (epochs=10000, platoo_epochs=500, n_nearest=3) instead of `LKOptions`' actual overrides (epochs=100, platoo_epochs=10, n_nearest=5).
- `max_depth` was described as "currently unused in the inner loop" — false, it's fully implemented (`find_lk_move`/`lk_pass` in `src/tsp/lin_kernighan.rs`).
- The Benchmark section had stale ~8-9% gap numbers from before issue #184 shipped full LK chain search; the real current default-config result is 0.0% gap (matches `docs/benchmarks.md`).
- `--max_depth` (underscore) → `--max-depth` (hyphen) — the doc didn't match the real shipped flag.

Also documented, accurately, that `epochs`/`platoo_epochs` are *not* validated at 0 for LK, but LK's loop doesn't implement the "0 = run forever" convention some other solvers use — `epochs=0` runs zero ILS restarts, `platoo_epochs=0` stops at the first non-improving restart.

## Test plan

- [x] `cargo build --workspace` / `cargo test --workspace` (302 lib tests + all integration/e2e suites)
- [x] `cargo fmt -- --check`, `cargo clippy --workspace -- -D warnings`
- [x] `./tests/bats/bin/bats tests/e2e/pipeline.bats` (13/13, incl. 2 new lk/som cases)
- [x] New unit tests: TOML sub-table parsing, heuristic-exclusion errors, wrong-solver rejection, `validate()` propagation (`max_depth=0`, `learning_rate=1.5` both error through the full pipeline path)
- [x] New integration tests: `pipeline_config_test.rs` (lk `max_depth`, som `epochs` applied + full pipeline run)
- [x] Manual: `[stage.lk]`/`[stage.som]` overrides resolve and apply; `[stage.heuristic]` under an lk stage errors with `` `[stage.heuristic]` is not valid for this solver ``

Closes #372.