### PR TITLE
docs: sync stale solver tables (add gec/aco rows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,18 +245,25 @@ done
 | Bellman–Held–Karp | `bhk` | exact | [→](docs/algorithms/bellman-held-karp.md) |
 | Branch and Bound | `branch_bound` | exact | [→](docs/algorithms/branch-bound.md) |
 | Nearest Neighbor | `nn` | heuristic — constructive | [→](docs/algorithms/nearest-neighbor.md) |
+| Christofides | `christofides`, `chr` | heuristic — constructive | [→](docs/algorithms/christofides.md) |
+| Greedy Edge | `greedy_edge`, `gec` | heuristic — constructive | [→](docs/algorithms/greedy-edge.md) |
+| Fourier | `fourier` | heuristic — constructive | [→](docs/algorithms/fourier.md) |
+| Kohonen SOM | `som` | heuristic — constructive | [→](docs/algorithms/som.md) |
 | 2-opt | `2opt` | heuristic — local search | [→](docs/algorithms/two-opt.md) |
 | 3-opt | `3opt` | heuristic — local search | [→](docs/algorithms/three-opt.md) |
+| Or-opt | `or_opt`, `or-opt` | heuristic — local search | [→](docs/algorithms/or-opt.md) |
 | Stochastic Hill Climbing | `stochastic_hill` | heuristic — local search | [→](docs/algorithms/stochastic-hill.md) |
+| Lin-Kernighan | `lin_kernighan`, `lk` | heuristic — local search | [→](docs/algorithms/lin-kernighan.md) |
 | Simulated Annealing | `sa` | heuristic — local search | [→](docs/algorithms/simulated-annealing.md) |
-| Tabu Search | `tabu_search` | heuristic — local search | [→](docs/algorithms/tabu-search.md) |
+| Tabu Search | `tabu_search`, `tabu` | heuristic — local search | [→](docs/algorithms/tabu-search.md) |
 | Genetic Algorithm | `ga` | heuristic — evolutionary | [→](docs/algorithms/genetic-algorithm.md) |
 | Particle Swarm | `pso` | heuristic — swarm | [→](docs/algorithms/particle-swarm.md) |
+| Gravitational Search | `gsa` | heuristic — swarm / physics | [→](docs/algorithms/gravitational-search.md) |
 | Cuckoo Search | `cs` | heuristic — nature-inspired | [→](docs/algorithms/cuckoo-search.md) |
 | Flower Pollination | `fpa` | heuristic — nature-inspired | [→](docs/algorithms/flower-pollination.md) |
-| Gravitational Search | `gsa` | heuristic — swarm / physics | [→](docs/algorithms/gravitational-search.md) |
+| Ant Colony Optimization | `ant_colony`, `aco` | heuristic — nature-inspired | [→](docs/algorithms/ant-colony.md) |
 
-Exact algorithms find the provably optimal tour but have exponential complexity — do not use on more than ~20 cities. See [docs/benchmarks.md](docs/benchmarks.md) for a quality and speed comparison of all heuristics.
+Exact algorithms find the provably optimal tour but have exponential complexity — do not use on more than ~20 cities. See [docs/benchmarks.md](docs/benchmarks.md) for a quality and speed comparison of all heuristics. (`savings`/`sav` is implemented but not yet documented.)
 
 ## Pipeline
 
@@ -270,9 +277,9 @@ Auto-expansion strategy depends on the solver type:
 
 | Solver type | Auto-expands to | Why |
 | --- | --- | --- |
-| **Deterministic local search** (2opt, 3opt, tabu) | `pipeline(nn, solver)` | Monotone hill-climbers: better start = better end |
-| **Stochastic** (sa, stochastic_hill, ga, pso, cs, fpa) | `pipeline(shuffle, solver)` | Temperature/diversity schedules are calibrated for cold starts; NN start constrains early exploration |
-| **Constructive** (nn, bhk, branch_bound) | no expansion | They build a tour from scratch |
+| **Deterministic local search** (2opt, 3opt, tabu, or_opt, lk, branch_bound) | `pipeline(nn, solver)` | Monotone hill-climbers (and B&B's upper bound) benefit from a good start |
+| **Stochastic** (sa, stochastic_hill, ga, pso, cs, fpa, gsa, fourier, aco) | `pipeline(shuffle, solver)` | Temperature/diversity schedules are calibrated for cold starts; NN start constrains early exploration |
+| **Constructive** (nn, christofides, greedy_edge, bhk) | no expansion | They build a tour from scratch |
 
 ```bash
 # sa auto-expands to pipeline(shuffle, sa)
@@ -385,7 +392,7 @@ Quick summary (pipeline presets first, then standalone `--no-seed` baselines):
 | Flower Pollination (default) | +17.5 % | 0.53 s |
 | Nearest Neighbour | +19.0 % | 0.01 s |
 
-> **Note:** Stochastic solvers (sa, ga, pso, cs, fpa, stochastic_hill) auto-expand to `pipeline(shuffle, solver)`. Use `--no-seed` to skip the shuffle and run from input city order. Use `teeline solve classic` for the best SA result via `nn → 2opt → sa`.
+> **Note:** Stochastic solvers (sa, stochastic_hill, ga, pso, cs, fpa, gsa, fourier, aco) auto-expand to `pipeline(shuffle, solver)`. Use `--no-seed` to skip the shuffle and run from input city order. Use `teeline solve classic` for the best SA result via `nn → 2opt → sa`.
 
 ---
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -28,23 +28,34 @@ world solver {
 ### Solver names
 
 | Name(s) | Algorithm |
-|---|---|
-| `sa`, `simulated_annealing` | Simulated Annealing |
-| `2opt`, `two_opt` | 2-opt local search |
-| `nn`, `nearest_neighbor` | Nearest Neighbor |
-| `ga`, `genetic_algorithm` | Genetic Algorithm |
-| `pso`, `particle_swarm` | Particle Swarm Optimisation |
-| `cs`, `cuckoo_search` | Cuckoo Search |
-| `fpa`, `flower_pollination` | Flower Pollination Algorithm |
-| `tabu_search` | Tabu Search |
-| `stochastic_hill` | Stochastic Hill Climbing |
+| --- | --- |
 | `bhk`, `bellman_karp` | Bellman–Held–Karp (**exact — ≤ 20 cities**) |
 | `branch_bound` | Branch and Bound (**exact — ≤ 20 cities**) |
+| `nn`, `nearest_neighbor` | Nearest Neighbor |
+| `christofides`, `chr` | Christofides (≤1.5× approximation) |
+| `savings`, `sav` | Savings (Clarke-Wright-inspired constructive) |
+| `greedy_edge`, `gec` | Greedy Edge Construction |
+| `fourier` | Fourier-basis constructive |
+| `som`, `kohonen_som` | Kohonen Self-Organizing Map |
+| `2opt`, `two_opt` | 2-opt local search |
+| `3opt`, `three_opt` | 3-opt local search |
+| `or_opt`, `or-opt` | Or-opt local search |
+| `stochastic_hill` | Stochastic Hill Climbing |
+| `lk`, `lin_kernighan` | Lin-Kernighan |
+| `sa`, `simulated_annealing` | Simulated Annealing |
+| `tabu_search`, `tabu` | Tabu Search |
+| `ga`, `genetic_algorithm` | Genetic Algorithm |
+| `pso`, `particle_swarm` | Particle Swarm Optimisation |
+| `gsa`, `gravitational_search` | Gravitational Search |
+| `cs`, `cuckoo_search` | Cuckoo Search |
+| `fpa`, `flower_pollination` | Flower Pollination Algorithm |
+| `aco`, `ant_colony` | Ant Colony Optimization |
+| `shuffle`, `random_shuffle` | Random shuffle (utility — baseline seed only) |
 
 ### Default solve-options
 
 | Field | Default | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `epochs` | 10 000 | Maximum iterations |
 | `platoo-epochs` | 500 | Iterations without improvement before restart |
 | `cooling-rate` | 0.0001 | SA temperature decay per step |
@@ -74,6 +85,7 @@ cargo component build --manifest-path teeline-wasm/Cargo.toml --release
 ```
 
 Artifacts:
+
 - Debug: `target/wasm32-wasip1/debug/teeline_wasm.wasm`
 - Release: `target/wasm32-wasip1/release/teeline_wasm.wasm`
 


### PR DESCRIPTION
## Summary

Fixes the stale solver documentation flagged in #401. Adds the missing `greedy_edge`/`gec` and `ant_colony`/`aco` rows and, while in the same tables, syncs several other entries that had drifted from the actual solver list.

## Changes

### `README.md`

**Algorithms table** — was missing 7 documented solvers. Added `greedy_edge` (gec) and `ant_colony` (aco) per the issue, plus `christofides`, `fourier`, `som`, `or_opt`, and `lk` so the table matches the `teeline solvers` CLI output (every row links to an existing `docs/algorithms/*.md` page). Added a note that `savings`/`sav` is implemented but not yet documented.

**Auto-expansion table** — corrected to match the actual `auto_expand_with_nn` / `auto_expand_with_shuffle` code (`src/tsp/mod.rs:129-157`):
- **Stochastic** row gains `gsa`, `fourier`, `aco` (all `auto_expand_with_shuffle`).
- **Deterministic** row gains `or_opt`, `lk`, `branch_bound` (all `auto_expand_with_nn`).
- `branch_bound` was misclassified as "Constructive / no expansion" — it actually auto-expands with NN (used as an upper-bound seed), so it moves up a row.
- `gec` is a parameter-free constructor and correctly stays out of the shuffle list. *(Note: the issue body's parenthetical "gec auto-expands with NN, not shuffle" is itself slightly off — `gec` is in **neither** list; it builds from scratch and needs no seed. The actionable conclusion — add `aco`, not `gec`, to the shuffle list — is correct, which is what this PR implements.)*

**Pipeline prose note** (~line 388) — updated the stochastic-solver list to match the table.

### `docs/wasm.md`

**Solver-names table** — was missing 10 entries. Added `3opt`, `or_opt`, `christofides`, `fourier`, `som`, `gsa`, `gec`, `aco`, `lk`, `savings`, reordered to match the README/CLI grouping, and added `shuffle` (utility). Ran `markdownlint --fix` to satisfy the pre-commit MD060 rule (table-separator spacing) across the file.

## Scope note

The issue's literal scope was gec + aco rows + the docs/wasm.md table. I expanded slightly to make the tables **fully** accurate rather than leaving them half-fixed (e.g. `lk` — a headline solver — was missing from the README table). Flagging in case you'd prefer a narrower change.

## Verification

- [x] All 20 README doc-page links resolve (`docs/algorithms/*.md`).
- [x] `markdownlint README.md docs/wasm.md` — clean (the repo's `markdownlint` CLI v0.49, the same tool the pre-commit hook runs).
- [x] Pre-commit hook passed (markdownlint).
- [x] Auto-expansion table cross-checked against `auto_expand_with_nn` / `auto_expand_with_shuffle` and their unit tests in `src/tsp/mod.rs`.

## Out of scope / related

- `docs/wasm.md`'s **Default solve-options** table will need `alpha`/`beta`/`evaporation-rate`/`num-ants` once #398 (PR #415) merges — not added here to avoid documenting an unmerged WIT change. Worth a tiny follow-up post-merge.
- `savings`/`sav` has no docs page yet (separate from its web follow-up #408).