### PR TITLE
Add Savings constructive (sav) TSP solver

### DIFF
--- a/src/tsp/graph.rs
+++ b/src/tsp/graph.rs
@@ -78,6 +78,57 @@ pub(crate) fn sorted_edges(n: usize, distances: &DistanceMatrix) -> Vec<(f32, u3
     edges
 }
 
+/// Walks `edges` (sorted by some weight the caller chooses) and greedily accepts
+/// each one unless it would give either endpoint degree 3+, or close a sub-cycle
+/// before all `n` edges have been placed.
+///
+/// Shared by the Kruskal-style constructive solvers (`greedy_edge` sorts edges
+/// ascending by distance; `savings` sorts descending by Clarke-Wright savings).
+/// The leading `f32` weight is unused inside the loop — only the sort order the
+/// caller established before calling matters — so this primitive is agnostic to
+/// the sort key's meaning.
+///
+/// Always terminates with exactly `n` accepted edges on a complete graph: both
+/// rejection reasons are monotone — degree never decreases, and union-find
+/// components never split — so by scan end, any two positions that still have
+/// degree < 2 must already share a component (otherwise the edge between them
+/// would have been accepted when scanned). That means exactly one path fragment
+/// survives before the closing edge, which is why `accepted.len() == n - 1` is
+/// the correct — and only — point at which a same-component edge may be accepted.
+pub(crate) fn select_edges(n: usize, edges: &[(f32, u32, u32)]) -> Vec<(usize, usize)> {
+    let mut uf = UnionFind::new(n);
+    let mut degree = vec![0u8; n];
+    let mut accepted: Vec<(usize, usize)> = Vec::with_capacity(n);
+
+    for &(_, uu, vv) in edges {
+        if accepted.len() == n {
+            break;
+        }
+        let u = uu as usize;
+        let v = vv as usize;
+        if degree[u] >= 2 || degree[v] >= 2 {
+            continue;
+        }
+        if uf.connected(u, v) && accepted.len() != n - 1 {
+            continue;
+        }
+        uf.union(u, v);
+        degree[u] += 1;
+        degree[v] += 1;
+        accepted.push((u, v));
+    }
+
+    assert_eq!(
+        accepted.len(),
+        n,
+        "kruskal-style edge selection must always place exactly n edges on a complete graph \
+         (see select_edges doc comment); got {}",
+        accepted.len()
+    );
+
+    accepted
+}
+
 /// Walks a degree-exactly-2 edge set forming a single cycle over `0..n` into an
 /// ordered path, starting at position 0.
 ///
