### PR TITLE
feat(qt): add ACO solver support to teeline-qt

### DIFF
--- a/teeline-qt/Cargo.lock
+++ b/teeline-qt/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "teeline"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "clap",
  "num-complex",

--- a/teeline-qt/Cargo.toml
+++ b/teeline-qt/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "teeline-qt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Timo Sulg <timgluz@gmail.com>"]
 repository = "https://github.com/timgluz/teeline"
@@ -14,7 +14,7 @@ name = "teeline-qt"
 path = "src/main.rs"
 
 [package.metadata.dist]
-dist = false  # requires Qt runtime; not a standalone distributable binary
+dist = false # requires Qt runtime; not a standalone distributable binary
 
 [dependencies]
 qtbridge = { git = "https://github.com/qt/qtbridge-rust", rev = "66583b7be5f7060feb27790741996ce350836091" }

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -639,23 +639,6 @@ ApplicationWindow {
                                 Text { text: "Range [0, 1]"; color: theme.textHint; font.pixelSize: 11 }
                             }
 
-                            // ── PSO: swarm size ────────────────────────────────
-                            ColumnLayout {
-                                visible: isPSO
-                                spacing: 6
-                                Text { text: "Swarm size (n_nearest)"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
-                                TextField {
-                                    id: swarmField
-                                    Layout.preferredWidth: 140; font.pixelSize: 14
-                                    text: psoDefaults.n_nearest.toString(); placeholderText: "30"
-                                    color: acceptableInput ? theme.textDark : theme.inputError
-                                    placeholderTextColor: theme.fieldPlaceholder
-                                    validator: IntValidator { bottom: 1; top: 10000 }
-                                    background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
-                                }
-                                Text { text: "Minimum particle count (floor is 30)"; color: theme.textHint; font.pixelSize: 11 }
-                            }
-
                             // ── ACO: alpha, beta, evaporation rate, num_ants ─
                             ColumnLayout {
                                 visible: isACO
@@ -720,6 +703,23 @@ ApplicationWindow {
                                     }
                                     Text { text: "Ants per iteration (higher = smoother, slower)"; color: theme.textHint; font.pixelSize: 11 }
                                 }
+                            }
+
+                            // ── PSO: swarm size ────────────────────────────────
+                            ColumnLayout {
+                                visible: isPSO
+                                spacing: 6
+                                Text { text: "Swarm size (n_nearest)"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
+                                TextField {
+                                    id: swarmField
+                                    Layout.preferredWidth: 140; font.pixelSize: 14
+                                    text: psoDefaults.n_nearest.toString(); placeholderText: "30"
+                                    color: acceptableInput ? theme.textDark : theme.inputError
+                                    placeholderTextColor: theme.fieldPlaceholder
+                                    validator: IntValidator { bottom: 1; top: 10000 }
+                                    background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                }
+                                Text { text: "Minimum particle count (floor is 30)"; color: theme.textHint; font.pixelSize: 11 }
                             }
 
                             Item { Layout.preferredHeight: 16 }
@@ -1093,19 +1093,6 @@ ApplicationWindow {
                                     }
                                 }
 
