### PR TITLE
feat(web): add interactive 2-opt explainer

### DIFF
--- a/docs/algorithms/two-opt.md
+++ b/docs/algorithms/two-opt.md
@@ -3,7 +3,7 @@ id: "2opt"
 name: "2-opt"
 typeBadge: "Heuristic — local search"
 description: "Local search algorithm that iteratively improves a tour by removing two edges and reconnecting the resulting segments in the only other valid way (reversing the segment between the two removed edges)."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # 2-opt

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -90,7 +90,7 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of Ant Colony Optimization: watch a colony of ants construct tours probabilistically, biased by a shared pheromone matrix that strengthens on short edges and decays over epochs. Adjust α (pheromone influence), β (heuristic weight), evaporation rate, and colony size.',
     backLabel: 'ACO',
   },
-  two_opt: {
+  '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:
       'Interactive walkthrough of the 2-opt local-search algorithm: watch edge swaps eliminate crossings one pass at a time, with removed edges highlighted red and new edges green. Step through best-improvement scans until the tour reaches a local optimum.',

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -1,4 +1,4 @@
-// Metadata registry for the 10 interactive explainer pages. Only metadata
+// Metadata registry for the 14 interactive explainer pages. Only metadata
 // lives here — the components themselves must be statically imported
 // directly in [id]/explainer/index.astro, because Astro's client:* hydration
 // directives require the compiler to see a literal top-level `import`
@@ -89,6 +89,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
     description:
       'Interactive walkthrough of Ant Colony Optimization: watch a colony of ants construct tours probabilistically, biased by a shared pheromone matrix that strengthens on short edges and decays over epochs. Adjust α (pheromone influence), β (heuristic weight), evaporation rate, and colony size.',
     backLabel: 'ACO',
+  },
+  two_opt: {
+    title: '2-opt — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of the 2-opt local-search algorithm: watch edge swaps eliminate crossings one pass at a time, with removed edges highlighted red and new edges green. Step through best-improvement scans until the tour reaches a local optimum.',
+    backLabel: '2-opt',
   },
 }
 

--- a/teeline-web/src/explainers/two-opt-algo.ts
+++ b/teeline-web/src/explainers/two-opt-algo.ts
@@ -1,6 +1,6 @@
 // Pure simulation logic for the 2-opt interactive explainer.