@@ -143,6 +194,7 @@ pub(crate) fn hamiltonian_cycle_to_path(n: usize, edges: &[(usize, usize)]) -> V
 mod tests {
     use super::*;
     use crate::tsp::{distance_matrix, kdtree};
+    use rand::RngExt;
 
     // -----------------------------------------------------------------
     // UnionFind
@@ -248,6 +300,127 @@ mod tests {
         // Cheapest edges on a unit square are the 4 sides (length 1.0); diagonals
         // (length sqrt(2)) must sort after them.
         assert!((edges[0].0 - 1.0).abs() < 1e-6);
+    }
+
+    // -----------------------------------------------------------------
+    // select_edges
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn select_edges_returns_exactly_n_edges() {
+        let (_, dm) = square_problem();
+        let n = 4;
+        let edges = sorted_edges(n, &dm);
+        let selected = select_edges(n, &edges);
+        assert_eq!(selected.len(), n);
+    }
+
+    #[test]
+    fn select_edges_never_exceeds_degree_2() {
+        // A "star" layout where the center is closest to every other point — naive
+        // greedy-by-weight would want to give the center degree 4 without the guard.
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![-1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, -1.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        let n = cities.len();
+        let edges = sorted_edges(n, &dm);
+        let selected = select_edges(n, &edges);
+
+        let mut degree = vec![0u8; n];
+        for &(u, v) in &selected {
+            degree[u] += 1;
+            degree[v] += 1;
+        }
+        for (pos, &d) in degree.iter().enumerate() {
+            assert_eq!(d, 2, "position {pos} must have degree exactly 2, got {d}");
+        }
+    }
+
+    #[test]
+    fn select_edges_rejects_premature_cycle() {
+        // 5 collinear-ish points where the two cheapest edges plus a third cheap
+        // edge would close a 3-cycle before all 5 cities are covered.
+        let cities = kdtree::build_points(&[
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![2.0, 0.0],
+            vec![1.0, 1.0], // close to (1,0) and (2,0) — tempts a premature triangle
+            vec![10.0, 0.0],
+        ]);
+        let dm = distance_matrix::from_cities(&cities);
+        let n = cities.len();
+        let edges = sorted_edges(n, &dm);
+        let selected = select_edges(n, &edges);
+
+        assert_eq!(selected.len(), n);
+        // The result must form a single cycle over all 5 positions — this call
+        // panics if select_edges ever let a premature sub-cycle through.
+        let path = hamiltonian_cycle_to_path(n, &selected);
+        let mut sorted = path.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, (0..n).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn select_edges_accepts_final_cycle_closing_edge() {
+        // Small square: after 3 edges are placed on a 4-city cycle, the 4th
+        // (cheapest remaining) edge necessarily closes the cycle and must be
+        // accepted, not rejected as "premature".
+        let (_, dm) = square_problem();
+        let n = 4;
+        let edges = sorted_edges(n, &dm);
+        let selected = select_edges(n, &edges);
+        assert_eq!(selected.len(), 4);
+
+        let mut degree = vec![0u8; n];
+        for &(u, v) in &selected {
+            degree[u] += 1;
+            degree[v] += 1;
+        }
+        assert!(degree.iter().all(|&d| d == 2));
+    }
+
+    #[test]
+    fn select_edges_property_random_instances_always_form_one_cycle() {
+        let mut rng = rand::rng();
+        for n in 4..12 {
+            let mut rows: Vec<Vec<f32>> = (0..n)
+                .map(|_| vec![rng.random_range(0.0..50.0), rng.random_range(0.0..50.0)])
+                .collect();
+            // Force some duplicate/tied-distance points.
+            if n >= 2 {
+                rows[1] = rows[0].clone();
+            }
+            let cities = kdtree::build_points(&rows);
+            let dm = distance_matrix::from_cities(&cities);
+            let edges = sorted_edges(n, &dm);
+            let selected = select_edges(n, &edges);
+
+            assert_eq!(selected.len(), n, "n={n}: must select exactly n edges");
+            let mut degree = vec![0u8; n];
+            for &(u, v) in &selected {
+                degree[u] += 1;
+                degree[v] += 1;
+            }
+            assert!(
+                degree.iter().all(|&d| d == 2),
+                "n={n}: every position must have degree exactly 2, got {degree:?}"
+            );
+            // Single component: this panics if selected forms disjoint cycles.
+            let path = hamiltonian_cycle_to_path(n, &selected);
+            let mut sorted = path.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                sorted,
+                (0..n).collect::<Vec<_>>(),
+                "n={n}: must visit all positions"
+            );
+        }
     }
 
     // -----------------------------------------------------------------

--- a/src/tsp/graph.rs
+++ b/src/tsp/graph.rs
@@ -83,7 +83,7 @@ pub(crate) fn sorted_edges(n: usize, distances: &DistanceMatrix) -> Vec<(f32, u3
 /// before all `n` edges have been placed.
 ///
 /// Shared by the Kruskal-style constructive solvers (`greedy_edge` sorts edges
-/// ascending by distance; `savings` sorts descending by Clarke-Wright savings).
+/// ascending by distance; `savings` sorts descending by savings value).
 /// The leading `f32` weight is unused inside the loop — only the sort order the
 /// caller established before calling matters — so this primitive is agnostic to
 /// the sort key's meaning.

--- a/src/tsp/greedy_edge.rs
+++ b/src/tsp/greedy_edge.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc;
 
-use super::graph::{UnionFind, hamiltonian_cycle_to_path, sorted_edges};
+use super::graph::{hamiltonian_cycle_to_path, select_edges, sorted_edges};
 use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{HeuristicOptions, Solution, TspProblem};
@@ -64,60 +64,10 @@ pub fn solve(
     Solution::from_parts(&path, cities, distances)
 }
 
-// ---------------------------------------------------------------------------
-// Step 2: greedy accept/reject with union-find
-// ---------------------------------------------------------------------------
-
-/// Walks `edges` (sorted ascending by weight) and greedily accepts each one unless
-/// it would give either endpoint degree 3+, or close a sub-cycle before all `n`
-/// edges have been placed.
-///
-/// Always terminates with exactly `n` accepted edges on a complete graph: both
-/// rejection reasons are monotone — degree never decreases, and union-find
-/// components never split — so by scan end, any two positions that still have
-/// degree < 2 must already share a component (otherwise the edge between them
-/// would have been accepted when scanned). That means exactly one path fragment
-/// survives before the closing edge, which is why `accepted.len() == n - 1` is
-/// the correct — and only — point at which a same-component edge may be accepted.
-fn select_edges(n: usize, edges: &[(f32, u32, u32)]) -> Vec<(usize, usize)> {
-    let mut uf = UnionFind::new(n);
-    let mut degree = vec![0u8; n];
-    let mut accepted: Vec<(usize, usize)> = Vec::with_capacity(n);
-
-    for &(_, uu, vv) in edges {
-        if accepted.len() == n {
-            break;
-        }
-        let u = uu as usize;
-        let v = vv as usize;
-        if degree[u] >= 2 || degree[v] >= 2 {
-            continue;
-        }
-        if uf.connected(u, v) && accepted.len() != n - 1 {
-            continue;
-        }
-        uf.union(u, v);
-        degree[u] += 1;
-        degree[v] += 1;
-        accepted.push((u, v));
-    }
-
-    assert_eq!(
-        accepted.len(),
-        n,
-        "greedy edge selection must always place exactly n edges on a complete graph \
-         (see select_edges doc comment); got {}",
-        accepted.len()
-    );
-
-    accepted
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
-    use rand::RngExt;
 
     fn make_problem(coords: &[[f32; 2]]) -> TspProblem {
         let cities =
@@ -127,116 +77,8 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // select_edges
+    // select_edges tests live in graph.rs (the primitive's home).
     // ------------------------------------------------------------------
-
-    #[test]
-    fn select_edges_returns_exactly_n_edges() {
-        let problem = make_problem(&[[0., 0.], [1., 0.], [1., 1.], [0., 1.], [2., 0.5]]);
-        let n = problem.cities.len();
-        let edges = sorted_edges(n, &problem.distances);
-        let selected = select_edges(n, &edges);
-        assert_eq!(selected.len(), n);
-    }
-
-    #[test]
-    fn select_edges_never_exceeds_degree_2() {
-        // A "star" layout where the center is closest to every other point — naive
-        // greedy-by-weight would want to give the center degree 4 without the guard.
-        let problem = make_problem(&[[0., 0.], [1., 0.], [-1., 0.], [0., 1.], [0., -1.]]);
-        let n = problem.cities.len();
-        let edges = sorted_edges(n, &problem.distances);
-        let selected = select_edges(n, &edges);
-
-        let mut degree = vec![0u8; n];
-        for &(u, v) in &selected {
-            degree[u] += 1;
-            degree[v] += 1;
-        }
-        for (pos, &d) in degree.iter().enumerate() {
-            assert_eq!(d, 2, "position {pos} must have degree exactly 2, got {d}");
-        }
-    }
-
-    #[test]
-    fn select_edges_rejects_premature_cycle() {
-        // 5 collinear-ish points where the two cheapest edges plus a third cheap
-        // edge would close a 3-cycle before all 5 cities are covered.
-        let problem = make_problem(&[
-            [0., 0.],
-            [1., 0.],
-            [2., 0.],
-            [1., 1.], // close to (1,0) and (2,0) — tempts a premature triangle
-            [10., 0.],
-        ]);
-        let n = problem.cities.len();
-        let edges = sorted_edges(n, &problem.distances);
-        let selected = select_edges(n, &edges);
-
-        assert_eq!(selected.len(), n);
-        // The result must form a single cycle over all 5 positions — this call
-        // panics if select_edges ever let a premature sub-cycle through.
-        let path = hamiltonian_cycle_to_path(n, &selected);
-        let mut sorted = path.clone();
-        sorted.sort_unstable();
-        assert_eq!(sorted, (0..n).collect::<Vec<_>>());
-    }
-
-    #[test]
-    fn select_edges_accepts_final_cycle_closing_edge() {
-        // Small square: after 3 edges are placed on a 4-city cycle, the 4th
-        // (cheapest remaining) edge necessarily closes the cycle and must be
-        // accepted, not rejected as "premature".
-        let problem = make_problem(&[[0., 0.], [1., 0.], [1., 1.], [0., 1.]]);
-        let n = problem.cities.len();
-        let edges = sorted_edges(n, &problem.distances);
-        let selected = select_edges(n, &edges);
-        assert_eq!(selected.len(), 4);
-
-        let mut degree = vec![0u8; n];
-        for &(u, v) in &selected {
-            degree[u] += 1;
-            degree[v] += 1;
-        }
-        assert!(degree.iter().all(|&d| d == 2));
-    }
-
-    #[test]
-    fn select_edges_property_random_instances_always_form_one_cycle() {
-        let mut rng = rand::rng();
-        for n in 4..12 {
-            let mut coords: Vec<[f32; 2]> = (0..n)
-                .map(|_| [rng.random_range(0.0..50.0), rng.random_range(0.0..50.0)])
-                .collect();
-            // Force some duplicate/tied-distance points.
-            if n >= 2 {
-                coords[1] = coords[0];
-            }
-            let problem = make_problem(&coords);
-            let edges = sorted_edges(n, &problem.distances);
-            let selected = select_edges(n, &edges);
-
-            assert_eq!(selected.len(), n, "n={n}: must select exactly n edges");
-            let mut degree = vec![0u8; n];
-            for &(u, v) in &selected {
-                degree[u] += 1;
-                degree[v] += 1;
-            }
-            assert!(
-                degree.iter().all(|&d| d == 2),
-                "n={n}: every position must have degree exactly 2, got {degree:?}"
-            );
-            // Single component: this panics if selected forms disjoint cycles.
-            let path = hamiltonian_cycle_to_path(n, &selected);
-            let mut sorted = path.clone();
-            sorted.sort_unstable();
-            assert_eq!(
-                sorted,
-                (0..n).collect::<Vec<_>>(),
-                "n={n}: must visit all positions"
-            );
-        }
-    }
 
     // ------------------------------------------------------------------
     // solve() end-to-end

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -50,7 +50,7 @@ pub enum Solvers {
     BellmanKarp,
     BranchBound,
     Christofides,
-    ClarkeWright,
+    Savings,
     CuckooSearch,
     FlowerPollination,
     Fourier,
@@ -81,8 +81,8 @@ impl Solvers {
             "branch_bound",
             "christofides",
             "chr",
-            "clarke_wright",
-            "cw",
+            "savings",
+            "sav",
             "cs",
             "cuckoo_search",
             "fpa",
@@ -239,8 +239,8 @@ impl Solvers {
                 kind: SolverKind::Heuristic,
             },
             SolverMeta {
-                name: "clarke_wright",
-                alias: Some("cw"),
+                name: "savings",
+                alias: Some("sav"),
                 kind: SolverKind::Heuristic,
             },
             SolverMeta {
@@ -412,11 +412,12 @@ static SOLVER_LIST: [SolverInfo; 22] = [
         exact: false,
     },
     SolverInfo {
-        name: "Clarke-Wright",
-        alias: "cw",
+        name: "Savings",
+        alias: "sav",
         category: "Constructive",
-        desc: "Savings algorithm: ranks edges by s(i,j)=d(hub,i)+d(hub,j)-d(i,j) relative to a \
-               centroid-nearest hub, then greedily accepts each (Kruskal-style degree/cycle guard).",
+        desc: "Savings construction: ranks edges by s(i,j)=d(hub,i)+d(hub,j)-d(i,j) relative to a \
+               centroid-nearest hub, then greedily accepts each (Kruskal-style degree/cycle guard). \
+               Inspired by Clarke-Wright but mechanically a savings-ordered greedy-edge builder.",
         complexity: "O(n\u{00b2} log n) time, O(n\u{00b2}) memory",
         has_options: false,
         exact: false,
@@ -562,7 +563,7 @@ impl FromStr for Solvers {
             "bhk" | "bellman_karp" => Ok(Solvers::BellmanKarp),
             "branch_bound" => Ok(Solvers::BranchBound),
             "christofides" | "chr" => Ok(Solvers::Christofides),
-            "cw" | "clarke_wright" => Ok(Solvers::ClarkeWright),
+            "sav" | "savings" => Ok(Solvers::Savings),
             "cs" | "cuckoo_search" => Ok(Solvers::CuckooSearch),
             "fpa" | "flower_pollination" => Ok(Solvers::FlowerPollination),
             "fourier" => Ok(Solvers::Fourier),
@@ -1657,7 +1658,7 @@ pub fn solve_with_context(
         Solvers::BellmanKarp => bellman_karp::solve(problem, &h, tx, init_tour),
         Solvers::BranchBound => branch_bound::solve(problem, &h, tx, init_tour),
         Solvers::Christofides => christofides::solve(problem, &h, tx, init_tour),
-        Solvers::ClarkeWright => savings::solve(problem, &h, tx, init_tour),
+        Solvers::Savings => savings::solve(problem, &h, tx, init_tour),
         Solvers::CuckooSearch => {
             let cs = opts.cs.as_ref().cloned().unwrap_or_default();
             cuckoo_search::solve(problem, &cs, tx, init_tour)

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -24,6 +24,7 @@ pub mod probability;
 pub mod progress;
 pub mod random_shuffle;
 pub mod route;
+pub mod savings;
 pub mod simulated_annealing;
 pub mod som;
 pub mod stochastic_hill;
@@ -49,6 +50,7 @@ pub enum Solvers {
     BellmanKarp,
     BranchBound,
     Christofides,
+    ClarkeWright,
     CuckooSearch,
     FlowerPollination,
     Fourier,
@@ -79,6 +81,8 @@ impl Solvers {
             "branch_bound",
             "christofides",
             "chr",
+            "clarke_wright",
+            "cw",
             "cs",
             "cuckoo_search",
             "fpa",
@@ -235,6 +239,11 @@ impl Solvers {
                 kind: SolverKind::Heuristic,
             },
             SolverMeta {
+                name: "clarke_wright",
+                alias: Some("cw"),
+                kind: SolverKind::Heuristic,
+            },
+            SolverMeta {
                 name: "nearest_neighbor",
                 alias: Some("nn"),
                 kind: SolverKind::Heuristic,
@@ -337,7 +346,7 @@ pub struct SolverInfo {
     pub exact: bool,
 }
 
-static SOLVER_LIST: [SolverInfo; 21] = [
+static SOLVER_LIST: [SolverInfo; 22] = [
     SolverInfo {
         name: "Ant Colony",
         alias: "aco",
@@ -398,6 +407,16 @@ static SOLVER_LIST: [SolverInfo; 21] = [
         category: "Constructive",
         desc: "Kruskal-style construction: sorts all edges shortest-first and greedily \
                accepts each unless it creates degree 3+ or a premature sub-cycle.",
+        complexity: "O(n\u{00b2} log n) time, O(n\u{00b2}) memory",
+        has_options: false,
+        exact: false,
+    },
+    SolverInfo {
+        name: "Clarke-Wright",
+        alias: "cw",
+        category: "Constructive",
+        desc: "Savings algorithm: ranks edges by s(i,j)=d(hub,i)+d(hub,j)-d(i,j) relative to a \
+               centroid-nearest hub, then greedily accepts each (Kruskal-style degree/cycle guard).",
         complexity: "O(n\u{00b2} log n) time, O(n\u{00b2}) memory",
         has_options: false,
         exact: false,
@@ -543,6 +562,7 @@ impl FromStr for Solvers {
             "bhk" | "bellman_karp" => Ok(Solvers::BellmanKarp),
             "branch_bound" => Ok(Solvers::BranchBound),
             "christofides" | "chr" => Ok(Solvers::Christofides),
+            "cw" | "clarke_wright" => Ok(Solvers::ClarkeWright),
             "cs" | "cuckoo_search" => Ok(Solvers::CuckooSearch),
             "fpa" | "flower_pollination" => Ok(Solvers::FlowerPollination),
             "fourier" => Ok(Solvers::Fourier),
@@ -1637,6 +1657,7 @@ pub fn solve_with_context(
         Solvers::BellmanKarp => bellman_karp::solve(problem, &h, tx, init_tour),
         Solvers::BranchBound => branch_bound::solve(problem, &h, tx, init_tour),
         Solvers::Christofides => christofides::solve(problem, &h, tx, init_tour),
+        Solvers::ClarkeWright => savings::solve(problem, &h, tx, init_tour),
         Solvers::CuckooSearch => {
             let cs = opts.cs.as_ref().cloned().unwrap_or_default();
             cuckoo_search::solve(problem, &cs, tx, init_tour)

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -102,6 +102,10 @@ pub fn stage_warnings(solvers: &[Solvers]) -> Vec<String> {
                     "greedy_edge at stage {i} discards the warm-start seed from the previous \
                      stage (it always rebuilds from scratch)"
                 )),
+                Solvers::ClarkeWright => warnings.push(format!(
+                    "clarke_wright at stage {i} discards the warm-start seed from the previous \
+                     stage (it always rebuilds from scratch)"
+                )),
                 _ => {}
             }
         }

--- a/src/tsp/pipeline.rs
+++ b/src/tsp/pipeline.rs
@@ -102,8 +102,8 @@ pub fn stage_warnings(solvers: &[Solvers]) -> Vec<String> {
                     "greedy_edge at stage {i} discards the warm-start seed from the previous \
                      stage (it always rebuilds from scratch)"
                 )),
-                Solvers::ClarkeWright => warnings.push(format!(
-                    "clarke_wright at stage {i} discards the warm-start seed from the previous \
+                Solvers::Savings => warnings.push(format!(
+                    "savings at stage {i} discards the warm-start seed from the previous \
                      stage (it always rebuilds from scratch)"
                 )),
                 _ => {}

--- a/src/tsp/savings.rs
+++ b/src/tsp/savings.rs
@@ -119,9 +119,14 @@ fn hub_position(cities: &[KDPoint]) -> usize {
 /// most by being linked directly (rather than both via the hub) sort first.
 ///
 /// Hub-involving pairs (`i == hub` or `j == hub`) have savings `0.0` (since
-/// `d(hub,hub)=0`), so they sink to the bottom of the descending sort and are
-/// accepted only when needed to fill the hub's two edges — guaranteeing the run
-/// terminates with exactly `n` edges covering every position including the hub.
+/// `d(hub,hub)=0`). Under EUC_2D the triangle inequality keeps every non-hub
+/// savings ≥ 0, so hub pairs sort last; under GEO (floored great-circle
+/// distances) flooring can break the triangle inequality and produce negative
+/// non-hub savings, so hub pairs may not be last. This is irrelevant to
+/// termination: `select_edges` always places exactly `n` edges forming one
+/// Hamiltonian cycle regardless of sort order (its spanning-forest argument is
+/// order-independent), so the hub always ends up with degree 2 like every other
+/// position.
 fn sorted_edges_by_savings(
     n: usize,
     hub: usize,

--- a/src/tsp/savings.rs
+++ b/src/tsp/savings.rs
@@ -7,10 +7,16 @@ use super::progress::ProgressMessage;
 use super::route::Route;
 use super::{HeuristicOptions, Solution, TspProblem};
 
-/// Clarke-Wright savings algorithm: a constructive solver that ranks pairwise
-/// edges by the *savings* of linking two cities directly instead of routing both
-/// through a reference "hub", then greedily accepts each on the same Kruskal-style
+/// Savings construction: a constructive solver that ranks pairwise edges by the
+/// *savings* of linking two cities directly instead of routing both through a
+/// reference "hub", then greedily accepts each on the same Kruskal-style
 /// scaffolding as `greedy_edge` (degree ≤ 2, no premature sub-cycle).
+///
+/// Inspired by the Clarke-Wright savings heuristic, but **not** canonical
+/// Clarke-Wright route merging: there is no hub-edge removal or route-endpoint
+/// merge step. The hub is used *only* to compute the savings sort key —
+/// mechanically this is a savings-ordered greedy-edge construction. Reusing
+/// `graph::select_edges` unchanged is what makes that distinction precise.
 ///
 /// The hub is chosen as the city nearest the coordinate centroid, which gives a
 /// balanced savings distribution and is order-independent (unlike a fixed
@@ -35,7 +41,7 @@ pub fn solve(
     let distances = &problem.distances;
     let n = cities.len();
 
-    tracing::info!(cities = n, "clarke_wright starting");
+    tracing::info!(cities = n, "savings starting");
 
     if n <= 2 {
         let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
@@ -55,7 +61,7 @@ pub fn solve(
         let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&identity), 0.0));
     }
 
-    // Step 2: all pairwise edges, ranked by Clarke-Wright savings (descending).
+    // Step 2: all pairwise edges, ranked by savings (descending).
     let edges = sorted_edges_by_savings(n, hub, distances);
 
     // Step 3: greedily accept edges subject to degree <= 2 and no-premature-cycle
@@ -115,7 +121,7 @@ fn hub_position(cities: &[KDPoint]) -> usize {
 // ---------------------------------------------------------------------------
 
 /// All `n*(n-1)/2` pairwise edges among position indices `0..n`, sorted
-/// **descending** by Clarke-Wright savings relative to `hub`: pairs that save the
+/// **descending** by savings relative to `hub`: pairs that save the
 /// most by being linked directly (rather than both via the hub) sort first.
 ///
 /// Hub-involving pairs (`i == hub` or `j == hub`) have savings `0.0` (since
@@ -244,14 +250,14 @@ mod tests {
     // defensively, matching `greedy_edge::solve`'s guard.
 
     #[test]
-    fn clarke_wright_n2_returns_both_cities() {
+    fn savings_n2_returns_both_cities() {
         let problem = make_problem(&[[0., 0.], [1., 0.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         assert_eq!(sol.route().len(), 2);
     }
 
     #[test]
-    fn clarke_wright_n3_valid() {
+    fn savings_n3_valid() {
         let problem = make_problem(&[[0., 0.], [1., 0.], [0., 1.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         let mut visited = sol.route().to_vec();
@@ -260,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn clarke_wright_all_cities_visited_once() {
+    fn savings_all_cities_visited_once() {
         let problem = make_problem(&[[0., 0.], [1., 0.], [5., 5.], [2., 0.], [3., 0.], [4., 1.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         let mut visited = sol.route().to_vec();
@@ -270,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn clarke_wright_tour_cost_matches_reported() {
+    fn savings_tour_cost_matches_reported() {
         let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [3., 0.], [4., 0.]]);
         let sol = solve(&problem, &HeuristicOptions::default(), None, None);
         let route = sol.route();
@@ -292,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn clarke_wright_property_random_instances_form_one_cycle() {
+    fn savings_property_random_instances_form_one_cycle() {
         let mut rng = rand::rng();
         for n in 4..12 {
             let mut coords: Vec<[f32; 2]> = (0..n)

--- a/src/tsp/savings.rs
+++ b/src/tsp/savings.rs
@@ -1,0 +1,312 @@
+use std::sync::mpsc;
+
+use super::distance_matrix::DistanceMatrix;
+use super::graph::{hamiltonian_cycle_to_path, select_edges};
+use super::kdtree::KDPoint;
+use super::progress::ProgressMessage;
+use super::route::Route;
+use super::{HeuristicOptions, Solution, TspProblem};
+
+/// Clarke-Wright savings algorithm: a constructive solver that ranks pairwise
+/// edges by the *savings* of linking two cities directly instead of routing both
+/// through a reference "hub", then greedily accepts each on the same Kruskal-style
+/// scaffolding as `greedy_edge` (degree ≤ 2, no premature sub-cycle).
+///
+/// The hub is chosen as the city nearest the coordinate centroid, which gives a
+/// balanced savings distribution and is order-independent (unlike a fixed
+/// city-0 hub, whose merge ordering would shift if the input were permuted). The
+/// hub is still visited like every other city — it only biases the *ordering* of
+/// candidate merges, not the set of cities toured.
+///
+/// Mechanically it differs from `greedy_edge` only in its sort key (savings,
+/// descending, vs raw distance, ascending) and its hub reference. Both reuse
+/// `graph::select_edges` and `graph::hamiltonian_cycle_to_path`.
+///
+/// Deterministic and parameter-free: like `greedy_edge`, correctness relies on
+/// scanning the complete pairwise edge set, so `HeuristicOptions` is accepted
+/// but entirely ignored.
+pub fn solve(
+    problem: &TspProblem,
+    _opts: &HeuristicOptions,
+    progress_tx: Option<&mpsc::Sender<ProgressMessage>>,
+    _init_tour: Option<&[usize]>,
+) -> Solution {
+    let cities = &problem.cities;
+    let distances = &problem.distances;
+    let n = cities.len();
+
+    tracing::info!(cities = n, "clarke_wright starting");
+
+    if n <= 2 {
+        let path: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressMessage::Done);
+        }
+        return Solution::from_parts(&path, cities, distances);
+    }
+
+    // Step 1: pick the hub as the city nearest the coordinate centroid.
+    let hub = hub_position(cities);
+
+    // Emit a placeholder progress update so the viz window doesn't appear frozen —
+    // this solver has no meaningful intermediate state to stream (mirrors greedy_edge).
+    if let Some(tx) = progress_tx {
+        let identity: Vec<usize> = cities.iter().map(|c| c.id).collect();
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&identity), 0.0));
+    }
+
+    // Step 2: all pairwise edges, ranked by Clarke-Wright savings (descending).
+    let edges = sorted_edges_by_savings(n, hub, distances);
+
+    // Step 3: greedily accept edges subject to degree <= 2 and no-premature-cycle
+    // (shared with greedy_edge — only the sort order above differs).
+    let selected = select_edges(n, &edges);
+
+    // Step 4: walk the single resulting cycle into an ordered path.
+    let pos_path = hamiltonian_cycle_to_path(n, &selected);
+    let path: Vec<usize> = pos_path.iter().map(|&pos| cities[pos].id).collect();
+
+    if let Some(tx) = progress_tx {
+        let total = distances.tour_length(&path);
+        let _ = tx.send(ProgressMessage::PathUpdate(Route::new(&path), total));
+        let _ = tx.send(ProgressMessage::Done);
+    }
+
+    Solution::from_parts(&path, cities, distances)
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: hub selection — centroid-nearest
+// ---------------------------------------------------------------------------
+
+/// Returns the position index of the city nearest the coordinate centroid.
+///
+/// Uses squared Euclidean distance for the comparison (the argmin is invariant
+/// under the monotone sqrt, so skipping it avoids n square roots). A single O(n)
+/// pass — cheaper than building a KD-tree for one query, and `TspProblem` carries
+/// no pre-built tree to reuse.
+fn hub_position(cities: &[KDPoint]) -> usize {
+    let n = cities.len();
+    let mut cx = 0.0f32;
+    let mut cy = 0.0f32;
+    for c in cities {
+        cx += c.coords[0];
+        cy += c.coords[1];
+    }
+    cx /= n as f32;
+    cy /= n as f32;
+
+    let mut best = 0usize;
+    let mut best_d2 = f32::MAX;
+    for (i, c) in cities.iter().enumerate() {
+        let dx = c.coords[0] - cx;
+        let dy = c.coords[1] - cy;
+        let d2 = dx * dx + dy * dy;
+        if d2 < best_d2 {
+            best_d2 = d2;
+            best = i;
+        }
+    }
+    best
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: savings-ranked candidate edges
+// ---------------------------------------------------------------------------
+
+/// All `n*(n-1)/2` pairwise edges among position indices `0..n`, sorted
+/// **descending** by Clarke-Wright savings relative to `hub`: pairs that save the
+/// most by being linked directly (rather than both via the hub) sort first.
+///
+/// Hub-involving pairs (`i == hub` or `j == hub`) have savings `0.0` (since
+/// `d(hub,hub)=0`), so they sink to the bottom of the descending sort and are
+/// accepted only when needed to fill the hub's two edges — guaranteeing the run
+/// terminates with exactly `n` edges covering every position including the hub.
+fn sorted_edges_by_savings(
+    n: usize,
+    hub: usize,
+    distances: &DistanceMatrix,
+) -> Vec<(f32, u32, u32)> {
+    let mut edges = Vec::with_capacity(n * (n.saturating_sub(1)) / 2);
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let d_hub_i = distances
+                .distance_by_pos(hub, i)
+                .expect("hub, i are within 0..n by construction");
+            let d_hub_j = distances
+                .distance_by_pos(hub, j)
+                .expect("hub, j are within 0..n by construction");
+            let d_ij = distances
+                .distance_by_pos(i, j)
+                .expect("i, j are within 0..n by construction");
+            // s(i,j) = d(hub,i) + d(hub,j) - d(i,j); 0 when either endpoint is the hub.
+            let savings = d_hub_i + d_hub_j - d_ij;
+            edges.push((savings, i as u32, j as u32));
+        }
+    }
+    // Descending by savings. `total_cmp` gives a real total order over all f32 bit
+    // patterns (including NaN), matching `sorted_edges`'s NaN-safety rationale —
+    // never panics on malformed input the way `partial_cmp(...).unwrap()` would.
+    edges.sort_unstable_by(|a, b| b.0.total_cmp(&a.0));
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tsp::{HeuristicOptions, TspProblem, distance_matrix, kdtree};
+    use rand::RngExt;
+
+    fn make_problem(coords: &[[f32; 2]]) -> TspProblem {
+        let cities =
+            kdtree::build_points(&coords.iter().map(|c| vec![c[0], c[1]]).collect::<Vec<_>>());
+        let dm = distance_matrix::from_cities(&cities);
+        TspProblem::new(cities, dm)
+    }
+
+    // ------------------------------------------------------------------
+    // hub_position
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn hub_position_picks_centroid_nearest() {
+        // Centroid is (0,0); the city at the origin is the nearest to it.
+        let problem = make_problem(&[[0., 0.], [10., 0.], [0., 10.], [10., 10.]]);
+        let hub = hub_position(&problem.cities);
+        assert_eq!(hub, 0);
+    }
+
+    #[test]
+    fn hub_position_is_within_bounds() {
+        let problem = make_problem(&[[1., 2.], [3., 4.], [5., 6.], [7., 8.]]);
+        let hub = hub_position(&problem.cities);
+        assert!(hub < problem.cities.len());
+    }
+
+    // ------------------------------------------------------------------
+    // sorted_edges_by_savings
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn savings_list_has_n_choose_2_entries() {
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [3., 0.]]);
+        let n = problem.cities.len();
+        let edges = sorted_edges_by_savings(n, 0, &problem.distances);
+        assert_eq!(edges.len(), n * (n - 1) / 2);
+    }
+
+    #[test]
+    fn savings_list_is_sorted_descending() {
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [3., 0.]]);
+        let edges = sorted_edges_by_savings(4, 0, &problem.distances);
+        for pair in edges.windows(2) {
+            assert!(
+                pair[0].0 >= pair[1].0,
+                "savings must be sorted descending, got {} before {}",
+                pair[0].0,
+                pair[1].0
+            );
+        }
+    }
+
+    #[test]
+    fn savings_for_hub_pair_is_zero() {
+        // Any pair involving the hub has savings 0.
+        let problem = make_problem(&[[0., 0.], [5., 0.], [10., 0.]]);
+        let edges = sorted_edges_by_savings(3, 0, &problem.distances);
+        for &(_s, i, j) in &edges {
+            if i as usize == 0 || j as usize == 0 {
+                // hub-involving pair
+                let s = edges
+                    .iter()
+                    .find(|&&(_, ii, jj)| ii == i && jj == j)
+                    .unwrap()
+                    .0;
+                assert!(
+                    (s - 0.0).abs() < 1e-6,
+                    "hub-pair savings must be 0, got {s}"
+                );
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // solve() end-to-end
+    // ------------------------------------------------------------------
+
+    // Note: n=1 is not separately tested — `DistanceMatrix::build` (and therefore
+    // `TspProblem`) requires at least 2 points. The `n <= 2` guard covers it
+    // defensively, matching `greedy_edge::solve`'s guard.
+
+    #[test]
+    fn clarke_wright_n2_returns_both_cities() {
+        let problem = make_problem(&[[0., 0.], [1., 0.]]);
+        let sol = solve(&problem, &HeuristicOptions::default(), None, None);
+        assert_eq!(sol.route().len(), 2);
+    }
+
+    #[test]
+    fn clarke_wright_n3_valid() {
+        let problem = make_problem(&[[0., 0.], [1., 0.], [0., 1.]]);
+        let sol = solve(&problem, &HeuristicOptions::default(), None, None);
+        let mut visited = sol.route().to_vec();
+        visited.sort_unstable();
+        assert_eq!(visited, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn clarke_wright_all_cities_visited_once() {
+        let problem = make_problem(&[[0., 0.], [1., 0.], [5., 5.], [2., 0.], [3., 0.], [4., 1.]]);
+        let sol = solve(&problem, &HeuristicOptions::default(), None, None);
+        let mut visited = sol.route().to_vec();
+        visited.sort_unstable();
+        let expected: Vec<usize> = (0..problem.cities.len()).collect();
+        assert_eq!(visited, expected);
+    }
+
+    #[test]
+    fn clarke_wright_tour_cost_matches_reported() {
+        let problem = make_problem(&[[0., 0.], [1., 0.], [2., 0.], [3., 0.], [4., 0.]]);
+        let sol = solve(&problem, &HeuristicOptions::default(), None, None);
+        let route = sol.route();
+        let n = route.len();
+        let recomputed: f32 = (0..n)
+            .map(|i| {
+                problem
+                    .distances
+                    .distance_between(route[i], route[(i + 1) % n])
+                    .unwrap_or(f32::MAX)
+            })
+            .sum();
+        assert!(
+            (sol.total - recomputed).abs() < 1.0,
+            "reported total ({:.2}) must match recomputed distance ({:.2})",
+            sol.total,
+            recomputed
+        );
+    }
+
+    #[test]
+    fn clarke_wright_property_random_instances_form_one_cycle() {
+        let mut rng = rand::rng();
+        for n in 4..12 {
+            let mut coords: Vec<[f32; 2]> = (0..n)
+                .map(|_| [rng.random_range(0.0..50.0), rng.random_range(0.0..50.0)])
+                .collect();
+            // Force some duplicate/tied-distance points.
+            if n >= 2 {
+                coords[1] = coords[0];
+            }
+            let problem = make_problem(&coords);
+            let sol = solve(&problem, &HeuristicOptions::default(), None, None);
+
+            let mut visited = sol.route().to_vec();
+            visited.sort_unstable();
+            assert_eq!(
+                visited,
+                (0..n).collect::<Vec<_>>(),
+                "n={n}: must visit all positions exactly once"
+            );
+        }
+    }
+}

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -112,7 +112,7 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
         "fourier"         => "Constructive Fourier-basis solver; best as warm-start: pipeline(fourier,2opt)",
         "som"             => "Topology-preserving constructive solver; best piped: pipeline(som,2opt) or pipeline(som,sa)",
         "gec"             => "Deterministic edge-by-edge construction; usually beats nn as a warm-start: pipeline(greedy_edge,2opt) or pipeline(greedy_edge,lk)",
-        "cw"              => "Savings-based construction; strong warm-start: pipeline(clarke_wright,2opt) or pipeline(clarke_wright,lk)",
+        "sav"             => "Savings-based construction; strong warm-start: pipeline(savings,2opt) or pipeline(savings,lk)",
         _                 => info.category,
     }
     .to_string()
@@ -123,7 +123,7 @@ fn kind_for(solver: Solvers) -> String {
         Solvers::BellmanKarp | Solvers::BranchBound => "exact",
         Solvers::NearestNeighbor
         | Solvers::Christofides
-        | Solvers::ClarkeWright
+        | Solvers::Savings
         | Solvers::Fourier
         | Solvers::KohonenSom
         | Solvers::GreedyEdge => "constructive",

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -112,6 +112,7 @@ fn recommendation_for(info: &teeline::tsp::SolverInfo) -> String {
         "fourier"         => "Constructive Fourier-basis solver; best as warm-start: pipeline(fourier,2opt)",
         "som"             => "Topology-preserving constructive solver; best piped: pipeline(som,2opt) or pipeline(som,sa)",
         "gec"             => "Deterministic edge-by-edge construction; usually beats nn as a warm-start: pipeline(greedy_edge,2opt) or pipeline(greedy_edge,lk)",
+        "cw"              => "Savings-based construction; strong warm-start: pipeline(clarke_wright,2opt) or pipeline(clarke_wright,lk)",
         _                 => info.category,
     }
     .to_string()
@@ -122,6 +123,7 @@ fn kind_for(solver: Solvers) -> String {
         Solvers::BellmanKarp | Solvers::BranchBound => "exact",
         Solvers::NearestNeighbor
         | Solvers::Christofides
+        | Solvers::ClarkeWright
         | Solvers::Fourier
         | Solvers::KohonenSom
         | Solvers::GreedyEdge => "constructive",

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -423,7 +423,7 @@ EOF\n";
 #[test]
 fn test_list_algorithms_returns_all_solvers() {
     let algorithms = run_list_algorithms();
-    assert_eq!(algorithms.len(), 21, "expected 21 solvers");
+    assert_eq!(algorithms.len(), 22, "expected 22 solvers");
     let ids: Vec<&str> = algorithms.iter().map(|a| a.id.as_str()).collect();
     for expected_id in &[
         "aco",
@@ -447,6 +447,7 @@ fn test_list_algorithms_returns_all_solvers() {
         "fourier",
         "som",
         "gec",
+        "sav",
     ] {
         assert!(
             ids.contains(expected_id),

--- a/tests/clarke_wright_test.rs
+++ b/tests/clarke_wright_test.rs
@@ -1,0 +1,112 @@
+/// Integration tests for the Clarke-Wright Savings TSP solver.
+use std::path::Path;
+use teeline::tsp::{
+    AppOptions, HeuristicOptions, Solvers, TspProblem, distance_matrix, kdtree, pipeline, savings,
+    tsplib,
+};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn load_tsp(fixture: &str) -> tsplib::TspLibData {
+    let path = Path::new("tests/fixtures").join(fixture);
+    tsplib::read_from_file(&path).unwrap_or_else(|e| panic!("failed to read {fixture}: {e}"))
+}
+
+fn make_problem(cities: Vec<kdtree::KDPoint>) -> TspProblem {
+    let dm = distance_matrix::from_cities(&cities);
+    TspProblem::new(cities, dm)
+}
+
+fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
+    let mut expected: Vec<usize> = cities.iter().map(|c| c.id).collect();
+    expected.sort_unstable();
+    let mut got = route.to_vec();
+    got.sort_unstable();
+    got == expected
+}
+
+// ─── fast structural tests ────────────────────────────────────────────────────
+
+#[test]
+fn clarke_wright_berlin52_returns_valid_tour() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let sol = savings::solve(&problem, &HeuristicOptions::default(), None, None);
+    assert_eq!(sol.route().len(), 52, "tour must visit all 52 cities");
+    assert!(
+        is_valid_tour(sol.route(), &cities),
+        "tour must contain every city exactly once"
+    );
+}
+
+#[test]
+fn clarke_wright_berlin52_reported_distance_matches_tour() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities.clone());
+    let dm = distance_matrix::from_cities(&cities);
+    let sol = savings::solve(&problem, &HeuristicOptions::default(), None, None);
+
+    let route = sol.route();
+    let n = route.len();
+    let recomputed: f32 = (0..n)
+        .map(|i| {
+            dm.distance_between(route[i], route[(i + 1) % n])
+                .unwrap_or(f32::MAX)
+        })
+        .sum();
+
+    assert!(
+        (sol.total - recomputed).abs() < 1.0,
+        "reported total ({:.1}) must match recomputed tour length ({:.1})",
+        sol.total,
+        recomputed,
+    );
+}
+
+/// Empirical quality floor. Known optimum for berlin52 = 7542. Clarke-Wright
+/// savings is deterministic and, measured directly, produces 8379 on berlin52
+/// (~11% above optimal — better than greedy_edge's ~9954 on the same instance,
+/// since the savings ordering avoids the expensive closing edges that pure
+/// distance-greedy forces on berlin52's isolated points). Assert a ceiling ~10%
+/// above the measured value to catch regressions without depending on random
+/// variation.
+#[test]
+fn clarke_wright_berlin52_empirical_quality() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+    let problem = make_problem(cities);
+    let sol = savings::solve(&problem, &HeuristicOptions::default(), None, None);
+    assert!(
+        sol.total <= 9200.0,
+        "clarke_wright empirical quality regression: got {:.1}, want ≤9200 (measured ~8379)",
+        sol.total,
+    );
+}
+
+/// Proves the pipeline-seed value proposition: clarke_wright should be at least
+/// as good a seed for two_opt as it is alone.
+#[test]
+fn clarke_wright_pipeline_as_seed_for_two_opt() {
+    let cities = load_tsp("berlin52.tsp").cities().to_vec();
+
+    let solo_problem = make_problem(cities.clone());
+    let solo = savings::solve(&solo_problem, &HeuristicOptions::default(), None, None);
+
+    let piped_problem = make_problem(cities);
+    let stages = [
+        pipeline::PipelineStage::new(
+            Solvers::ClarkeWright,
+            AppOptions::default(),
+            piped_problem.clone(),
+            None,
+        ),
+        pipeline::PipelineStage::new(Solvers::TwoOpt, AppOptions::default(), piped_problem, None),
+    ];
+    let piped = pipeline::run_pipeline(&stages).unwrap();
+
+    assert!(
+        piped.total <= solo.total,
+        "clarke_wright -> two_opt ({:.1}) must be no worse than clarke_wright alone ({:.1})",
+        piped.total,
+        solo.total,
+    );
+}

--- a/tests/savings_test.rs
+++ b/tests/savings_test.rs
@@ -1,4 +1,4 @@
-/// Integration tests for the Clarke-Wright Savings TSP solver.
+/// Integration tests for the Savings constructive TSP solver.
 use std::path::Path;
 use teeline::tsp::{
     AppOptions, HeuristicOptions, Solvers, TspProblem, distance_matrix, kdtree, pipeline, savings,
@@ -28,7 +28,7 @@ fn is_valid_tour(route: &[usize], cities: &[kdtree::KDPoint]) -> bool {
 // ─── fast structural tests ────────────────────────────────────────────────────
 
 #[test]
-fn clarke_wright_berlin52_returns_valid_tour() {
+fn savings_berlin52_returns_valid_tour() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let problem = make_problem(cities.clone());
     let sol = savings::solve(&problem, &HeuristicOptions::default(), None, None);
@@ -40,7 +40,7 @@ fn clarke_wright_berlin52_returns_valid_tour() {
 }
 
 #[test]
-fn clarke_wright_berlin52_reported_distance_matches_tour() {
+fn savings_berlin52_reported_distance_matches_tour() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let problem = make_problem(cities.clone());
     let dm = distance_matrix::from_cities(&cities);
@@ -63,29 +63,29 @@ fn clarke_wright_berlin52_reported_distance_matches_tour() {
     );
 }
 
-/// Empirical quality floor. Known optimum for berlin52 = 7542. Clarke-Wright
-/// savings is deterministic and, measured directly, produces 8379 on berlin52
+/// Empirical quality floor. Known optimum for berlin52 = 7542. The savings
+/// construction is deterministic and, measured directly, produces 8379 on berlin52
 /// (~11% above optimal — better than greedy_edge's ~9954 on the same instance,
 /// since the savings ordering avoids the expensive closing edges that pure
 /// distance-greedy forces on berlin52's isolated points). Assert a ceiling ~10%
 /// above the measured value to catch regressions without depending on random
 /// variation.
 #[test]
-fn clarke_wright_berlin52_empirical_quality() {
+fn savings_berlin52_empirical_quality() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
     let problem = make_problem(cities);
     let sol = savings::solve(&problem, &HeuristicOptions::default(), None, None);
     assert!(
         sol.total <= 9200.0,
-        "clarke_wright empirical quality regression: got {:.1}, want ≤9200 (measured ~8379)",
+        "savings empirical quality regression: got {:.1}, want ≤9200 (measured ~8379)",
         sol.total,
     );
 }
 
-/// Proves the pipeline-seed value proposition: clarke_wright should be at least
+/// Proves the pipeline-seed value proposition: savings should be at least
 /// as good a seed for two_opt as it is alone.
 #[test]
-fn clarke_wright_pipeline_as_seed_for_two_opt() {
+fn savings_pipeline_as_seed_for_two_opt() {
     let cities = load_tsp("berlin52.tsp").cities().to_vec();
 
     let solo_problem = make_problem(cities.clone());
@@ -94,7 +94,7 @@ fn clarke_wright_pipeline_as_seed_for_two_opt() {
     let piped_problem = make_problem(cities);
     let stages = [
         pipeline::PipelineStage::new(
-            Solvers::ClarkeWright,
+            Solvers::Savings,
             AppOptions::default(),
             piped_problem.clone(),
             None,
@@ -105,7 +105,7 @@ fn clarke_wright_pipeline_as_seed_for_two_opt() {
 
     assert!(
         piped.total <= solo.total,
-        "clarke_wright -> two_opt ({:.1}) must be no worse than clarke_wright alone ({:.1})",
+        "savings -> two_opt ({:.1}) must be no worse than savings alone ({:.1})",
         piped.total,
         solo.total,
     );


### PR DESCRIPTION
## Summary

Adds a savings constructive TSP solver (alias `sav`), reusing the `UnionFind` / `select_edges` / `hamiltonian_cycle_to_path` scaffolding introduced for `greedy_edge` (PR #393).

Closes #394.

> **Naming note:** originally drafted as `cw`/`ClarkeWright`. Code review flagged that the implementation is mechanically a *savings-ordered greedy-edge construction*, not canonical Clarke-Wright route merging (no hub-edge removal or route-endpoint merge step). Renamed to `sav`/`Savings` to avoid implying classic CW behavior/quality. The solver doc comments now state this distinction explicitly.

## Algorithm

1. **Hub** = city nearest the coordinate centroid (O(n) linear scan — order-independent, unlike a fixed city-0 hub; chosen because `TspProblem` carries no pre-built KD-tree and a single nearest query is cheaper as a scan than building one).
2. **Savings** for every pair `(i,j)`: `s(i,j) = d(hub,i) + d(hub,j) - d(i,j)`, sorted **descending** via `f32::total_cmp` (same NaN-safety rationale as `sorted_edges`).
3. Hub-involving pairs have savings `0`, and are accepted only when needed to fill the hub's two edges — so the run terminates with exactly `n` edges forming one Hamiltonian cycle, reusing `graph::select_edges` unchanged. (Termination is order-independent — see `select_edges`'s spanning-forest argument — so it holds regardless of where hub pairs sort, including under `GEO` flooring where non-hub savings can go negative.)
4. `graph::hamiltonian_cycle_to_path` → map positions to city IDs.

## Refactor: extract shared `select_edges`

`greedy_edge`'s private `select_edges` (degree ≤ 2 + close-only-on-last-edge) is identical to what savings needs — only the input sort order differs. Extracted into `graph.rs` as `pub(crate) fn select_edges`; `greedy_edge` now calls it. The `graph.rs` header doc comment already anticipated this reuse. Its unit tests move to `graph.rs`.

## Changes

| File | Change |
| --- | --- |
| `src/tsp/savings.rs` (new) | `solve()` + `hub_position` (centroid-nearest) + `sorted_edges_by_savings`; 9 unit tests |
| `src/tsp/graph.rs` | extracted shared `pub(crate) fn select_edges`; moved its 5 unit tests here |
| `src/tsp/greedy_edge.rs` | calls `graph::select_edges` (−162 lines of duplicated logic/tests) |
| `src/tsp/mod.rs` | registered `Savings` across enum / `variants` / `FromStr` / `all_meta` / `SOLVER_LIST` (21→22) / dispatch |
| `src/tsp/pipeline.rs` | warm-start-discard warning mirroring `greedy_edge` |
| `teeline-wasm/src/lib.rs` | `kind_for` (constructive) + `recommendation_for` (`sav` line) |
| `tests/savings_test.rs` (new) | 4 integration tests: validity, cost-match, empirical quality, pipeline-as-seed |

## Verification

- `cargo test` — 375 unit + 4 savings + 4 greedy_edge, **0 failures**
- `cargo fmt` clean, no new clippy warnings in changed files
- `cargo component build` (WASM) succeeds — no `.d.ts`/WIT change needed (dynamic enumeration)
- CLI: `solve sav` and `solve savings` both → **8378.97** on berlin52; old `cw` alias correctly rejected
- `solvers` lists `savings` / `sav` / heuristic; pipeline warning fires correctly

## Empirical quality

Measured on berlin52 (optimum 7542): **8379 (~11% over optimal)** — notably better than `greedy_edge`'s ~9954 (~32% over optimal) on the same instance, since the savings ordering avoids the expensive closing edges that pure distance-greedy forces on berlin52's isolated points. The integration test asserts a ≤9200 ceiling (~10% above measured), matching `greedy_edge_test`'s regression-ceiling convention.

## Review-driven changes (this branch)

1. **Doc precision fix** (`9aaeb2f`): corrected an imprecise comment claiming hub pairs "sink to the bottom, guaranteeing termination" — termination is order-independent, and under `GEO` flooring non-hub savings can go negative.
2. **Rename** (`9529891`): `cw`/`ClarkeWright` → `sav`/`Savings`, per review feedback that the implementation is not canonical Clarke-Wright route merging.

## Follow-ups (separate issues)

Per the planning conversation, these are tracked as separate issues (not in this PR):
- Algorithm doc page (`docs/algorithms/savings.md`) — #403
- teeline-web nav integration (`nav-data.ts`) — #404
- WASM rebuild + redeploy for the web solver picker — #405
- teeline-api verification (zero code change — fully dynamic) — #406
- Interactive explainer (deferred) — #407