### PR TITLE
Add ACO solver support to teeline-api

### DIFF
--- a/teeline-api/src/models/request.rs
+++ b/teeline-api/src/models/request.rs
@@ -111,6 +111,21 @@ pub struct FpaConfig {
     pub mutation_probability: Option<f32>,
 }
 
+/// Ant Colony Optimization. Mirrors `AcoOptions`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct AcoConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic: Option<HeuristicConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beta: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaporation_rate: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_ants: Option<usize>,
+}
+
 /// Kohonen SOM. Mirrors `SOMOptions` (f64 fields match the lib).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct SomConfig {
@@ -171,6 +186,8 @@ pub struct SolverConfigs {
     pub cs: Option<CsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fpa: Option<FpaConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aco: Option<AcoConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub som: Option<SomConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -375,6 +392,43 @@ mod tests {
         let sa = back.configs.unwrap().sa.unwrap();
         assert_eq!(sa.cooling_rate, Some(0.001));
         assert_eq!(sa.heuristic.unwrap().epochs, Some(1000));
+    }
+
+    #[test]
+    fn solve_request_with_aco_config_round_trip() {
+        let req = SolveRequest {
+            input: TspInput {
+                cities: Some(vec![CityInput {
+                    id: None,
+                    x: 1.0,
+                    y: 2.0,
+                }]),
+                tsplib: None,
+            },
+            solver: "aco".to_string(),
+            configs: Some(SolverConfigs {
+                aco: Some(AcoConfig {
+                    heuristic: Some(HeuristicConfig {
+                        epochs: Some(300),
+                        platoo_epochs: None,
+                        n_nearest: None,
+                    }),
+                    alpha: None,
+                    beta: Some(3.0),
+                    evaporation_rate: Some(0.3),
+                    num_ants: Some(40),
+                }),
+                ..SolverConfigs::default()
+            }),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: SolveRequest = serde_json::from_str(&json).unwrap();
+        let aco = back.configs.unwrap().aco.unwrap();
+        assert_eq!(aco.beta, Some(3.0));
+        assert_eq!(aco.evaporation_rate, Some(0.3));
+        assert_eq!(aco.num_ants, Some(40));
+        assert_eq!(aco.alpha, None);
+        assert_eq!(aco.heuristic.unwrap().epochs, Some(300));
     }
 
     #[test]

--- a/teeline-api/src/openapi.rs
+++ b/teeline-api/src/openapi.rs
@@ -60,6 +60,7 @@ impl Modify for SecurityAddon {
         request::GaConfig,
         request::CsConfig,
         request::FpaConfig,
+        request::AcoConfig,
         request::SomConfig,
         request::FourierConfig,
         request::SolverConfigs,

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -6,8 +6,9 @@ use teeline::tsp::kdtree::KDPoint;
 use teeline::tsp::pipeline::{PipelineStage, run_pipeline_stages, stage_warnings};
 use teeline::tsp::tsplib;
 use teeline::tsp::{
-    AppOptions, CSOptions, DistanceType, FPAOptions, FourierOptions, GAOptions, HeuristicOptions,
-    LKOptions, SAOptions, SOMOptions, Solvers, TspProblem, find_solver, solve_problem,
+    AcoOptions, AppOptions, CSOptions, DistanceType, FPAOptions, FourierOptions, GAOptions,
+    HeuristicOptions, LKOptions, SAOptions, SOMOptions, Solvers, TspProblem, find_solver,
+    solve_problem,
 };
 
 use super::TspSolverService;
@@ -140,6 +141,26 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
         }
     });
 