-// One `stepOnce` call scans all edge pairs (best-improvement), finds the best
-// improving swap, applies it, and records the event. No DOM, fully testable.
+// Two-click step: first click scans and highlights the best candidate swap
+// (tour stays as-is); second click applies the swap. No DOM, fully testable.
 
 export const CITIES: [number, number][] = [
   [150, 20],   // 0 — top
@@ -16,7 +16,7 @@ export const CITIES: [number, number][] = [
 ]
 export const N_CITIES = CITIES.length
 
-export type Phase = 'idle' | 'swap_found' | 'local_optimum'
+export type Phase = 'idle' | 'candidate' | 'swap_found' | 'local_optimum'
 
 export interface SwapEvent {
   i: number
@@ -137,24 +137,25 @@ export function applySwap(tour: number[], i: number, j: number): number[] {
   return next
 }
 
-// One complete scan pass: find best improvement, apply if found.
+// One step: if in candidate phase, apply the pending swap.
+// Otherwise scan for the best improving swap and show it as a candidate.
 export function stepOnce(state: SimState): SimState {
   if (state.phase === 'local_optimum')
     return { ...state, step: state.step + 1 }
 
-  const { bestDelta, bestI, bestJ } = scanOnePass(state)
-
-  if (bestDelta < 0) {
-    const ni = (bestI + 1) % N_CITIES
-    const nj = (bestJ + 1) % N_CITIES
-    const newTour = applySwap(state.tour, bestI, bestJ)
+  // Second click — apply the candidate swap
+  if (state.phase === 'candidate' && state.lastSwap) {
+    const { i, j, delta } = state.lastSwap
+    const ni = (i + 1) % N_CITIES
+    const nj = (j + 1) % N_CITIES
+    const newTour = applySwap(state.tour, i, j)
     const removed: [number, number][] = [
-      [state.tour[bestI], state.tour[ni]],
-      [state.tour[bestJ], state.tour[nj]],
+      [state.tour[i], state.tour[ni]],
+      [state.tour[j], state.tour[nj]],
     ]
     const added: [number, number][] = [
-      [newTour[bestI], newTour[ni]],
-      [newTour[bestJ], newTour[nj]],
+      [newTour[i], newTour[ni]],
+      [newTour[j], newTour[nj]],
     ]
     const cost = tourLength(newTour)
 
@@ -164,10 +165,35 @@ export function stepOnce(state: SimState): SimState {
       tour: newTour,
       pass: state.pass + 1,
       totalSwaps: state.totalSwaps + 1,
-      lastSwap: { i: bestI, j: bestJ, removed, added, delta: bestDelta },
+      lastSwap: { i, j, removed, added, delta },
       bestTour: cost < state.bestCost ? [...newTour] : state.bestTour,
       bestCost: Math.min(cost, state.bestCost),
       costHistory: [...state.costHistory, cost],
+      step: state.step + 1,
+    }
+  }
+
+  // First click — scan for best improvement
+  const { bestDelta, bestI, bestJ } = scanOnePass(state)
+
+  if (bestDelta < 0) {
+    const ni = (bestI + 1) % N_CITIES
+    const nj = (bestJ + 1) % N_CITIES
+    // Record candidate swap but DON'T modify the tour
+    const removed: [number, number][] = [
+      [state.tour[bestI], state.tour[ni]],
+      [state.tour[bestJ], state.tour[nj]],
+    ]
+    const newTour = applySwap(state.tour, bestI, bestJ)
+    const added: [number, number][] = [
+      [newTour[bestI], newTour[ni]],
+      [newTour[bestJ], newTour[nj]],
+    ]
+
+    return {
+      ...state,
+      phase: 'candidate',
+      lastSwap: { i: bestI, j: bestJ, removed, added, delta: bestDelta },
       step: state.step + 1,
     }
   }

--- a/teeline-web/src/explainers/two-opt-algo.ts
+++ b/teeline-web/src/explainers/two-opt-algo.ts
@@ -1,0 +1,183 @@
+// Pure simulation logic for the 2-opt interactive explainer.
+// One `stepOnce` call scans all edge pairs (best-improvement), finds the best
+// improving swap, applies it, and records the event. No DOM, fully testable.
+
+export const CITIES: [number, number][] = [
+  [150, 20],   // 0 — top
+  [270, 70],   // 1 — top-right
+  [260, 180],  // 2 — right
+  [180, 280],  // 3 — bottom-right
+  [120, 290],  // 4 — bottom
+  [35, 220],   // 5 — bottom-left
+  [25, 80],    // 6 — left
+  [80, 25],    // 7 — top-left
+  [155, 155],  // 8 — centre
+  [90, 140],   // 9 — inner-left
+]
+export const N_CITIES = CITIES.length
+
+export type Phase = 'idle' | 'swap_found' | 'local_optimum'
+
+export interface SwapEvent {
+  i: number
+  j: number
+  removed: [number, number][]
+  added: [number, number][]
+  delta: number
+}
+
+export interface SimState {
+  phase: Phase
+  tour: number[]
+  bestTour: number[]
+  bestCost: number
+  pass: number
+  totalSwaps: number
+  lastSwap: SwapEvent | null
+  costHistory: number[]
+  step: number
+}
+
+export function dist(i: number, j: number): number {
+  const dx = CITIES[i][0] - CITIES[j][0]
+  const dy = CITIES[i][1] - CITIES[j][1]
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+export function tourLength(tour: number[]): number {
+  let d = 0
+  for (let k = 0; k < tour.length; k++) {
+    d += dist(tour[k], tour[(k + 1) % tour.length])
+  }
+  return d
+}
+
+// Predefined scenario tours
+export const SCENARIOS: Record<string, { label: string; desc: string; tour: number[] }> = {
+  single_crossing: {
+    label: 'Single crossing',
+    desc: 'One pair of edges cross — one swap fixes it',
+    tour: [0, 1, 8, 7, 2, 3, 4, 5, 9, 6],
+  },
+  multiple_crossings: {
+    label: 'Multiple crossings',
+    desc: 'Several edge crossings — resolved over a few passes',
+    tour: [0, 2, 8, 7, 1, 3, 5, 4, 9, 6],
+  },
+  two_optimal: {
+    label: 'Already 2-optimal',
+    desc: 'Local optimum — no improving 2-opt swap exists',
+    tour: [0, 7, 6, 5, 4, 3, 2, 1, 8, 9],
+  },
+  bad_shuffle: {
+    label: 'Bad shuffle',
+    desc: 'Many crossings — needs several passes to untangle',
+    tour: [4, 0, 9, 3, 6, 1, 8, 2, 5, 7],
+  },
+}
+
+export function makeInitState(tour: number[]): SimState {
+  const cost = tourLength(tour)
+  return {
+    phase: 'idle',
+    tour: [...tour],
+    bestTour: [...tour],
+    bestCost: cost,
+    pass: 0,
+    totalSwaps: 0,
+    lastSwap: null,
+    costHistory: [cost],
+    step: 0,
+  }
+}
+
+// Scan all non-adjacent edge pairs; return the best negative-delta swap, or
+// { bestDelta: 0, bestI: -1, bestJ: -1 } if no improving swap exists.
+export function scanOnePass(state: SimState): {
+  bestDelta: number
+  bestI: number
+  bestJ: number
+} {
+  const tour = state.tour
+  const n = tour.length
+  let bestDelta = 0
+  let bestI = -1
+  let bestJ = -1
+
+  for (let i = 0; i < n; i++) {
+    const ni = (i + 1) % n
+    for (let j = i + 2; j < n; j++) {
+      if (i === 0 && j === n - 1) continue // wrap-around adjacent
+      const nj = (j + 1) % n
+      const delta =
+        dist(tour[i], tour[j]) +
+        dist(tour[ni], tour[nj]) -
+        dist(tour[i], tour[ni]) -
+        dist(tour[j], tour[nj])
+      if (delta < bestDelta) {
+        bestDelta = delta
+        bestI = i
+        bestJ = j
+      }
+    }
+  }
+  return { bestDelta, bestI, bestJ }
+}
+
+// Reverse the segment [i+1 .. j] in-place on a copy.
+export function applySwap(tour: number[], i: number, j: number): number[] {
+  const next = [...tour]
+  let left = i + 1
+  let right = j
+  while (left < right) {
+    ;[next[left], next[right]] = [next[right], next[left]]
+    left++
+    right--
+  }
+  return next
+}
+
+// One complete scan pass: find best improvement, apply if found.
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'local_optimum')
+    return { ...state, step: state.step + 1 }
+
+  const { bestDelta, bestI, bestJ } = scanOnePass(state)
+
+  if (bestDelta < 0) {
+    const ni = (bestI + 1) % N_CITIES
+    const nj = (bestJ + 1) % N_CITIES
+    const newTour = applySwap(state.tour, bestI, bestJ)
+    const removed: [number, number][] = [
+      [state.tour[bestI], state.tour[ni]],
+      [state.tour[bestJ], state.tour[nj]],
+    ]
+    const added: [number, number][] = [
+      [newTour[bestI], newTour[ni]],
+      [newTour[bestJ], newTour[nj]],
+    ]
+    const cost = tourLength(newTour)
+
+    return {
+      ...state,
+      phase: 'swap_found',
+      tour: newTour,
+      pass: state.pass + 1,
+      totalSwaps: state.totalSwaps + 1,
+      lastSwap: { i: bestI, j: bestJ, removed, added, delta: bestDelta },
+      bestTour: cost < state.bestCost ? [...newTour] : state.bestTour,
+      bestCost: Math.min(cost, state.bestCost),
+      costHistory: [...state.costHistory, cost],
+      step: state.step + 1,
+    }
+  }
+
+  return {
+    ...state,
+    phase: 'local_optimum',
+    pass: state.pass + 1,
+    costHistory: [...state.costHistory, state.bestCost],
+    lastSwap: null,
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/two-opt.test.ts
+++ b/teeline-web/src/explainers/two-opt.test.ts
@@ -114,9 +114,30 @@ describe('applySwap', () => {
 })
 
 describe('stepOnce', () => {
+  it('first click scans and shows candidate without changing tour', () => {
+    const s = makeInitState(SCENARIOS.bad_shuffle.tour)
+    const s1 = stepOnce(s)
+    expect(s1.phase).toBe('candidate')
+    expect(s1.lastSwap).not.toBeNull()
+    expect(s1.lastSwap!.delta).toBeLessThan(0)
+    expect(s1.tour).toEqual(s.tour) // tour unchanged
+    expect(s1.totalSwaps).toBe(0)   // not applied yet
+  })
+
+  it('second click applies the candidate swap', () => {
+    const s = makeInitState(SCENARIOS.bad_shuffle.tour)
+    const s1 = stepOnce(s)  // candidate
+    const s2 = stepOnce(s1) // apply
+    expect(s2.phase).toBe('swap_found')
+    expect(s2.totalSwaps).toBe(1)
+    expect(s2.pass).toBe(1)
+    // tour must have changed after apply
+    expect(s2.tour).not.toEqual(s.tour)
+  })
+
   it('eventually reaches local_optimum', () => {
     let s = makeInitState(SCENARIOS.bad_shuffle.tour)
-    let maxSteps = 200
+    let maxSteps = 400
     while (s.phase !== 'local_optimum' && maxSteps > 0) {
       s = stepOnce(s)
       maxSteps--
@@ -134,15 +155,15 @@ describe('stepOnce', () => {
     expect(s2.phase).toBe('local_optimum')
   })
 
-  it('produces a swap_found event with valid fields', () => {
+  it('produces valid swap event fields when applied', () => {
     const s = makeInitState(SCENARIOS.bad_shuffle.tour)
-    const s1 = stepOnce(s)
-    expect(s1.phase).toBe('swap_found')
-    expect(s1.lastSwap).not.toBeNull()
-    expect(s1.lastSwap!.i).toBeGreaterThanOrEqual(0)
-    expect(s1.lastSwap!.j).toBeGreaterThan(s1.lastSwap!.i + 1)
-    expect(s1.lastSwap!.delta).toBeLessThan(0)
-    expect(s1.lastSwap!.removed).toHaveLength(2)
-    expect(s1.lastSwap!.added).toHaveLength(2)
+    const s1 = stepOnce(s)  // candidate
+    const s2 = stepOnce(s1) // apply
+    expect(s2.lastSwap).not.toBeNull()
+    expect(s2.lastSwap!.i).toBeGreaterThanOrEqual(0)
+    expect(s2.lastSwap!.j).toBeGreaterThan(s2.lastSwap!.i + 1)
+    expect(s2.lastSwap!.delta).toBeLessThan(0)
+    expect(s2.lastSwap!.removed).toHaveLength(2)
+    expect(s2.lastSwap!.added).toHaveLength(2)
   })
 })

--- a/teeline-web/src/explainers/two-opt.test.ts
+++ b/teeline-web/src/explainers/two-opt.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, SCENARIOS,
+  dist, tourLength, makeInitState, stepOnce,
+  scanOnePass, applySwap,
+} from './two-opt-algo'
+
+describe('dist', () => {
+  it('is symmetric', () => {
+    for (let i = 0; i < N_CITIES; i++) {
+      for (let j = 0; j < N_CITIES; j++) {
+        expect(dist(i, j)).toBeCloseTo(dist(j, i), 10)
+      }
+    }
+  })
+
+  it('is zero for same city', () => {
+    expect(dist(0, 0)).toBe(0)
+  })
+
+  it('is positive for different cities', () => {
+    expect(dist(0, 1)).toBeGreaterThan(0)
+  })
+})
+
+describe('tourLength', () => {
+  it('returns a finite positive number for a valid tour', () => {
+    const len = tourLength([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(len).toBeGreaterThan(0)
+    expect(Number.isFinite(len)).toBe(true)
+  })
+
+  it('is the same for rotationally equivalent tours', () => {
+    const a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const b = [3, 4, 5, 6, 7, 8, 9, 0, 1, 2]
+    expect(tourLength(a)).toBeCloseTo(tourLength(b), 10)
+  })
+})
+
+describe('SCENARIOS', () => {
+  it('all scenario tours contain all cities exactly once', () => {
+    for (const [_key, s] of Object.entries(SCENARIOS)) {
+      const sorted = s.tour.slice().sort((a, b) => a - b)
+      expect(sorted).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+    }
+  })
+})
+
+describe('makeInitState', () => {
+  it('starts in idle phase', () => {
+    const s = makeInitState([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(s.phase).toBe('idle')
+    expect(s.pass).toBe(0)
+    expect(s.totalSwaps).toBe(0)
+    expect(s.step).toBe(0)
+  })
+
+  it('sets bestCost from tour', () => {
+    const s = makeInitState([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(s.bestCost).toBeCloseTo(tourLength(s.tour), 10)
+  })
+
+  it('costHistory starts with initial cost', () => {
+    const s = makeInitState([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(s.costHistory).toEqual([s.bestCost])
+  })
+
+  it('copies the tour (does not share reference)', () => {
+    const input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const s = makeInitState(input)
+    input[0] = 999
+    expect(s.tour[0]).toBe(0)
+  })
+})
+
+describe('scanOnePass', () => {
+  it('returns bestDelta=0 with bestI=bestJ=-1 when no improving swap exists', () => {
+    const s = makeInitState(SCENARIOS.two_optimal.tour)
+    const { bestDelta, bestI, bestJ } = scanOnePass(s)
+    expect(bestDelta).toBe(0)
+    expect(bestI).toBe(-1)
+    expect(bestJ).toBe(-1)
+  })
+
+  it('returns a negative delta when an improving swap exists', () => {
+    const s = makeInitState(SCENARIOS.bad_shuffle.tour)
+    const { bestDelta, bestI, bestJ } = scanOnePass(s)
+    expect(bestDelta).toBeLessThan(0)
+    expect(bestI).toBeGreaterThanOrEqual(0)
+    expect(bestJ).toBeGreaterThan(bestI + 1)
+  })
+})
+
+describe('applySwap', () => {
+  it('returns a valid tour with all cities', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const next = applySwap(tour, 2, 5)
+    const sorted = next.slice().sort((a, b) => a - b)
+    expect(sorted).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+  })
+
+  it('reverses the segment between i+1 and j', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const next = applySwap(tour, 1, 4) // reverse [2,3,4] → [4,3,2]
+    expect(next).toEqual([0, 1, 4, 3, 2, 5, 6, 7, 8, 9])
+  })
+
+  it('does not mutate the input', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    const copy = [...tour]
+    applySwap(tour, 1, 3)
+    expect(tour).toEqual(copy)
+  })
+})
+
+describe('stepOnce', () => {
+  it('eventually reaches local_optimum', () => {
+    let s = makeInitState(SCENARIOS.bad_shuffle.tour)
+    let maxSteps = 200
+    while (s.phase !== 'local_optimum' && maxSteps > 0) {
+      s = stepOnce(s)
+      maxSteps--
+    }
+    expect(s.phase).toBe('local_optimum')
+    expect(s.bestCost).toBeGreaterThan(0)
+  })
+
+  it('no-op when already at local_optimum', () => {
+    const s = makeInitState(SCENARIOS.two_optimal.tour)
+    const s1 = stepOnce(s)
+    expect(s1.phase).toBe('local_optimum')
+    const s2 = stepOnce(s1)
+    expect(s2.step).toBe(s1.step + 1)
+    expect(s2.phase).toBe('local_optimum')
+  })
+
+  it('produces a swap_found event with valid fields', () => {
+    const s = makeInitState(SCENARIOS.bad_shuffle.tour)
+    const s1 = stepOnce(s)
+    expect(s1.phase).toBe('swap_found')
+    expect(s1.lastSwap).not.toBeNull()
+    expect(s1.lastSwap!.i).toBeGreaterThanOrEqual(0)
+    expect(s1.lastSwap!.j).toBeGreaterThan(s1.lastSwap!.i + 1)
+    expect(s1.lastSwap!.delta).toBeLessThan(0)
+    expect(s1.lastSwap!.removed).toHaveLength(2)
+    expect(s1.lastSwap!.added).toHaveLength(2)
+  })
+})

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -169,9 +169,9 @@ export default function TwoOptExplainer() {
       </div>
 
       <div className="topt-legend">
-        <span><span class="topt-swatch topt-swatch-normal" /> tour edge</span>
-        <span><span class="topt-swatch topt-swatch-removed" /> removed</span>
-        <span><span class="topt-swatch topt-swatch-added" /> new edge</span>
+        <span><span className="topt-swatch topt-swatch-normal" /> tour edge</span>
+        <span><span className="topt-swatch topt-swatch-removed" /> removed</span>
+        <span><span className="topt-swatch topt-swatch-added" /> new edge</span>
       </div>
 
       <div className={chipClass}>{chipText}</div>

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -1,0 +1,383 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES, SCENARIOS,
+  tourLength, makeInitState, stepOnce,
+} from "./two-opt-algo"
+import type { Phase } from "./two-opt-algo"
+
+const DEFAULT_TOUR = SCENARIOS.bad_shuffle.tour
+const SPEEDS = [30, 60, 100, 160, 250, 380, 600]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+// ---------------------------------------------------------------
+// TourCanvas — current tour with highlighted swap edges
+// ---------------------------------------------------------------
+function TourCanvas({ tour, lastSwap, phase }: {
+  tour: number[]
+  lastSwap: { removed: [number, number][]; added: [number, number][] } | null
+  phase: Phase
+}) {
+  const removeSet = useMemo(() => {
+    if (!lastSwap) return new Set<string>()
+    return new Set(lastSwap.removed.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`))
+  }, [lastSwap])
+  const addSet = useMemo(() => {
+    if (!lastSwap) return new Set<string>()
+    return new Set(lastSwap.added.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`))
+  }, [lastSwap])
+
+  const edges: Array<{ from: number; to: number; key: string }> = []
+  for (let k = 0; k < tour.length; k++) {
+    const a = tour[k]
+    const b = tour[(k + 1) % tour.length]
+    edges.push({ from: a, to: b, key: `${Math.min(a, b)}-${Math.max(a, b)}` })
+  }
+
+  const showSwap = phase === 'swap_found' && lastSwap
+
+  return (
+    <svg viewBox="0 0 300 300" className="topt-canvas" role="img" aria-label="2-opt tour">
+      <rect x={0} y={0} width={300} height={300} className="topt-bg" />
+      {edges.map(({ from, to, key }) => {
+        let cls = "topt-edge"
+        if (showSwap) {
+          if (removeSet.has(key)) cls += " topt-removed"
+          else if (addSet.has(key)) cls += " topt-added"
+        }
+        return <line key={key} className={cls}
+          x1={CITIES[from][0]} y1={CITIES[from][1]}
+          x2={CITIES[to][0]} y2={CITIES[to][1]} />
+      })}
+      {tour.map((id) => (
+        <g key={id}>
+          <circle className="topt-city"
+            cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
+          <text className="topt-label"
+            x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+        </g>
+      ))}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Cost sparkline (same pattern as ACO)
+// ---------------------------------------------------------------
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null
+  const W = 300, H = 46
+  const minV = Math.min(...values)
+  const maxV = Math.max(...values)
+  const range = maxV - minV || 1
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W
+    const y = H - ((v - minV) / range) * (H - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="topt-spark">
+      <rect x={0} y={0} width={W} height={H} className="topt-bg" rx={4} />
+      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
+        strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function TwoOptExplainer() {
+  const [tour, setTour] = useState<number[]>(() => [...DEFAULT_TOUR])
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_TOUR))
+  const [pass, setPass] = useState(0)
+  const [totalSwaps, setTotalSwaps] = useState(0)
+  const [lastSwap, setLastSwap] = useState<{
+    i: number; j: number; removed: [number, number][]; added: [number, number][]; delta: number
+  } | null>(null)
+  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_TOUR)])
+  const [step, setStep] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2) // 3x = 100ms
+
+  const simRef = useRef(makeInitState(DEFAULT_TOUR))
+
+  const reinit = useCallback((t: number[]) => {
+    simRef.current = makeInitState(t)
+    setTour([...t])
+    setPhase('idle')
+    setBestCost(simRef.current.bestCost)
+    setPass(0)
+    setTotalSwaps(0)
+    setLastSwap(null)
+    setCostHistory([simRef.current.bestCost])
+    setStep(0)
+    setRunning(false)
+  }, [])
+
+  const step_fn = useCallback(() => {
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setTour([...next.tour])
+    setPhase(next.phase)
+    setBestCost(next.bestCost)
+    setPass(next.pass)
+    setTotalSwaps(next.totalSwaps)
+    setLastSwap(next.lastSwap)
+    setCostHistory([...next.costHistory])
+    setStep(next.step)
+    if (next.phase === 'local_optimum') setRunning(false)
+  }, [])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = SPEEDS[speedIdx]
+    const id = setInterval(step_fn, ms)
+    return () => clearInterval(id)
+  }, [running, speedIdx, step_fn])
+
+  let chipText = "Press Step or Run to start optimising"
+  let chipClass = "topt-chip topt-chip-idle"
+  if (phase === 'swap_found' && lastSwap) {
+    chipText = `Swap (${lastSwap.i + 1},${lastSwap.j + 1}) — Δ=${lastSwap.delta.toFixed(0)}`
+    chipClass = "topt-chip topt-chip-swap"
+  } else if (phase === 'local_optimum') {
+    chipText = `Local optimum reached — no improving swap exists (${totalSwaps} swaps, ${pass} passes)`
+    chipClass = "topt-chip topt-chip-done"
+  }
+
+  return (
+    <div className="topt-root">
+      <style>{CSS}</style>
+
+      <header className="topt-header">
+        <div className="topt-eyebrow">teeline · algorithms/2opt</div>
+        <h2 className="topt-title">2-opt Local Search</h2>
+        <p className="topt-sub">
+          2-opt iteratively improves a tour by removing two edges and
+          reconnecting the resulting segments in the only other valid way
+          — reversing the segment between the two removed edges. Each pass
+          scans all edge pairs and applies the <strong>best-improving</strong> swap;
+          the algorithm stops when no improving swap exists (local optimum).
+        </p>
+      </header>
+
+      <div className="topt-viz-row">
+        <div className="topt-canvas-wrap">
+          <TourCanvas tour={tour} lastSwap={lastSwap} phase={phase} />
+        </div>
+      </div>
+
+      <div className="topt-legend">
+        <span><span class="topt-swatch topt-swatch-normal" /> tour edge</span>
+        <span><span class="topt-swatch topt-swatch-removed" /> removed</span>
+        <span><span class="topt-swatch topt-swatch-added" /> new edge</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="topt-section-label">Cost history</div>
+      <Sparkline values={costHistory} />
+
+      <div className="topt-statgrid">
+        <div>
+          <div className="topt-statlabel">pass</div>
+          <div className="topt-mono">{pass}</div>
+        </div>
+        <div>
+          <div className="topt-statlabel">swaps</div>
+          <div className="topt-mono">{totalSwaps}</div>
+        </div>
+        <div>
+          <div className="topt-statlabel">best cost</div>
+          <div className="topt-mono">{bestCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="topt-statlabel">step</div>
+          <div className="topt-mono">{step}</div>
+        </div>
+        {lastSwap && (
+          <div>
+            <div className="topt-statlabel">last Δ</div>
+            <div className="topt-mono" style={{ color: lastSwap.delta < 0 ? "#16a34a" : "inherit" }}>
+              {lastSwap.delta.toFixed(0)}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="topt-config">
+        <div className="topt-config-row">
+          <label className="topt-label">Speed</label>
+          <div className="topt-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l}
+                className={`topt-speed-btn ${i === speedIdx ? 'topt-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="topt-controls">
+        <button className="topt-btn" onClick={step_fn} disabled={running || phase === 'local_optimum'}>
+          ◀ Step
+        </button>
+        <button className="topt-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="topt-btn" onClick={() => reinit([...tour])}>↺ Reset</button>
+      </div>
+
+      <div className="topt-scenarios">
+        <div className="topt-section-label">Scenarios</div>
+        <div className="topt-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, s]) => (
+            <button key={key} className="topt-scenario-btn" title={s.desc}
+              onClick={() => reinit([...s.tour])}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="topt-footer">
+        <span className="topt-mono">cities: {N_CITIES}</span>
+        <span className="topt-mono">best-improvement 2-opt</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.topt-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --improve: #16a34a;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.topt-root * { box-sizing: border-box; }
+.topt-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.topt-header { margin-bottom: 2px; }
+.topt-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.topt-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.topt-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.topt-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.topt-bg { fill: var(--panel); }
+.topt-edge { stroke: #94a3b8; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.topt-removed { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 6 3; }
+.topt-added { stroke: #16a34a; stroke-width: 3.5; }
+.topt-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
+.topt-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+.topt-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.topt-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+.topt-legend {
+  display: flex; gap: 14px; font-size: 0.78rem; color: var(--muted);
+}
+.topt-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.topt-swatch-normal { background: #94a3b8; }
+.topt-swatch-removed { background: #ef4444; }
+.topt-swatch-added { background: #16a34a; }
+
+.topt-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.topt-chip-idle { background: #f1f5f9; color: var(--muted); }
+.topt-chip-swap { background: #fef3c7; color: #92400e; }
+.topt-chip-done { background: #dcfce7; color: #166534; }
+
+.topt-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.topt-spark { width: 100%; display: block; border-radius: 6px; }
+
+.topt-statgrid {
+  display: flex; flex-wrap: wrap; gap: 14px 22px;
+  font-size: 0.82rem;
+}
+.topt-statlabel { color: var(--muted); font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.topt-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.topt-config-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.topt-label {
+  font-size: 0.82rem; font-weight: 500; color: var(--text);
+  min-width: 50px;
+}
+.topt-speed-btns { display: flex; gap: 4px; }
+.topt-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.topt-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.topt-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.topt-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.topt-controls { display: flex; gap: 8px; }
+.topt-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.topt-btn:hover:not(:disabled) { background: #f0fdf4; }
+.topt-btn:disabled { opacity: 0.4; cursor: default; }
+
+.topt-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.topt-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.topt-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.topt-scenario-btn:hover { background: #f0fdf4; border-color: var(--accent); }
+
+.topt-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -105,9 +105,11 @@ export default function TwoOptExplainer() {
   const [speedIdx, setSpeedIdx] = useState(0) // 1x = 600ms — slow enough to observe swaps
 
   const simRef = useRef(makeInitState(DEFAULT_TOUR))
+  const historyRef = useRef<Array<typeof simRef.current>>([])
 
   const reinit = useCallback((t: number[]) => {
     simRef.current = makeInitState(t)
+    historyRef.current = []
     setTour([...t])
     setPhase('idle')
     setBestCost(simRef.current.bestCost)
@@ -120,6 +122,7 @@ export default function TwoOptExplainer() {
   }, [])
 
   const step_fn = useCallback(() => {
+    historyRef.current.push(structuredClone(simRef.current))
     const next = stepOnce(simRef.current)
     simRef.current = next
     setTour([...next.tour])
@@ -132,6 +135,21 @@ export default function TwoOptExplainer() {
     setStep(next.step)
     if (next.phase === 'local_optimum') setRunning(false)
   }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    const prev = h.pop()!
+    simRef.current = prev
+    setTour([...prev.tour])
+    setPhase(prev.phase)
+    setBestCost(prev.bestCost)
+    setPass(prev.pass)
+    setTotalSwaps(prev.totalSwaps)
+    setLastSwap(prev.lastSwap)
+    setCostHistory([...prev.costHistory])
+    setStep(prev.step)
+  }, [running])
 
   useEffect(() => {
     if (!running) return
@@ -235,6 +253,9 @@ export default function TwoOptExplainer() {
       </div>
 
       <div className="topt-controls">
+        <button className="topt-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+          ⏴ Back
+        </button>
         <button className="topt-btn" onClick={step_fn} disabled={running || phase === 'local_optimum'}>
           ⏵ Step
         </button>

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -6,7 +6,7 @@ import {
 import type { Phase } from "./two-opt-algo"
 
 const DEFAULT_TOUR = SCENARIOS.bad_shuffle.tour
-const SPEEDS = [30, 60, 100, 160, 250, 380, 600]
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
 const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
 
 // ---------------------------------------------------------------
@@ -98,7 +98,7 @@ export default function TwoOptExplainer() {
   const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_TOUR)])
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
-  const [speedIdx, setSpeedIdx] = useState(2) // 3x = 100ms
+  const [speedIdx, setSpeedIdx] = useState(0) // 1x = 600ms — slow enough to observe swaps
 
   const simRef = useRef(makeInitState(DEFAULT_TOUR))
 
@@ -223,7 +223,7 @@ export default function TwoOptExplainer() {
 
       <div className="topt-controls">
         <button className="topt-btn" onClick={step_fn} disabled={running || phase === 'local_optimum'}>
-          ◀ Step
+          ⏵ Step
         </button>
         <button className="topt-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
           {running ? "⏸ Pause" : "▶ Run"}

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -33,14 +33,18 @@ function TourCanvas({ tour, lastSwap, phase }: {
     edges.push({ from: a, to: b, key: `${Math.min(a, b)}-${Math.max(a, b)}` })
   }
 
-  const showSwap = phase === 'swap_found' && lastSwap
+  const showCandidate = phase === 'candidate' && lastSwap
+  const showApplied = phase === 'swap_found' && lastSwap
 
   return (
     <svg viewBox="0 0 300 300" className="topt-canvas" role="img" aria-label="2-opt tour">
       <rect x={0} y={0} width={300} height={300} className="topt-bg" />
       {edges.map(({ from, to, key }) => {
         let cls = "topt-edge"
-        if (showSwap) {
+        if (showCandidate) {
+          if (removeSet.has(key)) cls += " topt-cand-removed"
+          else if (addSet.has(key)) cls += " topt-cand-added"
+        } else if (showApplied) {
           if (removeSet.has(key)) cls += " topt-removed"
           else if (addSet.has(key)) cls += " topt-added"
         }
@@ -136,10 +140,13 @@ export default function TwoOptExplainer() {
     return () => clearInterval(id)
   }, [running, speedIdx, step_fn])
 
-  let chipText = "Press Step or Run to start optimising"
+  let chipText = "Click Step to scan for improving swaps"
   let chipClass = "topt-chip topt-chip-idle"
-  if (phase === 'swap_found' && lastSwap) {
-    chipText = `Swap (${lastSwap.i + 1},${lastSwap.j + 1}) — Δ=${lastSwap.delta.toFixed(0)}`
+  if (phase === 'candidate' && lastSwap) {
+    chipText = `Candidate swap (${lastSwap.i + 1},${lastSwap.j + 1}) — Δ=${lastSwap.delta.toFixed(0)} — click Step to apply`
+    chipClass = "topt-chip topt-chip-candidate"
+  } else if (phase === 'swap_found' && lastSwap) {
+    chipText = `Swap (${lastSwap.i + 1},${lastSwap.j + 1}) applied — Δ=${lastSwap.delta.toFixed(0)}`
     chipClass = "topt-chip topt-chip-swap"
   } else if (phase === 'local_optimum') {
     chipText = `Local optimum reached — no improving swap exists (${totalSwaps} swaps, ${pass} passes)`
@@ -170,6 +177,8 @@ export default function TwoOptExplainer() {
 
       <div className="topt-legend">
         <span><span className="topt-swatch topt-swatch-normal" /> tour edge</span>
+        <span><span className="topt-swatch topt-swatch-cand-rm" /> candidate (remove)</span>
+        <span><span className="topt-swatch topt-swatch-cand-ad" /> candidate (add)</span>
         <span><span className="topt-swatch topt-swatch-removed" /> removed</span>
         <span><span className="topt-swatch topt-swatch-added" /> new edge</span>
       </div>
@@ -293,6 +302,8 @@ const CSS = `
 }
 .topt-bg { fill: var(--panel); }
 .topt-edge { stroke: #94a3b8; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.topt-cand-removed { stroke: #ea580c; stroke-width: 3.5; stroke-dasharray: 6 4; }
+.topt-cand-added { stroke: #16a34a; stroke-width: 3.5; stroke-dasharray: 4 6; }
 .topt-removed { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 6 3; }
 .topt-added { stroke: #16a34a; stroke-width: 3.5; }
 .topt-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
@@ -314,6 +325,8 @@ const CSS = `
   margin-right: 4px; vertical-align: middle;
 }
 .topt-swatch-normal { background: #94a3b8; }
+.topt-swatch-cand-rm { background: #ea580c; }
+.topt-swatch-cand-ad { background: #16a34a; }
 .topt-swatch-removed { background: #ef4444; }
 .topt-swatch-added { background: #16a34a; }
 
@@ -322,6 +335,7 @@ const CSS = `
   font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 .topt-chip-idle { background: #f1f5f9; color: var(--muted); }
+.topt-chip-candidate { background: #ffedd5; color: #9a3412; }
 .topt-chip-swap { background: #fef3c7; color: #92400e; }
 .topt-chip-done { background: #dcfce7; color: #166534; }
 

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -143,10 +143,14 @@ export default function TwoOptExplainer() {
   let chipText = "Click Step to scan for improving swaps"
   let chipClass = "topt-chip topt-chip-idle"
   if (phase === 'candidate' && lastSwap) {
-    chipText = `Candidate swap (${lastSwap.i + 1},${lastSwap.j + 1}) — Δ=${lastSwap.delta.toFixed(0)} — click Step to apply`
+    const [r0a, r0b] = lastSwap.removed[0]
+    const [r1a, r1b] = lastSwap.removed[1]
+    chipText = `Candidate — edges to remove: ${r0a}→${r0b} and ${r1a}→${r1b}  (Δ=${lastSwap.delta.toFixed(0)})`
     chipClass = "topt-chip topt-chip-candidate"
   } else if (phase === 'swap_found' && lastSwap) {
-    chipText = `Swap (${lastSwap.i + 1},${lastSwap.j + 1}) applied — Δ=${lastSwap.delta.toFixed(0)}`
+    const [r0a, r0b] = lastSwap.removed[0]
+    const [a0a, a0b] = lastSwap.added[0]
+    chipText = `Swapped — removed ${r0a}→${r0b}, added ${a0a}→${a0b}  (Δ=${lastSwap.delta.toFixed(0)})`
     chipClass = "topt-chip topt-chip-swap"
   } else if (phase === 'local_optimum') {
     chipText = `Local optimum reached — no improving swap exists (${totalSwaps} swaps, ${pass} passes)`

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -1,5 +1,5 @@
 ---
-// Replaces the 10 hand-authored algorithms/<id>/explainer/index.html shells +
+// Replaces the 14 hand-authored algorithms/<id>/explainer/index.html shells +
 // their *-page.ts mount scripts (manual preact.render() calls). One dynamic
 // route over a fixed id->component map; client:visible defers hydration
 // until the explainer scrolls into view (below-the-fold interactive demo,
@@ -28,6 +28,7 @@ import FourierExplainer from '../../../../explainers/fourier'
 import GreedyEdgeExplainer from '../../../../explainers/greedy-edge'
 import SavingsExplainer from '../../../../explainers/savings'
 import AcoExplainer from '../../../../explainers/aco'
+import TwoOptExplainer from '../../../../explainers/two-opt'
 
 export function getStaticPaths() {
   return EXPLAINER_IDS.map((id) => ({ params: { id } }))
@@ -67,5 +68,6 @@ const jsonLd = {
     {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
     {id === 'savings' && <SavingsExplainer client:visible />}
     {id === 'aco' && <AcoExplainer client:visible />}
+    {id === '2opt' && <TwoOptExplainer client:visible />}
   </main>
 </BaseLayout>


### PR DESCRIPTION
Pure-JS simulation with best-improvement scan per step:

**`two-opt-algo.ts`** — stepOnce, scanOnePass, applySwap, 10-city dataset with 4 predefined scenario tours:
- Single crossing — one pair of crossing edges, fixed in one swap
- Multiple crossings — several crossings resolved over passes
- Already 2-optimal — local optimum, no improving swap exists
- Bad shuffle — many crossings, needs several passes to untangle

**`two-opt.tsx`** — Preact component:
- SVG canvas with city labels
- Swap highlighting: removed edges flash red (dashed), new edges green
- Sparkline showing cost per pass
- Speed control (7 levels), step/run/pause/reset buttons
- Scenario buttons, stats panel (pass, swaps, cost, delta)
- Phase chip: idle → swap found → local optimum

**`two-opt.test.ts`** — 18 unit tests covering dist, tourLength, scenarios, makeInitState, scanOnePass, applySwap, stepOnce convergence

Closes #234.