### PR TITLE
Add Ant Colony Optimization (ACO) TSP solver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ cat ./data/tsplib/berlin52.tsp | ./target/debug/teeline solve nn
 | `gravitational_search.rs` | Gravitational Search Algorithm (Rashedi 2009): mass-weighted swap-velocity swarm (educational) | `gsa` |
 | `fourier.rs` | Fourier-basis constructive solver: closed-curve gradient descent + argsort decode | `fourier` |
 | `greedy_edge.rs` | Greedy edge construction: Kruskal-style, sorts all edges shortest-first and greedily accepts unless it creates degree 3+ or a premature sub-cycle (uses `graph.rs`'s union-find) | `gec` |
+| `ant_colony.rs` | Ant Colony Optimization (Ant System): pheromone- and heuristic-biased probabilistic tour construction; global evaporate + all-ants-deposit update per epoch | `aco` |
 
 **Tests:**
 

--- a/docs/algorithms/ant-colony.md
+++ b/docs/algorithms/ant-colony.md
@@ -70,6 +70,7 @@ teeline solve aco -i ./data/tsplib/berlin52.tsp --num-ants=40 --beta=3.0 --evapo
 
 ## References
 
-- Dorigo, M. (1996) — "Ant System: Optimization by a Colony of Cooperating Agents", *IEEE Transactions on Systems, Man, and Cybernetics, Part B*, 26(1), pp. 29–41
-- Dorigo, M. & Stützle, T. (2004) — *Ant Colony Optimization*, MIT Press
+- Dorigo, M., Maniezzo, V. & Colorni, A. (1996) — "Ant System: Optimization by a Colony of Cooperating Agents", *IEEE Transactions on Systems, Man, and Cybernetics, Part B: Cybernetics*, 26(1), pp. 29–41
+- Dorigo, M. & Stützle, T. (2004) — *Ant Colony Optimization*, MIT Press, ISBN 0-262-04219-3
+- Stützle, T. & Hoos, H.H. (2000) — "MAX–MIN Ant System", *Future Generation Computer Systems*, 16(8), pp. 889–914 (source of the pheromone-floor technique referenced in the adaptations table above)
 - [Ant colony optimization algorithms (Wikipedia)](https://en.wikipedia.org/wiki/Ant_colony_optimization_algorithms)

--- a/docs/algorithms/ant-colony.md
+++ b/docs/algorithms/ant-colony.md
@@ -1,0 +1,75 @@
+---
+id: "aco"
+name: "Ant Colony Optimization"
+typeBadge: "Heuristic — nature-inspired metaheuristic"
+description: "Nature-inspired metaheuristic (Ant System, Dorigo 1996) that models pheromone-trail foraging in ant colonies. Maintains a shared pheromone matrix across a colony of ants. Each epoch:"
+hasExplainer: false
+---
+
+# Ant Colony Optimization
+
+| | |
+| --- | --- |
+| **Alias** | `aco`, `ant_colony` |
+| **Type** | Heuristic — nature-inspired metaheuristic |
+| **Auto-seeds from** | `shuffle` (random ants); a warm-start tour also bootstraps the initial pheromone level (see below) |
+
+## Description
+
+Nature-inspired metaheuristic (Ant System, Dorigo 1996) that models pheromone-trail foraging in ant colonies. A shared *pheromone matrix* persists across epochs — unlike Cuckoo Search's or Flower Pollination's mutated population arrays, ants themselves carry no memory between epochs. Each epoch:
+
+1. Every ant independently constructs a full tour from a random start city, choosing each next city probabilistically, weighted by `pheromone(i,j)^alpha * (1/distance(i,j))^beta` among unvisited cities.
+2. After all ants finish, pheromone **evaporates** uniformly (`*= 1 - evaporation_rate`), then **every** ant deposits `1/tour_cost` along the edges of its own tour (not just the iteration-best — that would be Elitist AS or Ant Colony System, different variants).
+
+Implements classic Ant System: fully probabilistic transition rule, single global pheromone update, no candidate-list restriction (transition probability considered over all unvisited cities each step, matching the textbook algorithm rather than a k-nearest-restricted variant).
+
+**TSP-specific adaptations** (deviations from Dorigo 1996):
+
+| Adaptation | Reason |
+| --- | --- |
+| τ0 bootstraps from a warm-start tour when available (`τ0 = num_ants / tour_length`), else a flat constant with a logged warning | Scales initial pheromone to the same order of magnitude as real deposits (`Δτ = 1/L`); a flat constant at TSPLIB-scale tour costs would be swamped by or swamp real deposits for many epochs |
+| Pheromone floor after evaporation (`tau_min = tau0 * 1e-4`) | Without a floor, an un-deposited edge decays to exact `f32` `0.0` within a few hundred epochs, making it permanently unreachable regardless of heuristic distance — an MMAS-influenced one-line fix |
+| Warm-start biases epoch-1 via one extra deposit pass along its edges | Since ants carry no memory between epochs, a passed-in `init_tour` would otherwise only affect the `epochs: 0` passthrough case, not actually shape search |
+| Graceful degradation to eta-only (then first-candidate) selection if pheromone^alpha * eta^beta underflows/overflows to a non-finite sum | Avoids panics or NaN costs on pathological inputs (e.g. very high `beta` with coincident cities) without discarding distance information entirely |
+
+Auto-expands to `pipeline(shuffle, aco)`.
+
+```text
+procedure AntColony(cities, num_ants, alpha, beta, evaporation_rate, epochs):
+    pheromone ← initialize(tau0)
+    eta ← precompute(1 / distance)^beta
+    best ← best_tour_so_far
+    for epoch in 1..epochs:
+        for each ant:
+            tour ← construct_tour(pheromone, eta, alpha)
+            if length(tour) < length(best):
+                best ← tour
+        pheromone ← evaporate(pheromone, evaporation_rate)
+        for each ant:
+            deposit(pheromone, ant.tour, 1 / length(ant.tour))
+    return best
+```
+
+## Options
+
+| Flag | Description | Default |
+| ------ | ------------- | --------- |
+| `--epochs` | Maximum iterations | 150 |
+| `--alpha` | Pheromone influence on transition probability | 1.0 |
+| `--beta` | Heuristic (1/distance) influence on transition probability (validated to `[0, 10]`) | 2.0 |
+| `--evaporation-rate` | Fraction of pheromone lost per epoch, in `(0, 1)` | 0.5 |
+| `--num-ants` | Colony size — tours constructed per epoch | 25 |
+
+## Usage
+
+```bash
+teeline solve aco -i ./data/tsplib/berlin52.tsp
+teeline solve ant_colony -i ./data/tsplib/berlin52.tsp --epochs=500
+teeline solve aco -i ./data/tsplib/berlin52.tsp --num-ants=40 --beta=3.0 --evaporation-rate=0.3
+```
+
+## References
+
+- Dorigo, M. (1996) — "Ant System: Optimization by a Colony of Cooperating Agents", *IEEE Transactions on Systems, Man, and Cybernetics, Part B*, 26(1), pp. 29–41
+- Dorigo, M. & Stützle, T. (2004) — *Ant Colony Optimization*, MIT Press
+- [Ant colony optimization algorithms (Wikipedia)](https://en.wikipedia.org/wiki/Ant_colony_optimization_algorithms)

--- a/docs/algorithms/ant-colony.md
+++ b/docs/algorithms/ant-colony.md
@@ -56,7 +56,7 @@ procedure AntColony(cities, num_ants, alpha, beta, evaporation_rate, epochs):
 | ------ | ------------- | --------- |
 | `--epochs` | Maximum iterations | 150 |
 | `--alpha` | Pheromone influence on transition probability | 1.0 |
-| `--beta` | Heuristic (1/distance) influence on transition probability (validated to `[0, 10]`) | 2.0 |
+| `--beta` | Heuristic (1/distance) influence on transition probability (validated to `[0, 6]`) | 2.0 |
 | `--evaporation-rate` | Fraction of pheromone lost per epoch, in `(0, 1)` | 0.5 |
 | `--num-ants` | Colony size — tours constructed per epoch | 25 |
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -49,6 +49,7 @@ representative, not as a guarantee.
 | **Christofides** | default (MST + greedy matching) | 8 707.66 | +15.4 % | < 0.01 s | 50 % | 6.5 MB |
 | **Greedy Edge** | default (Kruskal-style construction) | 9 954.06 | +31.9 % | < 0.01 s | 100 % | 6.9 MB |
 | **Greedy Edge + 2-opt** | `pipeline(greedy_edge,2opt)` | 8 415.55 | +11.5 % | < 0.01 s | 77 % | 7.0 MB |
+| **Ant Colony (ACO)** | default (`--epochs=150`, α=1, β=2, evaporation_rate=0.5, num_ants=25) | *to be measured* | *to be measured* | *to be measured* | *to be measured* | *to be measured* |
 | **Gravitational Search (GSA)** | default (`--epochs=10000 --n_nearest=25`, G0=20, α=1, W=0) | ~18 500 | ~+145 % | 1.2 s | 99 % | 7.6 MB |
 | **Fourier** | default (`k_max=4, m=200, epochs=400`) | 8 549.14 | +13.3 % | 2.5 s | 99 % | 6.6 MB |
 | **Fourier + 2-opt** | `pipeline(fourier,2opt)` | 7 948.88 | +5.4 % | 1.9 s | 99 % | 6.8 MB |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::tsp::{
-    AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, LKOptions,
-    SAOptions, SOMOptions, Solvers,
+    AcoOptions, AppOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions,
+    LKOptions, SAOptions, SOMOptions, Solvers,
 };
 
 /// Unifies CLI args and TOML tables as the same kind of options source.
@@ -13,8 +13,8 @@ pub trait AppOptionsProvider {
 }
 
 /// Applies recognised sub-tables from a `toml::Table` to the base `AppOptions`.
-/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, `fourier`, `lk`, `som`, and `heuristic` are
-/// valid top-level keys.
+/// Only `solver`, `sa`, `ga`, `cs`, `fpa`, `fourier`, `lk`, `som`, `aco`, and `heuristic`
+/// are valid top-level keys.
 /// Returns `Err` on unknown keys or mis-typed sub-tables.
 pub struct TomlTableProvider<'a>(pub &'a toml::Table);
 
@@ -53,6 +53,10 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                     let t = value.as_table().ok_or("config: `som` must be a table")?;
                     base.som = Some(SOMOptions::from_toml(t)?);
                 }
+                "aco" => {
+                    let t = value.as_table().ok_or("config: `aco` must be a table")?;
+                    base.aco = Some(AcoOptions::from_toml(t)?);
+                }
                 "heuristic" => {
                     let t = value
                         .as_table()
@@ -61,7 +65,7 @@ impl AppOptionsProvider for TomlTableProvider<'_> {
                 }
                 other => {
                     return Err(format!(
-                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, fourier, lk, som, heuristic"
+                        "config: unknown field `{other}` — valid stage fields: solver, sa, ga, cs, fpa, fourier, lk, som, aco, heuristic"
                     ));
                 }
             }
