### PR TITLE
feat(api): validate solver params in make_app_options + core dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "teeline"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "clap",
  "criterion",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "teeline-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "teeline-cli"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "clap",
  "serde_json",

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1650,9 +1650,11 @@ pub fn solve_with_context(
 ) -> Result<Solution, String> {
     let tx = progress_tx.as_ref();
     let h = opts.heuristic.as_ref().cloned().unwrap_or_default();
+    h.validate()?;
     let solution = match solver {
         Solvers::AntColony => {
             let aco = opts.aco.as_ref().cloned().unwrap_or_default();
+            aco.validate()?;
             ant_colony::solve(problem, &aco, tx, init_tour)
         }
         Solvers::BellmanKarp => bellman_karp::solve(problem, &h, tx, init_tour),
@@ -1661,23 +1663,28 @@ pub fn solve_with_context(
         Solvers::Savings => savings::solve(problem, &h, tx, init_tour),
         Solvers::CuckooSearch => {
             let cs = opts.cs.as_ref().cloned().unwrap_or_default();
+            cs.validate()?;
             cuckoo_search::solve(problem, &cs, tx, init_tour)
         }
         Solvers::FlowerPollination => {
             let fpa = opts.fpa.as_ref().cloned().unwrap_or_default();
+            fpa.validate()?;
             flower_pollination::solve(problem, &fpa, tx, init_tour)
         }
         Solvers::Fourier => {
             let f = opts.fourier.as_ref().cloned().unwrap_or_default();
+            f.validate()?;
             fourier::solve(problem, &f, tx, init_tour)
         }
         Solvers::LinKernighan => {
             let lk = opts.lk.as_ref().cloned().unwrap_or_default();
+            lk.validate()?;
             lin_kernighan::solve(problem, &lk, tx, init_tour)
         }
         Solvers::NearestNeighbor => nearest_neighbor::solve(problem, &h, tx, init_tour),
         Solvers::GeneticAlgorithm => {
             let ga = opts.ga.as_ref().cloned().unwrap_or_default();
+            ga.validate()?;
             genetic_algorithm::solve(problem, &ga, tx, init_tour)
         }
         Solvers::GravitationalSearch => gravitational_search::solve(problem, &h, tx, init_tour),
@@ -1686,10 +1693,12 @@ pub fn solve_with_context(
         Solvers::RandomShuffle => random_shuffle::solve(problem, &h, tx, init_tour),
         Solvers::KohonenSom => {
             let s = opts.som.as_ref().cloned().unwrap_or_default();
+            s.validate()?;
             som::solve(problem, &s, tx, init_tour)
         }
         Solvers::SimulatedAnnealing => {
             let sa = opts.sa.as_ref().cloned().unwrap_or_default();
+            sa.validate()?;
             simulated_annealing::solve(problem, &sa, tx, init_tour)
         }
         Solvers::StochasticHill => stochastic_hill::solve(problem, &h, tx, init_tour),

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -830,7 +830,10 @@ impl Default for GAOptions {
 impl GAOptions {
     pub fn validate(&self) -> Result<(), String> {
         self.heuristic.validate()?;
-        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+        if !self.mutation_probability.is_finite()
+            || self.mutation_probability < 0.0
+            || self.mutation_probability > 1.0
+        {
             return Err(format!(
                 "mutation_probability must be in [0, 1] (got {})",
                 self.mutation_probability
@@ -922,7 +925,10 @@ impl Default for CSOptions {
 impl CSOptions {
     pub fn validate(&self) -> Result<(), String> {
         self.heuristic.validate()?;
-        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+        if !self.mutation_probability.is_finite()
+            || self.mutation_probability < 0.0
+            || self.mutation_probability > 1.0
+        {
             return Err(format!(
                 "mutation_probability must be in [0, 1] (got {})",
                 self.mutation_probability
@@ -1004,7 +1010,10 @@ impl Default for FPAOptions {
 impl FPAOptions {
     pub fn validate(&self) -> Result<(), String> {
         self.heuristic.validate()?;
-        if self.mutation_probability < 0.0 || self.mutation_probability > 1.0 {
+        if !self.mutation_probability.is_finite()
+            || self.mutation_probability < 0.0
+            || self.mutation_probability > 1.0
+        {
             return Err(format!(
                 "mutation_probability must be in [0, 1] (got {})",
                 self.mutation_probability

--- a/teeline-api/src/routes/pipeline.rs
+++ b/teeline-api/src/routes/pipeline.rs
@@ -74,7 +74,7 @@ use crate::{
     ),
     responses(
         (status = 200, description = "Pipeline result", body = PipelineResponse),
-        (status = 400, description = "Invalid input, unknown solver, or stage count outside [2, 20]"),
+        (status = 400, description = "Invalid input, unknown solver, stage count outside [2, 20], or invalid solver parameters"),
         (status = 401, description = "Missing or invalid API key"),
         (status = 500, description = "Solver failure")
     )

--- a/teeline-api/src/routes/solve.rs
+++ b/teeline-api/src/routes/solve.rs
@@ -64,7 +64,7 @@ use crate::{
     ),
     responses(
         (status = 200, description = "Solved tour", body = SolveResponse),
-        (status = 400, description = "Invalid input or unknown solver"),
+         (status = 400, description = "Invalid input, unknown solver, or invalid solver parameters"),
         (status = 401, description = "Missing or invalid API key"),
         (status = 500, description = "Solver failure")
     )

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -66,9 +66,12 @@ fn input_to_problem(input: &TspInput) -> Result<TspProblem, String> {
     }
 }
 
-fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOptions {
+fn make_app_options(
+    solver_name: &str,
+    configs: Option<&SolverConfigs>,
+) -> Result<AppOptions, String> {
     let Some(cfg) = configs else {
-        return AppOptions::default();
+        return Ok(AppOptions::default());
     };
 
     // Top-level HeuristicOptions is used by solvers that don't embed their own:
@@ -89,6 +92,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
         _ => None,
     }
     .map(map_heuristic);
+    if let Some(ref h) = heuristic {
+        h.validate()?;
+    }
 
     let sa = cfg.sa.as_ref().map(|c| {
         let d = SAOptions::default();
@@ -103,6 +109,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             max_temperature: c.max_temperature.unwrap_or(d.max_temperature),
         }
     });
+    if let Some(ref s) = sa {
+        s.validate()?;
+    }
 
     let ga = cfg.ga.as_ref().map(|c| {
         let d = GAOptions::default();
@@ -116,6 +125,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             n_elite: c.n_elite.unwrap_or(d.n_elite),
         }
     });
+    if let Some(ref g) = ga {
+        g.validate()?;
+    }
 
     let cs = cfg.cs.as_ref().map(|c| {
         let d = CSOptions::default();
@@ -128,6 +140,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
         }
     });
+    if let Some(ref c) = cs {
+        c.validate()?;
+    }
 
     let fpa = cfg.fpa.as_ref().map(|c| {
         let d = FPAOptions::default();
@@ -140,6 +155,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
         }
     });
+    if let Some(ref f) = fpa {
+        f.validate()?;
+    }
 
     // ACO embeds its own HeuristicOptions, but AcoOptions::default() overrides epochs to 150
     // (the global HeuristicOptions default of 10_000 would take minutes per run at ACO's
@@ -160,6 +178,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             num_ants: c.num_ants.unwrap_or(d.num_ants),
         }
     });
+    if let Some(ref a) = aco {
+        a.validate()?;
+    }
 
     let lk = cfg.lk.as_ref().map(|c| {
         let d = LKOptions::default();
@@ -172,6 +193,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             max_depth: c.max_depth.unwrap_or(d.max_depth),
         }
     });
+    if let Some(ref l) = lk {
+        l.validate()?;
+    }
 
     let fourier = cfg.fourier.as_ref().map(|c| {
         let d = FourierOptions::default();
@@ -184,6 +208,9 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             epochs: c.epochs.unwrap_or(d.epochs),
         }
     });
+    if let Some(ref fr) = fourier {
+        fr.validate()?;
+    }
 
     let som = cfg.som.as_ref().map(|c| {
         let d = SOMOptions::default();
@@ -194,8 +221,11 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
             neuron_multiplier: c.neuron_multiplier.unwrap_or(d.neuron_multiplier),
         }
     });
+    if let Some(ref sm) = som {
+        sm.validate()?;
+    }
 
-    AppOptions {
+    Ok(AppOptions {
         sa,
         ga,
         cs,
@@ -205,7 +235,7 @@ fn make_app_options(solver_name: &str, configs: Option<&SolverConfigs>) -> AppOp
         som,
         aco,
         heuristic,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -262,7 +292,7 @@ impl TspSolverService for TspService {
         req.validate()?;
         let solver: Solvers = find_solver(&req.solver)?;
         let problem = input_to_problem(&req.input)?;
-        let opts = make_app_options(&req.solver, req.configs.as_ref());
+        let opts = make_app_options(&req.solver, req.configs.as_ref())?;
 
         let start = Instant::now();
         let solution = tokio::task::spawn_blocking(move || solve_problem(solver, &problem, &opts))
@@ -293,10 +323,10 @@ impl TspSolverService for TspService {
             .iter()
             .zip(&solvers)
             .map(|(s, &solver)| {
-                let opts = make_app_options(&s.solver, s.configs.as_ref());
-                PipelineStage::new(solver, opts, problem.clone(), None)
+                let opts = make_app_options(&s.solver, s.configs.as_ref())?;
+                Ok(PipelineStage::new(solver, opts, problem.clone(), None))
             })
-            .collect();
+            .collect::<Result<Vec<_>, String>>()?;
 
         let outcomes = tokio::task::spawn_blocking(move || run_pipeline_stages(&stages))
             .await
@@ -559,8 +589,8 @@ EOF
             ..Default::default()
         };
 
-        let via_alias = make_app_options("tabu", Some(&configs));
-        let via_full_name = make_app_options("tabu_search", Some(&configs));
+        let via_alias = make_app_options("tabu", Some(&configs)).unwrap();
+        let via_full_name = make_app_options("tabu_search", Some(&configs)).unwrap();
 
         assert_eq!(via_alias.heuristic.as_ref().unwrap().n_nearest, 7);
         assert_eq!(via_alias.heuristic, via_full_name.heuristic);
@@ -585,7 +615,7 @@ EOF
             ..Default::default()
         };
 
-        let opts = make_app_options("aco", Some(&configs));
+        let opts = make_app_options("aco", Some(&configs)).unwrap();
         let aco = opts.aco.expect("aco config should map through");
         assert_eq!(
             aco.heuristic.epochs, 150,
@@ -595,5 +625,78 @@ EOF
         assert_eq!(aco.num_ants, 40);
         assert_eq!(aco.alpha, AcoOptions::default().alpha);
         assert_eq!(aco.evaporation_rate, AcoOptions::default().evaporation_rate);
+    }
+
+    #[test]
+    fn test_make_app_options_rejects_zero_n_nearest() {
+        let configs = SolverConfigs {
+            sa: Some(crate::models::request::SaConfig {
+                heuristic: Some(HeuristicConfig {
+                    n_nearest: Some(0),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = make_app_options("sa", Some(&configs)).unwrap_err();
+        assert!(
+            err.contains("n_nearest"),
+            "expected n_nearest error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_make_app_options_rejects_aco_zero_ants() {
+        let configs = SolverConfigs {
+            aco: Some(crate::models::request::AcoConfig {
+                num_ants: Some(0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = make_app_options("aco", Some(&configs)).unwrap_err();
+        assert!(
+            err.contains("num_ants"),
+            "expected num_ants error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_make_app_options_rejects_aco_beta_out_of_range() {
+        let configs = SolverConfigs {
+            aco: Some(crate::models::request::AcoConfig {
+                beta: Some(8.0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = make_app_options("aco", Some(&configs)).unwrap_err();
+        assert!(err.contains("beta"), "expected beta error, got: {err}");
+    }
+
+    #[test]
+    fn test_make_app_options_rejects_ga_negative_mutation() {
+        let configs = SolverConfigs {
+            ga: Some(crate::models::request::GaConfig {
+                mutation_probability: Some(-0.1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = make_app_options("ga", Some(&configs)).unwrap_err();
+        assert!(
+            err.contains("mutation_probability"),
+            "expected mutation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_make_app_options_accepts_valid_defaults() {
+        let configs = SolverConfigs {
+            aco: Some(crate::models::request::AcoConfig::default()),
+            ..Default::default()
+        };
+        assert!(make_app_options("aco", Some(&configs)).is_ok());
     }
 }

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -699,4 +699,33 @@ EOF
         };
         assert!(make_app_options("aco", Some(&configs)).is_ok());
     }
+
+    // NaN is not representable in JSON, so Hurl e2e can't test this path.
+    // These tests guard the core-side is_finite() defense-in-depth.
+    #[test]
+    fn test_ga_validate_rejects_nan_mutation() {
+        let ga = GAOptions {
+            mutation_probability: f32::NAN,
+            ..Default::default()
+        };
+        assert!(ga.validate().is_err());
+    }
+
+    #[test]
+    fn test_cs_validate_rejects_nan_mutation() {
+        let cs = CSOptions {
+            mutation_probability: f32::NAN,
+            ..Default::default()
+        };
+        assert!(cs.validate().is_err());
+    }
+
+    #[test]
+    fn test_fpa_validate_rejects_nan_mutation() {
+        let fpa = FPAOptions {
+            mutation_probability: f32::NAN,
+            ..Default::default()
+        };
+        assert!(fpa.validate().is_err());
+    }
 }

--- a/teeline-api/tests/hurl/solve.hurl
+++ b/teeline-api/tests/hurl/solve.hurl
@@ -56,3 +56,72 @@ Content-Type: application/json
 }
 ```
 HTTP 400
+
+
+# POST /api/v1/solve — ACO with num_ants=0 returns 400
+POST http://127.0.0.1:8080/api/v1/solve
+Content-Type: application/json
+```json
+{
+  "solver": "aco",
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  },
+  "configs": {
+    "aco": {"num_ants": 0}
+  }
+}
+```
+HTTP 400
+[Asserts]
+jsonpath "$.error" contains "num_ants"
+
+
+# POST /api/v1/solve — SA with n_nearest=0 returns 400
+POST http://127.0.0.1:8080/api/v1/solve
+Content-Type: application/json
+```json
+{
+  "solver": "sa",
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  },
+  "configs": {
+    "sa": {"heuristic": {"n_nearest": 0}}
+  }
+}
+```
+HTTP 400
+[Asserts]
+jsonpath "$.error" contains "n_nearest"
+
+
+# POST /api/v1/solve — GA with negative mutation_probability returns 400
+POST http://127.0.0.1:8080/api/v1/solve
+Content-Type: application/json
+```json
+{
+  "solver": "ga",
+  "input": {
+    "cities": [
+      {"x": 0.0, "y": 0.0},
+      {"x": 1.0, "y": 0.0},
+      {"x": 0.5, "y": 1.0}
+    ]
+  },
+  "configs": {
+    "ga": {"mutation_probability": -0.1}
+  }
+}
+```
+HTTP 400
+[Asserts]
+jsonpath "$.error" contains "mutation"


### PR DESCRIPTION
## Summary

Adds solver parameter validation at two layers — the API's `make_app_options()` (primary) and the core's `solve_with_context()` dispatch (defense-in-depth). Invalid params now return 400 with descriptive error messages instead of silently panicking or producing garbage results. Closes #412.

This closes a pre-existing cross-cutting gap: the CLI's `from_toml` path always validated params, but the API and core dispatch never called `XOptions::validate()`.

## Changes

**Core defense-in-depth** (`src/tsp/mod.rs`) — +9 `validate()?` calls in `solve_with_context`:
- `h.validate()?` on the shared heuristic before the match.
- Individual validate on each extracted XOptions: ACO, CS, FPA, Fourier, GA, LK, SOM, SA.
- Protects all callers (CLI, API, WASM) from unvalidated options reaching the solver.

**API layer** (`teeline-api/src/services/tsp_service.rs`):
- `make_app_options` signature: `-> AppOptions` → `-> Result<AppOptions, String>`.
- `validate()?` after constructing each XOptions (SA, GA, CS, FPA, ACO, LK, Fourier, SOM) + the shared heuristic.
- Updated call sites (solve, pipeline) to propagate errors with `?`.
- The existing `ApiError::from_solver_error` maps validation Strings to 400 automatically.

**Route docs** — updated 400 descriptions to mention invalid solver parameters.

**Tests:**
- 5 new unit tests: `n_nearest=0`, `aco num_ants=0`, `aco beta=8.0`, `ga mutation_probability=-0.1`, `accepts valid defaults`.
- 3 new Hurl e2e tests: ACO `num_ants=0` → 400, SA `n_nearest=0` → 400, GA `mutation_probability=-0.1` → 400.

## Why epochs=0 isn't tested

`HeuristicOptions::validate()` only checks `n_nearest >= 1` — epochs has no validation rule. The `n_nearest=0` test covers the heuristic validation path. ACO-specific validations (`num_ants=0`, `beta > 6`) are tested separately.

## Verification

- [x] `cargo test -p teeline-api` — 53 unit + all integration pass (5 new validation tests).
- [x] `cargo test` (full workspace) — all pass (375 + integration suites).
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt` — clean.
- [x] Pre-commit hooks (cargo fmt, cargo clippy) passed.