### PR TITLE
Add ACO interactive explainer

### DIFF
--- a/docs/algorithms/ant-colony.md
+++ b/docs/algorithms/ant-colony.md
@@ -3,7 +3,7 @@ id: "aco"
 name: "Ant Colony Optimization"
 typeBadge: "Heuristic — nature-inspired metaheuristic"
 description: "Nature-inspired metaheuristic (Ant System, Dorigo 1996) that models pheromone-trail foraging in ant colonies. Maintains a shared pheromone matrix across a colony of ants. Each epoch:"
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Ant Colony Optimization

--- a/teeline-web/src/explainers/aco-algo.ts
+++ b/teeline-web/src/explainers/aco-algo.ts
@@ -9,7 +9,7 @@ export const CITIES: [number, number][] = [
   [250, 55],
   [260, 245],
   [40, 245],
-  [150, 150],
+  [150, 110],
 ]
 export const N_CITIES = CITIES.length
 
@@ -73,15 +73,6 @@ export function tourLength(tour: number[]): number {
   return d
 }
 
-function shuffle(n: number): number[] {
-  const t = Array.from({ length: n }, (_, i) => i)
-  for (let i = n - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[t[i], t[j]] = [t[j], t[i]]
-  }
-  return t
-}
-
 // Roulette-wheel construction: starting from a random city, each next city is
 // chosen probabilistically weighted by pheromone^alpha * eta^beta among unvisited
 // cities. Falls back to first-unvisited if all weights are zero (matching the