@@ -119,6 +123,7 @@ pub fn load_pipeline_config(
             ("fourier", matches!(solver, Solvers::Fourier)),
             ("lk", matches!(solver, Solvers::LinKernighan)),
             ("som", matches!(solver, Solvers::KohonenSom)),
+            ("aco", matches!(solver, Solvers::AntColony)),
             (
                 "heuristic",
                 !matches!(
@@ -130,6 +135,7 @@ pub fn load_pipeline_config(
                         | Solvers::Fourier
                         | Solvers::LinKernighan
                         | Solvers::KohonenSom
+                        | Solvers::AntColony
                 ),
             ),
         ] {
@@ -485,6 +491,52 @@ mod tests {
         let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
         let sa = stages[0].1.sa.as_ref().unwrap();
         assert!((sa.max_temperature - 200.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_toml_provider_aco_sub_table_works() {
+        let table: toml::Table =
+            toml::from_str("solver = \"aco\"\n[aco]\nnum_ants = 10\nbeta = 3.0").unwrap();
+        let opts = TomlTableProvider(&table)
+            .provide(AppOptions::default())
+            .unwrap();
+        let aco = opts.aco.unwrap();
+        assert_eq!(aco.num_ants, 10);
+        assert!((aco.beta - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_load_pipeline_config_aco_sub_table_on_nn_errors() {
+        let toml = "[[stage]]\nsolver = \"nn\"\n\n[stage.aco]\nnum_ants = 10\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("aco"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_heuristic_sub_table_on_aco_errors() {
+        // ACO reads only opts.aco at solve time, never opts.heuristic —
+        // [stage.heuristic] on an aco stage is a silent no-op unless rejected here.
+        let toml = "[[stage]]\nsolver = \"aco\"\n\n[stage.aco]\nnum_ants = 10\n\n[stage.heuristic]\nepochs = 500\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("heuristic"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_aco_evaporation_rate_zero_errors() {
+        // Proves validate() actually fires through load_pipeline_config -> from_toml.
+        let toml = "[[stage]]\nsolver = \"aco\"\n\n[stage.aco]\nevaporation_rate = 0.0\n";
+        let err = load_pipeline_config(toml, AppOptions::default()).unwrap_err();
+        assert!(err.contains("evaporation_rate"), "got: {err}");
+    }
+
+    #[test]
+    fn test_load_pipeline_config_aco_num_ants_in_sub_table() {
+        let toml = "[[stage]]\nsolver = \"aco\"\n\n[stage.aco]\nnum_ants = 15\nalpha = 2.0\n";
+        let stages = load_pipeline_config(toml, AppOptions::default()).unwrap();
+        assert_eq!(stages[0].0, Solvers::AntColony);
+        let aco = stages[0].1.aco.as_ref().unwrap();
+        assert_eq!(aco.num_ants, 15);
+        assert!((aco.alpha - 2.0).abs() < 1e-6);
     }
 
     #[test]

--- a/src/tsp/ant_colony.rs
+++ b/src/tsp/ant_colony.rs
@@ -1,0 +1,474 @@
+use std::sync::mpsc;
+
+use rand::RngExt;
+
+use super::progress::ProgressMessage;
+use super::route::Route;
+use super::{AcoOptions, Solution, TspProblem};
+
+/// How far below tau0 the evaporation floor sits. Without a floor, an un-deposited edge
+/// decays to exact f32 0.0 within a few hundred epochs at typical parameters, making it
+/// permanently unreachable regardless of heuristic distance — a real bug, not a
+/// theoretical edge case. This is a one-line, MMAS-influenced deviation from pure
+/// textbook Ant System.
+const TAU_MIN_RATIO: f32 = 1e-4;
+
+/// Minimum distance used when computing the heuristic desirability term `1/distance`,
+/// avoiding division by zero for coincident cities. Deliberately not `f32::EPSILON`
+/// (~1.19e-7, the ULP at magnitude 1.0) — this codebase has two prior-bug comments
+/// (kdtree.rs, bellman_karp.rs) about that exact tolerance being wrong away from 1.0.
+const MIN_DIST: f32 = 1e-6;
+
+/// Evaporates every pheromone value by `rate`, then clamps below `tau_min` back up to it.
+fn evaporate_and_floor(pheromone: &mut [f32], rate: f32, tau_min: f32) {
+    for t in pheromone.iter_mut() {
+        *t *= 1.0 - rate;
+        if *t < tau_min {
+            *t = tau_min;
+        }
+    }
+}
+
+/// Deposits `amount` symmetrically on edge (u, v). Teeline only solves symmetric TSP, so
+/// pheromone mirrors that symmetry (both `pheromone[u*n+v]` and `pheromone[v*n+u]` are written).
+fn deposit_edge(pheromone: &mut [f32], n: usize, u: usize, v: usize, amount: f32) {
+    pheromone[u * n + v] += amount;
+    pheromone[v * n + u] += amount;
+}
+
+/// Deposits `1 / cost` along every edge of a closed tour given in position-space
+/// (wraps last -> first). No-op for degenerate tours/costs.
+fn deposit_tour(pheromone: &mut [f32], n: usize, tour_pos: &[usize], cost: f32) {
+    if tour_pos.len() < 2 || cost <= 0.0 {
+        return;
+    }
+    let amount = 1.0 / cost;
+    let last = *tour_pos.last().expect("checked len >= 2 above");
+    deposit_edge(pheromone, n, last, tour_pos[0], amount);
+    for w in tour_pos.windows(2) {
+        deposit_edge(pheromone, n, w[0], w[1], amount);
+    }
+}
+
+/// Roulette-wheel selection over `weights`, given `sum` (the caller-provided total, which
+/// may differ slightly from the true sum due to floating-point rounding over 50+ terms)
+/// and `r` drawn uniformly from `[0, 1)`. If the accumulation loop exhausts without
+/// crossing `r * sum` — a real, reachable path given f32 rounding, not a theoretical one —
+/// falls back to the last candidate rather than panicking.
+fn roulette_select(weights: &[(usize, f32)], sum: f32, r: f32) -> usize {
+    let target = r * sum;
+    let mut acc = 0.0f32;
+    for &(pos, w) in weights {
+        acc += w;
+        if acc >= target {
+            return pos;
+        }
+    }
+    weights.last().expect("weights must be non-empty").0
+}
+
+/// Selects the next city with graceful degradation for numerically degenerate weight sets.
+/// `primary` = (position, pheromone^alpha * eta^beta) pairs for the candidate set; `fallback`
+/// = (position, eta^beta) pairs for the same candidates. If `primary`'s sum is non-positive
+/// or non-finite (e.g. all products underflowed, or beta pushed a term to `inf`), falls back
+/// to eta-only proportional selection — discarding distance information entirely (uniform
+/// random) would be strictly worse than degrading toward greedy-by-distance behavior. If even
+/// `fallback` is degenerate (fully pathological — every remaining distance non-finite), returns
+/// the first fallback candidate as a last resort so callers never panic or stall.
+/// `r1`/`r2` are independent uniform samples in `[0, 1)` for the primary/fallback rolls,
+/// passed in rather than an RNG so this function stays pure and unit-testable.
+fn select_next(primary: &[(usize, f32)], fallback: &[(usize, f32)], r1: f32, r2: f32) -> usize {
+    let primary_sum: f32 = primary.iter().map(|&(_, w)| w).sum();
+    if primary_sum > 0.0 && primary_sum.is_finite() {
+        return roulette_select(primary, primary_sum, r1);
+    }
+    let fallback_sum: f32 = fallback.iter().map(|&(_, w)| w).sum();
+    if fallback_sum > 0.0 && fallback_sum.is_finite() {
+        return roulette_select(fallback, fallback_sum, r2);
+    }
+    fallback
+        .first()
+        .map(|&(pos, _)| pos)
+        .unwrap_or_else(|| primary.first().expect("candidate set must be non-empty").0)
+}
+
+/// Ant System (Dorigo 1996): a colony of stateless ants probabilistically construct tours
+/// biased by a shared pheromone matrix and heuristic desirability (1/distance), then all
+/// ants deposit pheromone proportional to `1/tour_cost` along their edges after a uniform
+/// evaporation pass. Unlike Elitist AS or Ant Colony System, every ant deposits every epoch
+/// (not just the iteration-best), and there is no local pheromone decay during construction.
+///
+/// Ants carry no memory between epochs — only the pheromone matrix persists — so `init_tour`
+/// is not replayed as a permanent "ant 0" the way CS/FPA's mutated population arrays do.
+/// Instead it seeds the incumbent best/best_cost and biases the initial pheromone level
+/// (tau0) and epoch-1 construction via one extra deposit pass.
+pub fn solve(
+    problem: &TspProblem,
+    opts: &AcoOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    init_tour: Option<&[usize]>,
+) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
+    let n = cities.len();
+
+    tracing::info!(cities = n, num_ants = opts.num_ants, "ACO starting");
+
+    if n <= 2 {
+        let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::Done);
+        }
+        return Solution::from_parts(&path, cities, distances);
+    }
+
+    let mut rng = rand::rng();
+
+    let to_pos = |id: usize| -> usize {
+        distances
+            .city_id2pos(id)
+            .expect("init_tour city id must exist in this problem")
+    };
+    let to_id = |pos: usize| -> usize {
+        distances
+            .pos2city_id(pos)
+            .expect("position must map to a known city id")
+    };
+
+    let best_pos_seed: Vec<usize> = match init_tour {
+        Some(t) => t.iter().map(|&id| to_pos(id)).collect(),
+        None => {
+            let mut positions: Vec<usize> = (0..n).collect();
+            for i in (1..n).rev() {
+                let j = rng.random_range(0..=i);
+                positions.swap(i, j);
+            }
+            positions
+        }
+    };
+    let mut best_cost = distances.tour_length_by_pos(&best_pos_seed);
+    let mut best: Vec<usize> = best_pos_seed.clone();
+
+    if let Some(tx) = progress_tx {
+        let best_ids: Vec<usize> = best.iter().map(|&p| to_id(p)).collect();
+        let _ = tx.send(ProgressMessage::PathUpdate(
+            Route::new(&best_ids),
+            best_cost,
+        ));
+    }
+
+    let tau0 = if init_tour.is_some() && best_cost > 0.0 {
+        opts.num_ants as f32 / best_cost
+    } else {
+        tracing::warn!(
+            "ACO: no usable init_tour, using flat tau0=1.0 — pheromone differentiation may take longer to emerge"
+        );
+        1.0
+    };
+    let tau_min = tau0 * TAU_MIN_RATIO;
+
+    let mut pheromone: Vec<f32> = vec![tau0; n * n];
+
+    // Static per run since beta is fixed — precomputed once, not per ant-step.
+    // Diagonal (self-loops) left at 0.0; they're never valid transitions.
+    let mut eta_beta = vec![0.0f32; n * n];
+    for u in 0..n {
+        for v in 0..n {
+            if u == v {
+                continue;
+            }
+            let dist = distances.distance_by_pos(u, v).unwrap_or(0.0).max(MIN_DIST);
+            eta_beta[u * n + v] = (1.0 / dist).powf(opts.beta);
+        }
+    }
+
+    if init_tour.is_some() {
+        deposit_tour(&mut pheromone, n, &best_pos_seed, best_cost);
+    }
+
+    for epoch in 0..opts.heuristic.epochs {
+        // Precomputed once per epoch, not once per ant-step: with num_ants ants each
+        // scanning up to n unvisited cities per step, per-step powf would cost roughly
+        // num_ants * n^2 / 2 evaluations vs n^2 here.
+        let tau_alpha: Vec<f32> = pheromone.iter().map(|&t| t.powf(opts.alpha)).collect();
+
+        let mut ant_tours: Vec<Vec<usize>> = Vec::with_capacity(opts.num_ants);
+        let mut ant_costs: Vec<f32> = Vec::with_capacity(opts.num_ants);
+
+        for _ in 0..opts.num_ants {
+            let start = rng.random_range(0..n);
+            let mut visited = vec![false; n];
+            visited[start] = true;
+            let mut tour = Vec::with_capacity(n);
+            tour.push(start);
+            let mut current = start;
+
+            for _ in 1..n {
+                let mut primary: Vec<(usize, f32)> = Vec::with_capacity(n - tour.len());
+                let mut fallback: Vec<(usize, f32)> = Vec::with_capacity(n - tour.len());
+                for v in 0..n {
+                    if visited[v] {
+                        continue;
+                    }
+                    let eta = eta_beta[current * n + v];
+                    primary.push((v, tau_alpha[current * n + v] * eta));
+                    fallback.push((v, eta));
+                }
+
+                let r1: f32 = rng.random();
+                let r2: f32 = rng.random();
+                let next = select_next(&primary, &fallback, r1, r2);
+
+                visited[next] = true;
+                tour.push(next);
+                current = next;
+            }
+
+            let cost = distances.tour_length_by_pos(&tour);
+            if cost < best_cost {
+                best = tour.clone();
+                best_cost = cost;
+                if let Some(tx) = progress_tx {
+                    let best_ids: Vec<usize> = best.iter().map(|&p| to_id(p)).collect();
+                    let _ = tx.send(ProgressMessage::PathUpdate(
+                        Route::new(&best_ids),
+                        best_cost,
+                    ));
+                }
+            }
+            ant_tours.push(tour);
+            ant_costs.push(cost);
+        }
+
+        evaporate_and_floor(&mut pheromone, opts.evaporation_rate, tau_min);
+        for (tour, &cost) in ant_tours.iter().zip(ant_costs.iter()) {
+            deposit_tour(&mut pheromone, n, tour, cost);
+        }
+
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::EpochUpdate(epoch));
+        }
+    }
+
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(ProgressMessage::Done);
+    }
+
+    let best_ids: Vec<usize> = best.iter().map(|&p| to_id(p)).collect();
+    Solution::from_parts(&best_ids, cities, distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{AcoOptions, HeuristicOptions, TspProblem, distance_matrix, kdtree};
+
+    #[test]
+    fn test_evaporate_and_floor_decays_above_floor() {
+        let mut pheromone = vec![1.0, 1.0];
+        evaporate_and_floor(&mut pheromone, 0.5, 0.0);
+        assert!((pheromone[0] - 0.5).abs() < 1e-6);
+        assert!((pheromone[1] - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_evaporate_and_floor_clamps_below_floor() {
+        let mut pheromone = vec![0.001, 1.0];
+        evaporate_and_floor(&mut pheromone, 0.99, 0.001);
+        // 0.001 * 0.01 = 0.00001, which is below the 0.001 floor -> clamped up.
+        assert!((pheromone[0] - 0.001).abs() < 1e-9);
+        // 1.0 * 0.01 = 0.01, which is above the floor -> left as decayed.
+        assert!((pheromone[1] - 0.01).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_deposit_edge_writes_both_directions() {
+        let n = 3;
+        let mut pheromone = vec![0.0; n * n];
+        deposit_edge(&mut pheromone, n, 0, 2, 0.5);
+        assert!((pheromone[0 * n + 2] - 0.5).abs() < 1e-6);
+        assert!((pheromone[2 * n + 0] - 0.5).abs() < 1e-6);
+        assert!((pheromone[0 * n + 1]).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_deposit_tour_touches_only_tour_edges() {
+        // n=4, but the tour only visits positions [0, 1, 2] (closed: 2 -> 0 too).
+        // Edges touching position 3 must remain untouched.
+        let n = 4;
+        let mut pheromone = vec![0.0; n * n];
+        let cost = 10.0;
+        deposit_tour(&mut pheromone, n, &[0, 1, 2], cost);
+        let amount = 1.0 / cost;
+        for &(u, v) in &[(0usize, 1usize), (1, 2), (2, 0)] {
+            assert!(
+                (pheromone[u * n + v] - amount).abs() < 1e-6,
+                "edge ({u},{v}) not deposited"
+            );
+            assert!(
+                (pheromone[v * n + u] - amount).abs() < 1e-6,
+                "edge ({v},{u}) not deposited"
+            );
+        }
+        for pos in 0..n {
+            assert!(
+                (pheromone[pos * n + 3]).abs() < 1e-9,
+                "edge touching position 3 must remain untouched"
+            );
+            assert!(
+                (pheromone[3 * n + pos]).abs() < 1e-9,
+                "edge touching position 3 must remain untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn test_deposit_tour_noop_on_degenerate_cost() {
+        let n = 3;
+        let mut pheromone = vec![0.0; n * n];
+        deposit_tour(&mut pheromone, n, &[0, 1, 2], 0.0);
+        assert!(pheromone.iter().all(|&t| t == 0.0));
+    }
+
+    #[test]
+    fn test_roulette_select_picks_correct_bucket() {
+        let weights = [(0usize, 1.0f32), (1usize, 3.0f32)];
+        // sum=4.0, r=0.5 -> target=2.0; acc after (0,1.0)=1.0 < 2.0; acc after (1,3.0)=4.0 >= 2.0.
+        assert_eq!(roulette_select(&weights, 4.0, 0.5), 1);
+        // r close to 0 should pick the first bucket.
+        assert_eq!(roulette_select(&weights, 4.0, 0.01), 0);
+    }
+
+    #[test]
+    fn test_roulette_select_exhaustion_falls_back_to_last() {
+        // Caller-provided sum (3.0) is inflated relative to the true weight total (2.0) —
+        // simulates f32 rounding drift. With r close to 1, target (2.9997) exceeds the max
+        // achievable accumulation (2.0), so the loop must exhaust and fall back to the last
+        // candidate rather than panicking.
+        let weights = [(0usize, 1.0f32), (1usize, 1.0f32)];
+        assert_eq!(roulette_select(&weights, 3.0, 0.9999), 1);
+    }
+
+    #[test]
+    fn test_select_next_uses_primary_when_healthy() {
+        let primary = [(0usize, 1.0f32), (1usize, 3.0f32)];
+        let fallback = [(0usize, 1.0f32), (1usize, 1.0f32)];
+        assert_eq!(select_next(&primary, &fallback, 0.5, 0.5), 1);
+    }
+
+    #[test]
+    fn test_select_next_falls_back_to_eta_when_primary_degenerate() {
+        let primary = [(0usize, 0.0f32), (1usize, 0.0f32)];
+        let fallback = [(0usize, 1.0f32), (1usize, 3.0f32)];
+        assert_eq!(select_next(&primary, &fallback, 0.5, 0.5), 1);
+    }
+
+    #[test]
+    fn test_select_next_falls_back_to_first_when_fully_degenerate() {
+        let primary = [(0usize, 0.0f32), (1usize, f32::NAN)];
+        let fallback = [(0usize, 0.0f32), (1usize, 0.0f32)];
+        assert_eq!(select_next(&primary, &fallback, 0.5, 0.5), 0);
+    }
+
+    #[test]
+    fn test_aco_respects_initial_tour() {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![0.0, 0.5],
+            vec![0.0, 1.0],
+            vec![1.0, 1.0],
+            vec![1.0, 0.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        let optimal: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let optimal_cost = dm.tour_length(&optimal);
+        let opts = AcoOptions {
+            heuristic: HeuristicOptions {
+                epochs: 0,
+                ..HeuristicOptions::default()
+            },
+            ..AcoOptions::default()
+        };
+        let problem = TspProblem::new(cities.clone(), dm);
+        let result = solve(&problem, &opts, None, Some(&optimal));
+        assert!((result.total - optimal_cost).abs() < 1e-4);
+        let mut visited = result.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected);
+    }
+
+    #[test]
+    fn test_solve_returns_valid_tour_on_small_instance() {
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.0],
+            vec![0.0, 1.0],
+        ]);
+        let distances = distance_matrix::from_cities(&cities);
+        let opts = AcoOptions {
+            heuristic: HeuristicOptions {
+                epochs: 20,
+                ..HeuristicOptions::default()
+            },
+            num_ants: 8,
+            ..AcoOptions::default()
+        };
+        let problem = TspProblem::new(cities.clone(), distances);
+        let sol = solve(&problem, &opts, None, None);
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(
+            visited, expected,
+            "ACO tour does not visit all cities exactly once"
+        );
+        assert!(sol.total > 0.0 && sol.total.is_finite());
+    }
+
+    #[test]
+    fn test_solve_returns_valid_tour_with_no_init_tour_uses_flat_tau0() {
+        // Exercises the flat-tau0 + warn fallback (not reachable via a normal CLI run,
+        // since `aco` auto-expands with shuffle, which always supplies an init_tour).
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![2.0, 0.0],
+            vec![2.0, 2.0],
+            vec![0.0, 2.0],
+            vec![1.0, 3.0],
+        ]);
+        let distances = distance_matrix::from_cities(&cities);
+        let opts = AcoOptions {
+            heuristic: HeuristicOptions {
+                epochs: 15,
+                ..HeuristicOptions::default()
+            },
+            num_ants: 6,
+            ..AcoOptions::default()
+        };
+        let problem = TspProblem::new(cities.clone(), distances);
+        let sol = solve(&problem, &opts, None, None);
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected);
+        assert!(sol.total > 0.0 && sol.total.is_finite());
+    }
+
+    #[test]
+    fn test_solve_n_le_2_returns_trivial_tour() {
+        let cities = kdtree::build_points(&[vec![0.0, 0.0], vec![1.0, 1.0]]);
+        let distances = distance_matrix::from_cities(&cities);
+        let problem = TspProblem::new(cities.clone(), distances);
+        let sol = solve(&problem, &AcoOptions::default(), None, None);
+        let mut visited = sol.route().to_vec();
+        visited.sort();
+        let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        expected.sort();
+        assert_eq!(visited, expected);
+    }
+}

--- a/src/tsp/ant_colony.rs
+++ b/src/tsp/ant_colony.rs
@@ -1,6 +1,7 @@
 use std::sync::mpsc;
 
 use rand::RngExt;
+use rand::seq::SliceRandom;
 
 use super::probability::roulette_select;
 use super::progress::ProgressMessage;
@@ -130,10 +131,7 @@ pub fn solve(
         Some(t) => t.iter().map(|&id| to_pos(id)).collect(),
         None => {
             let mut positions: Vec<usize> = (0..n).collect();
-            for i in (1..n).rev() {
-                let j = rng.random_range(0..=i);
-                positions.swap(i, j);
-            }
+            positions.shuffle(&mut rng);
             positions
         }
     };
@@ -193,9 +191,15 @@ pub fn solve(
             tour.push(start);
             let mut current = start;
 
+            // Reused across every step of this ant's tour construction (cleared and
+            // refilled each step) instead of freshly allocating both Vecs on every
+            // iteration — up to n-1 allocation pairs per ant, per epoch, otherwise.
+            let mut primary: Vec<(usize, f32)> = Vec::with_capacity(n);
+            let mut fallback: Vec<(usize, f32)> = Vec::with_capacity(n);
+
             for _ in 1..n {
-                let mut primary: Vec<(usize, f32)> = Vec::with_capacity(n - tour.len());
-                let mut fallback: Vec<(usize, f32)> = Vec::with_capacity(n - tour.len());
+                primary.clear();
+                fallback.clear();
                 for v in 0..n {
                     if visited[v] {
                         continue;
@@ -275,9 +279,19 @@ mod tests {
         let n = 3;
         let mut pheromone = vec![0.0; n * n];
         deposit_edge(&mut pheromone, n, 0, 2, 0.5);
-        assert!((pheromone[0 * n + 2] - 0.5).abs() < 1e-6);
-        assert!((pheromone[2 * n + 0] - 0.5).abs() < 1e-6);
-        assert!((pheromone[0 * n + 1]).abs() < 1e-9);
+        // u=0, so `u*n+v`/`v*n+u` reduce to `v`/`v*n` — written pre-reduced (rather than
+        // `0 * n + 2` / `2 * n + 0`) since clippy's `erasing_op`/`identity_op` lints (deny
+        // and warn by default respectively) flag the literal `0 * n` form as almost
+        // certainly unintentional, and this crate's CI runs clippy with `-D warnings`.
+        assert!((pheromone[2] - 0.5).abs() < 1e-6, "edge (0,2) via u*n+v");
+        assert!(
+            (pheromone[2 * n] - 0.5).abs() < 1e-6,
+            "edge (2,0) via v*n+u"
+        );
+        assert!(
+            (pheromone[1]).abs() < 1e-9,
+            "edge (0,1) must remain untouched"
+        );
     }
 
     #[test]

--- a/src/tsp/ant_colony.rs
+++ b/src/tsp/ant_colony.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc;
 
 use rand::RngExt;
 
+use super::probability::roulette_select;
 use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{AcoOptions, Solution, TspProblem};
@@ -50,23 +51,6 @@ fn deposit_tour(pheromone: &mut [f32], n: usize, tour_pos: &[usize], cost: f32) 
     }
 }
 
-/// Roulette-wheel selection over `weights`, given `sum` (the caller-provided total, which
-/// may differ slightly from the true sum due to floating-point rounding over 50+ terms)
-/// and `r` drawn uniformly from `[0, 1)`. If the accumulation loop exhausts without
-/// crossing `r * sum` — a real, reachable path given f32 rounding, not a theoretical one —
-/// falls back to the last candidate rather than panicking.
-fn roulette_select(weights: &[(usize, f32)], sum: f32, r: f32) -> usize {
-    let target = r * sum;
-    let mut acc = 0.0f32;
-    for &(pos, w) in weights {
-        acc += w;
-        if acc >= target {
-            return pos;
-        }
-    }
-    weights.last().expect("weights must be non-empty").0
-}
-
 /// Selects the next city with graceful degradation for numerically degenerate weight sets.
 /// `primary` = (position, pheromone^alpha * eta^beta) pairs for the candidate set; `fallback`
 /// = (position, eta^beta) pairs for the same candidates. If `primary`'s sum is non-positive
@@ -90,6 +74,13 @@ fn select_next(primary: &[(usize, f32)], fallback: &[(usize, f32)], r1: f32, r2:
         .first()
         .map(|&(pos, _)| pos)
         .unwrap_or_else(|| primary.first().expect("candidate set must be non-empty").0)
+}
+
+/// A single ant's constructed tour (position-space) and its cost, grouped together rather
+/// than tracked as parallel `Vec<Vec<usize>>`/`Vec<f32>` arrays matched by index.
+struct Ant {
+    tour: Vec<usize>,
+    cost: f32,
 }
 
 /// Ant System (Dorigo 1996): a colony of stateless ants probabilistically construct tours
@@ -192,8 +183,7 @@ pub fn solve(
         // num_ants * n^2 / 2 evaluations vs n^2 here.
         let tau_alpha: Vec<f32> = pheromone.iter().map(|&t| t.powf(opts.alpha)).collect();
 
-        let mut ant_tours: Vec<Vec<usize>> = Vec::with_capacity(opts.num_ants);
-        let mut ant_costs: Vec<f32> = Vec::with_capacity(opts.num_ants);
+        let mut ants: Vec<Ant> = Vec::with_capacity(opts.num_ants);
 
         for _ in 0..opts.num_ants {
             let start = rng.random_range(0..n);
@@ -236,13 +226,12 @@ pub fn solve(
                     ));
                 }
             }
-            ant_tours.push(tour);
-            ant_costs.push(cost);
+            ants.push(Ant { tour, cost });
         }
 
         evaporate_and_floor(&mut pheromone, opts.evaporation_rate, tau_min);
-        for (tour, &cost) in ant_tours.iter().zip(ant_costs.iter()) {
-            deposit_tour(&mut pheromone, n, tour, cost);
+        for ant in &ants {
+            deposit_tour(&mut pheromone, n, &ant.tour, ant.cost);
         }
 
         if let Some(tx) = progress_tx {
@@ -328,25 +317,6 @@ mod tests {
         let mut pheromone = vec![0.0; n * n];
         deposit_tour(&mut pheromone, n, &[0, 1, 2], 0.0);
         assert!(pheromone.iter().all(|&t| t == 0.0));
-    }
-
-    #[test]
-    fn test_roulette_select_picks_correct_bucket() {
-        let weights = [(0usize, 1.0f32), (1usize, 3.0f32)];
-        // sum=4.0, r=0.5 -> target=2.0; acc after (0,1.0)=1.0 < 2.0; acc after (1,3.0)=4.0 >= 2.0.
-        assert_eq!(roulette_select(&weights, 4.0, 0.5), 1);
-        // r close to 0 should pick the first bucket.
-        assert_eq!(roulette_select(&weights, 4.0, 0.01), 0);
-    }
-
-    #[test]
-    fn test_roulette_select_exhaustion_falls_back_to_last() {
-        // Caller-provided sum (3.0) is inflated relative to the true weight total (2.0) —
-        // simulates f32 rounding drift. With r close to 1, target (2.9997) exceeds the max
-        // achievable accumulation (2.0), so the loop must exhaust and fall back to the last
-        // candidate rather than panicking.
-        let weights = [(0usize, 1.0f32), (1usize, 1.0f32)];
-        assert_eq!(roulette_select(&weights, 3.0, 0.9999), 1);
     }
 
     #[test]

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1,3 +1,4 @@
+pub mod ant_colony;
 pub mod bellman_karp;
 pub mod branch_bound;
 pub mod christofides;
@@ -44,6 +45,7 @@ use std::str::FromStr;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Solvers {
+    AntColony,
     BellmanKarp,
     BranchBound,
     Christofides,
@@ -70,6 +72,8 @@ pub enum Solvers {
 impl Solvers {
     pub fn variants() -> Vec<&'static str> {
         vec![
+            "ant_colony",
+            "aco",
             "bellman_karp",
             "bhk",
             "branch_bound",
@@ -144,6 +148,7 @@ impl Solvers {
                 | Solvers::CuckooSearch
                 | Solvers::FlowerPollination
                 | Solvers::Fourier
+                | Solvers::AntColony
         )
     }
 }
@@ -206,6 +211,11 @@ impl SolverMeta {
 impl Solvers {
     pub fn all_meta() -> &'static [SolverMeta] {
         &[
+            SolverMeta {
+                name: "ant_colony",
+                alias: Some("aco"),
+                kind: SolverKind::Heuristic,
+            },
             SolverMeta {
                 name: "bellman_karp",
                 alias: Some("bhk"),
@@ -327,7 +337,16 @@ pub struct SolverInfo {
     pub exact: bool,
 }
 
-static SOLVER_LIST: [SolverInfo; 20] = [
+static SOLVER_LIST: [SolverInfo; 21] = [
+    SolverInfo {
+        name: "Ant Colony",
+        alias: "aco",
+        category: "Metaheuristic",
+        desc: "Colony of ants probabilistically construct tours biased by a shared pheromone matrix and heuristic desirability (1/distance); pheromone evaporates and reinforces on strong edges over epochs.",
+        complexity: "O(epochs \u{00b7} ants \u{00b7} n\u{00b2})",
+        has_options: true,
+        exact: false,
+    },
     SolverInfo {
         name: "Bellman-Held-Karp",
         alias: "bhk",
@@ -520,6 +539,7 @@ impl FromStr for Solvers {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "aco" | "ant_colony" => Ok(Solvers::AntColony),
             "bhk" | "bellman_karp" => Ok(Solvers::BellmanKarp),
             "branch_bound" => Ok(Solvers::BranchBound),
             "christofides" | "chr" => Ok(Solvers::Christofides),
@@ -1028,6 +1048,149 @@ impl FPAOptions {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct AcoOptions {
+    pub heuristic: HeuristicOptions,
+    pub alpha: f32,
+    pub beta: f32,
+    pub evaporation_rate: f32,
+    pub num_ants: usize,
+}
+
+impl Default for AcoOptions {
+    fn default() -> Self {
+        AcoOptions {
+            // ACO's per-epoch cost is O(ants * n^2) — roulette-wheel construction scans
+            // every unvisited city each step, unlike CS/FPA/GA's O(pop * n). Inheriting
+            // HeuristicOptions::default()'s epochs=10_000 would take minutes on berlin52
+            // and far longer on larger instances, a real hang risk for any bare
+            // AcoOptions::default() construction (see LKOptions::default() for the same
+            // override pattern).
+            heuristic: HeuristicOptions {
+                epochs: 150,
+                platoo_epochs: 20,
+                n_nearest: 3,
+                verbose: false,
+            },
+            alpha: 1.0,
+            beta: 2.0,
+            evaporation_rate: 0.5,
+            num_ants: 25,
+        }
+    }
+}
+
+impl AcoOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        self.heuristic.validate()?;
+        if self.alpha < 0.0 {
+            return Err(format!("alpha must be >= 0 (got {})", self.alpha));
+        }
+        if !(0.0..=10.0).contains(&self.beta) {
+            // Upper bound: with the 1e-6 minimum-distance floor used during transition-weight
+            // computation, (1e6)^beta overflows f32 (~3.4e38) around beta≈7, producing inf/NaN
+            // weights — reachable with coincident cities plus a high user-supplied beta.
+            return Err(format!("beta must be in [0, 10] (got {})", self.beta));
+        }
+        if self.evaporation_rate <= 0.0 {
+            return Err(format!(
+                "evaporation_rate must be > 0 (got {})",
+                self.evaporation_rate
+            ));
+        }
+        if self.evaporation_rate >= 1.0 {
+            return Err(format!(
+                "evaporation_rate must be < 1 (got {})",
+                self.evaporation_rate
+            ));
+        }
+        if self.num_ants == 0 {
+            return Err("num_ants must be >= 1".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn from_toml(table: &toml::Table) -> Result<Self, String> {
+        let mut aco = AcoOptions::default();
+        for (k, v) in table.iter() {
+            match k.as_str() {
+                "epochs" => {
+                    aco.heuristic.epochs = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
+                        as usize;
+                }
+                "platoo_epochs" => {
+                    aco.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
+                        format!("config: `platoo_epochs` must be an integer, got {v}")
+                    })? as usize;
+                }
+                "n_nearest" => {
+                    aco.heuristic.n_nearest = v
+                        .as_integer()
+                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
+                        as usize;
+                }
+                "verbose" => {
+                    aco.heuristic.verbose = v
+                        .as_bool()
+                        .ok_or_else(|| format!("config: `verbose` must be a bool, got {v}"))?;
+                }
+                "alpha" => {
+                    aco.alpha = parse_f32(v, "aco.alpha")?;
+                }
+                "beta" => {
+                    aco.beta = parse_f32(v, "aco.beta")?;
+                }
+                "evaporation_rate" => {
+                    aco.evaporation_rate = parse_f32(v, "aco.evaporation_rate")?;
+                }
+                "num_ants" => {
+                    aco.num_ants = v.as_integer().ok_or_else(|| {
+                        format!("config: `aco.num_ants` must be an integer, got {v}")
+                    })? as usize;
+                }
+                other => {
+                    return Err(format!(
+                        "config: unknown field `{other}` in [aco] — valid: epochs, platoo_epochs, n_nearest, verbose, alpha, beta, evaporation_rate, num_ants"
+                    ));
+                }
+            }
+        }
+        aco.validate()?;
+        Ok(aco)
+    }
+
+    pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
+        let mut aco = AcoOptions {
+            heuristic: HeuristicOptions::from_cli(args)?,
+            ..AcoOptions::default()
+        };
+        if let Some(v) = args.get_one::<String>("alpha") {
+            aco.alpha = v
+                .parse()
+                .map_err(|_| format!("--alpha: invalid float `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("beta") {
+            aco.beta = v
+                .parse()
+                .map_err(|_| format!("--beta: invalid float `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("evaporation_rate") {
+            aco.evaporation_rate = v
+                .parse()
+                .map_err(|_| format!("--evaporation-rate: invalid float `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("num_ants") {
+            aco.num_ants = v
+                .parse()
+                .map_err(|_| format!("--num-ants: invalid integer `{v}`"))?;
+        }
+        aco.validate()?;
+        Ok(aco)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct LKOptions {
     pub heuristic: HeuristicOptions,
     pub max_depth: usize,
@@ -1372,6 +1535,7 @@ pub struct AppOptions {
     pub lk: Option<LKOptions>,
     pub fourier: Option<FourierOptions>,
     pub som: Option<SOMOptions>,
+    pub aco: Option<AcoOptions>,
     pub heuristic: Option<HeuristicOptions>,
 }
 
@@ -1431,6 +1595,10 @@ pub fn solve_with_context(
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
     let solution = match solver {
+        Solvers::AntColony => {
+            let aco = opts.aco.as_ref().cloned().unwrap_or_default();
+            ant_colony::solve(problem, &aco, tx, init_tour)
+        }
         Solvers::BellmanKarp => bellman_karp::solve(problem, &h, tx, init_tour),
         Solvers::BranchBound => branch_bound::solve(problem, &h, tx, init_tour),
         Solvers::Christofides => christofides::solve(problem, &h, tx, init_tour),
@@ -1702,6 +1870,7 @@ mod tests {
             lk: None,
             fourier: None,
             som: None,
+            aco: None,
             heuristic: None,
         };
         drop(a);
@@ -1909,6 +2078,7 @@ mod tests {
         assert!(Solvers::FlowerPollination.auto_expand_with_shuffle());
         assert!(Solvers::Fourier.auto_expand_with_shuffle());
         assert!(Solvers::GravitationalSearch.auto_expand_with_shuffle());
+        assert!(Solvers::AntColony.auto_expand_with_shuffle());
     }
 
     #[test]
@@ -2066,6 +2236,132 @@ mod tests {
         let args = cmd.get_matches_from(["t", "--max-depth", "3"]); // hyphen matches production CLI
         let opts = LKOptions::from_cli(&args).unwrap();
         assert_eq!(opts.max_depth, 3);
+    }
+
+    #[test]
+    fn aco_options_default_is_valid() {
+        AcoOptions::default()
+            .validate()
+            .expect("default AcoOptions must be valid");
+    }
+
+    #[test]
+    fn aco_options_validate_rejects_zero_evaporation_rate() {
+        let opts = AcoOptions {
+            evaporation_rate: 0.0,
+            ..AcoOptions::default()
+        };
+        assert!(
+            opts.validate().is_err(),
+            "evaporation_rate=0.0 must be rejected"
+        );
+    }
+
+    #[test]
+    fn aco_options_validate_rejects_evaporation_rate_at_or_above_one() {
+        let opts = AcoOptions {
+            evaporation_rate: 1.0,
+            ..AcoOptions::default()
+        };
+        assert!(
+            opts.validate().is_err(),
+            "evaporation_rate=1.0 must be rejected"
+        );
+    }
+
+    #[test]
+    fn aco_options_validate_rejects_zero_num_ants() {
+        let opts = AcoOptions {
+            num_ants: 0,
+            ..AcoOptions::default()
+        };
+        assert!(opts.validate().is_err(), "num_ants=0 must be rejected");
+    }
+
+    #[test]
+    fn aco_options_validate_rejects_negative_alpha() {
+        let opts = AcoOptions {
+            alpha: -0.1,
+            ..AcoOptions::default()
+        };
+        assert!(opts.validate().is_err(), "negative alpha must be rejected");
+    }
+
+    #[test]
+    fn aco_options_validate_rejects_beta_above_upper_bound() {
+        let opts = AcoOptions {
+            beta: 10.1,
+            ..AcoOptions::default()
+        };
+        assert!(opts.validate().is_err(), "beta above 10.0 must be rejected");
+    }
+
+    #[test]
+    fn aco_options_from_toml_parses_all_fields() {
+        let t: toml::Table = toml::from_str(
+            "epochs=50\nn_nearest=7\nalpha=1.5\nbeta=3.0\nevaporation_rate=0.4\nnum_ants=10",
+        )
+        .unwrap();
+        let opts = AcoOptions::from_toml(&t).unwrap();
+        assert_eq!(opts.heuristic.epochs, 50);
+        assert_eq!(opts.heuristic.n_nearest, 7);
+        assert!((opts.alpha - 1.5).abs() < 1e-6);
+        assert!((opts.beta - 3.0).abs() < 1e-6);
+        assert!((opts.evaporation_rate - 0.4).abs() < 1e-6);
+        assert_eq!(opts.num_ants, 10);
+    }
+
+    #[test]
+    fn aco_options_from_toml_rejects_unknown_field() {
+        let t: toml::Table = toml::from_str("not_a_real_field=1").unwrap();
+        let err = AcoOptions::from_toml(&t).unwrap_err();
+        assert!(err.contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn aco_options_from_cli_parses_own_flags() {
+        use clap::{Arg, ArgAction, Command};
+        let cmd = Command::new("t")
+            .arg(Arg::new("epochs").long("epochs").action(ArgAction::Set))
+            .arg(
+                Arg::new("platoo_epochs")
+                    .long("platoo_epochs")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("n_nearest")
+                    .long("n_nearest")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(Arg::new("alpha").long("alpha").action(ArgAction::Set))
+            .arg(Arg::new("beta").long("beta").action(ArgAction::Set))
+            .arg(
+                Arg::new("evaporation_rate")
+                    .long("evaporation-rate")
+                    .action(ArgAction::Set),
+            )
+            .arg(Arg::new("num_ants").long("num-ants").action(ArgAction::Set));
+        let args = cmd.get_matches_from([
+            "t",
+            "--alpha",
+            "2.0",
+            "--beta",
+            "4.0",
+            "--evaporation-rate",
+            "0.3",
+            "--num-ants",
+            "12",
+        ]);
+        let opts = AcoOptions::from_cli(&args).unwrap();
+        assert!((opts.alpha - 2.0).abs() < 1e-6);
+        assert!((opts.beta - 4.0).abs() < 1e-6);
+        assert!((opts.evaporation_rate - 0.3).abs() < 1e-6);
+        assert_eq!(opts.num_ants, 12);
     }
 
     fn fourier_cli_command() -> clap::Command {

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1081,25 +1081,36 @@ impl Default for AcoOptions {
 
 impl AcoOptions {
     pub fn validate(&self) -> Result<(), String> {
-        self.heuristic.validate()?;
-        if self.alpha < 0.0 {
+        // Not `self.heuristic.validate()?` — that only checks `n_nearest >= 1`, but ACO's
+        // transition rule has no candidate-list restriction (see docs/algorithms/ant-colony.md)
+        // and never reads `n_nearest`, so rejecting `n_nearest == 0` here would error on a
+        // value that has zero effect on this solver.
+        //
+        // NOTE: `<`/`<=`/`>=` comparisons are all `false` for `NaN`, so a bare `if x < 0.0`
+        // silently lets `x = NaN` through — and clippy's `neg_cmp_op_on_partial_ord` lint
+        // (deny under this crate's `-D warnings` CI) rightly rejects the tempting fix of
+        // just negating the comparison (`!(x >= 0.0)`), since a future refactor could
+        // "simplify" that back to `x < 0.0` and silently reintroduce the same NaN gap. Use
+        // `.is_finite()` (an explicit, non-comparison check) alongside plain positive
+        // comparisons instead, mirroring how `beta`'s `RangeInclusive::contains` already
+        // rejects NaN via `low <= x && x <= high`.
+        if !self.alpha.is_finite() || self.alpha < 0.0 {
             return Err(format!("alpha must be >= 0 (got {})", self.alpha));
         }
-        if !(0.0..=10.0).contains(&self.beta) {
+        if !(0.0..=6.0).contains(&self.beta) {
             // Upper bound: with the 1e-6 minimum-distance floor used during transition-weight
-            // computation, (1e6)^beta overflows f32 (~3.4e38) around beta≈7, producing inf/NaN
-            // weights — reachable with coincident cities plus a high user-supplied beta.
-            return Err(format!("beta must be in [0, 10] (got {})", self.beta));
+            // computation, (1e6)^beta overflows f32 (~3.4e38) once beta exceeds ~6.42
+            // (= log10(f32::MAX) / 6). 6.0 keeps a safety margin below that exact cutoff —
+            // the previous 10.0 ceiling was above it, so in-range values like beta=8 could
+            // already silently overflow eta_beta to +inf for ordinary close-together cities.
+            return Err(format!("beta must be in [0, 6] (got {})", self.beta));
         }
-        if self.evaporation_rate <= 0.0 {
+        if !self.evaporation_rate.is_finite()
+            || self.evaporation_rate <= 0.0
+            || self.evaporation_rate >= 1.0
+        {
             return Err(format!(
-                "evaporation_rate must be > 0 (got {})",
-                self.evaporation_rate
-            ));
-        }
-        if self.evaporation_rate >= 1.0 {
-            return Err(format!(
-                "evaporation_rate must be < 1 (got {})",
+                "evaporation_rate must be in (0, 1) (got {})",
                 self.evaporation_rate
             ));
         }
@@ -1114,21 +1125,13 @@ impl AcoOptions {
         for (k, v) in table.iter() {
             match k.as_str() {
                 "epochs" => {
-                    aco.heuristic.epochs = v
-                        .as_integer()
-                        .ok_or_else(|| format!("config: `epochs` must be an integer, got {v}"))?
-                        as usize;
+                    aco.heuristic.epochs = parse_nonneg_usize(v, "epochs")?;
                 }
                 "platoo_epochs" => {
-                    aco.heuristic.platoo_epochs = v.as_integer().ok_or_else(|| {
-                        format!("config: `platoo_epochs` must be an integer, got {v}")
-                    })? as usize;
+                    aco.heuristic.platoo_epochs = parse_nonneg_usize(v, "platoo_epochs")?;
                 }
                 "n_nearest" => {
-                    aco.heuristic.n_nearest = v
-                        .as_integer()
-                        .ok_or_else(|| format!("config: `n_nearest` must be an integer, got {v}"))?
-                        as usize;
+                    aco.heuristic.n_nearest = parse_nonneg_usize(v, "n_nearest")?;
                 }
                 "verbose" => {
                     aco.heuristic.verbose = v
@@ -1145,9 +1148,7 @@ impl AcoOptions {
                     aco.evaporation_rate = parse_f32(v, "aco.evaporation_rate")?;
                 }
                 "num_ants" => {
-                    aco.num_ants = v.as_integer().ok_or_else(|| {
-                        format!("config: `aco.num_ants` must be an integer, got {v}")
-                    })? as usize;
+                    aco.num_ants = parse_nonneg_usize(v, "aco.num_ants")?;
                 }
                 other => {
                     return Err(format!(
@@ -1161,10 +1162,33 @@ impl AcoOptions {
     }
 
     pub fn from_cli(args: &clap::ArgMatches) -> Result<Self, String> {
-        let mut aco = AcoOptions {
-            heuristic: HeuristicOptions::from_cli(args)?,
-            ..AcoOptions::default()
-        };
+        // Deliberately not `heuristic: HeuristicOptions::from_cli(args)?`: that helper seeds
+        // from the generic `HeuristicOptions::default()` (epochs=10_000), and since `heuristic`
+        // would be assigned explicitly in this struct literal, the trailing
+        // `..AcoOptions::default()` spread never gets a chance to apply this struct's own
+        // epochs=150 override (a functional-update spread only fills fields that aren't
+        // explicitly listed) — every CLI invocation omitting `--epochs` would silently run
+        // 10_000 epochs instead of the documented/intended 150. Building `heuristic` field by
+        // field from `AcoOptions::default()` keeps the override whenever a flag isn't passed.
+        let mut aco = AcoOptions::default();
+        if let Some(v) = args.get_one::<String>("epochs") {
+            aco.heuristic.epochs = v
+                .parse()
+                .map_err(|_| format!("--epochs: invalid integer `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("platoo_epochs") {
+            aco.heuristic.platoo_epochs = v
+                .parse()
+                .map_err(|_| format!("--platoo-epochs: invalid integer `{v}`"))?;
+        }
+        if let Some(v) = args.get_one::<String>("n_nearest") {
+            aco.heuristic.n_nearest = v
+                .parse()
+                .map_err(|_| format!("--n-nearest: invalid integer `{v}`"))?;
+        }
+        if args.get_flag("verbose") {
+            aco.heuristic.verbose = true;
+        }
         if let Some(v) = args.get_one::<String>("alpha") {
             aco.alpha = v
                 .parse()
@@ -1548,6 +1572,17 @@ fn parse_f32(v: &toml::Value, name: &str) -> Result<f32, String> {
         .or_else(|| v.as_integer().map(|i| i as f64))
         .ok_or_else(|| format!("config: `{name}` must be a float, got {v}"))
         .map(|f| f as f32)
+}
+
+/// Parses a non-negative TOML integer into a `usize`. `toml::Value::as_integer()` returns
+/// the raw signed `i64` with no range enforcement, so a bare `as usize` cast on a negative
+/// value would silently wrap into a huge positive number (e.g. `-5i64 as usize` is over
+/// 1.8*10^19) instead of erroring — `usize::try_from` rejects negatives cleanly instead.
+fn parse_nonneg_usize(v: &toml::Value, name: &str) -> Result<usize, String> {
+    let n = v
+        .as_integer()
+        .ok_or_else(|| format!("config: `{name}` must be an integer, got {v}"))?;
+    usize::try_from(n).map_err(|_| format!("config: `{name}` must be >= 0, got {n}"))
 }
 
 pub fn validate_tour(tour: &[usize], cities: &[KDPoint]) -> Result<(), String> {
@@ -2290,10 +2325,10 @@ mod tests {
     #[test]
     fn aco_options_validate_rejects_beta_above_upper_bound() {
         let opts = AcoOptions {
-            beta: 10.1,
+            beta: 6.1,
             ..AcoOptions::default()
         };
-        assert!(opts.validate().is_err(), "beta above 10.0 must be rejected");
+        assert!(opts.validate().is_err(), "beta above 6.0 must be rejected");
     }
 
     #[test]

--- a/src/tsp/probability.rs
+++ b/src/tsp/probability.rs
@@ -52,6 +52,23 @@ pub fn sample_without_replacement(rng: &mut impl RngExt, n: usize, excluded: &[u
     }
 }
 
+/// Roulette-wheel selection over `(id, weight)` pairs, given `sum` (the caller-provided
+/// total, which may differ slightly from the true sum due to floating-point rounding over
+/// many terms) and `r` drawn uniformly from `[0, 1)`. If the accumulation loop exhausts
+/// without crossing `r * sum` — a real, reachable path given f32 rounding, not a
+/// theoretical one — falls back to the last candidate rather than panicking.
+pub fn roulette_select(weights: &[(usize, f32)], sum: f32, r: f32) -> usize {
+    let target = r * sum;
+    let mut acc = 0.0f32;
+    for &(id, w) in weights {
+        acc += w;
+        if acc >= target {
+            return id;
+        }
+    }
+    weights.last().expect("weights must be non-empty").0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +138,24 @@ mod tests {
         for _ in 0..100 {
             assert!(bernoulli(&mut rng, 1.1));
         }
+    }
+
+    #[test]
+    fn test_roulette_select_picks_correct_bucket() {
+        let weights = [(0usize, 1.0f32), (1usize, 3.0f32)];
+        // sum=4.0, r=0.5 -> target=2.0; acc after (0,1.0)=1.0 < 2.0; acc after (1,3.0)=4.0 >= 2.0.
+        assert_eq!(roulette_select(&weights, 4.0, 0.5), 1);
+        // r close to 0 should pick the first bucket.
+        assert_eq!(roulette_select(&weights, 4.0, 0.01), 0);
+    }
+
+    #[test]
+    fn test_roulette_select_exhaustion_falls_back_to_last() {
+        // Caller-provided sum (3.0) is inflated relative to the true weight total (2.0) —
+        // simulates f32 rounding drift. With r close to 1, target (2.9997) exceeds the max
+        // achievable accumulation (2.0), so the loop must exhaust and fall back to the last
+        // candidate rather than panicking.
+        let weights = [(0usize, 1.0f32), (1usize, 1.0f32)];
+        assert_eq!(roulette_select(&weights, 3.0, 0.9999), 1);
     }
 }

--- a/src/tsp/probability.rs
+++ b/src/tsp/probability.rs
@@ -57,12 +57,21 @@ pub fn sample_without_replacement(rng: &mut impl RngExt, n: usize, excluded: &[u
 /// many terms) and `r` drawn uniformly from `[0, 1)`. If the accumulation loop exhausts
 /// without crossing `r * sum` — a real, reachable path given f32 rounding, not a
 /// theoretical one — falls back to the last candidate rather than panicking.
+///
+/// Uses a strict `acc > target` test rather than `>=`: with `r = 0.0` (a legitimately
+/// reachable draw from `[0, 1)`), `target` is `0.0`, and a non-strict `>=` would return the
+/// very first candidate as soon as `acc` reaches `0.0` — true after adding *any*
+/// non-negative weight, including an explicit `0.0` weight. That would let a candidate
+/// whose weight underflowed to exactly zero (i.e. should have zero selection probability)
+/// still get picked whenever it's first in iteration order and `r` happens to land on
+/// `0.0`. The strict comparison correctly requires `acc` to exceed `target`, so a
+/// zero-width bucket can never "contain" the target.
 pub fn roulette_select(weights: &[(usize, f32)], sum: f32, r: f32) -> usize {
     let target = r * sum;
     let mut acc = 0.0f32;
     for &(id, w) in weights {
         acc += w;
-        if acc >= target {
+        if acc > target {
             return id;
         }
     }
@@ -157,5 +166,16 @@ mod tests {
         // candidate rather than panicking.
         let weights = [(0usize, 1.0f32), (1usize, 1.0f32)];
         assert_eq!(roulette_select(&weights, 3.0, 0.9999), 1);
+    }
+
+    #[test]
+    fn test_roulette_select_at_r_zero_skips_zero_weight_first_candidate() {
+        // r=0.0 -> target=0.0. A non-strict `acc >= target` would return id 0 as soon as
+        // acc reaches 0.0, which is true even after adding its own zero weight — wrongly
+        // picking a candidate with zero selection probability. The strict `acc > target`
+        // requires actually exceeding the target, so id 0's empty bucket is correctly
+        // skipped in favor of id 1, the only candidate with any real weight.
+        let weights = [(0usize, 0.0f32), (1usize, 5.0f32)];
+        assert_eq!(roulette_select(&weights, 5.0, 0.0), 1);
     }
 }

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -182,6 +182,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
         lk,
         fourier,
         som,
+        // ACO has no API-facing config yet (teeline-api wiring is a follow-up to GH #395,
+        // which shipped core solver + CLI only) — always defaults inside solve_with_context.
+        aco: None,
         heuristic,
     }
 }

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -36,10 +36,13 @@ impl<'a> CliArgsProvider<'a> {
 impl AppOptionsProvider for CliArgsProvider<'_> {
     fn provide(&self, mut base: AppOptions) -> Result<AppOptions, String> {
         use teeline::tsp::{
-            CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions, LKOptions,
-            SAOptions,
+            AcoOptions, CSOptions, FPAOptions, FourierOptions, GAOptions, HeuristicOptions,
+            LKOptions, SAOptions,
         };
         match self.solver {
+            Solvers::AntColony => {
+                base.aco = Some(AcoOptions::from_cli(self.args)?);
+            }
             Solvers::SimulatedAnnealing => {
                 base.sa = Some(SAOptions::from_cli(self.args)?);
             }
@@ -89,7 +92,7 @@ fn build_cli() -> Command {
     let solve_cmd = Command::new("solve")
         .about(
             "Solve a TSP instance. Deterministic solvers (2opt, 3opt, tabu, lk) auto-expand to \
-                pipeline(nn, solver); stochastic solvers (sa, ga, pso, cs, fpa, stochastic_hill) \
+                pipeline(nn, solver); stochastic solvers (sa, ga, pso, cs, fpa, stochastic_hill, aco) \
                 auto-expand to pipeline(shuffle, solver).",
         )
         .arg(
@@ -315,6 +318,30 @@ fn tuning_args() -> Vec<Arg> {
                  (without k_max) can worsen quality; k_max is the primary lever, see \
                  docs/algorithms/fourier.md",
             )
+            .action(ArgAction::Set)
+            .required(false),
+        Arg::new("alpha")
+            .long("alpha")
+            .value_name("N")
+            .help("ACO: pheromone influence on transition probability (default 1.0)")
+            .action(ArgAction::Set)
+            .required(false),
+        Arg::new("beta")
+            .long("beta")
+            .value_name("N")
+            .help("ACO: heuristic (1/distance) influence on transition probability (default 2.0, max 10.0)")
+            .action(ArgAction::Set)
+            .required(false),
+        Arg::new("evaporation_rate")
+            .long("evaporation-rate")
+            .value_name("N")
+            .help("ACO: fraction of pheromone lost per epoch, in (0, 1) (default 0.5)")
+            .action(ArgAction::Set)
+            .required(false),
+        Arg::new("num_ants")
+            .long("num-ants")
+            .value_name("N")
+            .help("ACO: colony size — number of ants constructing tours per epoch (default 25)")
             .action(ArgAction::Set)
             .required(false),
     ]
@@ -799,6 +826,31 @@ mod tests {
         let args = options_cmd().get_matches_from(["test", "fourier", "--k-max", "32"]);
         let opts = solver_options_from_args(&args, Solvers::Fourier);
         assert_eq!(opts.fourier.unwrap().k_max, 32);
+    }
+
+    #[test]
+    fn test_solver_options_aco_num_ants_parsed() {
+        // Exercises the CliArgsProvider::provide match arm for Solvers::AntColony —
+        // without it, base.aco is never populated regardless of flags (compiles fine,
+        // silently ignores the flag).
+        let args = options_cmd().get_matches_from([
+            "test",
+            "aco",
+            "--num-ants",
+            "12",
+            "--alpha",
+            "2.0",
+            "--beta",
+            "4.0",
+            "--evaporation-rate",
+            "0.3",
+        ]);
+        let opts = solver_options_from_args(&args, Solvers::AntColony);
+        let aco = opts.aco.unwrap();
+        assert_eq!(aco.num_ants, 12);
+        assert!((aco.alpha - 2.0).abs() < 1e-6);
+        assert!((aco.beta - 4.0).abs() < 1e-6);
+        assert!((aco.evaporation_rate - 0.3).abs() < 1e-6);
     }
 
     #[test]

--- a/teeline-cli/src/main.rs
+++ b/teeline-cli/src/main.rs
@@ -329,7 +329,7 @@ fn tuning_args() -> Vec<Arg> {
         Arg::new("beta")
             .long("beta")
             .value_name("N")
-            .help("ACO: heuristic (1/distance) influence on transition probability (default 2.0, max 10.0)")
+            .help("ACO: heuristic (1/distance) influence on transition probability (default 2.0, max 6.0)")
             .action(ArgAction::Set)
             .required(false),
         Arg::new("evaporation_rate")

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -423,9 +423,10 @@ EOF\n";
 #[test]
 fn test_list_algorithms_returns_all_solvers() {
     let algorithms = run_list_algorithms();
-    assert_eq!(algorithms.len(), 20, "expected 20 solvers");
+    assert_eq!(algorithms.len(), 21, "expected 21 solvers");
     let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
     for expected_id in &[
+        "aco",
         "nn",
         "2opt",
         "3opt",

--- a/tests/ant_colony_test.rs
+++ b/tests/ant_colony_test.rs
@@ -1,0 +1,96 @@
+/// Integration tests for the Ant Colony Optimization (Ant System) TSP solver.
+///
+/// Uses an explicit `fast_opts()` helper rather than `AcoOptions::default()` — ACO's
+/// per-epoch cost is O(ants * n^2), so even the solver's own (already-reduced) default
+/// epoch count would make this test noticeably slower than necessary.
+use std::path::Path;
+use teeline::tsp::{AcoOptions, HeuristicOptions, TspProblem, distance_matrix, kdtree, tsplib};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn load_tsp(fixture: &str) -> tsplib::TspLibData {
+    let path = Path::new("tests/fixtures").join(fixture);
+    tsplib::read_from_file(&path).unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
+}
+
+fn make_problem(cities: Vec<kdtree::KDPoint>) -> TspProblem {
+    let dm = distance_matrix::from_cities(&cities);
+    TspProblem::new(cities, dm)
+}
+
+fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
+    let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+    expected.sort_unstable();
+    let mut got = route.to_vec();
+    got.sort_unstable();
+    got == expected
+}
+
+fn fast_opts() -> AcoOptions {
+    AcoOptions {
+        heuristic: HeuristicOptions {
+            epochs: 30,
+            ..HeuristicOptions::default()
+        },
+        num_ants: 10,
+        ..AcoOptions::default()
+    }
+}
+
+// ─── fast structural tests ────────────────────────────────────────────────────
+
+#[test]
+fn ant_colony_valid_tour_berlin52() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let sol = teeline::tsp::ant_colony::solve(&problem, &fast_opts(), None, None);
+    assert_eq!(sol.route().len(), 52, "tour must visit all 52 cities");
+    assert!(
+        is_valid_tour(sol.route(), &cities),
+        "tour must contain every city exactly once"
+    );
+    assert!(sol.total > 0.0, "tour distance must be positive");
+    assert!(sol.total.is_finite(), "tour distance must be finite");
+}
+
+#[test]
+fn ant_colony_valid_tour_with_warm_start() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let nn_seed =
+        teeline::tsp::nearest_neighbor::solve(&problem, &HeuristicOptions::default(), None, None);
+    let sol = teeline::tsp::ant_colony::solve(&problem, &fast_opts(), None, Some(nn_seed.route()));
+    assert!(
+        is_valid_tour(sol.route(), &cities),
+        "tour must contain every city exactly once"
+    );
+    assert!(sol.total > 0.0 && sol.total.is_finite());
+}
+
+#[test]
+fn ant_colony_valid_tour_small() {
+    // Cities with non-contiguous IDs to validate the position -> city ID mapping.
+    let cities: Vec<kdtree::KDPoint> = vec![5usize, 10, 15, 20, 25]
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| {
+            use std::f32::consts::PI;
+            kdtree::KDPoint {
+                id,
+                coords: [
+                    (2.0 * PI * i as f32 / 5.0).cos(),
+                    (2.0 * PI * i as f32 / 5.0).sin(),
+                ],
+            }
+        })
+        .collect();
+    let problem = make_problem(cities.clone());
+    let sol = teeline::tsp::ant_colony::solve(&problem, &fast_opts(), None, None);
+    let mut got = sol.route().to_vec();
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        vec![5, 10, 15, 20, 25],
+        "tour must contain original city IDs [5,10,15,20,25], not array positions [0..4]"
+    );
+}

--- a/tests/fixtures/pipeline_aco.toml
+++ b/tests/fixtures/pipeline_aco.toml
@@ -1,0 +1,6 @@
+[[stage]]
+solver = "aco"
+
+[stage.aco]
+epochs = 30
+num_ants = 10

--- a/tests/pipeline_config_test.rs
+++ b/tests/pipeline_config_test.rs
@@ -71,6 +71,23 @@ fn test_pipeline_config_fourier_stage_k_max_applied() {
 }
 
 #[test]
+fn test_pipeline_config_aco_stage_num_ants_applied() {
+    let p = fixture("pipeline_aco.toml");
+    let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();
+    // ACO stage should have epochs=30/num_ants=10 from its [stage.aco] options
+    let aco_stage = stage_configs.iter().find(|(s, _)| *s == Solvers::AntColony);
+    assert!(aco_stage.is_some(), "expected ACO stage in fixture");
+    let (_, opts) = aco_stage.unwrap();
+    let aco_opts = opts.aco.as_ref().unwrap();
+    assert_eq!(aco_opts.heuristic.epochs, 30);
+    assert_eq!(aco_opts.num_ants, 10);
+    // Also verify it runs to completion
+    let stages = berlin52_stages(stage_configs);
+    let solution = run_pipeline(&stages).unwrap();
+    assert_eq!(solution.route().len(), 52);
+}
+
+#[test]
 fn test_pipeline_config_lk_stage_max_depth_applied() {
     let p = fixture("pipeline_lk.toml");
     let stage_configs = resolve_config_file(&p, &IdentityProvider).unwrap();


### PR DESCRIPTION
## Summary

- Adds a classic Ant System (Dorigo 1996) ACO solver (`aco`/`ant_colony`), the next algorithm in the metaheuristic family after greedy edge construction (#393) and the savings-algorithm placeholder (#394).
- Fully probabilistic transition rule (pheromone^alpha * (1/distance)^beta over all unvisited cities, no candidate-list restriction), single global pheromone update per epoch (evaporate + **all-ants** deposit — not just iteration-best, which would be Elitist AS/ACS).
- New `AcoOptions` (alpha, beta, evaporation_rate, num_ants) wired through the same `HeuristicOptions`-embedding pattern as `CSOptions`/`FPAOptions`, including TOML pipeline config and CLI flags (`--alpha`, `--beta`, `--evaporation-rate`, `--num-ants`).
- **Core-first scope**: solver + registry + config/CLI + tests/docs only. `teeline-api`, `teeline-wasm` (needs new WIT fields + jco/bindings regen), `teeline-qt`, and `teeline-web` wiring are deferred to follow-up issues, mirroring how `gec` shipped.

### Notable design decisions
- Pheromone matrix (new territory — no other solver holds O(n²) mutable state) is a dense `n*n` array with a **floor after evaporation** (`tau_min = tau0 * 1e-4`) to prevent underflow to exact `f32` `0.0`, which would otherwise make an edge permanently unreachable within a few hundred epochs.
- τ0 bootstraps from a warm-start tour's cost when available (`τ0 = num_ants / L`); falls back to a flat constant + logged warning otherwise. Since `aco` auto-expands with shuffle, a bare CLI run always has a warm start.
- Graceful degradation chain for numerically degenerate transition weights (pheromone-weighted → heuristic-only → first-candidate), rather than panicking or silently corrupting the tour.
- `AcoOptions::default()` overrides `heuristic.epochs` to 150 (not the base 10,000) since ACO's O(epochs·ants·n²) is far more expensive per epoch than CS/FPA/GA's O(epochs·pop·n) — avoids a hang risk on bare construction.

This plan went through an independent second review pass (different model) against the live codebase before implementation started, which caught 5 real bugs (a compile-breaking exhaustive struct literal, the epoch hang-risk, the pheromone-underflow bug, a `Result`-typed API misuse, and a position/city-id mismatch in progress updates) — all fixed before/during implementation. During implementation an additional instance of the same exhaustive-struct-literal issue was found and fixed in `teeline-api/src/services/tsp_service.rs` (out of scope for this PR, but required for the workspace to compile).

## Test plan

- [x] `cargo build -p teeline-cli` — clean
- [x] `cargo test --workspace` — 364+ lib tests plus all integration suites, 0 failures
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p teeline -p teeline-cli -- -D warnings` and `cargo clippy -p teeline-api -- -D warnings` (the actual CI invocations) — both clean
- [x] Manual CLI smoke test: `teeline solve aco --epochs 150` on berlin52 auto-expands to `pipeline(shuffle, aco)`, completes in ~1.1s, +3.3% gap (7792.57 vs optimal 7544.37); `--beta 3.0` improves to +1.2% (7634.50)
- [x] `pipeline --steps nn,aco --epochs 0` returns cost 8980.918 — exact match to NN's documented berlin52 result, confirming the warm-start passthrough contract