### PR TITLE
fix(api): unify make_app_options on map_heuristic_onto, remove footgun

### DIFF
--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -25,10 +25,6 @@ pub struct TspService;
 // Private helpers
 // ---------------------------------------------------------------------------
 
-fn map_heuristic(h: &HeuristicConfig) -> HeuristicOptions {
-    map_heuristic_onto(h, HeuristicOptions::default())
-}
-
 // Maps partial HeuristicConfig onto a caller-supplied base so that solver-specific
 // defaults (e.g. LKOptions has n_nearest=5 vs the global default of 3) are preserved
 // when the caller omits a field.
@@ -91,7 +87,7 @@ fn make_app_options(
         "gsa" | "gravitational_search" => cfg.gsa.as_ref().and_then(|c| c.heuristic.as_ref()),
         _ => None,
     }
-    .map(map_heuristic);
+    .map(|h| map_heuristic_onto(h, HeuristicOptions::default()));
     if let Some(ref h) = heuristic {
         h.validate()?;
     }
@@ -102,7 +98,7 @@ fn make_app_options(
             heuristic: c
                 .heuristic
                 .as_ref()
-                .map(map_heuristic)
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
                 .unwrap_or(d.heuristic),
             cooling_rate: c.cooling_rate.unwrap_or(d.cooling_rate),
             min_temperature: c.min_temperature.unwrap_or(d.min_temperature),
@@ -119,7 +115,7 @@ fn make_app_options(
             heuristic: c
                 .heuristic
                 .as_ref()
-                .map(map_heuristic)
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
                 .unwrap_or(d.heuristic),
             mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
             n_elite: c.n_elite.unwrap_or(d.n_elite),
@@ -135,7 +131,7 @@ fn make_app_options(
             heuristic: c
                 .heuristic
                 .as_ref()
-                .map(map_heuristic)
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
                 .unwrap_or(d.heuristic),
             mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
         }
@@ -150,7 +146,7 @@ fn make_app_options(
             heuristic: c
                 .heuristic
                 .as_ref()
-                .map(map_heuristic)
+                .map(|h| map_heuristic_onto(h, d.heuristic.clone()))
                 .unwrap_or(d.heuristic),
             mutation_probability: c.mutation_probability.unwrap_or(d.mutation_probability),
         }
@@ -625,6 +621,39 @@ EOF
         assert_eq!(aco.num_ants, 40);
         assert_eq!(aco.alpha, AcoOptions::default().alpha);
         assert_eq!(aco.evaporation_rate, AcoOptions::default().evaporation_rate);
+    }
+
+    // LKOptions::default() overrides n_nearest to 5 (vs the global HeuristicOptions
+    // default of 3) and epochs to 100 (vs 10_000). The lk mapping must preserve those
+    // overrides when the fields are omitted — i.e. map onto LKOptions's own default
+    // via map_heuristic_onto, not the global default.
+    #[test]
+    fn test_make_app_options_lk_preserves_default_overrides_when_omitted() {
+        use crate::models::request::LkConfig;
+
+        let configs = SolverConfigs {
+            lk: Some(LkConfig {
+                heuristic: None,
+                max_depth: Some(8),
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("lk", Some(&configs)).unwrap();
+        let lk = opts.lk.expect("lk config should map through");
+        assert_eq!(
+            lk.heuristic.n_nearest, 5,
+            "omitting n_nearest must fall back to LK's 5 default, not the global 3"
+        );
+        assert_eq!(
+            lk.heuristic.epochs, 100,
+            "omitting epochs must fall back to LK's 100 default, not the global 10_000"
+        );
+        assert_eq!(lk.max_depth, 8);
+        assert_eq!(
+            lk.heuristic.platoo_epochs,
+            LKOptions::default().heuristic.platoo_epochs
+        );
     }
 
     #[test]

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -656,6 +656,109 @@ EOF
         );
     }
 
+    // SA/GA/CS/FPA use map_heuristic_onto(h, d.heuristic.clone()) so that a future
+    // solver-side Default override can't be silently discarded. These tests assert the
+    // mapping is wired correctly — custom fields flow through, solver defaults survive.
+    #[test]
+    fn test_make_app_options_sa_maps_heuristic_onto_own_default() {
+        use crate::models::request::SaConfig;
+
+        let configs = SolverConfigs {
+            sa: Some(SaConfig {
+                heuristic: Some(HeuristicConfig {
+                    n_nearest: Some(7),
+                    ..Default::default()
+                }),
+                cooling_rate: Some(0.005),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("sa", Some(&configs)).unwrap();
+        let sa = opts.sa.expect("sa config should map through");
+        assert_eq!(sa.heuristic.n_nearest, 7);
+        assert_eq!(sa.cooling_rate, 0.005);
+        assert_eq!(sa.heuristic.epochs, SAOptions::default().heuristic.epochs);
+        assert_eq!(sa.min_temperature, SAOptions::default().min_temperature);
+    }
+
+    #[test]
+    fn test_make_app_options_ga_maps_heuristic_onto_own_default() {
+        use crate::models::request::GaConfig;
+
+        let configs = SolverConfigs {
+            ga: Some(GaConfig {
+                heuristic: Some(HeuristicConfig {
+                    epochs: Some(500),
+                    ..Default::default()
+                }),
+                mutation_probability: Some(0.05),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("ga", Some(&configs)).unwrap();
+        let ga = opts.ga.expect("ga config should map through");
+        assert_eq!(ga.heuristic.epochs, 500);
+        assert_eq!(ga.mutation_probability, 0.05);
+        assert_eq!(
+            ga.heuristic.n_nearest,
+            GAOptions::default().heuristic.n_nearest
+        );
+        assert_eq!(ga.n_elite, GAOptions::default().n_elite);
+    }
+
+    #[test]
+    fn test_make_app_options_cs_maps_heuristic_onto_own_default() {
+        use crate::models::request::CsConfig;
+
+        let configs = SolverConfigs {
+            cs: Some(CsConfig {
+                heuristic: Some(HeuristicConfig {
+                    platoo_epochs: Some(200),
+                    ..Default::default()
+                }),
+                mutation_probability: Some(0.1),
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("cs", Some(&configs)).unwrap();
+        let cs = opts.cs.expect("cs config should map through");
+        assert_eq!(cs.heuristic.platoo_epochs, 200);
+        assert_eq!(cs.mutation_probability, 0.1);
+        assert_eq!(cs.heuristic.epochs, CSOptions::default().heuristic.epochs);
+    }
+
+    #[test]
+    fn test_make_app_options_fpa_maps_heuristic_onto_own_default() {
+        use crate::models::request::FpaConfig;
+
+        let configs = SolverConfigs {
+            fpa: Some(FpaConfig {
+                heuristic: Some(HeuristicConfig {
+                    epochs: Some(800),
+                    n_nearest: Some(7),
+                    ..Default::default()
+                }),
+                mutation_probability: Some(0.02),
+            }),
+            ..Default::default()
+        };
+
+        let opts = make_app_options("fpa", Some(&configs)).unwrap();
+        let fpa = opts.fpa.expect("fpa config should map through");
+        assert_eq!(fpa.heuristic.epochs, 800);
+        assert_eq!(fpa.heuristic.n_nearest, 7);
+        assert_eq!(fpa.mutation_probability, 0.02);
+        assert_eq!(
+            fpa.heuristic.platoo_epochs,
+            FPAOptions::default().heuristic.platoo_epochs
+        );
+    }
+
     #[test]
     fn test_make_app_options_rejects_zero_n_nearest() {
         let configs = SolverConfigs {


### PR DESCRIPTION
All six solver blocks (SA, GA, CS, FPA, ACO, LK) now use the solver-aware `map_heuristic_onto` with their own `Default` as the base. This is a no-op for SA/GA/CS/FPA today (their defaults happen to match the global default), but prevents silent correctness bugs if they ever add overrides like LK and ACO already did.

Removed `map_heuristic` entirely so the footgun cannot recur.

Added `test_make_app_options_lk_preserves_default_overrides_when_omitted` mirroring the existing ACO test.

Closes #414.