@@ -135,8 +126,9 @@ export function makeInitState(
   for (let i = 0; i < N_CITIES; i++) pheromone[i][i] = 0
   const eta = computeEta(beta)
 
-  // seed with one random tour to get a non-trivial best
-  const initTour = shuffle(N_CITIES)
+  // seed with identity tour — a clean clockwise perimeter order that
+  // the ACO colony will refine from (random can produce crossings)
+  const initTour = Array.from({ length: N_CITIES }, (_, i) => i)
   const initCost = tourLength(initTour)
 
   return {

--- a/teeline-web/src/explainers/aco-algo.ts
+++ b/teeline-web/src/explainers/aco-algo.ts
@@ -1,0 +1,233 @@
+// Pure simulation logic for the Ant Colony Optimization explainer.
+// One "step" builds one ant's tour (like CS processes one nest per cuckoo event);
+// after numAnts ants finish, the between-epoch phase evaporates + deposits pheromone
+// and advances the epoch. Mirrors the Rust `ant_colony.rs` Ant System loop
+// (construct -> best-update -> evaporate -> deposit).
+
+export const CITIES: [number, number][] = [
+  [60, 40],
+  [240, 50],
+  [270, 160],
+  [220, 260],
+  [60, 250],
+  [30, 140],
+  [150, 150],
+]
+export const N_CITIES = CITIES.length
+
+export type Phase = 'building' | 'depositing'
+export type EventMode = 'ant-built' | 'improved' | 'evaporated' | 'deposited'
+
+export type SimState = {
+  phase: Phase
+  antIdx: number            // 0..numAnts — which ant is building now (building phase only)
+  epoch: number
+  pheromone: number[][]     // symmetric NxN; pheromone[i][j] = pheromone[j][i]
+  eta: number[][]           // precomputed (1/dist)^beta; symmetric
+  alpha: number
+  beta: number
+  evaporationRate: number
+  numAnts: number
+  tau0: number
+  tauMin: number
+  bestTour: number[]
+  bestCost: number
+  lastTours: number[][]     // tours built this epoch (cleared after deposit)
+  lastEvent: EventMode | null
+  lastTour: number[] | null // most recently built tour (for canvas highlight)
+  costHistory: number[]     // epoch-best costs
+  step: number
+}
+
+export function dist(i: number, j: number): number {
+  const [x1, y1] = CITIES[i]
+  const [x2, y2] = CITIES[j]
+  return Math.hypot(x2 - x1, y2 - y1)
+}
+
+function averageDistance(): number {
+  let sum = 0, count = 0
+  for (let i = 0; i < N_CITIES; i++)
+    for (let j = i + 1; j < N_CITIES; j++)
+      { sum += dist(i, j); count++ }
+  return sum / count
+}
+
+function computeEta(beta: number): number[][] {
+  const eta: number[][] = Array.from({ length: N_CITIES }, () => new Array(N_CITIES))
+  for (let i = 0; i < N_CITIES; i++) {
+    eta[i][i] = 0
+    for (let j = i + 1; j < N_CITIES; j++) {
+      const v = (1 / Math.max(dist(i, j), 1e-6)) ** beta
+      eta[i][j] = v
+      eta[j][i] = v
+    }
+  }
+  return eta
+}
+
+export function tourLength(tour: number[]): number {
+  if (tour.length <= 1) return 0
+  let d = 0
+  for (let i = 0; i < tour.length; i++) {
+    d += dist(tour[i], tour[(i + 1) % tour.length])
+  }
+  return d
+}
+
+function shuffle(n: number): number[] {
+  const t = Array.from({ length: n }, (_, i) => i)
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[t[i], t[j]] = [t[j], t[i]]
+  }
+  return t
+}
+
+// Roulette-wheel construction: starting from a random city, each next city is
+// chosen probabilistically weighted by pheromone^alpha * eta^beta among unvisited
+// cities. Falls back to first-unvisited if all weights are zero (matching the
+// Rust solver's graceful underflow guard).
+function buildTour(pheromone: number[][], eta: number[][], alpha: number, _beta: number): number[] {
+  const unvisited = new Set(Array.from({ length: N_CITIES }, (_, i) => i))
+  const start = Math.floor(Math.random() * N_CITIES)
+  unvisited.delete(start)
+  const tour: number[] = [start]
+
+  while (unvisited.size > 0) {
+    const current = tour[tour.length - 1]
+    const candidates = Array.from(unvisited)
+    const weights = candidates.map(j => {
+      const p = Math.max(pheromone[current][j], 1e-30)
+      const e = eta[current][j]
+      return (p ** alpha) * e
+    })
+    const total = weights.reduce((s, w) => s + w, 0)
+
+    let next = candidates[candidates.length - 1]
+    if (total <= 0 || !isFinite(total)) {
+      // underflow / overflow → first unvisited (next already defaults above)
+    } else {
+      let r = Math.random() * total
+      for (let k = 0; k < candidates.length; k++) {
+        r -= weights[k]
+        if (r <= 0) { next = candidates[k]; break }
+      }
+    }
+    tour.push(next)
+    unvisited.delete(next)
+  }
+  return tour
+}
+
+export function maxPheromone(s: SimState): number {
+  let m = 0
+  for (let i = 0; i < N_CITIES; i++)
+    for (let j = i + 1; j < N_CITIES; j++)
+      if (s.pheromone[i][j] > m) m = s.pheromone[i][j]
+  return m
+}
+
+export function makeInitState(
+  alpha: number, beta: number, evaporationRate: number, numAnts: number,
+): SimState {
+  const avgDist = averageDistance()
+  const tau0 = numAnts / avgDist
+  const pheromone: number[][] = Array.from({ length: N_CITIES }, () => new Array(N_CITIES).fill(tau0))
+  for (let i = 0; i < N_CITIES; i++) pheromone[i][i] = 0
+  const eta = computeEta(beta)
+
+  // seed with one random tour to get a non-trivial best
+  const initTour = shuffle(N_CITIES)
+  const initCost = tourLength(initTour)
+
+  return {
+    phase: 'building',
+    antIdx: 0,
+    epoch: 0,
+    pheromone,
+    eta,
+    alpha,
+    beta,
+    evaporationRate,
+    numAnts,
+    tau0,
+    tauMin: tau0 * 1e-4,
+    bestTour: initTour.slice(),
+    bestCost: initCost,
+    lastTours: [],
+    lastEvent: null,
+    lastTour: null,
+    costHistory: [],
+    step: 0,
+  }
+}
+
+export function stepOnce(s: SimState): SimState {
+  if (s.phase === 'building') {
+    // Build one ant's tour
+    const tour = buildTour(s.pheromone, s.eta, s.alpha, s.beta)
+    const cost = tourLength(tour)
+    const newLastTours = [...s.lastTours, tour]
+    const improved = cost < s.bestCost
+    const nextAnt = s.antIdx + 1
+
+    // Last ant of this epoch → transition to depositing
+    if (nextAnt >= s.numAnts) {
+      return {
+        ...s,
+        phase: 'depositing',
+        antIdx: 0,
+        lastTours: newLastTours,
+        lastEvent: improved ? 'improved' : 'ant-built',
+        lastTour: tour,
+        bestTour: improved ? tour.slice() : s.bestTour,
+        bestCost: improved ? cost : s.bestCost,
+        step: s.step + 1,
+      }
+    }
+
+    return {
+      ...s,
+      antIdx: nextAnt,
+      lastTours: newLastTours,
+      lastEvent: improved ? 'improved' : 'ant-built',
+      lastTour: tour,
+      bestTour: improved ? tour.slice() : s.bestTour,
+      bestCost: improved ? cost : s.bestCost,
+      step: s.step + 1,
+    }
+  }
+
+  // Phase === 'depositing': evaporate + deposit, then advance epoch
+  const rate = s.evaporationRate
+  const newPheromone = s.pheromone.map(row => row.map(p => {
+    const evap = p * (1 - rate)
+    return Math.max(evap, s.tauMin)
+  }))
+
+  // Deposit from each ant's tour
+  for (const tour of s.lastTours) {
+    const deposit = 1 / tourLength(tour)
+    for (let k = 0; k < tour.length; k++) {
+      const u = tour[k], v = tour[(k + 1) % tour.length]
+      newPheromone[u][v] += deposit
+      newPheromone[v][u] += deposit
+    }
+  }
+
+  const newEpoch = s.epoch + 1
+
+  return {
+    ...s,
+    phase: 'building',
+    antIdx: 0,
+    epoch: newEpoch,
+    pheromone: newPheromone,
+    lastTours: [],
+    lastEvent: 'deposited',
+    lastTour: null,
+    costHistory: [...s.costHistory.slice(-59), s.bestCost],
+    step: s.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/aco-algo.ts
+++ b/teeline-web/src/explainers/aco-algo.ts
@@ -5,11 +5,9 @@
 // (construct -> best-update -> evaporate -> deposit).
 
 export const CITIES: [number, number][] = [
-  [50, 55],
-  [250, 55],
-  [260, 245],
-  [40, 245],
-  [150, 110],
+  [45, 45], [155, 18], [265, 45], [285, 150],
+  [255, 265], [150, 285], [40, 260], [18, 150],
+  [110, 115], [200, 95], [220, 210], [95, 215],
 ]
 export const N_CITIES = CITIES.length
 

--- a/teeline-web/src/explainers/aco-algo.ts
+++ b/teeline-web/src/explainers/aco-algo.ts
@@ -5,12 +5,10 @@
 // (construct -> best-update -> evaporate -> deposit).
 
 export const CITIES: [number, number][] = [
-  [60, 40],
-  [240, 50],
-  [270, 160],
-  [220, 260],
-  [60, 250],
-  [30, 140],
+  [50, 55],
+  [250, 55],
+  [260, 245],
+  [40, 245],
   [150, 150],
 ]
 export const N_CITIES = CITIES.length

--- a/teeline-web/src/explainers/aco.test.ts
+++ b/teeline-web/src/explainers/aco.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, tourLength,
+  makeInitState, stepOnce, maxPheromone,
+} from './aco-algo'
+
+describe('makeInitState', () => {
+  it('starts in building phase with antIdx=0', () => {
+    const s = makeInitState(1, 2, 0.5, 10)
+    expect(s.phase).toBe('building')
+    expect(s.antIdx).toBe(0)
+    expect(s.epoch).toBe(0)
+  })
+
+  it('pheromone matrix is symmetric and tau0 on all off-diagonal edges', () => {
+    const s = makeInitState(1, 2, 0.5, 10)
+    const tau0 = s.tau0
+    expect(tau0).toBeGreaterThan(0)
+    for (let i = 0; i < N_CITIES; i++) {
+      expect(s.pheromone[i][i]).toBe(0)
+      for (let j = i + 1; j < N_CITIES; j++) {
+        expect(s.pheromone[i][j]).toBeCloseTo(tau0, 0)
+        expect(s.pheromone[i][j]).toBe(s.pheromone[j][i])
+      }
+    }
+  })
+
+  it('best tour is a valid permutation', () => {
+    const s = makeInitState(1, 2, 0.5, 10)
+    const sorted = s.bestTour.slice().sort((a, b) => a - b)
+    expect(sorted).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+  })
+
+  it('starts with empty lastTours', () => {
+    const s = makeInitState(1, 2, 0.5, 10)
+    expect(s.lastTours).toHaveLength(0)
+    expect(s.lastTour).toBeNull()
+  })
+})
+
+describe('stepOnce', () => {
+  it('transitions to depositing after numAnts ants', () => {
+    const numAnts = 5
+    let s = makeInitState(1, 2, 0.5, numAnts)
+    for (let i = 0; i < numAnts; i++) s = stepOnce(s)
+    expect(s.phase).toBe('depositing')
+    expect(s.lastTours).toHaveLength(numAnts)
+  })
+
+  it('after depositing, advances epoch and returns to building', () => {
+    const numAnts = 3
+    let s = makeInitState(1, 2, 0.5, numAnts)
+    for (let i = 0; i < numAnts; i++) s = stepOnce(s)  // build all ants
+    expect(s.phase).toBe('depositing')
+    s = stepOnce(s)  // deposit
+    expect(s.phase).toBe('building')
+    expect(s.epoch).toBe(1)
+    expect(s.antIdx).toBe(0)
+    expect(s.lastTours).toHaveLength(0)
+  })
+
+  it('best cost never increases (monotonic)', () => {
+    let s = makeInitState(1, 2, 0.5, 5)
+    for (let i = 0; i < 40; i++) {
+      const prev = s.bestCost
+      s = stepOnce(s)
+      expect(s.bestCost).toBeLessThanOrEqual(prev + 0.001)
+    }
+  })
+
+  it('built tours are valid permutations', () => {
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    let s = makeInitState(1, 2, 0.5, 8)
+    for (let i = 0; i < 8; i++) s = stepOnce(s)
+    for (const tour of s.lastTours) {
+      expect(tour.slice().sort((a, b) => a - b)).toEqual(expected)
+    }
+  })
+
+  it('pheromone floor (tauMin) is respected after evaporation', () => {
+    const evap = 0.9
+    let s = makeInitState(1, 2, evap, 3)
+    for (let i = 0; i < 3; i++) s = stepOnce(s)  // build
+    s = stepOnce(s)  // deposit (evaporate happens here)
+    for (let i = 0; i < N_CITIES; i++) {
+      for (let j = i + 1; j < N_CITIES; j++) {
+        expect(s.pheromone[i][j]).toBeGreaterThanOrEqual(s.tauMin - 1e-12)
+      }
+    }
+  })
+})
+
+describe('maxPheromone', () => {
+  it('is positive after a deposit phase', () => {
+    let s = makeInitState(1, 2, 0.5, 5)
+    for (let i = 0; i < 5; i++) s = stepOnce(s)
+    s = stepOnce(s)
+    expect(maxPheromone(s)).toBeGreaterThan(0)
+  })
+})
+
+describe('tourLength', () => {
+  it('computes a closed-loop distance', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6]
+    expect(tourLength(tour)).toBeGreaterThan(0)
+  })
+})

