### PR TITLE
Surface Ant Colony Optimization (aco) in teeline-web

### DIFF
--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { SOLVER_META, SOLVER_GROUPS, PAGED_SOLVERS, EXPLAINER_SOLVERS } from './nav-data'
 
 describe('SOLVER_META', () => {
-  it('contains exactly 19 solvers', () => {
-    expect(Object.keys(SOLVER_META)).toHaveLength(19)
+  it('contains exactly 20 solvers', () => {
+    expect(Object.keys(SOLVER_META)).toHaveLength(20)
   })
 
   it('every entry has id and name', () => {

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -27,6 +27,7 @@ export const SOLVER_META: Record<string, SolverMeta> = {
   fpa: { id: 'fpa', name: 'Flower Pollination' },
   gsa: { id: 'gsa', name: 'Gravitational Search' },
   som: { id: 'som', name: 'Kohonen SOM' },
+  aco: { id: 'aco', name: 'Ant Colony Optimization' },
 }
 
 export interface SolverGroup {
@@ -38,7 +39,7 @@ export const SOLVER_GROUPS: SolverGroup[] = [
   { label: 'Exact', ids: ['bhk', 'branch_bound'] },
   { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'som'] },
   { label: 'Local search', ids: ['2opt', '3opt', 'or_opt', 'stochastic_hill', 'lk'] },
-  { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa'] },
+  { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa', 'aco'] },
 ]
 
 // Every id in SOLVER_META has a generated doc page under /algorithms/<id>/.

--- a/teeline-web/src/pages/algorithms/[id]/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/index.astro
@@ -1,6 +1,6 @@
 ---
 // Replaces scripts/build-docs.mjs + scripts/templates/algorithm-page.eta.
-// One dynamic route generates all 18 algorithm doc pages from the `docs`
+// One dynamic route generates every algorithm doc page from the `docs`
 // content collection (src/content.config.ts, sourced directly from
 // docs/algorithms/*.md — no copying, no separate generation step).
 import { getCollection, render } from 'astro:content'

--- a/teeline-web/src/pages/index.astro
+++ b/teeline-web/src/pages/index.astro
@@ -108,6 +108,7 @@ const jsonLd = {
           <button type="button" class="pill outline secondary" data-solver="sa" aria-current="false">SA</button>
           <button type="button" class="pill outline secondary" data-solver="ga" aria-current="false">GA</button>
           <button type="button" class="pill outline secondary" data-solver="gec" aria-current="false">GEC</button>
+          <button type="button" class="pill outline secondary" data-solver="aco" aria-current="false">ACO</button>
           <select id="solver-select" aria-label="All solvers">
             <option value="">All solvers…</option>
           </select>
@@ -202,7 +203,7 @@ const jsonLd = {
       <h1>Teeline TSP Solver</h1>
       <p class="tagline">
         Find the shortest route through your cities — one of computing's oldest hard
-        problems, solved live in your browser with 18 algorithms, from exact search to
+        problems, solved live in your browser with 20 algorithms, from exact search to
         genetic algorithms and swarm intelligence.
       </p>
       <p class="tagline-link">


### PR DESCRIPTION
## Summary

Surfaces the `aco` solver (added to the Rust core in #396) across teeline-web's navigation and landing page. Closes #400.

The docs page (`docs/algorithms/ant-colony.md`) already existed from #396 — this PR is purely routing/wiring.

## Changes

- **`nav-data.ts`** — added `aco` to `SOLVER_META` and the `Metaheuristic` `SOLVER_GROUPS` entry. This routes `/algorithms/aco/` to the existing docs page (via the content collection) and links it from the AlgorithmCards Metaheuristic card + sidebar.
- **`nav-data.test.ts`** — bumped the pinned `SOLVER_META` count (19 → 20).
- **`index.astro`** — added the `ACO` quick-pick pill; corrected the hero tagline's now-stale "18 algorithms" → "20 algorithm" count.
- **`[id]/index.astro`** — made a stale "generates all 18 algorithm doc pages" code comment count-agnostic so it stops rotting on every solver addition.

## On the #398 dependency

The issue noted that `aco` "won't appear in any WASM-driven dynamic solver picker" until #398 (WIT params). That's **inaccurate**, and worth correcting for the record:

- `aco` **is** in Rust's `SOLVER_LIST`, so the WASM `list_algorithms` already emits it — `wasm_component.rs` asserts 22 solvers incl. `"aco"`. The dropdown and the new landing pill resolve it today.
- What #398 actually gates is the *tunable params*: `params_for_solver` has no `AntColony` arm, so the web config panel shows "No configurable options" until #398 adds `alpha`/`beta`/`evaporation_rate`/`num_ants`. The solver is still **runnable** from the web with Rust defaults (`build_opts` wildcards it → `AppOptions::default()`).

So this PR is unblocked and ships useful routing now; #398 remains open for the param-tunability gap.

## Out of scope (deferred)

- **Interactive explainer** — explicitly deferred per #400's scope decision. Filed **#410** to track it. `hasExplainer` stays `false`. (CS/FPA, aco's closest siblings, both have ~800-line explainers; doing ACO justice is its own piece of work.)
- **Blog post** — `content/blog/webmcp-tsp-solver.md` also says "pick from 18 algorithms". Left unchanged: it's dated published copy. Flagging here in case it warrants a separate edit.

## Verification

- [x] `astro check` + `tsc --noEmit` + `astro build` — clean (38 pages built)
- [x] `vitest run` — 199 tests pass (incl. the bumped nav-data count test)
- [x] Build emits `/algorithms/aco/`, linked from the Metaheuristic AlgorithmCard; `ACO` pill present; hero reads "20 algorithms"; no explainer CTA on the aco page (`hasExplainer: false`)
- [x] Pre-commit hook (tsc) passed

## Follow-ups

- **#398** — expose ACO tunables (alpha/beta/evaporation_rate/num_ants) via WIT, so the web config panel can tune them.
- **#410** — interactive ACO explainer (deferred from this PR).