### PR TITLE
test(api): add savings solver registry regression test

### DIFF
--- a/teeline-api/src/services/solver_registry.rs
+++ b/teeline-api/src/services/solver_registry.rs
@@ -49,4 +49,16 @@ mod tests {
         assert!(nn.is_some());
         assert_eq!(nn.unwrap().name, "Nearest Neighbor");
     }
+
+    #[test]
+    fn list_contains_savings() {
+        let registry = SolverRegistry;
+        let solvers = registry.list();
+        let sav = solvers.iter().find(|s| s.alias == "sav");
+        assert!(
+            sav.is_some(),
+            "savings/sav must appear in the solver registry"
+        );
+        assert_eq!(sav.unwrap().name, "Savings");
+    }
 }


### PR DESCRIPTION
## Summary

Adds a regression test confirming the `savings`/`sav` solver appears in the teeline-api solver registry automatically — no API-side plumbing needed. Closes #406.

The solver registry (`solver_registry.rs:13`) reads `teeline::tsp::list_solvers()` dynamically, so every new core solver (including `savings` added in #402) appears in `/api/v1/solvers` without any registries to update. This issue existed mainly to prove that property and add a regression guard.

## Change

- `solver_registry.rs` tests — new `list_contains_savings` test, mirroring the existing `list_contains_nn`, asserting that the dynamic registry returns `savings`/`sav` with the expected name.

## Note on naming

The issue references `cw`/`clarke_wright` — the original naming from before #402's rename to `savings`/`sav`. The test uses the actual current alias (`sav`) and name (`Savings`), not the stale `cw`/`Clarke-Wright`.

## Why no other changes

Both paths are fully dynamic:
- The **registry** (`list()`) maps over `list_solvers()` — new solvers appear automatically.
- The **solve path** resolves via `find_solver` — new aliases are accepted automatically.
- There is **no** hardcoded solver count in `solver_registry.rs` (the test only checks non-empty + contains specific entries), so no count bump is needed.

## Verification

- [x] `cargo test -p teeline-api` — 48 passed; `list_contains_savings` returns `sav`/`Savings`.
- [x] Pre-commit (cargo fmt, cargo clippy) passed.