### PR TITLE
fix(ci): decouple release workflow from flaky Qt builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,8 @@ jobs:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' }}
-    continue-on-error: true
+    outputs:
+      artifact-ready: ${{ steps.signal.outputs.ready }}
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -405,17 +406,22 @@ jobs:
           ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin qt --output appimage
           # linuxdeploy names the file using the desktop entry Name + arch
           mv Teeline_Qt-x86_64.AppImage "teeline-qt-${{ needs.plan.outputs.tag }}-linux-x86_64.AppImage"
-      - uses: actions/upload-artifact@v7
+      - id: upload
+        uses: actions/upload-artifact@v7
         with:
           name: qt-linux
           path: teeline-qt-*-linux-x86_64.AppImage
           if-no-files-found: error
+      - id: signal
+        if: always()
+        run: echo "ready=${{ steps.upload.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   build-qt-windows:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' }}
-    continue-on-error: true
+    outputs:
+      artifact-ready: ${{ steps.signal.outputs.ready }}
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -437,31 +443,41 @@ jobs:
           cache: true
           extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
+        id: build
+        continue-on-error: true
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Deploy Qt dependencies
+        if: steps.build.outcome == 'success'
         shell: pwsh
         run: |
           $windeployqt = "${{ env.QT_ROOT_DIR }}\bin\windeployqt.exe"
           & $windeployqt --release --compiler-runtime --qmldir teeline-qt\src --dir deploy teeline-qt\target\release\teeline-qt.exe
           Copy-Item teeline-qt\target\release\teeline-qt.exe deploy\
       - name: Package zip
+        if: steps.build.outcome == 'success'
         shell: pwsh
         run: |
           $tag = "${{ needs.plan.outputs.tag }}"
           $name = "teeline-qt-${tag}-windows-x64"
           Rename-Item deploy $name
           Compress-Archive -Path $name -DestinationPath "${name}.zip"
-      - uses: actions/upload-artifact@v7
+      - id: upload
+        if: steps.build.outcome == 'success'
+        uses: actions/upload-artifact@v7
         with:
           name: qt-windows
           path: teeline-qt-*-windows-x64.zip
           if-no-files-found: error
+      - id: signal
+        if: always()
+        run: echo "ready=${{ steps.upload.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   build-qt-macos:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' }}
-    continue-on-error: true
+    outputs:
+      artifact-ready: ${{ steps.signal.outputs.ready }}
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -481,8 +497,11 @@ jobs:
           cache: true
           extra: '--base https://download.qt.io/'
       - name: Build teeline-qt
+        id: build
+        continue-on-error: true
         run: cargo build --release --manifest-path teeline-qt/Cargo.toml
       - name: Create .app bundle
+        if: steps.build.outcome == 'success'
         run: |
           mkdir -p TeelineQt.app/Contents/MacOS
           mkdir -p TeelineQt.app/Contents/Resources
@@ -510,6 +529,7 @@ jobs:
           </plist>
           EOF
       - name: Deploy Qt frameworks and create DMG
+        if: steps.build.outcome == 'success'
         run: |
           macdeployqt TeelineQt.app -always-overwrite -qmldir=teeline-qt/src
           codesign --force --deep -s - TeelineQt.app
@@ -518,11 +538,16 @@ jobs:
             -srcfolder TeelineQt.app \
             -ov -format UDZO \
             "teeline-qt-${{ needs.plan.outputs.tag }}-macos-arm64.dmg"
-      - uses: actions/upload-artifact@v7
+      - id: upload
+        if: steps.build.outcome == 'success'
+        uses: actions/upload-artifact@v7
         with:
           name: qt-macos
           path: teeline-qt-*-macos-arm64.dmg
           if-no-files-found: error
+      - id: signal
+        if: always()
+        run: echo "ready=${{ steps.upload.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   upload-qt-artifacts:
     needs:
@@ -531,27 +556,28 @@ jobs:
       - build-qt-linux
       - build-qt-windows
       - build-qt-macos
-    if: ${{ always() && needs.host.result == 'success' && (needs.build-qt-linux.result == 'success' || needs.build-qt-windows.result == 'success' || needs.build-qt-macos.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' }}
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/download-artifact@v8
-        if: ${{ needs.build-qt-linux.result == 'success' }}
+        if: ${{ needs.build-qt-linux.outputs.artifact-ready == 'true' }}
         with:
           name: qt-linux
           path: artifacts/
       - uses: actions/download-artifact@v8
-        if: ${{ needs.build-qt-windows.result == 'success' }}
+        if: ${{ needs.build-qt-windows.outputs.artifact-ready == 'true' }}
         with:
           name: qt-windows
           path: artifacts/
       - uses: actions/download-artifact@v8
-        if: ${{ needs.build-qt-macos.result == 'success' }}
+        if: ${{ needs.build-qt-macos.outputs.artifact-ready == 'true' }}
         with:
           name: qt-macos
           path: artifacts/
       - name: Attach Qt artifacts to GitHub Release
+        if: ${{ hashFiles('artifacts/*') != '' }}
         run: gh release upload "${{ needs.plan.outputs.tag }}" artifacts/* --repo "${{ github.repository }}"
 
   publish-wassette:


### PR DESCRIPTION
Qt build jobs (Windows/macOS) are known-flaky due to qtbridge-gen proc-macro issues. Previously, `continue-on-error` at the job level masked failures but caused `upload-qt-artifacts` to fail when trying to download nonexistent artifacts, making the whole release red.

Changes:
- Each Qt build job now exposes an `artifact-ready` output, set to `'true'` only after a successful upload-artifact step.
- Flaky build steps use `continue-on-error` at the **step** level; all dependent packaging/upload steps are guarded by `steps.build.outcome == 'success'`.
- `upload-qt-artifacts` checks `artifact-ready` outputs instead of `needs.*.result`, and `gh release upload` is guarded against empty artifacts dir.
- Release workflow stays green regardless of Qt build flakiness.

Closes #324.