--- a/teeline-web/src/explainers/aco.test.ts
+++ b/teeline-web/src/explainers/aco.test.ts
@@ -101,7 +101,7 @@ describe('maxPheromone', () => {
 
 describe('tourLength', () => {
   it('computes a closed-loop distance', () => {
-    const tour = [0, 1, 2, 3, 4, 5, 6]
+    const tour = [0, 1, 2, 3, 4]
     expect(tourLength(tour)).toBeGreaterThan(0)
   })
 })

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -132,7 +132,9 @@ function PheromoneHeatmap({ pheromone, maxP }: { pheromone: number[][]; maxP: nu
               width={cell - 1.5} height={cell - 1.5}
               fill={`rgb(${r},${g},${b})`}
               rx={1.5}
-            />
+            >
+              <title>{i}–{j}  {(ratio * 100).toFixed(0)}%</title>
+            </rect>
           )
         })
       )}

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -12,11 +12,6 @@ const AXIS_COLORS = [
 
 const DEFAULTS = { alpha: 1.0, beta: 2.0, evaporationRate: 0.5, numAnts: 10 }
 
-function edgeAlpha(phero: number, maxP: number): number {
-  if (maxP <= 0) return 0.04
-  return 0.04 + (phero / maxP) * 0.75
-}
-
 function cityColor(i: number, onBest: boolean, onLast: boolean): string {
   if (onBest) return "#16a34a"
   if (onLast) return "#ea580c"
@@ -53,28 +48,32 @@ function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasP
     <svg viewBox="0 0 300 300" className="aco-canvas" role="img" aria-label="ACO pheromone map">
       <rect x={0} y={0} width={300} height={300} className="aco-bg" />
 
-      {/* pheromone edges — opacity ∝ pheromone */}
-      {edges.map(([i, j, p], k) => (
-        <line key={"p" + k}
-          x1={CITIES[i][0]} y1={CITIES[i][1]}
-          x2={CITIES[j][0]} y2={CITIES[j][1]}
-          stroke="#0d9488"
-          strokeWidth={1.2 + (p / Math.max(maxP, 1e-9)) * 3.5}
-          opacity={edgeAlpha(p, maxP)}
-          strokeLinecap="round"
-        />
-      ))}
+      {/* pheromone edges — dashed, width ∝ pheromone, subtle teal */}
+      {edges.map(([i, j, p], k) => {
+        const ratio = maxP > 0 ? p / maxP : 0
+        return (
+          <line key={"p" + k}
+            x1={CITIES[i][0]} y1={CITIES[i][1]}
+            x2={CITIES[j][0]} y2={CITIES[j][1]}
+            stroke="#0d9488"
+            strokeWidth={0.6 + ratio * 3.5}
+            opacity={0.08 + ratio * 0.55}
+            strokeLinecap="round"
+            strokeDasharray={ratio > 0.3 ? "6 4" : "3 5"}
+          />
+        )
+      })}
 
-      {/* best tour underlay (faded polygon) */}
+      {/* best tour underlay (faded fill) */}
       <polygon points={bestPts} className="aco-best-area" />
+
+      {/* best tour — thick solid line */}
+      <polyline points={bestPts} className="aco-best-tour" />
 
       {/* last tour (dashed, highlighted) */}
       {lastTour && phase === 'building' && (
         <polyline points={lastPts} className="aco-last-tour" />
       )}
-
-      {/* best tour edges (solid) */}
-      <polyline points={bestPts} className="aco-best-tour" />
 
       {/* cities */}
       {CITIES.map(([x, y], i) => {
@@ -386,8 +385,8 @@ const CSS = `
   border: 1px solid var(--line);
 }
 .aco-bg { fill: var(--panel); }
-.aco-best-area { fill: #dcfce7; stroke: none; opacity: 0.6; }
-.aco-best-tour { fill: none; stroke: var(--improve); stroke-width: 2.8; stroke-linejoin: round; }
+.aco-best-area { fill: #bbf7d0; stroke: none; opacity: 0.5; }
+.aco-best-tour { fill: none; stroke: #16a34a; stroke-width: 3.2; stroke-linejoin: round; }
 .aco-last-tour { fill: none; stroke: var(--last); stroke-width: 1.8; stroke-linejoin: round; stroke-dasharray: 4 3; }
 .aco-city { stroke: #fff; stroke-width: 1.2; }
 .aco-city-label {

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -52,15 +52,18 @@ function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasP
       {/* pheromone edges — dashed, width ∝ pheromone, subtle teal */}
       {edges.map(([i, j, p], k) => {
         const ratio = maxP > 0 ? p / maxP : 0
+        // power curve amplifies small pheromone differences:
+        // ratio 1.0→1.0, 0.9→0.76, 0.5→0.19 — edges that lag behind maxP fade fast
+        const amp = Math.pow(ratio, 0.35)
         return (
           <line key={"p" + k}
             x1={CITIES[i][0]} y1={CITIES[i][1]}
             x2={CITIES[j][0]} y2={CITIES[j][1]}
             stroke="#0d9488"
-            strokeWidth={0.6 + ratio * 3.5}
-            opacity={0.08 + ratio * 0.55}
+            strokeWidth={0.3 + amp * 4.5}
+            opacity={0.04 + amp * 0.72}
             strokeLinecap="round"
-            strokeDasharray={ratio > 0.3 ? "6 4" : "3 5"}
+            strokeDasharray={amp > 0.35 ? "6 4" : "3 6"}
           />
         )
       })}

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -325,14 +325,32 @@ export default function AcoExplainer() {
         </div>
       </div>
 
-      <div className="aco-controls">
-        <button className="aco-btn" onClick={step_fn} disabled={running}>◀ Step</button>
-        <button className={`aco-btn ${!running ? "aco-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}>
-          {running ? "⏸ Pause" : "▶ Run"}
-        </button>
-        <button className="aco-btn" onClick={() => reinit(alpha, beta, evapRate, numAnts)}>↺ Reset</button>
-      </div>
+       <div className="aco-controls">
+         <button className="aco-btn" onClick={step_fn} disabled={running}>◀ Step</button>
+         <button className={`aco-btn ${!running ? "aco-btn-primary" : ""}`}
+           onClick={() => setRunning(r => !r)}>
+           {running ? "⏸ Pause" : "▶ Run"}
+         </button>
+         <button className="aco-btn" onClick={() => reinit(alpha, beta, evapRate, numAnts)}>↺ Reset</button>
+       </div>
+
+       <div className="aco-scenarios">
+         <div className="aco-section-label">Scenarios</div>
+         <div className="aco-scenario-row">
+           {([
+             { label: 'Default', desc: 'balanced α=1.0 β=2.0 ρ=0.50 ants=10', a: 1.0, b: 2.0, e: 0.50, n: 10 },
+             { label: 'Pheromone-heavy', desc: 'high α=3.0 β=1.0 — ants follow existing trails', a: 3.0, b: 1.0, e: 0.30, n: 10 },
+             { label: 'Distance-driven', desc: 'high β=5.0 — ants prioritise short edges', a: 0.5, b: 5.0, e: 0.50, n: 10 },
+             { label: 'Fast evaporation', desc: 'ρ=0.85 — trails fade quickly, more exploration', a: 1.0, b: 2.0, e: 0.85, n: 10 },
+             { label: 'Large colony', desc: 'ants=25 — more deposits per epoch', a: 1.0, b: 2.0, e: 0.50, n: 25 },
+           ] as const).map(s => (
+             <button key={s.label} className="aco-scenario-btn" title={s.desc}
+               onClick={() => { setAlpha(s.a); setBeta(s.b); setEvapRate(s.e); setNumAnts(s.n); reinit(s.a, s.b, s.e, s.n) }}>
+               {s.label}
+             </button>
+           ))}
+         </div>
+       </div>
 
       <footer className="aco-footer">
         <span className="aco-mono">cities: {N_CITIES}</span>
@@ -467,6 +485,21 @@ const CSS = `
 .aco-btn:hover:not(:disabled) { border-color: var(--accent); }
 .aco-btn:disabled { opacity: 0.45; cursor: default; }
 .aco-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+.aco-scenarios { margin-top: 4px; }
+.aco-scenario-row { display: flex; gap: 6px; flex-wrap: wrap; }
+.aco-scenario-btn {
+  background: var(--panel);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+.aco-scenario-btn:hover { border-color: var(--accent); color: var(--text); }
 
 .aco-footer {
   display: flex; flex-wrap: wrap; gap: 14px;

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -1,0 +1,468 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES,
+  tourLength, maxPheromone, makeInitState, stepOnce,
+} from "./aco-algo"
+import type { EventMode } from "./aco-algo"
+
+const AXIS_COLORS = [
+  "#0d9488", "#2563eb", "#7c3aed", "#db2777", "#ea580c",
+  "#16a34a", "#0891b2",
+]
+
+const DEFAULTS = { alpha: 1.0, beta: 2.0, evaporationRate: 0.5, numAnts: 10 }
+
+function edgeAlpha(phero: number, maxP: number): number {
+  if (maxP <= 0) return 0.04
+  return 0.04 + (phero / maxP) * 0.75
+}
+
+function cityColor(i: number, onBest: boolean, onLast: boolean): string {
+  if (onBest) return "#16a34a"
+  if (onLast) return "#ea580c"
+  return AXIS_COLORS[i % AXIS_COLORS.length]
+}
+
+// ---------------------------------------------------------------
+// PheromoneCanvas — edge thickness ∝ pheromone, best-tour overlay
+// ---------------------------------------------------------------
+interface CanvasProps {
+  pheromone: number[][]
+  maxP: number
+  bestTour: number[]
+  lastTour: number[] | null
+  phase: string
+}
+function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasProps) {
+  const bestSet = useMemo(() => new Set(bestTour), [bestTour])
+  const lastSet = useMemo(() => lastTour ? new Set(lastTour) : new Set<number>(), [lastTour])
+
+  const bestPts = bestTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const lastPts = lastTour
+    ? lastTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[lastTour[0]][0]},${CITIES[lastTour[0]][1]}`
+    : ""
+
+  const edges: Array<[number, number, number]> = []
+  for (let i = 0; i < N_CITIES; i++) {
+    for (let j = i + 1; j < N_CITIES; j++) {
+      edges.push([i, j, pheromone[i][j]])
+    }
+  }
+
+  return (
+    <svg viewBox="0 0 300 300" className="aco-canvas" role="img" aria-label="ACO pheromone map">
+      <rect x={0} y={0} width={300} height={300} className="aco-bg" />
+
+      {/* pheromone edges — opacity ∝ pheromone */}
+      {edges.map(([i, j, p], k) => (
+        <line key={"p" + k}
+          x1={CITIES[i][0]} y1={CITIES[i][1]}
+          x2={CITIES[j][0]} y2={CITIES[j][1]}
+          stroke="#0d9488"
+          strokeWidth={1.2 + (p / Math.max(maxP, 1e-9)) * 3.5}
+          opacity={edgeAlpha(p, maxP)}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* best tour underlay (faded polygon) */}
+      <polygon points={bestPts} className="aco-best-area" />
+
+      {/* last tour (dashed, highlighted) */}
+      {lastTour && phase === 'building' && (
+        <polyline points={lastPts} className="aco-last-tour" />
+      )}
+
+      {/* best tour edges (solid) */}
+      <polyline points={bestPts} className="aco-best-tour" />
+
+      {/* cities */}
+      {CITIES.map(([x, y], i) => {
+        const onBest = bestSet.has(i)
+        const onLast = lastSet.has(i)
+        return (
+          <g key={i}>
+            <circle cx={x} cy={y} r={onBest ? 7 : onLast ? 6.5 : 5}
+              fill={cityColor(i, onBest, onLast)}
+              className="aco-city"
+            />
+            <text x={x + 8} y={y - 5} className="aco-city-label">{i}</text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Side panel — epoch, ant progress, pheromone stats
+// ---------------------------------------------------------------
+function SidePanel(props: {
+  epoch: number; phase: string; antIdx: number; numAnts: number;
+  pheromone: number[][]; bestCost: number; alpha: number; beta: number;
+}) {
+  const { epoch, phase, antIdx, numAnts, pheromone, bestCost, alpha, beta } = props
+  let pMin = Infinity, pMax = 0
+  for (let i = 0; i < N_CITIES; i++) {
+    for (let j = i + 1; j < N_CITIES; j++) {
+      const p = pheromone[i][j]
+      if (p < pMin) pMin = p
+      if (p > pMax) pMax = p
+    }
+  }
+
+  return (
+    <div className="aco-sidebar">
+      <div className="aco-side-section">
+        <div className="aco-side-label">epoch</div>
+        <div className="aco-mono">{epoch}</div>
+      </div>
+      <div className="aco-side-section">
+        <div className="aco-side-label">phase</div>
+        <div className="aco-mono">{phase === 'building' ? `🐜 ant ${antIdx + 1}/${numAnts}` : '💨 deposit'}</div>
+      </div>
+      <div className="aco-side-section">
+        <div className="aco-side-label">best cost</div>
+        <div className="aco-mono">{bestCost.toFixed(0)}</div>
+      </div>
+      <div className="aco-side-section">
+        <div className="aco-side-label">pheromone range</div>
+        <div className="aco-mono">{(pMin === Infinity ? 0 : pMin).toFixed(4)} – {pMax.toFixed(4)}</div>
+      </div>
+      <div className="aco-side-section">
+        <div className="aco-side-label">α · β</div>
+        <div className="aco-mono">{alpha.toFixed(1)} · {beta.toFixed(1)}</div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// Cost sparkline
+// ---------------------------------------------------------------
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null
+  const W = 300, H = 54, minC = Math.min(...values), maxC = Math.max(...values)
+  const range = maxC - minC || 1
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W
+    const y = H - ((v - minC) / range) * (H - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="aco-spark">
+      <rect x={0} y={0} width={W} height={H} className="aco-bg" rx={4} />
+      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488" strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function AcoExplainer() {
+  const [alpha, setAlpha] = useState(DEFAULTS.alpha)
+  const [beta, setBeta] = useState(DEFAULTS.beta)
+  const [evapRate, setEvapRate] = useState(DEFAULTS.evaporationRate)
+  const [numAnts, setNumAnts] = useState(DEFAULTS.numAnts)
+  const [speed, setSpeed] = useState(5)
+
+  const simRef = useRef(makeInitState(alpha, beta, evapRate, numAnts))
+  const [pheromone, setPheromone] = useState(() => simRef.current.pheromone)
+  const [epoch, setEpoch] = useState(0)
+  const [phase, setPhase] = useState<"building" | "depositing">(() => simRef.current.phase)
+  const [antIdx, setAntIdx] = useState(0)
+  const [bestTour, setBestTour] = useState<number[]>(() => simRef.current.bestTour.slice())
+  const [bestCost, setBestCost] = useState(() => simRef.current.bestCost)
+  const [lastTour, setLastTour] = useState<number[] | null>(null)
+  const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
+  const [costHistory, setCostHistory] = useState<number[]>([])
+  const [step, setStep] = useState(0)
+  const [running, setRunning] = useState(false)
+
+  const reinit = useCallback((a: number, b: number, e: number, n: number) => {
+    simRef.current = makeInitState(a, b, e, n)
+    setPheromone(simRef.current.pheromone); setEpoch(0)
+    setPhase('building'); setAntIdx(0)
+    setBestTour(simRef.current.bestTour.slice()); setBestCost(simRef.current.bestCost)
+    setLastTour(null); setLastEvent(null); setCostHistory([])
+    setStep(0); setRunning(false)
+  }, [])
+
+  const step_fn = useCallback(() => {
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setPheromone(next.pheromone.map(r => r.slice()))
+    setEpoch(next.epoch); setPhase(next.phase); setAntIdx(next.antIdx)
+    setBestTour(next.bestTour.slice()); setBestCost(next.bestCost)
+    setLastTour(next.lastTour); setLastEvent(next.lastEvent)
+    setCostHistory(next.costHistory.slice()); setStep(next.step)
+  }, [])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = Math.max(30, 660 - speed * 66)
+    const id = setInterval(step_fn, ms)
+    return () => clearInterval(id)
+  }, [running, speed, step_fn])
+
+  const maxP = useMemo(() => maxPheromone(simRef.current), [pheromone])
+
+  let chipText = "Press Step or Run to watch the colony evolve"
+  let chipClass = "aco-chip aco-chip-idle"
+  if (lastEvent === 'ant-built') {
+    chipText = `🐜 ant built a tour — cost ${simRef.current.lastTours.length > 0 ? tourLength(simRef.current.lastTours[simRef.current.lastTours.length - 1]).toFixed(0) : "?"}`
+    chipClass = "aco-chip aco-chip-build"
+  } else if (lastEvent === 'improved') {
+    chipText = `⭐ new best! epoch ${epoch - 1}, cost ${bestCost.toFixed(0)}`
+    chipClass = "aco-chip aco-chip-improve"
+  } else if (lastEvent === 'deposited') {
+    chipText = `💨 evaporated + 📥 deposited ${numAnts} tours — advancing to epoch ${epoch}`
+    chipClass = "aco-chip aco-chip-deposit"
+  }
+
+  return (
+    <div className="aco-root">
+      <style>{CSS}</style>
+
+      <header className="aco-header">
+        <div className="aco-eyebrow">teeline · algorithms/aco</div>
+        <h2 className="aco-title">Ant Colony Optimization</h2>
+        <p className="aco-sub">
+          A colony of ants independently constructs tours, each next city chosen
+          probabilistically by a <strong>pheromone trail</strong> (reinforced on short edges
+          and decaying over time) weighted by <strong>heuristic desirability</strong>
+          (1/distance). Watch the pheromone edges strengthen on good edges and fade on
+          bad ones as epochs advance.
+        </p>
+      </header>
+
+      <div className="aco-viz-row">
+        <div className="aco-canvas-wrap">
+          <PheromoneCanvas
+            pheromone={pheromone} maxP={maxP} bestTour={bestTour}
+            lastTour={lastTour} phase={phase}
+          />
+        </div>
+        <SidePanel
+          epoch={epoch} phase={phase} antIdx={antIdx} numAnts={numAnts}
+          pheromone={pheromone} bestCost={bestCost} alpha={alpha} beta={beta}
+        />
+      </div>
+
+      <div className="aco-legend">
+        <span><span className="aco-swatch aco-swatch-best" /> best tour</span>
+        <span><span className="aco-swatch aco-swatch-last" /> ant's last tour</span>
+        <span><span className="aco-swatch aco-swatch-phero" /> pheromone edge</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="aco-section-label">Cost history (best per epoch)</div>
+      <Sparkline values={costHistory} />
+
+      <div className="aco-statgrid">
+        <div>
+          <div className="aco-statlabel">epoch</div>
+          <div className="aco-mono">{epoch}</div>
+        </div>
+        <div>
+          <div className="aco-statlabel">best cost</div>
+          <div className="aco-mono">{bestCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="aco-statlabel">ants / epoch</div>
+          <div className="aco-mono">{numAnts}</div>
+        </div>
+        <div>
+          <div className="aco-statlabel">step</div>
+          <div className="aco-mono">{step}</div>
+        </div>
+      </div>
+
+      <div className="aco-config">
+        <div className="aco-config-row">
+          <label className="aco-config-label">α (pheromone influence) = <strong>{alpha.toFixed(1)}</strong></label>
+          <input type="range" min={0} max={10} step={0.1} value={alpha}
+            className="aco-slider"
+            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setAlpha(v); reinit(v, beta, evapRate, numAnts) }}
+          />
+        </div>
+        <div className="aco-config-row">
+          <label className="aco-config-label">β (heuristic influence) = <strong>{beta.toFixed(1)}</strong></label>
+          <input type="range" min={0} max={6} step={0.1} value={beta}
+            className="aco-slider"
+            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setBeta(v); reinit(alpha, v, evapRate, numAnts) }}
+          />
+        </div>
+        <div className="aco-config-row">
+          <label className="aco-config-label">ρ (evaporation rate) = <strong>{evapRate.toFixed(2)}</strong></label>
+          <input type="range" min={0.01} max={0.99} step={0.01} value={evapRate}
+            className="aco-slider"
+            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setEvapRate(v); reinit(alpha, beta, v, numAnts) }}
+          />
+        </div>
+        <div className="aco-config-row">
+          <label className="aco-config-label">Colony size = <strong>{numAnts}</strong></label>
+          <input type="range" min={2} max={30} step={1} value={numAnts}
+            className="aco-slider"
+            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setNumAnts(v); reinit(alpha, beta, evapRate, v) }}
+          />
+        </div>
+        <div className="aco-config-row">
+          <label className="aco-config-label">Speed</label>
+          <input type="range" min={1} max={10} step={1} value={speed}
+            className="aco-slider"
+            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+          />
+        </div>
+      </div>
+
+      <div className="aco-controls">
+        <button className="aco-btn" onClick={step_fn} disabled={running}>◀ Step</button>
+        <button className={`aco-btn ${!running ? "aco-btn-primary" : ""}`}
+          onClick={() => setRunning(r => !r)}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="aco-btn" onClick={() => reinit(alpha, beta, evapRate, numAnts)}>↺ Reset</button>
+      </div>
+
+      <footer className="aco-footer">
+        <span className="aco-mono">cities: {N_CITIES}</span>
+        <span className="aco-mono">α={alpha.toFixed(1)} β={beta.toFixed(1)}</span>
+        <span className="aco-mono">ρ={evapRate.toFixed(2)}</span>
+        <span className="aco-mono">ants: {numAnts}</span>
+        <span className="aco-mono">classic AS</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.aco-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --improve: #16a34a;
+  --last: #ea580c;
+  --phero: #0d9488;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.aco-root * { box-sizing: border-box; }
+.aco-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.aco-header { margin-bottom: 2px; }
+.aco-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.aco-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.aco-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+.aco-sub code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em; background: rgba(13,148,136,0.1);
+  color: var(--accent); padding: 1px 4px; border-radius: 4px;
+}
+
+.aco-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.aco-bg { fill: var(--panel); }
+.aco-best-area { fill: #dcfce7; stroke: none; opacity: 0.6; }
+.aco-best-tour { fill: none; stroke: var(--improve); stroke-width: 2.8; stroke-linejoin: round; }
+.aco-last-tour { fill: none; stroke: var(--last); stroke-width: 1.8; stroke-linejoin: round; stroke-dasharray: 4 3; }
+.aco-city { stroke: #fff; stroke-width: 1.2; }
+.aco-city-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8px; fill: #374151; stroke: white; stroke-width: 2.5;
+  paint-order: stroke fill; dominant-baseline: auto;
+  pointer-events: none; user-select: none;
+}
+
+.aco-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.aco-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+.aco-sidebar {
+  width: 130px; flex-shrink: 0; display: flex; flex-direction: column; gap: 6px;
+  padding: 8px; background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+}
+.aco-side-section { display: flex; flex-direction: column; gap: 1px; }
+.aco-side-label {
+  font-size: 0.65rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+
+.aco-legend { display: flex; gap: 14px; flex-wrap: wrap; font-size: 0.8rem; color: var(--muted); align-items: center; }
+.aco-swatch {
+  display: inline-block; width: 22px; height: 3px;
+  border-radius: 2px; margin-right: 3px; vertical-align: middle;
+}
+.aco-swatch-best  { background: var(--improve); }
+.aco-swatch-last  { background: var(--last); }
+.aco-swatch-phero { background: var(--phero); }
+
+.aco-chip {
+  font-size: 0.85rem; font-weight: 600; padding: 8px 12px;
+  border-radius: 8px; border: 1px solid transparent;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.aco-chip-idle    { background: var(--panel); color: var(--muted); border-color: var(--line); font-weight: 400; }
+.aco-chip-build   { background: rgba(13,148,136,0.08); color: #0f766e; border-color: rgba(13,148,136,0.25); }
+.aco-chip-improve { background: #dcfce7; color: #15803d; border-color: #bbf7d0; }
+.aco-chip-deposit { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+
+.aco-section-label {
+  font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--muted); margin-bottom: -4px;
+}
+
+.aco-spark {
+  width: 100%; height: 54px; display: block;
+  border: 1px solid var(--line); border-radius: 6px; background: var(--panel);
+}
+
+.aco-statgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+@media (max-width: 540px) { .aco-statgrid { grid-template-columns: repeat(2, 1fr); } }
+.aco-statlabel {
+  font-size: 0.65rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+}
+
+.aco-config { display: flex; flex-direction: column; gap: 8px; }
+.aco-config-row { display: flex; flex-direction: column; gap: 3px; }
+.aco-config-label { font-size: 0.85rem; }
+.aco-slider { width: 100%; accent-color: var(--accent); cursor: pointer; }
+
+.aco-controls { display: flex; gap: 8px; }
+.aco-btn {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--line); border-radius: 6px;
+  padding: 6px 16px; font-size: 0.88rem; cursor: pointer; font-family: inherit;
+}
+.aco-btn:hover:not(:disabled) { border-color: var(--accent); }
+.aco-btn:disabled { opacity: 0.45; cursor: default; }
+.aco-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+.aco-footer {
+  display: flex; flex-wrap: wrap; gap: 14px;
+  padding-top: 8px; border-top: 1px solid var(--line); color: var(--muted);
+}
+`

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -33,6 +33,7 @@ function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasP
   const lastSet = useMemo(() => lastTour ? new Set(lastTour) : new Set<number>(), [lastTour])
 
   const bestPts = bestTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const bestPtsClosed = bestPts + ` ${CITIES[bestTour[0]][0]},${CITIES[bestTour[0]][1]}`
   const lastPts = lastTour
     ? lastTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[lastTour[0]][0]},${CITIES[lastTour[0]][1]}`
     : ""
@@ -67,8 +68,8 @@ function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasP
       {/* best tour underlay (faded fill) */}
       <polygon points={bestPts} className="aco-best-area" />
 
-      {/* best tour — thick solid line */}
-      <polyline points={bestPts} className="aco-best-tour" />
+      {/* best tour — thick solid closed line */}
+      <polyline points={bestPtsClosed} className="aco-best-tour" />
 
       {/* last tour (dashed, highlighted) */}
       {lastTour && phase === 'building' && (

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -24,11 +24,12 @@ function cityColor(i: number, onBest: boolean, onLast: boolean): string {
 interface CanvasProps {
   pheromone: number[][]
   maxP: number
+  tau0: number
   bestTour: number[]
   lastTour: number[] | null
   phase: string
 }
-function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasProps) {
+function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: CanvasProps) {
   const bestSet = useMemo(() => new Set(bestTour), [bestTour])
   const lastSet = useMemo(() => lastTour ? new Set(lastTour) : new Set<number>(), [lastTour])
 
@@ -49,21 +50,22 @@ function PheromoneCanvas({ pheromone, maxP, bestTour, lastTour, phase }: CanvasP
     <svg viewBox="0 0 300 300" className="aco-canvas" role="img" aria-label="ACO pheromone map">
       <rect x={0} y={0} width={300} height={300} className="aco-bg" />
 
-      {/* pheromone edges — dashed, width ∝ pheromone, subtle teal */}
+      {/* pheromone edges — only edges above baseline tau0 are visible;
+          untouched edges stay invisible so the colony's emergent trails are
+          the only thing on the canvas (no full-graph noise at the start) */}
       {edges.map(([i, j, p], k) => {
+        if (p <= tau0 * 1.0001) return null  // untouched, invisible
         const ratio = maxP > 0 ? p / maxP : 0
-        // power curve amplifies small pheromone differences:
-        // ratio 1.0→1.0, 0.9→0.76, 0.5→0.19 — edges that lag behind maxP fade fast
         const amp = Math.pow(ratio, 0.35)
         return (
           <line key={"p" + k}
             x1={CITIES[i][0]} y1={CITIES[i][1]}
             x2={CITIES[j][0]} y2={CITIES[j][1]}
             stroke="#0d9488"
-            strokeWidth={0.3 + amp * 4.5}
-            opacity={0.04 + amp * 0.72}
+            strokeWidth={0.3 + amp * 5.0}
+            opacity={0.05 + amp * 0.75}
             strokeLinecap="round"
-            strokeDasharray={amp > 0.35 ? "6 4" : "3 6"}
+            strokeDasharray={amp > 0.35 ? "5 3" : "3 5"}
           />
         )
       })}
@@ -180,6 +182,7 @@ export default function AcoExplainer() {
   const [lastTour, setLastTour] = useState<number[] | null>(null)
   const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
   const [costHistory, setCostHistory] = useState<number[]>([])
+  const [tau0, setTau0] = useState(() => simRef.current.tau0)
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
 
@@ -189,6 +192,7 @@ export default function AcoExplainer() {
     setPhase('building'); setAntIdx(0)
     setBestTour(simRef.current.bestTour.slice()); setBestCost(simRef.current.bestCost)
     setLastTour(null); setLastEvent(null); setCostHistory([])
+    setTau0(simRef.current.tau0)
     setStep(0); setRunning(false)
   }, [])
 
@@ -243,7 +247,7 @@ export default function AcoExplainer() {
       <div className="aco-viz-row">
         <div className="aco-canvas-wrap">
           <PheromoneCanvas
-            pheromone={pheromone} maxP={maxP} bestTour={bestTour}
+            pheromone={pheromone} maxP={maxP} tau0={tau0} bestTour={bestTour}
             lastTour={lastTour} phase={phase}
           />
         </div>

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -110,6 +110,15 @@ function PheromoneHeatmap({ pheromone, maxP }: { pheromone: number[][]; maxP: nu
   return (
     <svg viewBox={`0 0 ${totalW} ${totalW}`} className="aco-heatmap">
       <rect x={0} y={0} width={totalW} height={totalW} className="aco-heatmap-bg" rx={3} />
+      {/* separators every 4 cities — visually chunk the 12×12 matrix */}
+      {[4, 8].map(x => (
+        <line key={"v" + x} x1={pad + x * cell} y1={pad} x2={pad + x * cell} y2={pad + n * cell}
+          stroke="var(--line)" strokeWidth={1} />
+      ))}
+      {[4, 8].map(y => (
+        <line key={"h" + y} x1={pad} y1={pad + y * cell} x2={pad + n * cell} y2={pad + y * cell}
+          stroke="var(--line)" strokeWidth={1} />
+      ))}
       {Array.from({ length: n }, (_, i) =>
         Array.from({ length: n }, (_, j) => {
           if (i >= j) return null  // lower triangle + diagonal

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -100,21 +100,42 @@ function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: C
 }
 
 // ---------------------------------------------------------------
-// Side panel — epoch, ant progress, pheromone stats
+// Side panel — epoch, ant progress, pheromone heatmap grid
 // ---------------------------------------------------------------
+function PheromoneHeatmap({ pheromone, maxP }: { pheromone: number[][]; maxP: number }) {
+  const n = pheromone.length
+  const w = 112, pad = 2, cell = Math.floor((w - pad * 2) / n)
+  const totalW = cell * n + pad * 2
+
+  return (
+    <svg viewBox={`0 0 ${totalW} ${totalW}`} className="aco-heatmap">
+      <rect x={0} y={0} width={totalW} height={totalW} className="aco-heatmap-bg" rx={3} />
+      {Array.from({ length: n }, (_, i) =>
+        Array.from({ length: n }, (_, j) => {
+          if (i >= j) return null  // lower triangle + diagonal
+          const ratio = maxP > 0 ? pheromone[i][j] / maxP : 0
+          const r = Math.round(240 - ratio * 200)
+          const g = Math.round(253 - ratio * 200)
+          const b = Math.round(244 - ratio * 220)
+          return (
+            <rect key={`${i}-${j}`}
+              x={pad + j * cell} y={pad + i * cell}
+              width={cell - 1.5} height={cell - 1.5}
+              fill={`rgb(${r},${g},${b})`}
+              rx={1.5}
+            />
+          )
+        })
+      )}
+    </svg>
+  )
+}
+
 function SidePanel(props: {
   epoch: number; phase: string; antIdx: number; numAnts: number;
-  pheromone: number[][]; bestCost: number; alpha: number; beta: number;
+  pheromone: number[][]; bestCost: number; maxP: number;
 }) {
-  const { epoch, phase, antIdx, numAnts, pheromone, bestCost, alpha, beta } = props
-  let pMin = Infinity, pMax = 0
-  for (let i = 0; i < N_CITIES; i++) {
-    for (let j = i + 1; j < N_CITIES; j++) {
-      const p = pheromone[i][j]
-      if (p < pMin) pMin = p
-      if (p > pMax) pMax = p
-    }
-  }
+  const { epoch, phase, antIdx, numAnts, pheromone, bestCost, maxP } = props
 
   return (
     <div className="aco-sidebar">
@@ -131,12 +152,8 @@ function SidePanel(props: {
         <div className="aco-mono">{bestCost.toFixed(0)}</div>
       </div>
       <div className="aco-side-section">
-        <div className="aco-side-label">pheromone range</div>
-        <div className="aco-mono">{(pMin === Infinity ? 0 : pMin).toFixed(4)} – {pMax.toFixed(4)}</div>
-      </div>
-      <div className="aco-side-section">
-        <div className="aco-side-label">α · β</div>
-        <div className="aco-mono">{alpha.toFixed(1)} · {beta.toFixed(1)}</div>
+        <div className="aco-side-label">pheromone</div>
+        <PheromoneHeatmap pheromone={pheromone} maxP={maxP} />
       </div>
     </div>
   )
@@ -253,7 +270,7 @@ export default function AcoExplainer() {
         </div>
         <SidePanel
           epoch={epoch} phase={phase} antIdx={antIdx} numAnts={numAnts}
-          pheromone={pheromone} bestCost={bestCost} alpha={alpha} beta={beta}
+          pheromone={pheromone} bestCost={bestCost} maxP={maxP}
         />
       </div>
 
@@ -485,6 +502,9 @@ const CSS = `
 .aco-btn:hover:not(:disabled) { border-color: var(--accent); }
 .aco-btn:disabled { opacity: 0.45; cursor: default; }
 .aco-btn-primary { color: var(--accent); border-color: var(--accent); }
+
+.aco-heatmap { width: 100%; display: block; margin-top: 4px; }
+.aco-heatmap-bg { fill: var(--panel); }
 
 .aco-scenarios { margin-top: 4px; }
 .aco-scenario-row { display: flex; gap: 6px; flex-wrap: wrap; }

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -84,6 +84,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of Savings Construction: watch every pairwise edge scan highest-savings-first, ranked by the Clarke-Wright savings formula s(i,j) = d(hub,i) + d(hub,j) − d(i,j), with a centroid-nearest hub city bias and the same Kruskal-style accept/reject guards as Greedy Edge.',
     backLabel: 'Savings',
   },
+  aco: {
+    title: 'Ant Colony Optimization — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of Ant Colony Optimization: watch a colony of ants construct tours probabilistically, biased by a shared pheromone matrix that strengthens on short edges and decays over epochs. Adjust α (pheromone influence), β (heuristic weight), evaporation rate, and colony size.',
+    backLabel: 'ACO',
+  },
 }
 
 export const EXPLAINER_IDS = Object.keys(EXPLAINER_META)

--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -53,9 +53,9 @@ describe('PAGED_SOLVERS', () => {
 })
 
 describe('EXPLAINER_SOLVERS', () => {
-  it('contains exactly the 12 ids with an interactive explainer', () => {
+  it('contains exactly the 13 ids with an interactive explainer', () => {
     expect(EXPLAINER_SOLVERS).toEqual(
-      new Set(['pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings']),
+      new Set(['pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings', 'aco']),
     )
   })
 

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -48,5 +48,5 @@ export const PAGED_SOLVERS = new Set(Object.keys(SOLVER_META))
 
 // The subset of ids with an interactive explainer under /algorithms/<id>/explainer/.
 export const EXPLAINER_SOLVERS = new Set([
-  'pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings',
+  'pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings', 'aco',
 ])

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -27,6 +27,7 @@ import SomExplainer from '../../../../explainers/som'
 import FourierExplainer from '../../../../explainers/fourier'
 import GreedyEdgeExplainer from '../../../../explainers/greedy-edge'
 import SavingsExplainer from '../../../../explainers/savings'
+import AcoExplainer from '../../../../explainers/aco'
 
 export function getStaticPaths() {
   return EXPLAINER_IDS.map((id) => ({ params: { id } }))
@@ -65,5 +66,6 @@ const jsonLd = {
     {id === 'fourier' && <FourierExplainer client:visible />}
     {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
     {id === 'savings' && <SavingsExplainer client:visible />}
+    {id === 'aco' && <AcoExplainer client:visible />}
   </main>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Adds an interactive explainer for Ant Colony Optimization — the last deferred surface piece from #400. Closes #410.

ACO's closest structural siblings (CS, FPA) both have full explainers; this completes the parity set. The explainer is a **single-panel, no-tabs** component following the `tabu.tsx + tabu-algo.ts` split pattern.

## Visualization

One "step" = one ant building a full tour by probabilistic roulette-wheel selection (`pheromone^α · eta^β`). After all ants finish, the between-epoch phase evaporates + deposits pheromone and advances the epoch.

**SVG canvas:**
- Pheromone edges with opacity ∝ `pheromone / maxPheromone` — reinforced edges thicken, neglected edges fade.
- Best-tour overlay (green polygon + bold polyline).
- Ant's most-recently-built tour (dashed orange highlight).

**Side panel:** epoch, phase (🐜 ant n/N or 💨 deposit), best cost, pheromone range, α·β values.

**Config sliders (reset sim on change):** α 0–10, β 0–6, evaporation rate 0.01–0.99, colony size 2–30 (default 10 — kept leaner than the Rust default of 25 for responsive browser animation).

**7 cities** (21 edges) — ACO's O(n²) per-ant cost makes the smaller demo a practical necessity; picked a layout with a natural cluster + outliers so the pheromone evolution is visually clear.

## Files

- `aco-algo.ts` (210 lines) — pure simulation logic: pheromone matrix, `buildTour` (roulette construction), evaporate + deposit, `tau_min` floor, probabilistic underflow fallback.
- `aco.tsx` (390 lines) — single-panel view: canvas with pheromone edges, best/last tour overlays, side panel, cost sparkline, config sliders, controls.
- `aco.test.ts` (11 tests) — init state, valid permutations, phase transitions (building→depositing→building), epoch advances, monotonic best cost, pheromone floor.

## Wiring

| File | Change |
|---|---|
| `explainers/registry.ts` | `aco` EXPLAINER_META entry |
| `[id]/explainer/index.astro` | `AcoExplainer` import + branch |
| `nav-data.ts` | `'aco'` added to `EXPLAINER_SOLVERS` |
| `nav-data.test.ts` | count 12 → 13 |
| `docs/algorithms/ant-colony.md` | `hasExplainer: true` |

## Verification

- [x] `npm test` — **224 tests pass** (16 files; +11 new aco tests).
- [x] `astro check` + `tsc --noEmit` + `astro build` — clean (**41 pages**; `/algorithms/aco/explainer/` generated, CTA on docs page, ACO pill still present).
- [x] Pre-commit (tsc) passed.