-                                // PSO: swarm size (n_nearest)
-                                RowLayout {
-                                    visible: hasPSO; spacing: 12
-                                    Text { text: "Swarm size (n_nearest)"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
-                                    TextField {
-                                        id: swarmField
-                                        Layout.preferredWidth: 180
-                                        text: "30"; color: theme.textDark; font.pixelSize: 13
-                                        validator: IntValidator { bottom: 1; top: 10000 }
-                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
-                                    }
-                                }
-
                                 // ACO: alpha
                                 RowLayout {
                                     visible: hasACO; spacing: 12
@@ -1150,6 +1137,19 @@ ApplicationWindow {
                                         id: antsField
                                         Layout.preferredWidth: 180
                                         text: "25"; color: theme.textDark; font.pixelSize: 13
+                                        validator: IntValidator { bottom: 1; top: 10000 }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                }
+
+                                // PSO: swarm size (n_nearest)
+                                RowLayout {
+                                    visible: hasPSO; spacing: 12
+                                    Text { text: "Swarm size (n_nearest)"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
+                                    TextField {
+                                        id: swarmField
+                                        Layout.preferredWidth: 180
+                                        text: "30"; color: theme.textDark; font.pixelSize: 13
                                         validator: IntValidator { bottom: 1; top: 10000 }
                                         background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
                                     }

--- a/teeline-qt/src/Main.qml
+++ b/teeline-qt/src/Main.qml
@@ -277,6 +277,7 @@ ApplicationWindow {
         readonly property var psoDefaults: ({ epochs: 10000, n_nearest: 30 })
         readonly property var csDefaults:  ({ epochs: 10000, mutation_probability: 0.001 })
         readonly property var fpaDefaults: ({ epochs: 10000, mutation_probability: 0.001 })
+        readonly property var acoDefaults: ({ epochs: 150, alpha: 1.0, beta: 2.0, evaporation_rate: 0.5, num_ants: 25 })
 
         property string selectedAlias: selectedSolver ? selectedSolver.alias : ""
         property bool isSA:  selectedAlias === "sa"  || selectedAlias === "simulated_annealing"
@@ -284,6 +285,7 @@ ApplicationWindow {
         property bool isPSO: selectedAlias === "pso" || selectedAlias === "particle_swarm"
         property bool isCS:  selectedAlias === "cs"  || selectedAlias === "cuckoo_search"
         property bool isFPA: selectedAlias === "fpa" || selectedAlias === "flower_pollination"
+        property bool isACO: selectedAlias === "aco" || selectedAlias === "ant_colony"
 
         // Reset fields to defaults whenever the selected solver changes
         onSelectedSolverChanged: {
@@ -292,6 +294,7 @@ ApplicationWindow {
             else if (isPSO) { epochsField.text = psoDefaults.epochs.toString(); swarmField.text = psoDefaults.n_nearest.toString() }
             else if (isCS)  { epochsField.text = csDefaults.epochs.toString();  mpField2.text = csDefaults.mutation_probability.toString() }
             else if (isFPA) { epochsField.text = fpaDefaults.epochs.toString(); mpField2.text = fpaDefaults.mutation_probability.toString() }
+            else if (isACO) { epochsField.text = acoDefaults.epochs.toString(); alphaField.text = acoDefaults.alpha.toString(); betaField.text = acoDefaults.beta.toString(); evapField.text = acoDefaults.evaporation_rate.toString(); antsField.text = acoDefaults.num_ants.toString() }
         }
 
         function collectOpts() {
@@ -308,6 +311,11 @@ ApplicationWindow {
                 obj.n_nearest = parseInt(swarmField.text) || 30
             } else if (isCS || isFPA) {
                 obj.mutation_probability = parseFloat(mpField2.text) || 0.001
+            } else if (isACO) {
+                obj.alpha = parseFloat(alphaField.text) || 1.0
+                obj.beta = parseFloat(betaField.text) || 2.0
+                obj.evaporation_rate = parseFloat(evapField.text) || 0.5
+                obj.num_ants = parseInt(antsField.text) || 25
             }
             return JSON.stringify(obj)
         }
@@ -332,6 +340,15 @@ ApplicationWindow {
             if (isCS || isFPA) {
                 var mp2 = parseFloat(mpField2.text)
                 if (isNaN(mp2) || mp2 < 0 || mp2 > 1) return true
+            }
+            if (isACO) {
+                var alpha = parseFloat(alphaField.text)
+                var beta = parseFloat(betaField.text)
+                if (isNaN(alpha) || alpha < 0) return true
+                if (isNaN(beta) || beta < 0) return true
+                var evap = parseFloat(evapField.text)
+                if (isNaN(evap) || evap < 0 || evap > 1) return true
+                if (isNaN(parseInt(antsField.text)) || parseInt(antsField.text) < 1) return true
             }
             if (isPSO) {
                 if (isNaN(parseInt(swarmField.text)) || parseInt(swarmField.text) < 1) return true
@@ -639,6 +656,72 @@ ApplicationWindow {
                                 Text { text: "Minimum particle count (floor is 30)"; color: theme.textHint; font.pixelSize: 11 }
                             }
 
+                            // ── ACO: alpha, beta, evaporation rate, num_ants ─
+                            ColumnLayout {
+                                visible: isACO
+                                spacing: 8; Layout.fillWidth: true
+
+                                ColumnLayout {
+                                    spacing: 6
+                                    Text { text: "Alpha (pheromone weight)"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
+                                    TextField {
+                                        id: alphaField
+                                        Layout.preferredWidth: 140; font.pixelSize: 14
+                                        text: acoDefaults.alpha.toString(); placeholderText: "1.0"
+                                        color: acceptableInput ? theme.textDark : theme.inputError
+                                        placeholderTextColor: theme.fieldPlaceholder
+                                        validator: DoubleValidator { bottom: 0; top: 100; notation: DoubleValidator.StandardNotation }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                    Text { text: "Higher values favour pheromone over distance"; color: theme.textHint; font.pixelSize: 11 }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 6
+                                    Text { text: "Beta (heuristic weight)"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
+                                    TextField {
+                                        id: betaField
+                                        Layout.preferredWidth: 140; font.pixelSize: 14
+                                        text: acoDefaults.beta.toString(); placeholderText: "2.0"
+                                        color: acceptableInput ? theme.textDark : theme.inputError
+                                        placeholderTextColor: theme.fieldPlaceholder
+                                        validator: DoubleValidator { bottom: 0; top: 100; notation: DoubleValidator.StandardNotation }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                    Text { text: "Higher values favour distance over pheromone"; color: theme.textHint; font.pixelSize: 11 }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 6
+                                    Text { text: "Evaporation rate"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
+                                    TextField {
+                                        id: evapField
+                                        Layout.preferredWidth: 140; font.pixelSize: 14
+                                        text: acoDefaults.evaporation_rate.toString(); placeholderText: "0.5"
+                                        color: acceptableInput ? theme.textDark : theme.inputError
+                                        placeholderTextColor: theme.fieldPlaceholder
+                                        validator: DoubleValidator { bottom: 0; top: 1; notation: DoubleValidator.StandardNotation }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                    Text { text: "Range [0, 1]. Higher values evaporate faster"; color: theme.textHint; font.pixelSize: 11 }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 6
+                                    Text { text: "Number of ants"; color: theme.textLabel; font.pixelSize: 13; font.bold: true }
+                                    TextField {
+                                        id: antsField
+                                        Layout.preferredWidth: 140; font.pixelSize: 14
+                                        text: acoDefaults.num_ants.toString(); placeholderText: "25"
+                                        color: acceptableInput ? theme.textDark : theme.inputError
+                                        placeholderTextColor: theme.fieldPlaceholder
+                                        validator: IntValidator { bottom: 1; top: 10000 }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                    Text { text: "Ants per iteration (higher = smoother, slower)"; color: theme.textHint; font.pixelSize: 11 }
+                                }
+                            }
+
                             Item { Layout.preferredHeight: 16 }
                         }
                     }
@@ -791,10 +874,11 @@ ApplicationWindow {
                             property bool hasPSO: modelData.solver === "pso" || modelData.solver === "particle_swarm"
                             property bool hasCS:  modelData.solver === "cs"  || modelData.solver === "cuckoo_search"
                             property bool hasFPA: modelData.solver === "fpa" || modelData.solver === "flower_pollination"
-                            property bool hasAnyOpts: hasSA || hasGA || hasPSO || hasCS || hasFPA
+                            property bool hasACO: modelData.solver === "aco" || modelData.solver === "ant_colony"
+                            property bool hasAnyOpts: hasSA || hasGA || hasPSO || hasCS || hasFPA || hasACO
 
                             // Height: 64 base + accordion when open
-                            property int accordionExpandedH: hasSA ? 240 : (hasGA ? 180 : 130)
+                            property int accordionExpandedH: hasSA ? 240 : (hasGA ? 180 : (hasACO ? 300 : 130))
                             height: 64 + (configOpen ? accordionExpandedH : 0)
                             Behavior on height { NumberAnimation { duration: 180; easing.type: Easing.InOutQuad } }
 
@@ -812,6 +896,11 @@ ApplicationWindow {
                                     opts.n_nearest = parseInt(swarmField.text) || 30
                                 } else if (hasCS || hasFPA) {
                                     opts.mutation_probability = parseFloat(mpField.text) || 0.001
+                                } else if (hasACO) {
+                                    opts.alpha = parseFloat(alphaField.text) || 1.0
+                                    opts.beta = parseFloat(betaField.text) || 2.0
+                                    opts.evaporation_rate = parseFloat(evapField.text) || 0.5
+                                    opts.num_ants = parseInt(antsField.text) || 25
                                 }
                                 return opts
                             }
@@ -1012,6 +1101,55 @@ ApplicationWindow {
                                         id: swarmField
                                         Layout.preferredWidth: 180
                                         text: "30"; color: theme.textDark; font.pixelSize: 13
+                                        validator: IntValidator { bottom: 1; top: 10000 }
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                }
+
+                                // ACO: alpha
+                                RowLayout {
+                                    visible: hasACO; spacing: 12
+                                    Text { text: "Alpha"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
+                                    TextField {
+                                        id: alphaField
+                                        Layout.preferredWidth: 180
+                                        text: "1.0"; color: theme.textDark; font.pixelSize: 13
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                }
+
+                                // ACO: beta
+                                RowLayout {
+                                    visible: hasACO; spacing: 12
+                                    Text { text: "Beta"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
+                                    TextField {
+                                        id: betaField
+                                        Layout.preferredWidth: 180
+                                        text: "2.0"; color: theme.textDark; font.pixelSize: 13
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                }
+
+                                // ACO: evaporation rate
+                                RowLayout {
+                                    visible: hasACO; spacing: 12
+                                    Text { text: "Evaporation rate"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
+                                    TextField {
+                                        id: evapField
+                                        Layout.preferredWidth: 180
+                                        text: "0.5"; color: theme.textDark; font.pixelSize: 13
+                                        background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
+                                    }
+                                }
+
+                                // ACO: number of ants
+                                RowLayout {
+                                    visible: hasACO; spacing: 12
+                                    Text { text: "Number of ants"; color: theme.textMuted; font.pixelSize: 12; Layout.preferredWidth: 148 }
+                                    TextField {
+                                        id: antsField
+                                        Layout.preferredWidth: 180
+                                        text: "25"; color: theme.textDark; font.pixelSize: 13
                                         validator: IntValidator { bottom: 1; top: 10000 }
                                         background: Rectangle { color: theme.fieldBg; radius: 4; border.color: parent.activeFocus ? theme.accent : theme.fieldBorder; border.width: 1 }
                                     }

--- a/teeline-qt/src/file_loader.rs
+++ b/teeline-qt/src/file_loader.rs
@@ -1,6 +1,6 @@
+use qtbridge::qobject_impl;
 use std::path::Path;
 use teeline::tsp::{kdtree::KDPoint, opt_tour, tour_cost, tsplib};
-use qtbridge::qobject_impl;
 
 pub struct FileLoader {
     city_count: i32,
@@ -42,52 +42,157 @@ impl Default for FileLoader {
 
 #[qobject_impl(Singleton)]
 impl FileLoader {
-    qproperty!("cityCount",          Member = city_count,          Write = set_city_count,          Notify = "cityCountChanged");
-    qproperty!("problemName",        Member = problem_name,        Write = set_problem_name,        Notify = "problemNameChanged");
-    qproperty!("edgeWeightType",     Member = edge_weight_type,    Write = set_edge_weight_type,    Notify = "edgeWeightTypeChanged");
-    qproperty!("isLoaded",           Member = is_loaded,           Write = set_is_loaded,           Notify = "isLoadedChanged");
-    qproperty!("errorMessage",       Member = error_message,       Write = set_error_message,       Notify = "errorMessageChanged");
-    qproperty!("citiesJson",         Member = cities_json,         Write = set_cities_json,         Notify = "citiesJsonChanged");
-    qproperty!("recentFilesJson",    Member = recent_files_json,   Write = set_recent_files_json,   Notify = "recentFilesJsonChanged");
-    qproperty!("filePath",           Member = file_path,           Write = set_file_path,           Notify = "filePathChanged");
-    qproperty!("hasOptTour",         Member = has_opt_tour,        Write = set_has_opt_tour,        Notify = "hasOptTourChanged");
-    qproperty!("optTourRouteJson",   Member = opt_tour_route_json, Write = set_opt_tour_route_json, Notify = "optTourRouteJsonChanged");
-    qproperty!("optTourCost",        Member = opt_tour_cost,       Write = set_opt_tour_cost,       Notify = "optTourCostChanged");
-    qproperty!("optTourFilePath",    Member = opt_tour_file_path,  Write = set_opt_tour_file_path,  Notify = "optTourFilePathChanged");
+    qproperty!(
+        "cityCount",
+        Member = city_count,
+        Write = set_city_count,
+        Notify = "cityCountChanged"
+    );
+    qproperty!(
+        "problemName",
+        Member = problem_name,
+        Write = set_problem_name,
+        Notify = "problemNameChanged"
+    );
+    qproperty!(
+        "edgeWeightType",
+        Member = edge_weight_type,
+        Write = set_edge_weight_type,
+        Notify = "edgeWeightTypeChanged"
+    );
+    qproperty!(
+        "isLoaded",
+        Member = is_loaded,
+        Write = set_is_loaded,
+        Notify = "isLoadedChanged"
+    );
+    qproperty!(
+        "errorMessage",
+        Member = error_message,
+        Write = set_error_message,
+        Notify = "errorMessageChanged"
+    );
+    qproperty!(
+        "citiesJson",
+        Member = cities_json,
+        Write = set_cities_json,
+        Notify = "citiesJsonChanged"
+    );
+    qproperty!(
+        "recentFilesJson",
+        Member = recent_files_json,
+        Write = set_recent_files_json,
+        Notify = "recentFilesJsonChanged"
+    );
+    qproperty!(
+        "filePath",
+        Member = file_path,
+        Write = set_file_path,
+        Notify = "filePathChanged"
+    );
+    qproperty!(
+        "hasOptTour",
+        Member = has_opt_tour,
+        Write = set_has_opt_tour,
+        Notify = "hasOptTourChanged"
+    );
+    qproperty!(
+        "optTourRouteJson",
+        Member = opt_tour_route_json,
+        Write = set_opt_tour_route_json,
+        Notify = "optTourRouteJsonChanged"
+    );
+    qproperty!(
+        "optTourCost",
+        Member = opt_tour_cost,
+        Write = set_opt_tour_cost,
+        Notify = "optTourCostChanged"
+    );
+    qproperty!(
+        "optTourFilePath",
+        Member = opt_tour_file_path,
+        Write = set_opt_tour_file_path,
+        Notify = "optTourFilePathChanged"
+    );
 
-    fn set_city_count(&mut self, v: i32)          { self.city_count = v;          self.city_count_changed(); }
-    fn set_problem_name(&mut self, v: String)      { self.problem_name = v;        self.problem_name_changed(); }
-    fn set_edge_weight_type(&mut self, v: String)  { self.edge_weight_type = v;    self.edge_weight_type_changed(); }
-    fn set_is_loaded(&mut self, v: bool)           { self.is_loaded = v;           self.is_loaded_changed(); }
-    fn set_error_message(&mut self, v: String)     { self.error_message = v;       self.error_message_changed(); }
-    fn set_cities_json(&mut self, v: String)       { self.cities_json = v;         self.cities_json_changed(); }
-    fn set_recent_files_json(&mut self, v: String) { self.recent_files_json = v;   self.recent_files_json_changed(); }
-    fn set_file_path(&mut self, v: String)         { self.file_path = v;           self.file_path_changed(); }
-    fn set_has_opt_tour(&mut self, v: bool)        { self.has_opt_tour = v;        self.has_opt_tour_changed(); }
-    fn set_opt_tour_route_json(&mut self, v: String) { self.opt_tour_route_json = v; self.opt_tour_route_json_changed(); }
-    fn set_opt_tour_cost(&mut self, v: f32)        { self.opt_tour_cost = v;       self.opt_tour_cost_changed(); }
-    fn set_opt_tour_file_path(&mut self, v: String){ self.opt_tour_file_path = v;  self.opt_tour_file_path_changed(); }
+    fn set_city_count(&mut self, v: i32) {
+        self.city_count = v;
+        self.city_count_changed();
+    }
+    fn set_problem_name(&mut self, v: String) {
+        self.problem_name = v;
+        self.problem_name_changed();
+    }
+    fn set_edge_weight_type(&mut self, v: String) {
+        self.edge_weight_type = v;
+        self.edge_weight_type_changed();
+    }
+    fn set_is_loaded(&mut self, v: bool) {
+        self.is_loaded = v;
+        self.is_loaded_changed();
+    }
+    fn set_error_message(&mut self, v: String) {
+        self.error_message = v;
+        self.error_message_changed();
+    }
+    fn set_cities_json(&mut self, v: String) {
+        self.cities_json = v;
+        self.cities_json_changed();
+    }
+    fn set_recent_files_json(&mut self, v: String) {
+        self.recent_files_json = v;
+        self.recent_files_json_changed();
+    }
+    fn set_file_path(&mut self, v: String) {
+        self.file_path = v;
+        self.file_path_changed();
+    }
+    fn set_has_opt_tour(&mut self, v: bool) {
+        self.has_opt_tour = v;
+        self.has_opt_tour_changed();
+    }
+    fn set_opt_tour_route_json(&mut self, v: String) {
+        self.opt_tour_route_json = v;
+        self.opt_tour_route_json_changed();
+    }
+    fn set_opt_tour_cost(&mut self, v: f32) {
+        self.opt_tour_cost = v;
+        self.opt_tour_cost_changed();
+    }
+    fn set_opt_tour_file_path(&mut self, v: String) {
+        self.opt_tour_file_path = v;
+        self.opt_tour_file_path_changed();
+    }
 
-    #[qsignal] fn city_count_changed(&self);
-    #[qsignal] fn problem_name_changed(&self);
-    #[qsignal] fn edge_weight_type_changed(&self);
-    #[qsignal] fn is_loaded_changed(&self);
-    #[qsignal] fn error_message_changed(&self);
-    #[qsignal] fn cities_json_changed(&self);
-    #[qsignal] fn recent_files_json_changed(&self);
-    #[qsignal] fn file_path_changed(&self);
-    #[qsignal] fn has_opt_tour_changed(&self);
-    #[qsignal] fn opt_tour_route_json_changed(&self);
-    #[qsignal] fn opt_tour_cost_changed(&self);
-    #[qsignal] fn opt_tour_file_path_changed(&self);
+    #[qsignal]
+    fn city_count_changed(&self);
+    #[qsignal]
+    fn problem_name_changed(&self);
+    #[qsignal]
+    fn edge_weight_type_changed(&self);
+    #[qsignal]
+    fn is_loaded_changed(&self);
+    #[qsignal]
+    fn error_message_changed(&self);
+    #[qsignal]
+    fn cities_json_changed(&self);
+    #[qsignal]
+    fn recent_files_json_changed(&self);
+    #[qsignal]
+    fn file_path_changed(&self);
+    #[qsignal]
+    fn has_opt_tour_changed(&self);
+    #[qsignal]
+    fn opt_tour_route_json_changed(&self);
+    #[qsignal]
+    fn opt_tour_cost_changed(&self);
+    #[qsignal]
+    fn opt_tour_file_path_changed(&self);
 
     /// Load a TSPLIB file. `path` may be a filesystem path or a file:// URL.
     #[qslot]
     fn load_file(&mut self, path: String) {
-        let clean = path
-            .strip_prefix("file://")
-            .unwrap_or(&path)
-            .to_string();
+        let clean = path.strip_prefix("file://").unwrap_or(&path).to_string();
 
         // Reset opt-tour state whenever a new problem is loaded
         self.cached_cities = Vec::new();
@@ -99,7 +204,11 @@ impl FileLoader {
         eprintln!("[FileLoader] loading: {clean}");
         match tsplib::read_from_file(Path::new(&clean)) {
             Ok(data) => {
-                let ew_type = if data.has_explicit_weights() { "EXPLICIT" } else { "EUC_2D" };
+                let ew_type = if data.has_explicit_weights() {
+                    "EXPLICIT"
+                } else {
+                    "EUC_2D"
+                };
                 self.cached_cities = data.cities().to_vec();
                 self.set_problem_name(data.name.clone());
                 self.set_city_count(data.len() as i32);
@@ -114,10 +223,9 @@ impl FileLoader {
                 self.set_recent_files_json(updated);
 
                 // Auto-pair: load sibling .opt.tour if it exists
-                if let (Some(parent), Some(stem)) = (
-                    Path::new(&clean).parent(),
-                    Path::new(&clean).file_stem(),
-                ) {
+                if let (Some(parent), Some(stem)) =
+                    (Path::new(&clean).parent(), Path::new(&clean).file_stem())
+                {
                     let opt_path = parent.join(format!("{}.opt.tour", stem.to_string_lossy()));
                     if opt_path.exists() {
                         self.load_opt_tour(opt_path.to_string_lossy().into_owned());
@@ -134,10 +242,7 @@ impl FileLoader {
     /// Load a known-optimal .opt.tour file and compute its cost against the loaded problem.
     #[qslot]
     fn load_opt_tour(&mut self, path: String) {
-        let clean = path
-            .strip_prefix("file://")
-            .unwrap_or(&path)
-            .to_string();
+        let clean = path.strip_prefix("file://").unwrap_or(&path).to_string();
 
         if self.cached_cities.is_empty() {
             self.set_error_message("Load a .tsp file before loading an optimal tour".to_string());
@@ -150,14 +255,17 @@ impl FileLoader {
                 if opt.route.len() != self.cached_cities.len() {
                     self.set_error_message(format!(
                         "opt.tour has {} cities but problem has {}",
-                        opt.route.len(), self.cached_cities.len()
+                        opt.route.len(),
+                        self.cached_cities.len()
                     ));
                     return;
                 }
                 let valid_ids: std::collections::HashSet<usize> =
                     self.cached_cities.iter().map(|c| c.id).collect();
                 if opt.route.iter().any(|id| !valid_ids.contains(id)) {
-                    self.set_error_message("opt.tour contains city IDs not in the loaded problem".to_string());
+                    self.set_error_message(
+                        "opt.tour contains city IDs not in the loaded problem".to_string(),
+                    );
                     return;
                 }
 
@@ -220,9 +328,15 @@ fn cities_to_json(cities: &[KDPoint]) -> String {
         return "[]".to_string();
     }
     let min_x = cities.iter().map(|c| c.x()).fold(f32::INFINITY, f32::min);
-    let max_x = cities.iter().map(|c| c.x()).fold(f32::NEG_INFINITY, f32::max);
+    let max_x = cities
+        .iter()
+        .map(|c| c.x())
+        .fold(f32::NEG_INFINITY, f32::max);
     let min_y = cities.iter().map(|c| c.y()).fold(f32::INFINITY, f32::min);
-    let max_y = cities.iter().map(|c| c.y()).fold(f32::NEG_INFINITY, f32::max);
+    let max_y = cities
+        .iter()
+        .map(|c| c.y())
+        .fold(f32::NEG_INFINITY, f32::max);
     let rx = (max_x - min_x).max(1.0);
     let ry = (max_y - min_y).max(1.0);
 

--- a/teeline-qt/src/main.rs
+++ b/teeline-qt/src/main.rs
@@ -2,8 +2,8 @@ mod file_loader;
 mod solver_engine;
 
 use file_loader::FileLoader;
+use qtbridge::{QApp, qobject_impl};
 use solver_engine::SolverEngine;
-use qtbridge::{qobject_impl, QApp};
 
 #[derive(Default)]
 pub struct AppBackend {}

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use serde_json::json;
 use qtbridge::{QObjectHolder, invoke_method, qobject_impl};
 use teeline::tsp::{
-    self, AppOptions, GAOptions, CSOptions, FPAOptions, HeuristicOptions, SAOptions,
+    self, AcoOptions, AppOptions, GAOptions, CSOptions, FPAOptions, HeuristicOptions, SAOptions,
     Solvers, TspProblem,
     kdtree::KDPoint,
     pipeline::{PipelineStage, run_pipeline},
@@ -384,6 +384,19 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
                 fpa: Some(FPAOptions {
                     heuristic: h,
                     mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                }),
+                ..AppOptions::default()
+            }
+        }
+        "aco" | "ant_colony" => {
+            let def = AcoOptions::default();
+            AppOptions {
+                aco: Some(AcoOptions {
+                    heuristic: h,
+                    alpha: get_f32(&v, "alpha", def.alpha),
+                    beta: get_f32(&v, "beta", def.beta),
+                    evaporation_rate: get_f32(&v, "evaporation_rate", def.evaporation_rate),
+                    num_ants: get_usize(&v, "num_ants", def.num_ants),
                 }),
                 ..AppOptions::default()
             }

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -43,7 +43,9 @@ impl Default for SolverEngine {
 }
 
 fn build_solvers_json() -> String {
-    let arr: Vec<serde_json::Value> = teeline::tsp::list_solvers()
+    let mut list: Vec<_> = teeline::tsp::list_solvers().iter().collect();
+    list.sort_by_key(|s| s.category);
+    let arr: Vec<serde_json::Value> = list
         .iter()
         .map(|s| {
             json!({

--- a/teeline-qt/src/solver_engine.rs
+++ b/teeline-qt/src/solver_engine.rs
@@ -3,10 +3,10 @@ use std::str::FromStr;
 use std::sync::mpsc;
 use std::time::Instant;
 
-use serde_json::json;
 use qtbridge::{QObjectHolder, invoke_method, qobject_impl};
+use serde_json::json;
 use teeline::tsp::{
-    self, AcoOptions, AppOptions, GAOptions, CSOptions, FPAOptions, HeuristicOptions, SAOptions,
+    self, AcoOptions, AppOptions, CSOptions, FPAOptions, GAOptions, HeuristicOptions, SAOptions,
     Solvers, TspProblem,
     kdtree::KDPoint,
     pipeline::{PipelineStage, run_pipeline},
@@ -45,50 +45,133 @@ impl Default for SolverEngine {
 fn build_solvers_json() -> String {
     let arr: Vec<serde_json::Value> = teeline::tsp::list_solvers()
         .iter()
-        .map(|s| json!({
-            "name":       s.name,
-            "alias":      s.alias,
-            "category":   s.category,
-            "desc":       s.desc,
-            "complexity": s.complexity,
-            "hasOptions": s.has_options,
-            "exact":      s.exact
-        }))
+        .map(|s| {
+            json!({
+                "name":       s.name,
+                "alias":      s.alias,
+                "category":   s.category,
+                "desc":       s.desc,
+                "complexity": s.complexity,
+                "hasOptions": s.has_options,
+                "exact":      s.exact
+            })
+        })
         .collect();
     serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
 }
 
 #[qobject_impl(Singleton)]
 impl SolverEngine {
-    qproperty!("selectedSolver",    Member = selected_solver,    Write = set_selected_solver,    Notify = "selectedSolverChanged");
-    qproperty!("running",           Member = running,            Write = set_running,            Notify = "runningChanged");
-    qproperty!("bestCost",          Member = best_cost,          Write = set_best_cost,          Notify = "bestCostChanged");
-    qproperty!("iteration",         Member = iteration,          Write = set_iteration,          Notify = "iterationChanged");
-    qproperty!("elapsedMs",         Member = elapsed_ms,         Write = set_elapsed_ms,         Notify = "elapsedMsChanged");
-    qproperty!("tourJson",          Member = tour_json,          Write = set_tour_json,          Notify = "tourJsonChanged");
-    qproperty!("solversJson",       Member = solvers_json,       Write = set_solvers_json,       Notify = "solversJsonChanged");
-    qproperty!("optTourRouteJson",  Member = opt_tour_route_json, Write = set_opt_tour_route_json, Notify = "optTourRouteJsonChanged");
-    qproperty!("comparisonJson",    Member = comparison_json,    Write = set_comparison_json,    Notify = "comparisonJsonChanged");
+    qproperty!(
+        "selectedSolver",
+        Member = selected_solver,
+        Write = set_selected_solver,
+        Notify = "selectedSolverChanged"
+    );
+    qproperty!(
+        "running",
+        Member = running,
+        Write = set_running,
+        Notify = "runningChanged"
+    );
+    qproperty!(
+        "bestCost",
+        Member = best_cost,
+        Write = set_best_cost,
+        Notify = "bestCostChanged"
+    );
+    qproperty!(
+        "iteration",
+        Member = iteration,
+        Write = set_iteration,
+        Notify = "iterationChanged"
+    );
+    qproperty!(
+        "elapsedMs",
+        Member = elapsed_ms,
+        Write = set_elapsed_ms,
+        Notify = "elapsedMsChanged"
+    );
+    qproperty!(
+        "tourJson",
+        Member = tour_json,
+        Write = set_tour_json,
+        Notify = "tourJsonChanged"
+    );
+    qproperty!(
+        "solversJson",
+        Member = solvers_json,
+        Write = set_solvers_json,
+        Notify = "solversJsonChanged"
+    );
+    qproperty!(
+        "optTourRouteJson",
+        Member = opt_tour_route_json,
+        Write = set_opt_tour_route_json,
+        Notify = "optTourRouteJsonChanged"
+    );
+    qproperty!(
+        "comparisonJson",
+        Member = comparison_json,
+        Write = set_comparison_json,
+        Notify = "comparisonJsonChanged"
+    );
 
-    fn set_selected_solver(&mut self, v: String)      { self.selected_solver = v;      self.selected_solver_changed(); }
-    fn set_running(&mut self, v: bool)                { self.running = v;               self.running_changed(); }
-    fn set_best_cost(&mut self, v: f32)               { self.best_cost = v;             self.best_cost_changed(); }
-    fn set_iteration(&mut self, v: i32)               { self.iteration = v;             self.iteration_changed(); }
-    fn set_elapsed_ms(&mut self, v: i32)              { self.elapsed_ms = v;            self.elapsed_ms_changed(); }
-    fn set_tour_json(&mut self, v: String)            { self.tour_json = v;             self.tour_json_changed(); }
-    fn set_solvers_json(&mut self, v: String)         { self.solvers_json = v;          self.solvers_json_changed(); }
-    fn set_opt_tour_route_json(&mut self, v: String)  { self.opt_tour_route_json = v;   self.opt_tour_route_json_changed(); }
-    fn set_comparison_json(&mut self, v: String)      { self.comparison_json = v;       self.comparison_json_changed(); }
+    fn set_selected_solver(&mut self, v: String) {
+        self.selected_solver = v;
+        self.selected_solver_changed();
+    }
+    fn set_running(&mut self, v: bool) {
+        self.running = v;
+        self.running_changed();
+    }
+    fn set_best_cost(&mut self, v: f32) {
+        self.best_cost = v;
+        self.best_cost_changed();
+    }
+    fn set_iteration(&mut self, v: i32) {
+        self.iteration = v;
+        self.iteration_changed();
+    }
+    fn set_elapsed_ms(&mut self, v: i32) {
+        self.elapsed_ms = v;
+        self.elapsed_ms_changed();
+    }
+    fn set_tour_json(&mut self, v: String) {
+        self.tour_json = v;
+        self.tour_json_changed();
+    }
+    fn set_solvers_json(&mut self, v: String) {
+        self.solvers_json = v;
+        self.solvers_json_changed();
+    }
+    fn set_opt_tour_route_json(&mut self, v: String) {
+        self.opt_tour_route_json = v;
+        self.opt_tour_route_json_changed();
+    }
+    fn set_comparison_json(&mut self, v: String) {
+        self.comparison_json = v;
+        self.comparison_json_changed();
+    }
 
-    #[qsignal] fn selected_solver_changed(&self);
-    #[qsignal] fn running_changed(&self);
-    #[qsignal] fn best_cost_changed(&self);
-    #[qsignal] fn iteration_changed(&self);
-    #[qsignal] fn elapsed_ms_changed(&self);
-    #[qsignal] fn tour_json_changed(&self);
-    #[qsignal] fn solvers_json_changed(&self);
-    #[qsignal] fn opt_tour_route_json_changed(&self);
-    #[qsignal] fn comparison_json_changed(&self);
+    #[qsignal]
+    fn selected_solver_changed(&self);
+    #[qsignal]
+    fn running_changed(&self);
+    #[qsignal]
+    fn best_cost_changed(&self);
+    #[qsignal]
+    fn iteration_changed(&self);
+    #[qsignal]
+    fn elapsed_ms_changed(&self);
+    #[qsignal]
+    fn tour_json_changed(&self);
+    #[qsignal]
+    fn solvers_json_changed(&self);
+    #[qsignal]
+    fn opt_tour_route_json_changed(&self);
+    #[qsignal]
+    fn comparison_json_changed(&self);
 
     #[qslot]
     fn select_solver(&mut self, alias: String) {
@@ -111,7 +194,13 @@ impl SolverEngine {
 
     /// Called on the Qt main thread by the progress-forwarding thread.
     #[qslot]
-    fn on_progress_update(&mut self, tour_json: String, cost: f32, iteration: i32, elapsed_ms: i32) {
+    fn on_progress_update(
+        &mut self,
+        tour_json: String,
+        cost: f32,
+        iteration: i32,
+        elapsed_ms: i32,
+    ) {
         self.set_tour_json(tour_json);
         self.set_best_cost(cost);
         self.set_iteration(iteration);
@@ -169,7 +258,14 @@ impl SolverEngine {
             let distances = match data.distance_matrix() {
                 Ok(d) => d,
                 Err(e) => {
-                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, e.to_string());
+                    invoke_method!(
+                        inv_done,
+                        "onSolveDone",
+                        "[]".to_string(),
+                        0.0_f32,
+                        0i32,
+                        e.to_string()
+                    );
                     return;
                 }
             };
@@ -189,7 +285,9 @@ impl SolverEngine {
                             let ms = start.elapsed().as_millis() as i32;
                             invoke_method!(inv2, "onProgressUpdate", tour, cost, epoch, ms);
                         }
-                        ProgressMessage::EpochUpdate(n) => { epoch = n as i32; }
+                        ProgressMessage::EpochUpdate(n) => {
+                            epoch = n as i32;
+                        }
                         ProgressMessage::Done | ProgressMessage::OptimalTour(_) => break,
                         _ => {}
                     }
@@ -201,17 +299,29 @@ impl SolverEngine {
                 .filter_map(|s| {
                     let alias = s.get("solver")?.as_str()?;
                     let solver = Solvers::from_str(alias).ok()?;
-                    let opts_str = s.get("opts")
+                    let opts_str = s
+                        .get("opts")
                         .map(|v| v.to_string())
                         .unwrap_or_else(|| "{}".to_string());
                     let opts = build_app_options(alias, &opts_str);
-                    Some(PipelineStage::new(solver, opts, problem.clone(), Some(tx.clone())))
+                    Some(PipelineStage::new(
+                        solver,
+                        opts,
+                        problem.clone(),
+                        Some(tx.clone()),
+                    ))
                 })
                 .collect();
 
             if stages.is_empty() {
-                invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32,
-                               "No valid stages in pipeline".to_string());
+                invoke_method!(
+                    inv_done,
+                    "onSolveDone",
+                    "[]".to_string(),
+                    0.0_f32,
+                    0i32,
+                    "No valid stages in pipeline".to_string()
+                );
                 return;
             }
 
@@ -219,8 +329,16 @@ impl SolverEngine {
                 Ok(solution) => {
                     let tour = route_to_json(solution.route());
                     let ms = start.elapsed().as_millis() as i32;
-                    invoke_method!(inv_done, "onSolveDone", tour, solution.total, ms, String::new());
-                    let comp_json = make_comparison_json(&opt_json, solution.route(), &problem.cities);
+                    invoke_method!(
+                        inv_done,
+                        "onSolveDone",
+                        tour,
+                        solution.total,
+                        ms,
+                        String::new()
+                    );
+                    let comp_json =
+                        make_comparison_json(&opt_json, solution.route(), &problem.cities);
                     if !comp_json.is_empty() {
                         invoke_method!(inv_cmp, "onComparisonReady", comp_json);
                     }
@@ -252,8 +370,14 @@ impl SolverEngine {
             let solver = match Solvers::from_str(&alias) {
                 Ok(s) => s,
                 Err(_) => {
-                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32,
-                                   format!("Unknown solver: {alias}"));
+                    invoke_method!(
+                        inv_done,
+                        "onSolveDone",
+                        "[]".to_string(),
+                        0.0_f32,
+                        0i32,
+                        format!("Unknown solver: {alias}")
+                    );
                     return;
                 }
             };
@@ -270,7 +394,14 @@ impl SolverEngine {
             let distances = match data.distance_matrix() {
                 Ok(d) => d,
                 Err(e) => {
-                    invoke_method!(inv_done, "onSolveDone", "[]".to_string(), 0.0_f32, 0i32, e.to_string());
+                    invoke_method!(
+                        inv_done,
+                        "onSolveDone",
+                        "[]".to_string(),
+                        0.0_f32,
+                        0i32,
+                        e.to_string()
+                    );
                     return;
                 }
             };
@@ -289,7 +420,9 @@ impl SolverEngine {
                             let ms = start.elapsed().as_millis() as i32;
                             invoke_method!(inv_progress, "onProgressUpdate", tour, cost, epoch, ms);
                         }
-                        ProgressMessage::EpochUpdate(n) => { epoch = n as i32; }
+                        ProgressMessage::EpochUpdate(n) => {
+                            epoch = n as i32;
+                        }
                         ProgressMessage::Done | ProgressMessage::OptimalTour(_) => break,
                         _ => {}
                     }
@@ -300,8 +433,16 @@ impl SolverEngine {
                 Ok(solution) => {
                     let tour = route_to_json(solution.route());
                     let ms = start.elapsed().as_millis() as i32;
-                    invoke_method!(inv_done, "onSolveDone", tour, solution.total, ms, String::new());
-                    let comp_json = make_comparison_json(&opt_json, solution.route(), &problem.cities);
+                    invoke_method!(
+                        inv_done,
+                        "onSolveDone",
+                        tour,
+                        solution.total,
+                        ms,
+                        String::new()
+                    );
+                    let comp_json =
+                        make_comparison_json(&opt_json, solution.route(), &problem.cities);
                     if !comp_json.is_empty() {
                         invoke_method!(inv_cmp, "onComparisonReady", comp_json);
                     }
@@ -333,15 +474,16 @@ fn get_usize(v: &serde_json::Value, key: &str, default: usize) -> usize {
 fn build_heuristic(v: &serde_json::Value) -> HeuristicOptions {
     let def = HeuristicOptions::default();
     HeuristicOptions {
-        epochs:        get_usize(v, "epochs",        def.epochs),
+        epochs: get_usize(v, "epochs", def.epochs),
         platoo_epochs: get_usize(v, "platoo_epochs", def.platoo_epochs),
-        n_nearest:     get_usize(v, "n_nearest",     def.n_nearest),
-        verbose:       false,
+        n_nearest: get_usize(v, "n_nearest", def.n_nearest),
+        verbose: false,
     }
 }
 
 fn build_app_options(alias: &str, json: &str) -> AppOptions {
-    let v: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Object(Default::default()));
+    let v: serde_json::Value =
+        serde_json::from_str(json).unwrap_or(serde_json::Value::Object(Default::default()));
     let h = build_heuristic(&v);
 
     match alias {
@@ -350,7 +492,7 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
             AppOptions {
                 sa: Some(SAOptions {
                     heuristic: h,
-                    cooling_rate:    get_f32(&v, "cooling_rate",    def.cooling_rate),
+                    cooling_rate: get_f32(&v, "cooling_rate", def.cooling_rate),
                     min_temperature: get_f32(&v, "min_temperature", def.min_temperature),
                     max_temperature: get_f32(&v, "max_temperature", def.max_temperature),
                 }),
@@ -362,7 +504,11 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
             AppOptions {
                 ga: Some(GAOptions {
                     heuristic: h,
-                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                    mutation_probability: get_f32(
+                        &v,
+                        "mutation_probability",
+                        def.mutation_probability,
+                    ),
                     n_elite: get_usize(&v, "n_elite", def.n_elite),
                 }),
                 ..AppOptions::default()
@@ -373,7 +519,11 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
             AppOptions {
                 cs: Some(CSOptions {
                     heuristic: h,
-                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                    mutation_probability: get_f32(
+                        &v,
+                        "mutation_probability",
+                        def.mutation_probability,
+                    ),
                 }),
                 ..AppOptions::default()
             }
@@ -383,7 +533,11 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
             AppOptions {
                 fpa: Some(FPAOptions {
                     heuristic: h,
-                    mutation_probability: get_f32(&v, "mutation_probability", def.mutation_probability),
+                    mutation_probability: get_f32(
+                        &v,
+                        "mutation_probability",
+                        def.mutation_probability,
+                    ),
                 }),
                 ..AppOptions::default()
             }
@@ -410,9 +564,13 @@ fn build_app_options(alias: &str, json: &str) -> AppOptions {
 }
 
 fn make_comparison_json(opt_json: &str, solver: &[usize], cities: &[KDPoint]) -> String {
-    if opt_json == "[]" || opt_json.is_empty() { return String::new(); }
+    if opt_json == "[]" || opt_json.is_empty() {
+        return String::new();
+    }
     let opt: Vec<usize> = serde_json::from_str(opt_json).unwrap_or_default();
-    if opt.is_empty() { return String::new(); }
+    if opt.is_empty() {
+        return String::new();
+    }
     let s = teeline::tsp::compare_tours(solver, &opt, cities);
     serde_json::to_string(&json!({
         "optimalCost": s.optimal_cost,
@@ -421,7 +579,8 @@ fn make_comparison_json(opt_json: &str, solver: &[usize], cities: &[KDPoint]) ->
         "sharedEdges": s.shared_edges,
         "solverOnlyEdges": s.solver_only_edges,
         "optimalOnlyEdges": s.optimal_only_edges
-    })).unwrap_or_default()
+    }))
+    .unwrap_or_default()
 }
 
 fn route_to_json(route: &[usize]) -> String {


### PR DESCRIPTION
Rust (`solver_engine.rs`):
- New `"aco" | "ant_colony"` match arm in `build_app_options`
- Constructs `AcoOptions` with solver-specific defaults for alpha, beta, evaporation_rate, num_ants

QML (`Main.qml`):
- `acoDefaults`, `isACO` property on SolverPage
- 4 new input fields: Alpha, Beta, Evaporation rate, Number of ants
- Default-population on solver selection, validation in `hasError()`, serialization in `collectOpts()`
- Pipeline stage: `hasACO` flag, 4 accordion rows, `accordionExpandedH`=300, `getOpts()` serialization

Closes #399.