+    // ACO embeds its own HeuristicOptions, but AcoOptions::default() overrides epochs to 150
+    // (the global HeuristicOptions default of 10_000 would take minutes per run at ACO's
+    // O(ants * n²) per-epoch cost). So map onto ACO's own default — like the LK block above —
+    // rather than map_heuristic, which would re-introduce the 10_000 default and the hang
+    // AcoOptions::default()'s doc comment warns about.
+    let aco = cfg.aco.as_ref().map(|c| {
+        let d = AcoOptions::default();
+        AcoOptions {
+            heuristic: c
+                .heuristic
+                .as_ref()
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
+                .unwrap_or(d.heuristic),
+            alpha: c.alpha.unwrap_or(d.alpha),
+            beta: c.beta.unwrap_or(d.beta),
+            evaporation_rate: c.evaporation_rate.unwrap_or(d.evaporation_rate),
+            num_ants: c.num_ants.unwrap_or(d.num_ants),
+        }
+    });
+
     let lk = cfg.lk.as_ref().map(|c| {
         let d = LKOptions::default();
         LKOptions {
@@ -182,9 +203,7 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
         lk,
         fourier,
         som,
-        // ACO has no API-facing config yet (teeline-api wiring is a follow-up to GH #395,
-        // which shipped core solver + CLI only) — always defaults inside solve_with_context.
-        aco: None,
+        aco,
         heuristic,
     }
 }
@@ -545,5 +564,36 @@ EOF
 
         assert_eq!(via_alias.heuristic.as_ref().unwrap().n_nearest, 7);
         assert_eq!(via_alias.heuristic, via_full_name.heuristic);
+    }
+
+    // AcoOptions::default() overrides epochs to 150 (vs the global HeuristicOptions default of
+    // 10_000) because ACO's O(ants * n²) per-epoch cost would hang at 10_000. The aco mapping
+    // must preserve that override when `epochs` is omitted — i.e. map onto AcoOptions's own
+    // default via map_heuristic_onto, not map_heuristic (which would re-introduce 10_000).
+    #[test]
+    fn test_make_app_options_aco_preserves_default_epochs_when_omitted() {
+        use crate::models::request::AcoConfig;
+
+        let configs = SolverConfigs {
+            aco: Some(AcoConfig {
+                heuristic: None,
+                alpha: None,
+                beta: Some(3.0),
+                evaporation_rate: None,
+                num_ants: Some(40),
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("aco", Some(&configs));
+        let aco = opts.aco.expect("aco config should map through");
+        assert_eq!(
+            aco.heuristic.epochs, 150,
+            "omitting epochs must fall back to ACO's 150 default, not the global 10_000"
+        );
+        assert_eq!(aco.beta, 3.0);
+        assert_eq!(aco.num_ants, 40);
+        assert_eq!(aco.alpha, AcoOptions::default().alpha);
+        assert_eq!(aco.evaporation_rate, AcoOptions::default().evaporation_rate);
     }
 }


### PR DESCRIPTION
## Summary

Exposes the Ant Colony Optimization solver's tunables (`alpha`, `beta`, `evaporation_rate`, `num_ants`, plus `heuristic`) through the teeline-api REST surface. Closes #397.

The `aco` solver itself was fully wired at the core-library/CLI level in #396; this fills in the deferred API layer.

## Changes

- **`models/request.rs`** — new `AcoConfig` DTO (mirrors `CsConfig`/`FpaConfig` derives + `#[serde(skip_serializing_if)]`), and `pub aco: Option<AcoConfig>` on `SolverConfigs`.
- **`services/tsp_service.rs`** — `make_app_options()` now maps `cfg.aco` → `AcoOptions`, replacing the hardcoded `aco: None` placeholder (added in #396 just to keep the workspace compiling).
- **`openapi.rs`** — `AcoConfig` registered in the `components(...)` list so it appears in `/docs` / `/openapi.json`.
- **Tests** — `AcoConfig` serde round-trip; a `make_app_options` unit test guarding the default-preservation behavior (below).

## The non-obvious correctness detail

`AcoOptions::default()` overrides `epochs` to **150** (the global `HeuristicOptions` default is **10_000**) because ACO's `O(ants · n²)` per-epoch cost would take minutes at 10_000. The ACO mapping therefore uses `map_heuristic_onto(h, d.heuristic.clone())` — like the **LK** block — **not** `map_heuristic` (as cs/fpa do). A naive copy of the cs/fpa block would silently re-introduce the 10_000 default and the hang that `AcoOptions::default()`'s doc comment explicitly warns about. The unit test `test_make_app_options_aco_preserves_default_epochs_when_omitted` locks this in.

## On validation (decision recorded in #397 planning)

Following the existing pattern, `make_app_options()` does **not** call `AcoOptions::validate()` — neither do the `sa`/`ga`/`cs`/`fpa`/`lk` blocks, and the core's solve dispatch doesn't call `XOptions::validate()` either (only the CLI/`from_toml` path does). So invalid ACO params via the API currently reach the solver unguarded. This is a pre-existing, cross-cutting gap — fixing it for all solvers is tracked in **#412**, not done ACO-only here.

## Out of scope / no change

- **`/api/v1/solvers`** already includes `aco` — `SolverRegistry` reads `list_solvers()` directly, no hardcoded list.
- **`AppOptions.aco: None`** already works at the core (`unwrap_or_default()` at `mod.rs:1655`), so "run aco with defaults" was already functional; this PR adds the ability to *tune* it.

## Verification

- [x] `cargo build -p teeline-api` — clean
- [x] `cargo test -p teeline-api` — all pass (incl. the 2 new tests: `solve_request_with_aco_config_round_trip`, `test_make_app_options_aco_preserves_default_epochs_when_omitted`)
- [x] `cargo clippy -p teeline-api --all-targets -- -D warnings` — clean
- [x] Pre-commit hooks (cargo fmt, clippy) passed

## Related

- #412 — cross-solver API param validation (filed from this issue's planning)
- #398 — ACO tunables via WASM WIT (the WASM-side equivalent of this API work)