### PR TITLE
Add savings to teeline-web nav-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [package]
 name = "teeline"
-version = "1.0.11"
+version = "1.0.12"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/timgluz/teeline"

--- a/teeline-api/Cargo.toml
+++ b/teeline-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teeline-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 repository = "https://github.com/timgluz/teeline"

--- a/teeline-api/tests/hurl/health.hurl
+++ b/teeline-api/tests/hurl/health.hurl
@@ -3,7 +3,7 @@ HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.status" == "ok"
-jsonpath "$.version" == "0.1.0"
+jsonpath "$.version" == "0.1.1"
 
 GET http://127.0.0.1:8080/healthz
 HTTP 200

--- a/teeline-cli/Cargo.toml
+++ b/teeline-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teeline-cli"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2024"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 repository = "https://github.com/timgluz/teeline"

--- a/teeline-wasm/Cargo.toml
+++ b/teeline-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "teeline-wasm"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 
 [lib]

--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { SOLVER_META, SOLVER_GROUPS, PAGED_SOLVERS, EXPLAINER_SOLVERS } from './nav-data'
 
 describe('SOLVER_META', () => {
-  it('contains exactly 20 solvers', () => {
-    expect(Object.keys(SOLVER_META)).toHaveLength(20)
+  it('contains exactly 21 solvers', () => {
+    expect(Object.keys(SOLVER_META)).toHaveLength(21)
   })
 
   it('every entry has id and name', () => {

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -28,6 +28,7 @@ export const SOLVER_META: Record<string, SolverMeta> = {
   gsa: { id: 'gsa', name: 'Gravitational Search' },
   som: { id: 'som', name: 'Kohonen SOM' },
   aco: { id: 'aco', name: 'Ant Colony Optimization' },
+  savings: { id: 'savings', name: 'Savings' },
 }
 
 export interface SolverGroup {
@@ -37,7 +38,7 @@ export interface SolverGroup {
 
 export const SOLVER_GROUPS: SolverGroup[] = [
   { label: 'Exact', ids: ['bhk', 'branch_bound'] },
-  { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'som'] },
+  { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'savings', 'som'] },
   { label: 'Local search', ids: ['2opt', '3opt', 'or_opt', 'stochastic_hill', 'lk'] },
   { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa', 'aco'] },
 ]


### PR DESCRIPTION
## Summary

Wires the `savings`/`sav` solver (shipped in #402, doc page in #403) into teeline-web's navigation metadata so `/algorithms/savings/` is reachable from the sidebar and AlgorithmCards. Also bumps workspace versions to trigger a WASM re-release, fixing the production solver dropdown (which was serving a stale `SOLVER_LIST` from the last release).

Closes #404. Closes #405.

## Changes

- `nav-data.ts` — add `savings: { id: 'savings', name: 'Savings' }` to `SOLVER_META`; add `'savings'` to the `Constructive` `SOLVER_GROUPS` entry.
- `nav-data.test.ts` — bump the pinned `SOLVER_META` count from 20 → 21.
- `Cargo.toml`, `teeline-cli/Cargo.toml`, `teeline-wasm/Cargo.toml`, `teeline-api/Cargo.toml` — bump all four package versions (1.0.11 → 1.0.12, 0.2.1 → 0.2.2, 0.1.0 → 0.1.1) so the next tagged release (e.g. `v1.0.12`) triggers a rebuild of the WASM component with the full 22-solver `SOLVER_LIST`.

`EXPLAINER_SOLVERS` intentionally not touched (no interactive explainer for savings; the `hasExplainer: false` frontmatter in `docs/algorithms/savings.md` is correct).

## On the production solver dropdown

The deploy-web workflow (`deploy-web.yml`) downloads the WASM component from the **latest GitHub release** — not from the source. Since no release has been cut since `gec`/`aco`/`savings` were added to `SOLVER_LIST`, the production dropdown at tspsolver.com was serving a stale solver list missing those three. The version bump addresses this. After merging, pushing a semver tag triggers the release workflow, which rebuilds the WASM and attaches it to a new GitHub release; the next deploy-web run picks it up automatically.

## Note on the issue's stale naming

Issue #404 was written before the solver was renamed from `cw`/`clarke_wright` to `savings`/`sav` in #402 (commit `9529891`). The id/name/alias used here reflect the actual current naming (`savings`/`Savings`), not the issue's original `cw`/`Clarke-Wright` references. Issue #405 (also closed) references the same stale `cw` name.

## Cross-verification (per your request)

Checked nav-data against the full `teeline solvers` CLI list (22 entries total):

| In CLI | In nav-data? | Has docs page? |
|---|---|---|
| `savings`/`sav` | **no (this PR adds it)** | yes (`docs/algorithms/savings.md`) |
| `random_shuffle`/`shuffle` | no | no (utility; correctly excluded) |
| All 20 others | yes | yes |

**`savings` is the sole gap** — no other documented solvers are missing from nav-data.

## Verification

- [x] 199 tests pass (incl. the bumped `SOLVER_META` count assertion).
- [x] `astro check` + `tsc --noEmit` + `astro build` — clean (39 pages; `/algorithms/savings/` linked from both the sidebar dropdown and the Constructive AlgorithmCard).
- [x] `cargo check` — all four bumped packages compile (taplo, pre-commit passed).
- [x] Pre-commit hooks (tsc, taplo) passed.