### PR TITLE
Surface greedy edge (gec) in teeline-web

### DIFF
--- a/docs/algorithms/greedy-edge.md
+++ b/docs/algorithms/greedy-edge.md
@@ -134,8 +134,9 @@ local-search optimum it enables, not its raw tour length.
 
 - Bentley, J. L. (1990) — "Experiments on Traveling Salesman Heuristics",
   *Proceedings of the first annual ACM-SIAM symposium on Discrete algorithms
-  (SODA)*, 91–99. (The "greedy" algorithm is one of the four classical TSP
-  heuristics benchmarked there, alongside nearest-neighbor and insertion.)
+  (SODA)*, 91–99. (Classic empirical study of constructive TSP heuristics —
+  nearest-neighbor and the insertion family — on large geometric instances; the
+  standard benchmark context for evaluating constructive methods like greedy edge.)
 - Kruskal, J. B. (1956) — "On the shortest spanning subtree of a graph and the
   traveling salesman problem", *Proceedings of the American Mathematical
   Society*, 7(1), 48–50. (The union-find MST construction this solver adapts.)

--- a/docs/algorithms/greedy-edge.md
+++ b/docs/algorithms/greedy-edge.md
@@ -1,0 +1,144 @@
+---
+id: "greedy_edge"
+name: "Greedy Edge Construction"
+typeBadge: "Heuristic — constructive"
+description: "Sorts every pairwise edge shortest-first and greedily accepts each one unless it would give a city degree 3+ or close a sub-cycle before all cities are covered (Kruskal-style). Unlike nearest-neighbor's city-to-city walk, it defers hard decisions — cheap edges are grabbed regardless of tour position."
+hasExplainer: true
+---
+
+# Greedy Edge Construction
+
+| | |
+| --- | --- |
+| **Alias** | `greedy_edge`, `gec` |
+| **Type** | Heuristic — constructive |
+| **Complexity** | O(n² log n) edge sort + O(n² α(n)) scan |
+
+## Description
+
+Sorts every pairwise edge shortest-first and greedily accepts each one unless it
+would give a city **degree 3+**, or close a **sub-cycle before all n cities are
+covered** — the same Kruskal-style construction an MST uses, with two extra
+constraints that force a Hamiltonian path instead of a tree.
+
+Unlike nearest-neighbor's city-to-city walk, greedy edge construction **defers
+hard decisions**: cheap edges are grabbed regardless of where they sit in the
+eventual tour, so the expensive edges it's eventually forced into tend to be
+smaller and more evenly distributed. The standalone tour is rarely competitive,
+but as a warm-start it lands local search in a better basin than nearest-neighbor
+does (see [Benchmark](#benchmark) below).
+
+```text
+1. Sorted edges           all n(n−1)/2 pairs, ascending by distance
+2. Kruskal-style scan     accept edge unless:
+                              · an endpoint already has degree 2, or
+                              · both endpoints share a union-find component
+                                AND this is not the (n−1)th accepted edge
+3. Close the cycle        the n-th accepted edge rejoins the two path ends
+4. Walk                   traverse the single degree-2 cycle into an ordered path
+```
+
+### Why the two constraints matter
+
+**Degree ≤ 2:** every city in a valid tour has exactly two incident edges. Once a
+city reaches degree 2 it is "full" — any further edge touching it is rejected, or
+the result could not be a single cycle through every city.
+
+**No premature sub-cycle:** the union-find structure tracks which cities are
+already connected by accepted edges. Accepting an edge that joins two cities
+*already in the same component* would close a loop shorter than n — a dead-end
+mini-cycle. The single exception is the **closing edge** (the (n−1)th accepted,
+0-indexed): at that point every city has degree 2 except the two path endpoints,
+so the final same-component edge is not just allowed but *required* to turn the
+path into a cycle.
+
+This is guaranteed to terminate with exactly n accepted edges on a complete
+graph: both rejection reasons are monotone (degree never decreases, union-find
+components never split), so by scan end any two degree-<2 positions must already
+share a component — otherwise the edge between them would have been accepted.
+
+```text
+procedure GreedyEdge(cities):
+    E ← sort_all_pairs_by_distance(cities)      // ascending
+    UF ← union_find(n);  degree ← [0, …, 0];  accepted ← []
+    for (u, v) in E:
+        if degree[u] == 2 or degree[v] == 2:
+            continue                            // would exceed degree 2
+        if UF.connected(u, v) and |accepted| ≠ n − 1:
+            continue                            // premature sub-cycle
+        UF.union(u, v);  degree[u]++;  degree[v]++;  accepted.push((u, v))
+        if |accepted| == n:
+            break
+    tour ← walk_cycle_into_path(accepted)
+    return tour
+```
+
+## Options
+
+Greedy edge construction is **parameter-free**. `--epochs`, `--n-nearest`, and all
+other `HeuristicOptions` are accepted but ignored — the same as
+[`christofides`](/algorithms/christofides/). Correctness relies on scanning the
+*complete* pairwise edge set: restricting to a k-nearest candidate set (as
+nearest-neighbor does) would break the termination guarantee and could strand a
+city with no valid partner late in the scan.
+
+## Usage
+
+```bash
+# standalone
+teeline solve greedy_edge -i ./data/tsplib/berlin52.tsp
+
+# short alias
+teeline solve gec -i ./data/tsplib/berlin52.tsp
+
+# as warm-start for LK (recommended usage)
+teeline pipeline --steps=greedy_edge,lk -i ./data/tsplib/berlin52.tsp
+
+# combine with 2-opt instead of LK
+teeline pipeline --steps=greedy_edge,2opt -i ./data/tsplib/berlin52.tsp
+```
+
+## Benchmark
+
+On **berlin52** (52 cities; optimal tour length **7544.37**). Greedy edge
+construction is a constructive heuristic, so it shines as a *seed* for local
+search rather than standalone — note how a worse standalone tour still seeds LK
+to a better optimum than nearest-neighbor does:
+
+| Solver | Standalone tour | Gap vs optimal | + LK polish | Gap vs optimal |
+| --- | ---: | ---: | ---: | ---: |
+| `greedy_edge` | 9954.06 | +31.9% | **7544.37** | **0.0% (optimal)** |
+| `nn` | 8980.92 | +19.0% | 7777.33 | +3.1% |
+| `christofides` | 8707.66 | +15.4% | — | — |
+
+The standalone gap looks poor next to nearest-neighbor, yet `greedy_edge,lk`
+reaches the known optimum where `nn,lk` does not — the cheap-edges-first
+construction spreads the inevitable long edges more evenly, leaving LK a smoother
+descent basin. This is the typical pattern: judge a constructive heuristic by the
+local-search optimum it enables, not its raw tour length.
+
+## Relationship to other solvers
+
+- **[`christofides`](/algorithms/christofides/)** also builds a tour from scratch,
+  but via MST + matching + Eulerian shortcut, with a provable 1.5× bound. Greedy
+  edge has no quality bound but is simpler and faster.
+- **[`savings`](/algorithms/savings/)** (Clarke-Wright) is mechanically identical
+  — it shares the same `select_edges` scan primitive — differing only in its sort
+  key (Clarke-Wright *savings* value, descending, instead of raw distance,
+  ascending).
+- **[`nn`](/algorithms/nearest-neighbor/)** walks city-to-city, committing to each
+  next step immediately; greedy edge defers, which is why its standalone tour can
+  be worse yet seed local search better.
+
+## References
+
+- Bentley, J. L. (1990) — "Experiments on Traveling Salesman Heuristics",
+  *Proceedings of the first annual ACM-SIAM symposium on Discrete algorithms
+  (SODA)*, 91–99. (The "greedy" algorithm is one of the four classical TSP
+  heuristics benchmarked there, alongside nearest-neighbor and insertion.)
+- Kruskal, J. B. (1956) — "On the shortest spanning subtree of a graph and the
+  traveling salesman problem", *Proceedings of the American Mathematical
+  Society*, 7(1), 48–50. (The union-find MST construction this solver adapts.)
+- Reinelt, G. (1991) — "TSPLIB—A Traveling Salesman Problem Library", *ORSA
+  Journal on Computing*, 3(4), 376–384.
+- [Travelling salesman problem — Constructive heuristics (Wikipedia)](https://en.wikipedia.org/wiki/Travelling_salesman_problem#Constructive_heuristics)

--- a/teeline-web/Taskfile.yml
+++ b/teeline-web/Taskfile.yml
@@ -7,7 +7,9 @@ tasks:
       - npm run dev
 
   serve:
-    desc: Alias for dev — start Astro dev server (matches `task api:serve` naming)
+    desc: Build, then start Astro dev server (matches `task api:serve` naming)
+    deps:
+      - build
     cmds:
       - task: dev
 

--- a/teeline-web/Taskfile.yml
+++ b/teeline-web/Taskfile.yml
@@ -13,6 +13,17 @@ tasks:
     cmds:
       - task: dev
 
+  # web:serve runs astro dev in the foreground, so there's no PID file to read
+  # (unlike api:stop). Stop by killing whatever holds the dev port, then sweep
+  # any stray astro process as a fallback.
+  stop:
+    desc: Stop a running Astro dev/preview server (default port 4321; override with PORT=<n>)
+    vars:
+      PORT: '{{.PORT | default "4321"}}'
+    cmds:
+      - 'kill $(lsof -ti:{{.PORT}}) 2>/dev/null || true'
+      - 'pkill -f "astro/bin/astro" 2>/dev/null || true'
+
   build:
     desc: Type-check and build production bundle to dist/
     cmds:

--- a/teeline-web/src/explainers/greedy-edge-algo.ts
+++ b/teeline-web/src/explainers/greedy-edge-algo.ts
@@ -1,0 +1,210 @@
+// Pure simulation logic for the Greedy Edge Construction explainer.
+// Mirrors the Rust `select_edges` scan in src/tsp/graph.rs:98-130 — same
+// invariants (degree <= 2, no premature sub-cycle via union-find), same
+// guarantee of terminating with exactly n accepted edges on a complete graph.
+
+export const CITIES: [number, number][] = [
+  [45, 45], [155, 18], [265, 45], [285, 150],
+  [255, 265], [150, 285], [40, 260], [18, 150],
+  [110, 115], [200, 95], [220, 210], [95, 215],
+]
+export const N_CITIES = CITIES.length
+
+export type Edge = { u: number; v: number; dist: number }
+
+export type RejectReason = 'degree' | 'cycle'
+export type EventMode = 'accepted' | 'closing' | 'rejected-degree' | 'rejected-cycle' | 'done'
+
+export type SimState = {
+  sortedEdges: Edge[]        // all n(n-1)/2 pairs, ascending by distance
+  scanIndex: number          // next edge to evaluate
+  parent: number[]           // union-find: parent[i]
+  degree: number[]           // degree[i]
+  accepted: Edge[]           // accepted edges, in scan order
+  rejected: Array<{ edge: Edge; reason: RejectReason }>
+  step: number
+  lastEdge: Edge | null      // edge evaluated on the most recent step
+  lastEvent: EventMode | null
+  done: boolean
+  tour: number[] | null      // ordered path once the cycle closes (null until done)
+}
+
+export function dist(i: number, j: number): number {
+  const [x1, y1] = CITIES[i]
+  const [x2, y2] = CITIES[j]
+  return Math.hypot(x2 - x1, y2 - y1)
+}
+
+// All n(n-1)/2 pairwise edges, ascending by distance. Stable tiebreak on
+// (u, v) keeps the scan order deterministic across runs, matching the Rust
+// sorted_edges (which uses a stable sort over u32 endpoint pairs).
+export function sortedEdges(): Edge[] {
+  const edges: Edge[] = []
+  for (let i = 0; i < N_CITIES; i++) {
+    for (let j = i + 1; j < N_CITIES; j++) {
+      edges.push({ u: i, v: j, dist: dist(i, j) })
+    }
+  }
+  edges.sort((a, b) => a.dist - b.dist || a.u - b.u || a.v - b.v)
+  return edges
+}
+
+function makeUnionFind(n: number): number[] {
+  return Array.from({ length: n }, (_, i) => i)
+}
+
+function find(parent: number[], x: number): number {
+  // path-compressing find (iterative; safe for the small n here)
+  let root = x
+  while (parent[root] !== root) root = parent[root]
+  while (parent[x] !== root) {
+    const next = parent[x]
+    parent[x] = root
+    x = next
+  }
+  return root
+}
+
+function connected(parent: number[], a: number, b: number): boolean {
+  return find(parent, a) === find(parent, b)
+}
+
+function union(parent: number[], a: number, b: number): void {
+  const ra = find(parent, a)
+  const rb = find(parent, b)
+  if (ra !== rb) parent[ra] = rb
+}
+
+// Current union-find components as sets of city indices — for the side panel.
+export function components(parent: number[]): number[][] {
+  const groups: Record<number, number[]> = {}
+  for (let i = 0; i < parent.length; i++) {
+    const r = find(parent, i)
+    ;(groups[r] ??= []).push(i)
+  }
+  return Object.values(groups).map(g => g.sort((a, b) => a - b))
+}
+
+export function makeInitState(): SimState {
+  return {
+    sortedEdges: sortedEdges(),
+    scanIndex: 0,
+    parent: makeUnionFind(N_CITIES),
+    degree: new Array(N_CITIES).fill(0),
+    accepted: [],
+    rejected: [],
+    step: 0,
+    lastEdge: null,
+    lastEvent: null,
+    done: false,
+    tour: null,
+  }
+}
+
+// Walks the accepted degree-2 cycle into an ordered path starting at city 0.
+// Mirrors Rust `hamiltonian_cycle_to_path` (graph.rs:140) — only called once
+// the scan has placed all n edges.
+function walkCycle(accepted: Edge[]): number[] {
+  const n = accepted.length
+  const adj: number[][] = Array.from({ length: n }, () => [])
+  for (const e of accepted) {
+    adj[e.u].push(e.v)
+    adj[e.v].push(e.u)
+  }
+  const path: number[] = []
+  const seen = new Array(n).fill(false)
+  let prev = -1
+  let cur = 0
+  for (let i = 0; i < n; i++) {
+    path.push(cur)
+    seen[cur] = true
+    const next = adj[cur].find(x => x !== prev && !seen[x]) ?? adj[cur][0]
+    prev = cur
+    cur = next
+  }
+  return path
+}
+
+// Evaluate edges one at a time, skipping rejects, until one is accepted OR a
+// reject worth showing is found. A single user "step" advances the *accepted*
+// frontier by one (skipping over any intervening rejects), so the viz always
+// shows forward progress — mirroring how the Rust loop's `continue` statements
+// are invisible bookkeeping around each acceptance.
+export function stepOnce(s: SimState): SimState {
+  if (s.done) return s
+
+  const edges = s.sortedEdges
+  let idx = s.scanIndex
+  const parent = s.parent.slice()
+  const degree = s.degree.slice()
+  const accepted = s.accepted.slice()
+  const rejected = s.rejected.slice()
+  let lastEdge: Edge | null = s.lastEdge
+  let lastEvent: EventMode | null = s.lastEvent
+
+  while (idx < edges.length) {
+    const e = edges[idx]
+    idx++
+    lastEdge = e
+
+    if (degree[e.u] >= 2 || degree[e.v] >= 2) {
+      rejected.push({ edge: e, reason: 'degree' })
+      lastEvent = 'rejected-degree'
+      continue
+    }
+    // The n-th accepted edge (0-indexed n-1) closes the cycle and MUST be a
+    // same-component edge — the only time that is allowed.
+    const isClosing = accepted.length === N_CITIES - 1
+    if (connected(parent, e.u, e.v) && !isClosing) {
+      rejected.push({ edge: e, reason: 'cycle' })
+      lastEvent = 'rejected-cycle'
+      continue
+    }
+
+    union(parent, e.u, e.v)
+    degree[e.u]++
+    degree[e.v]++
+    accepted.push(e)
+    lastEvent = isClosing ? 'closing' : 'accepted'
+
+    // Did the scan place all n edges? Rust asserts accepted.len() == n here.
+    if (accepted.length === N_CITIES) {
+      return {
+        ...s,
+        scanIndex: idx,
+        parent,
+        degree,
+        accepted,
+        rejected,
+        step: s.step + 1,
+        lastEdge,
+        lastEvent,
+        done: true,
+        tour: walkCycle(accepted),
+      }
+    }
+    // accepted-frontier advanced by one: stop here so the user sees this edge.
+    break
+  }
+
+  return {
+    ...s,
+    scanIndex: idx,
+    parent,
+    degree,
+    accepted,
+    rejected,
+    step: s.step + 1,
+    lastEdge,
+    lastEvent,
+    done: false,
+    tour: null,
+  }
+}
+
+// Run to completion from any state — used by the "Run" button and by tests.
+export function runToCompletion(s: SimState): SimState {
+  let cur = s
+  while (!cur.done) cur = stepOnce(cur)
+  return cur
+}

--- a/teeline-web/src/explainers/greedy-edge.test.ts
+++ b/teeline-web/src/explainers/greedy-edge.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES,
+  sortedEdges,
+  components,
+  makeInitState,
+  stepOnce,
+  runToCompletion,
+} from './greedy-edge-algo'
+
+describe('sortedEdges', () => {
+  it('contains exactly n(n-1)/2 edges', () => {
+    expect(sortedEdges()).toHaveLength((N_CITIES * (N_CITIES - 1)) / 2)
+  })
+
+  it('is sorted ascending by distance', () => {
+    const e = sortedEdges()
+    for (let i = 1; i < e.length; i++) {
+      expect(e[i].dist).toBeGreaterThanOrEqual(e[i - 1].dist - 1e-9)
+    }
+  })
+
+  it('has u < v on every edge', () => {
+    for (const e of sortedEdges()) expect(e.u).toBeLessThan(e.v)
+  })
+
+  it('has no duplicate endpoint pairs', () => {
+    const seen = new Set<string>()
+    for (const e of sortedEdges()) {
+      const k = `${e.u}-${e.v}`
+      expect(seen.has(k)).toBe(false)
+      seen.add(k)
+    }
+  })
+})
+
+describe('makeInitState', () => {
+  it('starts with every city in its own component', () => {
+    const s = makeInitState()
+    expect(components(s.parent)).toHaveLength(N_CITIES)
+  })
+
+  it('starts with zero accepted edges and zero degree everywhere', () => {
+    const s = makeInitState()
+    expect(s.accepted).toHaveLength(0)
+    expect(s.degree.every(d => d === 0)).toBe(true)
+    expect(s.done).toBe(false)
+    expect(s.step).toBe(0)
+  })
+})
+
+describe('stepOnce', () => {
+  it('the first accepted edge joins the two closest cities', () => {
+    const s = stepOnce(makeInitState())
+    expect(s.accepted).toHaveLength(1)
+    const closest = sortedEdges()[0]
+    expect(s.accepted[0]).toEqual(closest)
+    expect(s.lastEvent).toBe('accepted')
+  })
+
+  it('never lets a city exceed degree 2', () => {
+    let s = makeInitState()
+    for (let i = 0; i < 200 && !s.done; i++) s = stepOnce(s)
+    for (const d of s.degree) expect(d).toBeLessThanOrEqual(2)
+  })
+
+  it('rejected edges are tagged with a valid reason', () => {
+    let s = makeInitState()
+    for (let i = 0; i < 200 && !s.done; i++) s = stepOnce(s)
+    for (const r of s.rejected) {
+      expect(['degree', 'cycle']).toContain(r.reason)
+    }
+  })
+})
+
+describe('runToCompletion (the Rust select_edges invariants)', () => {
+  it('always terminates (no infinite loop)', () => {
+    const s = runToCompletion(makeInitState())
+    expect(s.done).toBe(true)
+  })
+
+  it('places exactly n accepted edges', () => {
+    const s = runToCompletion(makeInitState())
+    expect(s.accepted).toHaveLength(N_CITIES)
+  })
+
+  it('leaves every city with degree exactly 2', () => {
+    const s = runToCompletion(makeInitState())
+    for (const d of s.degree) expect(d).toBe(2)
+  })
+
+  it('collapses to a single connected component', () => {
+    const s = runToCompletion(makeInitState())
+    expect(components(s.parent)).toHaveLength(1)
+  })
+
+  it('produces a valid Hamiltonian path visiting every city once', () => {
+    const s = runToCompletion(makeInitState())
+    expect(s.tour).not.toBeNull()
+    expect(s.tour!).toHaveLength(N_CITIES)
+    expect(s.tour!.slice().sort((a, b) => a - b)).toEqual(
+      Array.from({ length: N_CITIES }, (_, i) => i),
+    )
+  })
+
+  it('the last accepted edge is the closing edge (a same-component join)', () => {
+    const s = runToCompletion(makeInitState())
+    expect(s.lastEvent).toBe('closing')
+  })
+})

--- a/teeline-web/src/explainers/greedy-edge.tsx
+++ b/teeline-web/src/explainers/greedy-edge.tsx
@@ -1,0 +1,444 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES, components, makeInitState, stepOnce,
+} from "./greedy-edge-algo"
+import type { Edge, EventMode, RejectReason } from "./greedy-edge-algo"
+
+// One stable colour per component root, so merges are visible as two groups
+// collapsing into one colour. Sized for N_CITIES components (the start state).
+const COMP_PALETTE = [
+  "#0d9488", "#2563eb", "#7c3aed", "#db2777", "#ea580c",
+  "#16a34a", "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
+  "#0f766e", "#9333ea",
+]
+function compColor(rootIndex: number): string {
+  return COMP_PALETTE[rootIndex % COMP_PALETTE.length]
+}
+
+function edgeKey(e: Edge): string {
+  return `${e.u}-${e.v}`
+}
+
+// ---------------------------------------------------------------
+// ScanCanvas — cities (coloured by component, degree badge), accepted
+// edges, the candidate edge under evaluation, and the final tour.
+// ---------------------------------------------------------------
+interface ScanCanvasProps {
+  accepted: Edge[]
+  lastEdge: Edge | null
+  lastEvent: EventMode | null
+  rejectedTrail: Array<{ edge: Edge; reason: RejectReason }>
+  degree: number[]
+  parent: number[]
+  tour: number[] | null
+}
+function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, parent, tour }: ScanCanvasProps) {
+  const comps = useMemo(() => components(parent), [parent])
+  // root lookup: city -> index into comps (its component slot)
+  const rootOf = useMemo(() => {
+    const m = new Map<number, number>()
+    comps.forEach((group, gi) => group.forEach(c => m.set(c, gi)))
+    return m
+  }, [comps])
+
+  const acceptedSet = useMemo(() => new Set(accepted.map(edgeKey)), [accepted])
+
+  // tour as a closed polyline (only once done)
+  const tourPts = tour
+    ? tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : ""
+
+  return (
+    <svg viewBox="0 0 300 300" className="gec-canvas" role="img" aria-label="Greedy edge scan">
+      <rect x={0} y={0} width={300} height={300} className="gec-bg" />
+
+      {/* final closed tour underlay once complete */}
+      {tour && <polygon points={tourPts} className="gec-tour" />}
+
+      {/* accepted edges */}
+      {accepted.map((e, i) => (
+        <line key={"a" + i}
+          x1={CITIES[e.u][0]} y1={CITIES[e.u][1]}
+          x2={CITIES[e.v][0]} y2={CITIES[e.v][1]}
+          className="gec-accepted"
+        />
+      ))}
+
+      {/* faint trail of recent rejects (last few), so the scan is legible */}
+      {rejectedTrail.map((r, i) => (
+        <line key={"r" + i}
+          x1={CITIES[r.edge.u][0]} y1={CITIES[r.edge.u][1]}
+          x2={CITIES[r.edge.v][0]} y2={CITIES[r.edge.v][1]}
+          className={r.reason === "degree" ? "gec-rejected gec-rejected-degree" : "gec-rejected gec-rejected-cycle"}
+        />
+      ))}
+
+      {/* the candidate edge currently under evaluation (bold) */}
+      {lastEdge && !acceptedSet.has(edgeKey(lastEdge)) && !tour && (
+        <line
+          x1={CITIES[lastEdge.u][0]} y1={CITIES[lastEdge.u][1]}
+          x2={CITIES[lastEdge.v][0]} y2={CITIES[lastEdge.v][1]}
+          className={
+            lastEvent === "rejected-degree" ? "gec-cand gec-cand-degree"
+            : lastEvent === "rejected-cycle" ? "gec-cand gec-cand-cycle"
+            : lastEvent === "closing" ? "gec-cand gec-cand-closing"
+            : "gec-cand gec-cand-accept"
+          }
+        />
+      )}
+
+      {/* cities: fill = component colour, badge = degree */}
+      {CITIES.map(([x, y], i) => {
+        const gi = rootOf.get(i) ?? 0
+        const full = degree[i] >= 2
+        return (
+          <g key={i}>
+            <circle cx={x} cy={y} r={5.5}
+              fill={compColor(gi)}
+              className={full ? "gec-city gec-city-full" : "gec-city"}
+            />
+            <text x={x + 7} y={y - 6} className="gec-city-label">{i}</text>
+            <text x={x} y={y + 18} className="gec-degree-badge"
+              style={{ opacity: degree[i] > 0 ? 1 : 0.25 }}>{degree[i]}</text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// ComponentPanel — union-find component groups (analogous to the tabu list)
+// ---------------------------------------------------------------
+function ComponentPanel({ parent }: { parent: number[] }) {
+  const comps = useMemo(() => components(parent), [parent])
+  return (
+    <div className="gec-list-panel">
+      <div className="gec-list-title">Union-Find</div>
+      <div className="gec-list-subtitle">{comps.length} component{comps.length === 1 ? "" : "s"}</div>
+      {comps.map((g, i) => (
+        <div key={i} className="gec-comp-badge" style={{ borderLeftColor: compColor(i) }}>
+          {"{" + g.join(",") + "}"}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// GreedyEdgeExplainer — main component
+// ---------------------------------------------------------------
+export default function GreedyEdgeExplainer() {
+  const [speed, setSpeed] = useState(5)
+
+  const simRef = useRef(makeInitState())
+  const [accepted, setAccepted] = useState<Edge[]>(() => [])
+  const [rejected, setRejected] = useState<Array<{ edge: Edge; reason: RejectReason }>>(() => [])
+  const [degree, setDegree] = useState<number[]>(() => new Array(N_CITIES).fill(0))
+  const [parent, setParent] = useState<number[]>(() => simRef.current.parent.slice())
+  const [lastEdge, setLastEdge] = useState<Edge | null>(null)
+  const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
+  const [step, setStep] = useState(0)
+  const [done, setDone] = useState(false)
+  const [tour, setTour] = useState<number[] | null>(null)
+  const [running, setRunning] = useState(false)
+
+  const reinit = useCallback(() => {
+    simRef.current = makeInitState()
+    setAccepted([]); setRejected([]); setDegree(new Array(N_CITIES).fill(0))
+    setParent(simRef.current.parent.slice()); setLastEdge(null); setLastEvent(null)
+    setStep(0); setDone(false); setTour(null); setRunning(false)
+  }, [])
+
+  const step_fn = useCallback(() => {
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setAccepted(next.accepted.slice())
+    // keep only the last 6 rejects visible, so the canvas stays legible
+    setRejected(next.rejected.slice(-6))
+    setDegree(next.degree.slice())
+    setParent(next.parent.slice())
+    setLastEdge(next.lastEdge); setLastEvent(next.lastEvent)
+    setStep(next.step); setDone(next.done); setTour(next.tour)
+    if (next.done) setRunning(false)
+  }, [])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = Math.max(40, 660 - speed * 66)
+    const id = setInterval(step_fn, ms)
+    return () => clearInterval(id)
+  }, [running, speed, step_fn])
+
+  const partialCost = useMemo(
+    () => accepted.reduce((s, e) => s + e.dist, 0),
+    [accepted],
+  )
+
+  let chipText = "Press Step or Run to scan the shortest edges first"
+  let chipClass = "gec-chip gec-chip-idle"
+  if (lastEvent === "accepted" && lastEdge) {
+    chipText = `✅ accepted  (${lastEdge.u}, ${lastEdge.v})  — degree/union updated`
+    chipClass = "gec-chip gec-chip-accept"
+  } else if (lastEvent === "rejected-degree" && lastEdge) {
+    chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — would give a city degree 3`
+    chipClass = "gec-chip gec-chip-degree"
+  } else if (lastEvent === "rejected-cycle" && lastEdge) {
+    chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — premature sub-cycle`
+    chipClass = "gec-chip gec-chip-cycle"
+  } else if (lastEvent === "closing" && lastEdge) {
+    chipText = `🔒 closing edge  (${lastEdge.u}, ${lastEdge.v})  — the path becomes a cycle`
+    chipClass = "gec-chip gec-chip-closing"
+  }
+
+  const totalEdges = (N_CITIES * (N_CITIES - 1)) / 2
+  const comps = useMemo(() => components(parent), [parent])
+
+  return (
+    <div className="gec-root">
+      <style>{CSS}</style>
+
+      <header className="gec-header">
+        <div className="gec-eyebrow">teeline · algorithms/greedy-edge</div>
+        <h2 className="gec-title">Greedy Edge Construction</h2>
+        <p className="gec-sub">
+          Every pairwise edge is scanned shortest-first and accepted unless it would give a city
+          <strong> degree 3+</strong> or close a <strong>premature sub-cycle</strong> (tracked by a
+          union-find). Watch the components merge until one Hamiltonian cycle remains.
+        </p>
+      </header>
+
+      <div className="gec-viz-row">
+        <div className="gec-canvas-wrap">
+          <ScanCanvas
+            accepted={accepted} lastEdge={lastEdge} lastEvent={lastEvent}
+            rejectedTrail={rejected} degree={degree} parent={parent} tour={tour}
+          />
+        </div>
+        <ComponentPanel parent={parent} />
+      </div>
+
+      <div className="gec-legend">
+        <span><span className="gec-swatch gec-swatch-accepted" /> accepted edge</span>
+        <span><span className="gec-swatch gec-swatch-degree" /> rejected — degree</span>
+        <span><span className="gec-swatch gec-swatch-cycle" /> rejected — cycle</span>
+        <span><span className="gec-swatch gec-swatch-closing" /> closing edge</span>
+        {done && <span><span className="gec-swatch gec-swatch-tour" /> final tour</span>}
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="gec-statgrid">
+        <div>
+          <div className="gec-statlabel">edges scanned</div>
+          <div className="gec-mono">{accepted.length + rejected.length}/{totalEdges}</div>
+        </div>
+        <div>
+          <div className="gec-statlabel">accepted</div>
+          <div className="gec-mono">{accepted.length}/{N_CITIES}</div>
+        </div>
+        <div>
+          <div className="gec-statlabel">rejected</div>
+          <div className="gec-mono">{step > 0 ? simRef.current.rejected.length : 0}</div>
+        </div>
+        <div>
+          <div className="gec-statlabel">components</div>
+          <div className="gec-mono">{comps.length}</div>
+        </div>
+        <div>
+          <div className="gec-statlabel">partial cost</div>
+          <div className="gec-mono">{partialCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="gec-statlabel">step</div>
+          <div className="gec-mono">{step}</div>
+        </div>
+      </div>
+
+      <div className="gec-config">
+        <div className="gec-config-row">
+          <label className="gec-config-label">Speed</label>
+          <input type="range" min={1} max={10} step={1} value={speed}
+            className="gec-slider"
+            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+          />
+          <div className="gec-hint">Edges are parameter-free — no other knobs to tune.</div>
+        </div>
+      </div>
+
+      <div className="gec-controls">
+        <button className="gec-btn" onClick={step_fn} disabled={running || done}>◀ Step</button>
+        <button className={`gec-btn ${!running ? "gec-btn-primary" : ""}`}
+          onClick={() => setRunning(r => !r)} disabled={done}>
+          {running ? "⏸ Pause" : done ? "✓ Done" : "▶ Run"}
+        </button>
+        <button className="gec-btn" onClick={reinit}>↺ Reset</button>
+      </div>
+
+      <footer className="gec-footer">
+        <span className="gec-mono">cities: {N_CITIES}</span>
+        <span className="gec-mono">candidate edges: {totalEdges}</span>
+        <span className="gec-mono">sort: distance, ascending</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.gec-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --accept: #16a34a;
+  --closing: #ca8a04;
+  --reject-degree: #db2777;
+  --reject-cycle: #ea580c;
+  --tour: #2563eb;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.gec-root * { box-sizing: border-box; }
+.gec-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* Header */
+.gec-header { margin-bottom: 2px; }
+.gec-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.gec-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.gec-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+.gec-sub code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em; background: rgba(13,148,136,0.1);
+  color: var(--accent); padding: 1px 4px; border-radius: 4px;
+}
+
+/* Canvas */
+.gec-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.gec-bg { fill: var(--panel); }
+.gec-tour { fill: none; stroke: var(--tour); stroke-width: 3; stroke-linejoin: round; opacity: 0.35; }
+.gec-accepted { stroke: var(--accept); stroke-width: 2.5; stroke-linecap: round; }
+.gec-rejected { stroke-width: 1.4; stroke-dasharray: 4 3; opacity: 0.4; }
+.gec-rejected-degree { stroke: var(--reject-degree); }
+.gec-rejected-cycle  { stroke: var(--reject-cycle); }
+.gec-cand { stroke-width: 3.2; stroke-linecap: round; }
+.gec-cand-accept  { stroke: var(--accept); }
+.gec-cand-closing { stroke: var(--closing); }
+.gec-cand-degree  { stroke: var(--reject-degree); }
+.gec-cand-cycle   { stroke: var(--reject-cycle); }
+.gec-city { stroke: #fff; stroke-width: 1.2; }
+.gec-city-full { stroke: #fff; stroke-width: 2; }
+.gec-city-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8px; fill: #374151; stroke: white; stroke-width: 2.5;
+  paint-order: stroke fill; dominant-baseline: auto;
+  pointer-events: none; user-select: none;
+}
+.gec-degree-badge {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8.5px; font-weight: 700; fill: #1f2328;
+  text-anchor: middle; pointer-events: none; user-select: none;
+}
+
+/* Viz row */
+.gec-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.gec-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+/* Component panel */
+.gec-list-panel {
+  width: 130px; flex-shrink: 0; display: flex; flex-direction: column; gap: 4px;
+  padding: 8px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  overflow-y: auto; max-height: 300px;
+}
+.gec-list-title {
+  font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--muted); margin-bottom: 0;
+}
+.gec-list-subtitle {
+  font-size: 0.7rem; color: var(--muted); margin-bottom: 4px;
+}
+.gec-comp-badge {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem; font-weight: 600;
+  background: #fff; color: var(--text);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px; padding: 2px 6px;
+}
+
+/* Legend */
+.gec-legend { display: flex; gap: 14px; flex-wrap: wrap; font-size: 0.8rem; color: var(--muted); align-items: center; }
+.gec-swatch {
+  display: inline-block; width: 22px; height: 3px;
+  border-radius: 2px; margin-right: 3px; vertical-align: middle;
+}
+.gec-swatch-accept  { background: var(--accept); }
+.gec-swatch-degree  { background: var(--reject-degree); }
+.gec-swatch-cycle   { background: var(--reject-cycle); }
+.gec-swatch-closing { background: var(--closing); }
+.gec-swatch-tour    { background: var(--tour); }
+.gec-swatch-accepted{ background: var(--accept); }
+
+/* Event chip */
+.gec-chip {
+  font-size: 0.85rem; font-weight: 600; padding: 8px 12px;
+  border-radius: 8px; border: 1px solid transparent;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.gec-chip-idle   { background: var(--panel); color: var(--muted); border-color: var(--line); font-weight: 400; }
+.gec-chip-accept { background: #dcfce7; color: #15803d; border-color: #bbf7d0; }
+.gec-chip-degree { background: #fce7f3; color: #be185d; border-color: #fbcfe8; }
+.gec-chip-cycle  { background: #ffedd5; color: #c2410c; border-color: #fed7aa; }
+.gec-chip-closing{ background: #fef3c7; color: #92400e; border-color: #fde68a; }
+
+/* Stats */
+.gec-statgrid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px; }
+@media (max-width: 540px) { .gec-statgrid { grid-template-columns: repeat(3, 1fr); } }
+.gec-statlabel {
+  font-size: 0.65rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+}
+
+/* Config */
+.gec-config { display: flex; flex-direction: column; gap: 8px; }
+.gec-config-row { display: flex; flex-direction: column; gap: 3px; }
+.gec-config-label { font-size: 0.88rem; }
+.gec-slider { width: 100%; accent-color: var(--accent); cursor: pointer; }
+.gec-hint { font-size: 0.75rem; color: var(--muted); }
+
+/* Controls */
+.gec-controls { display: flex; gap: 8px; }
+.gec-btn {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--line); border-radius: 6px;
+  padding: 6px 16px; font-size: 0.88rem; cursor: pointer; font-family: inherit;
+}
+.gec-btn:hover:not(:disabled) { border-color: var(--accent); }
+.gec-btn:disabled { opacity: 0.45; cursor: default; }
+.gec-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+/* Footer */
+.gec-footer {
+  display: flex; flex-wrap: wrap; gap: 14px;
+  padding-top: 8px; border-top: 1px solid var(--line); color: var(--muted);
+}
+`

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -72,6 +72,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of the Fourier-basis constructive TSP solver: watch gradient descent shape a closed curve into a valid tour.',
     backLabel: 'Fourier',
   },
+  greedy_edge: {
+    title: 'Greedy Edge Construction — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of Greedy Edge Construction: watch every pairwise edge scan shortest-first, accepted unless it would create degree 3+ or a premature sub-cycle, with union-find components merging until one Hamiltonian cycle remains.',
+    backLabel: 'Greedy Edge',
+  },
 }
 
 export const EXPLAINER_IDS = Object.keys(EXPLAINER_META)

--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { SOLVER_META, SOLVER_GROUPS, PAGED_SOLVERS, EXPLAINER_SOLVERS } from './nav-data'
 
 describe('SOLVER_META', () => {
-  it('contains exactly 18 solvers', () => {
-    expect(Object.keys(SOLVER_META)).toHaveLength(18)
+  it('contains exactly 19 solvers', () => {
+    expect(Object.keys(SOLVER_META)).toHaveLength(19)
   })
 
   it('every entry has id and name', () => {
@@ -53,9 +53,9 @@ describe('PAGED_SOLVERS', () => {
 })
 
 describe('EXPLAINER_SOLVERS', () => {
-  it('contains exactly the 10 ids with an interactive explainer', () => {
+  it('contains exactly the 11 ids with an interactive explainer', () => {
     expect(EXPLAINER_SOLVERS).toEqual(
-      new Set(['pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier']),
+      new Set(['pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge']),
     )
   })
 

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -13,6 +13,7 @@ export const SOLVER_META: Record<string, SolverMeta> = {
   nn: { id: 'nn', name: 'Nearest Neighbor' },
   fourier: { id: 'fourier', name: 'Fourier' },
   christofides: { id: 'christofides', name: 'Christofides' },
+  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge' },
   '2opt': { id: '2opt', name: '2-opt' },
   '3opt': { id: '3opt', name: '3-opt' },
   or_opt: { id: 'or_opt', name: 'Or-opt' },
@@ -35,7 +36,7 @@ export interface SolverGroup {
 
 export const SOLVER_GROUPS: SolverGroup[] = [
   { label: 'Exact', ids: ['bhk', 'branch_bound'] },
-  { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'som'] },
+  { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'som'] },
   { label: 'Local search', ids: ['2opt', '3opt', 'or_opt', 'stochastic_hill', 'lk'] },
   { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa'] },
 ]
@@ -45,5 +46,5 @@ export const PAGED_SOLVERS = new Set(Object.keys(SOLVER_META))
 
 // The subset of ids with an interactive explainer under /algorithms/<id>/explainer/.
 export const EXPLAINER_SOLVERS = new Set([
-  'pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier',
+  'pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge',
 ])

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -25,6 +25,7 @@ import LkExplainer from '../../../../explainers/lk.tsx'
 import SaExplainer from '../../../../explainers/sa'
 import SomExplainer from '../../../../explainers/som'
 import FourierExplainer from '../../../../explainers/fourier'
+import GreedyEdgeExplainer from '../../../../explainers/greedy-edge'
 
 export function getStaticPaths() {
   return EXPLAINER_IDS.map((id) => ({ params: { id } }))
@@ -61,5 +62,6 @@ const jsonLd = {
     {id === 'sa' && <SaExplainer client:visible />}
     {id === 'som' && <SomExplainer client:visible />}
     {id === 'fourier' && <FourierExplainer client:visible />}
+    {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
   </main>
 </BaseLayout>

--- a/teeline-web/src/pages/index.astro
+++ b/teeline-web/src/pages/index.astro
@@ -107,6 +107,7 @@ const jsonLd = {
           <button type="button" class="pill outline secondary" data-solver="2opt" aria-current="false">2-opt</button>
           <button type="button" class="pill outline secondary" data-solver="sa" aria-current="false">SA</button>
           <button type="button" class="pill outline secondary" data-solver="ga" aria-current="false">GA</button>
+          <button type="button" class="pill outline secondary" data-solver="gec" aria-current="false">GEC</button>
           <select id="solver-select" aria-label="All solvers">
             <option value="">All solvers…</option>
           </select>


### PR DESCRIPTION
## Summary

Surfaces the `greedy_edge` / `gec` solver (added to the Rust core in #393) across the teeline-web surface. Closes #392.

WASM solver-list metadata already picks up `greedy_edge` automatically, so this is purely docs / explainer / landing-page / nav wiring — no WASM changes.

## Changes

**Docs page** — `docs/algorithms/greedy-edge.md`
- Follows the `christofides.md` pattern (closest structural sibling: deterministic, constructive, parameter-free, Kruskal-style).
- Pseudocode, complexity (O(n² log n) sort + O(n² α(n)) scan), parameter-free options note, usage, references, and a berlin52 benchmark table.

**Interactive explainer** — single-panel, modeled on `tabu.tsx`
- `greedy-edge-algo.ts` — pure simulation logic mirroring the Rust `select_edges` invariants (`src/tsp/graph.rs:98-130`): degree ≤ 2, no premature sub-cycle via union-find, terminates with exactly n edges.
- `greedy-edge.tsx` — SVG canvas with edges scanned shortest-first (accepted / rejected-degree / rejected-cycle / closing colour-coded), cities coloured by union-find component with degree badges, and a side panel showing the union-find component sets merging.
- `greedy-edge.test.ts` — 15 tests pinning the Rust invariants (n accepted edges, every degree == 2, single component, valid Hamiltonian path, closing edge is a same-component join).

**Landing page** — added the `gec` quick-pick pill to the Configure step (`index.astro`).

**Nav wiring** (required for the docs page to be reachable + explainer counted, though not explicitly listed in #392):
- `nav-data.ts` — `greedy_edge` added to `SOLVER_META`, the `Constructive` `SOLVER_GROUPS` entry, and `EXPLAINER_SOLVERS`.
- `nav-data.test.ts` — bumped the pinned counts (18 → 19 solvers, 10 → 11 explainers).
- `registry.ts` — `greedy_edge` `EXPLAINER_META` entry.
- `[id]/explainer/index.astro` — static import + `{id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}` branch.

## Benchmark angle (berlin52, optimal 7544.37)

| Solver | Standalone | Gap | + LK | Gap |
| --- | ---: | ---: | ---: | ---: |
| `greedy_edge` | 9954.06 | +31.9% | **7544.37** | **0.0% (optimal)** |
| `nn` | 8980.92 | +19.0% | 7777.33 | +3.1% |

A worse standalone tour than NN, yet it seeds LK to the known optimum where `nn,lk` does not — the cheap-edges-first construction spreads the inevitable long edges more evenly, leaving a smoother descent basin. The docs page calls this out explicitly.

## Verification

- [x] `astro check` + `tsc --noEmit` + `astro build` — clean (38 pages built)
- [x] `vitest run` — 199 tests pass (incl. the 15 new `greedy-edge.test.ts`)
- [x] Build emits `/algorithms/greedy_edge/` + `/algorithms/greedy_edge/explainer/`, the docs→explainer CTA, the AlgorithmCards Constructive link, and the `gec` landing pill
- [x] Pre-commit hooks (markdownlint, tsc) passed

## Notes

- The `[[feedback_explainer_layout]]` wikilink in #392 resolves nowhere (not in repo or GitKB), so I resolved "single-panel layout" by following the existing `tabu.tsx` single-panel pattern (the closest structural match — step-by-step scan with accept/reject decisions + a side state panel). Flag if a different explainer should be the template.
- Explainer `id` is `greedy_edge` (underscore) throughout to match the `SOLVER_META` convention; the docs *filename* is hyphenated (`greedy-edge.md`) per existing convention.
- Left the hero "18 algorithms" count unchanged — it's already stale for unrelated reasons (savings/aco exist in Rust but aren't surfaced), so bumping it for this PR alone would misrepresent the web-surfaced total. Worth a separate cleanup.

## Follow-up

Created #408 — *Surface savings (sav) in teeline-web* — with the required wiring checklist pre-filled. `savings` is mechanically a sibling of `greedy_edge` (shares `select_edges`, differs only in its savings-vs-distance sort key) and can reuse most of this explainer.