### PR TITLE
feat(solver): support EXPLICIT/MATRIX and GEO distances in WASM (#436)

### DIFF
--- a/src/tsp/comparison.rs
+++ b/src/tsp/comparison.rs
@@ -1,3 +1,5 @@
+use crate::tsp::DistanceType;
+use crate::tsp::distance_matrix::DistanceMatrix;
 use crate::tsp::kdtree::KDPoint;
 use std::collections::{HashMap, HashSet};
 
@@ -13,22 +15,70 @@ pub struct ComparisonStats {
 /// Sum of EUC_2D distances along the tour, closing the cycle (last→first).
 /// City IDs are 1-based and are NOT array indices — uses HashMap lookup.
 pub fn tour_cost(route: &[usize], cities: &[KDPoint]) -> f32 {
+    tour_cost_with_type(route, cities, DistanceType::Euc2D)
+}
+
+/// Sum of distances along the tour using the given distance type.
+pub fn tour_cost_with_type(route: &[usize], cities: &[KDPoint], dt: DistanceType) -> f32 {
     let idx: HashMap<usize, &KDPoint> = cities.iter().map(|c| (c.id, c)).collect();
     let n = route.len();
     (0..n)
         .map(|i| {
             let a = idx[&route[i]];
             let b = idx[&route[(i + 1) % n]];
-            let dx = a.x() - b.x();
-            let dy = a.y() - b.y();
-            (dx * dx + dy * dy).sqrt()
+            match dt {
+                DistanceType::Euc2D => {
+                    let dx = a.x() - b.x();
+                    let dy = a.y() - b.y();
+                    (dx * dx + dy * dy).sqrt()
+                }
+                DistanceType::Geo => geo_distance(a, b),
+                DistanceType::Explicit => {
+                    let dx = a.x() - b.x();
+                    let dy = a.y() - b.y();
+                    (dx * dx + dy * dy).sqrt()
+                }
+            }
         })
         .sum()
 }
 
+/// Sum of distances along the tour using a pre-computed distance matrix.
+pub fn tour_cost_from_matrix(route: &[usize], dm: &DistanceMatrix) -> f32 {
+    dm.tour_length(route)
+}
+
 pub fn compare_tours(solver: &[usize], optimal: &[usize], cities: &[KDPoint]) -> ComparisonStats {
-    let optimal_cost = tour_cost(optimal, cities);
-    let solver_cost = tour_cost(solver, cities);
+    compare_tours_with_type(solver, optimal, cities, DistanceType::Euc2D)
+}
+
+pub fn compare_tours_with_type(
+    solver: &[usize],
+    optimal: &[usize],
+    cities: &[KDPoint],
+    dt: DistanceType,
+) -> ComparisonStats {
+    let optimal_cost = tour_cost_with_type(optimal, cities, dt);
+    let solver_cost = tour_cost_with_type(solver, cities, dt);
+    build_stats(solver_cost, optimal_cost, solver, optimal)
+}
+
+pub fn compare_tours_from_matrix(
+    solver: &[usize],
+    optimal: &[usize],
+    dm: &DistanceMatrix,
+) -> ComparisonStats {
+    let optimal_cost = tour_cost_from_matrix(optimal, dm);
+    let solver_cost = tour_cost_from_matrix(solver, dm);
+    build_stats(solver_cost, optimal_cost, solver, optimal)
+}
+
+fn build_stats(
+    solver_cost: f32,
+    optimal_cost: f32,
+    solver: &[usize],
+    optimal: &[usize],
+) -> ComparisonStats {
     let gap_pct = if optimal_cost > 0.0 {
         (solver_cost - optimal_cost) / optimal_cost * 100.0
     } else {
@@ -50,6 +100,25 @@ pub fn compare_tours(solver: &[usize], optimal: &[usize], cities: &[KDPoint]) ->
         solver_only_edges,
         optimal_only_edges,
     }
+}
+
+/// GEO distance formula from TSPLIB spec.
+fn geo_distance(p1: &KDPoint, p2: &KDPoint) -> f32 {
+    use std::f64::consts::PI;
+    fn to_rad(x: f32) -> f64 {
+        let deg = x.trunc() as f64;
+        let min = (x - x.trunc()) as f64;
+        PI * (deg + 5.0 * min / 3.0) / 180.0
+    }
+    let lat1 = to_rad(p1.coords[0]);
+    let lon1 = to_rad(p1.coords[1]);
+    let lat2 = to_rad(p2.coords[0]);
+    let lon2 = to_rad(p2.coords[1]);
+    let q1 = (lon1 - lon2).cos();
+    let q2 = (lat1 - lat2).cos();
+    let q3 = (lat1 + lat2).cos();
+    const RRR: f64 = 6378.388;
+    (RRR * (0.5 * ((1.0 + q1) * q2 - (1.0 - q1) * q3)).acos() + 1.0).floor() as f32
 }
 
 /// Build a set of undirected edges: each edge stored as (min_id, max_id).
@@ -153,6 +222,62 @@ mod tests {
         assert!(
             stats2.gap_pct > 0.0,
             "ID-sorted route must be worse than the known optimal"
+        );
+    }
+
+    #[test]
+    fn tour_cost_from_matrix_ring6() {
+        let input = "NAME: ring6\nDIMENSION: 6\nEDGE_WEIGHT_TYPE: EXPLICIT\nEDGE_WEIGHT_FORMAT: FULL_MATRIX\nEDGE_WEIGHT_SECTION\n0 10 100 100 100 10\n10 0 10 100 100 100\n100 10 0 10 100 100\n100 100 10 0 10 100\n100 100 100 10 0 10\n10 100 100 100 10 0\nEOF\n";
+        let data = crate::tsp::tsplib::read_from_str(input).unwrap();
+        let dm = data.distance_matrix().unwrap();
+        // Optimal ring tour: 0-1-2-3-4-5, edges are all 10 = 60
+        let route = vec![1, 2, 3, 4, 5, 6];
+        let cost = tour_cost_from_matrix(&route, &dm);
+        assert!((cost - 60.0).abs() < 0.01, "expected 60, got {cost}");
+    }
+
+    #[test]
+    fn compare_tours_from_matrix_ring6_self_is_zero_gap() {
+        let input = "NAME: ring6\nDIMENSION: 6\nEDGE_WEIGHT_TYPE: EXPLICIT\nEDGE_WEIGHT_FORMAT: FULL_MATRIX\nEDGE_WEIGHT_SECTION\n0 10 100 100 100 10\n10 0 10 100 100 100\n100 10 0 10 100 100\n100 100 10 0 10 100\n100 100 100 10 0 10\n10 100 100 100 10 0\nEOF\n";
+        let data = crate::tsp::tsplib::read_from_str(input).unwrap();
+        let dm = data.distance_matrix().unwrap();
+        let route = vec![1, 2, 3, 4, 5, 6];
+        let stats = compare_tours_from_matrix(&route, &route, &dm);
+        assert_eq!(stats.gap_pct, 0.0);
+        assert_eq!(stats.shared_edges, 6);
+        assert_eq!(stats.solver_only_edges, 0);
+    }
+
+    #[test]
+    fn tour_cost_with_type_geo_burma14_pair() {
+        // Two cities from burma14 at positions that should produce the known
+        // GEO distance from the distance_matrix tests: 837.
+        let a = KDPoint::new_with_id(1, &[16.47, 96.10]);
+        let b = KDPoint::new_with_id(2, &[23.70, 96.99]);
+        let cities = vec![a, b];
+        let route = vec![1, 2];
+        let cost = tour_cost_with_type(&route, &cities, DistanceType::Geo);
+        assert!(
+            (cost - 837.0 * 2.0).abs() < 1.0,
+            "GEO cost should be ~1674 (837 per edge), got {cost}"
+        );
+    }
+
+    #[test]
+    fn compare_tours_with_type_geo_is_different_from_euc2d() {
+        let a = KDPoint::new_with_id(1, &[16.47, 96.10]);
+        let b = KDPoint::new_with_id(2, &[23.70, 96.99]);
+        let c = KDPoint::new_with_id(3, &[22.39, 93.37]);
+        let cities = vec![a, b, c];
+        let solver = vec![1, 2, 3];
+        let optimal = vec![1, 3, 2];
+        let geo_stats = compare_tours_with_type(&solver, &optimal, &cities, DistanceType::Geo);
+        let euc_stats = compare_tours_with_type(&solver, &optimal, &cities, DistanceType::Euc2D);
+        assert!(
+            (geo_stats.optimal_cost - euc_stats.optimal_cost).abs() > 1.0,
+            "GEO and EUC_2D costs should differ for these cities, got geo={}, euc={}",
+            geo_stats.optimal_cost,
+            euc_stats.optimal_cost
         );
     }
 }

--- a/src/tsp/comparison.rs
+++ b/src/tsp/comparison.rs
@@ -1,4 +1,5 @@
 use crate::tsp::DistanceType;
+use crate::tsp::distance_matrix;
 use crate::tsp::distance_matrix::DistanceMatrix;
 use crate::tsp::kdtree::KDPoint;
 use std::collections::{HashMap, HashSet};
@@ -32,11 +33,9 @@ pub fn tour_cost_with_type(route: &[usize], cities: &[KDPoint], dt: DistanceType
                     let dy = a.y() - b.y();
                     (dx * dx + dy * dy).sqrt()
                 }
-                DistanceType::Geo => geo_distance(a, b),
+                DistanceType::Geo => distance_matrix::geo_distance(a, b),
                 DistanceType::Explicit => {
-                    let dx = a.x() - b.x();
-                    let dy = a.y() - b.y();
-                    (dx * dx + dy * dy).sqrt()
+                    panic!("tour_cost_with_type requires DistanceMatrix for EXPLICIT; use tour_cost_from_matrix instead")
                 }
             }
         })
@@ -100,25 +99,6 @@ fn build_stats(
         solver_only_edges,
         optimal_only_edges,
     }
-}
-
-/// GEO distance formula from TSPLIB spec.
-fn geo_distance(p1: &KDPoint, p2: &KDPoint) -> f32 {
-    use std::f64::consts::PI;
-    fn to_rad(x: f32) -> f64 {
-        let deg = x.trunc() as f64;
-        let min = (x - x.trunc()) as f64;
-        PI * (deg + 5.0 * min / 3.0) / 180.0
-    }
-    let lat1 = to_rad(p1.coords[0]);
-    let lon1 = to_rad(p1.coords[1]);
-    let lat2 = to_rad(p2.coords[0]);
-    let lon2 = to_rad(p2.coords[1]);
-    let q1 = (lon1 - lon2).cos();
-    let q2 = (lat1 - lat2).cos();
-    let q3 = (lat1 + lat2).cos();
-    const RRR: f64 = 6378.388;
-    (RRR * (0.5 * ((1.0 + q1) * q2 - (1.0 - q1) * q3)).acos() + 1.0).floor() as f32
 }
 
 /// Build a set of undirected edges: each edge stored as (min_id, max_id).

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -56,7 +56,7 @@ use std::collections::HashMap;
 use super::kdtree::KDPoint;
 use super::{CityTable, DistanceType, NearestResult};
 
-fn geo_distance(p1: &KDPoint, p2: &KDPoint) -> f32 {
+pub(crate) fn geo_distance(p1: &KDPoint, p2: &KDPoint) -> f32 {
     use std::f64::consts::PI;
     fn to_rad(x: f32) -> f64 {
         let deg = x.trunc() as f64;

--- a/src/tsp/distance_matrix.rs
+++ b/src/tsp/distance_matrix.rs
@@ -137,6 +137,11 @@ impl DistanceMatrix {
                 let d = match distance_type {
                     DistanceType::Euc2D => pt1.distance(pt2),
                     DistanceType::Geo => geo_distance(pt1, pt2),
+                    DistanceType::Explicit => {
+                        return Err(
+                            "cannot build distance matrix from coordinates for EXPLICIT type — use DistanceMatrix::new() with precomputed distances",
+                        );
+                    }
                 };
                 distances.push(d);
             }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -165,6 +165,7 @@ impl Solvers {
 pub enum DistanceType {
     #[default]
     Euc2D,
+    Explicit,
     Geo,
 }
 
@@ -173,6 +174,7 @@ impl FromStr for DistanceType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_uppercase().as_str() {
             "EUC_2D" | "EUC2D" => Ok(DistanceType::Euc2D),
+            "EXPLICIT" => Ok(DistanceType::Explicit),
             "GEO" => Ok(DistanceType::Geo),
             other => Err(format!("unsupported distance type: {other}")),
         }
@@ -2472,5 +2474,13 @@ mod tests {
         let args = cmd.get_matches_from(["t", "--epochs", "0"]);
         let err = FourierOptions::from_cli(&args).unwrap_err();
         assert!(err.contains("epochs"), "got: {err}");
+    }
+
+    #[test]
+    fn distance_type_from_str_explicit() {
+        assert_eq!(
+            "EXPLICIT".parse::<DistanceType>().unwrap(),
+            DistanceType::Explicit
+        );
     }
 }

--- a/teeline-api/src/services/tsp_service.rs
+++ b/teeline-api/src/services/tsp_service.rs
@@ -40,6 +40,7 @@ fn map_heuristic_onto(h: &HeuristicConfig, base: HeuristicOptions) -> HeuristicO
 fn distance_type_str(dt: DistanceType) -> &'static str {
     match dt {
         DistanceType::Euc2D => "EUC_2D",
+        DistanceType::Explicit => "EXPLICIT",
         DistanceType::Geo => "GEO",
     }
 }

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -492,6 +492,13 @@ impl Guest for Component {
         opt_route: Vec<u32>,
         input: String,
     ) -> Result<ComparisonStats, String> {
+        if solver_route.len() != opt_route.len() {
+            return Err(format!(
+                "dimension mismatch: solver={} opt={}",
+                solver_route.len(),
+                opt_route.len()
+            ));
+        }
         let data = teeline::tsp::tsplib::read_from_str(&input)?;
         let dm = data.distance_matrix()?;
 

--- a/teeline-wasm/src/lib.rs
+++ b/teeline-wasm/src/lib.rs
@@ -92,12 +92,19 @@ fn kd_to_city(c: &KDPoint) -> City {
     }
 }
 
-fn parse_input_to_kd(input: &str) -> Result<Vec<KDPoint>, String> {
+fn parse_to_tsp_problem(input: &str) -> Result<TspProblem, String> {
     if input.trim_start().starts_with('[') {
-        teeline::tsp::tsplib::parse_json_cities(input)
+        let kd_cities = teeline::tsp::tsplib::parse_json_cities(input)?;
+        let distances = DistanceMatrix::from_cities(&kd_cities)
+            .map_err(|e| format!("distance matrix: {e}"))?;
+        Ok(TspProblem::new(kd_cities, distances))
     } else {
         let data = teeline::tsp::tsplib::read_from_str(input)?;
-        Ok(data.cities().to_vec())
+        let kd_cities = data.cities().to_vec();
+        let distances = data
+            .distance_matrix()
+            .map_err(|e| format!("distance matrix: {e}"))?;
+        Ok(TspProblem::new(kd_cities, distances))
     }
 }
 
@@ -316,6 +323,7 @@ impl Guest for Component {
             let data = teeline::tsp::tsplib::read_from_str(&input)?;
             let dt = match data.distance_type {
                 teeline::tsp::DistanceType::Euc2D => "EUC_2D",
+                teeline::tsp::DistanceType::Explicit => "EXPLICIT",
                 teeline::tsp::DistanceType::Geo => "GEO",
             };
             Ok(ParsedProblem {
@@ -332,8 +340,19 @@ impl Guest for Component {
         input: String,
         options: SolveOptions,
     ) -> Result<Solution, String> {
-        let kd_cities = parse_input_to_kd(&input)?;
-        solve_with_cities(&solver, kd_cities, &options)
+        let problem = parse_to_tsp_problem(&input)?;
+        let solver_id = teeline::tsp::find_solver(&solver)?;
+        let opts = build_opts(solver_id, &options);
+        let start = std::time::Instant::now();
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            teeline::tsp::solve_problem(solver_id, &problem, &opts)
+        }))
+        .map_err(|_| format!("solver '{}' panicked", solver))?
+        .map(|s| Solution {
+            total: s.total,
+            route: s.route().iter().map(|&id| id as u32).collect(),
+            duration_ms: start.elapsed().as_millis() as u32,
+        })
     }
 
     fn compare(
@@ -341,8 +360,8 @@ impl Guest for Component {
         input: String,
         options: SolveOptions,
     ) -> Vec<CompareResult> {
-        let kd_cities = match parse_input_to_kd(&input) {
-            Ok(c) => c,
+        let problem = match parse_to_tsp_problem(&input) {
+            Ok(p) => p,
             Err(e) => {
                 return algorithms
                     .into_iter()
@@ -357,7 +376,27 @@ impl Guest for Component {
         algorithms
             .into_iter()
             .map(|algo| {
-                let sol = solve_with_cities(&algo, kd_cities.clone(), &options);
+                let solver_id = match teeline::tsp::find_solver(&algo) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        return CompareResult {
+                            algorithm: algo,
+                            solution: Err(e),
+                        };
+                    }
+                };
+                let opts = build_opts(solver_id, &options);
+                let start = std::time::Instant::now();
+                let sol = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    teeline::tsp::solve_problem(solver_id, &problem, &opts)
+                }))
+                .map_err(|_| format!("solver '{}' panicked", algo))
+                .and_then(|r| r)
+                .map(|s| Solution {
+                    total: s.total,
+                    route: s.route().iter().map(|&id| id as u32).collect(),
+                    duration_ms: start.elapsed().as_millis() as u32,
+                });
                 CompareResult {
                     algorithm: algo,
                     solution: sol,
@@ -446,6 +485,38 @@ impl Guest for Component {
 
         let route: Vec<usize> = route.iter().map(|&x| x as usize).collect();
         Ok(comparison::tour_cost(&route, &kd_cities))
+    }
+
+    fn compare_tours_from_input(
+        solver_route: Vec<u32>,
+        opt_route: Vec<u32>,
+        input: String,
+    ) -> Result<ComparisonStats, String> {
+        let data = teeline::tsp::tsplib::read_from_str(&input)?;
+        let dm = data.distance_matrix()?;
+
+        let solver: Vec<usize> = solver_route.iter().map(|&x| x as usize).collect();
+        let opt: Vec<usize> = opt_route.iter().map(|&x| x as usize).collect();
+
+        let stats = comparison::compare_tours_from_matrix(&solver, &opt, &dm);
+        Ok(ComparisonStats {
+            optimal_cost: stats.optimal_cost,
+            solver_cost: stats.solver_cost,
+            gap_pct: stats.gap_pct,
+            shared_edges: stats.shared_edges as u32,
+            solver_only_edges: stats.solver_only_edges as u32,
+            optimal_only_edges: stats.optimal_only_edges as u32,
+        })
+    }
+
+    fn tour_distance_from_input(route: Vec<u32>, input: String) -> Result<f32, String> {
+        if route.len() < 2 {
+            return Err("route must contain at least 2 city ids".to_string());
+        }
+        let data = teeline::tsp::tsplib::read_from_str(&input)?;
+        let dm = data.distance_matrix()?;
+        let route: Vec<usize> = route.iter().map(|&x| x as usize).collect();
+        Ok(dm.tour_length(&route))
     }
 }
 

--- a/teeline-wasm/tests/wasm_component.rs
+++ b/teeline-wasm/tests/wasm_component.rs
@@ -212,6 +212,24 @@ fn run_tour_distance(
         .unwrap()
 }
 
+fn run_compare_tours_from_input(
+    solver_route: &[u32],
+    opt_route: &[u32],
+    input: &str,
+) -> Result<crate::teeline::solver::types::ComparisonStats, String> {
+    let (mut store, instance) = make_instance();
+    instance
+        .call_compare_tours_from_input(&mut store, solver_route, opt_route, input)
+        .unwrap()
+}
+
+fn run_tour_distance_from_input(route: &[u32], input: &str) -> Result<f32, String> {
+    let (mut store, instance) = make_instance();
+    instance
+        .call_tour_distance_from_input(&mut store, route, input)
+        .unwrap()
+}
+
 // Unit square, side 10: closed-loop perimeter is exactly 40.0.
 fn square_cities() -> Vec<crate::teeline::solver::types::City> {
     use crate::teeline::solver::types::City;
@@ -942,5 +960,117 @@ fn test_tour_distance_duplicate_city_id_returns_error() {
     assert!(
         msg.contains("duplicate"),
         "error must mention 'duplicate', got: {msg}"
+    );
+}
+
+// ── EXPLICIT / GEO distance tests ────────────────────────────────────────────
+
+#[test]
+fn test_parse_explicit_matrix_returns_explicit_distance_type() {
+    let input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/gr17.tsp"
+    ))
+    .expect("gr17.tsp missing");
+    let p = run_parse(&input);
+    assert_eq!(p.distance_type, "EXPLICIT");
+    assert_eq!(p.cities.len(), 17);
+}
+
+#[test]
+fn test_parse_geo_returns_geo_distance_type() {
+    let input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/burma14.tsp"
+    ))
+    .expect("burma14.tsp missing");
+    let p = run_parse(&input);
+    assert_eq!(p.distance_type, "GEO");
+    assert_eq!(p.cities.len(), 14);
+}
+
+#[test]
+fn test_parse_and_solve_explicit_matrix_uses_matrix_distances() {
+    let input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/gr17.tsp"
+    ))
+    .expect("gr17.tsp missing");
+    let solution = run_parse_and_solve("nn", &input);
+    assert_valid_tour(&solution, 17);
+    // gr17 has EXPLICIT distances. The Euclidean NN tour on the grid
+    // placeholder coordinates would be wildly different from the explicit
+    // matrix tour. Ensure the result is positive and finite.
+    assert!(solution.total > 0.0, "tour distance must be positive for gr17");
+    assert!(solution.total.is_finite(), "tour distance must be finite");
+}
+
+#[test]
+fn test_parse_and_solve_geo_uses_geo_distances() {
+    let input = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/burma14.tsp"
+    ))
+    .expect("burma14.tsp missing");
+    let solution = run_parse_and_solve("nn", &input);
+    assert_valid_tour(&solution, 14);
+    // For burma14 (GEO), the total should be different from a Euclidean NN.
+    // We can't assert an exact value, but we can verify it's positive and
+    // not the same as a Euclidean computation would produce.
+    assert!(solution.total > 100.0, "GEO distance should be substantial, got {}", solution.total);
+}
+
+#[test]
+fn test_compare_tours_from_input_explicit_self_is_zero_gap() {
+    let input =
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/fixtures/ring6_explicit.tsp"
+        ))
+        .expect("ring6_explicit.tsp missing");
+    let route = vec![1u32, 2, 3, 4, 5, 6];
+    let stats = run_compare_tours_from_input(&route, &route, &input)
+        .expect("compare_tours_from_input must succeed");
+    assert_eq!(stats.gap_pct, 0.0, "identical tour must have 0% gap");
+    assert_eq!(stats.shared_edges, 6);
+    assert_eq!(stats.solver_only_edges, 0);
+    assert_eq!(stats.optimal_only_edges, 0);
+}
+
+#[test]
+fn test_tour_distance_from_input_ring6_explicit() {
+    let input =
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/fixtures/ring6_explicit.tsp"
+        ))
+        .expect("ring6_explicit.tsp missing");
+    let route = vec![1u32, 2, 3, 4, 5, 6];
+    let distance = run_tour_distance_from_input(&route, &input)
+        .expect("tour_distance_from_input must succeed");
+    // Ring6 optimal is 60 (6 edges at distance 10 each)
+    assert!((distance - 60.0).abs() < 0.01, "expected 60, got {distance}");
+}
+
+#[test]
+fn test_tour_distance_from_input_geo_is_different_from_euc() {
+    let burma14_input =
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/fixtures/burma14.tsp"
+        ))
+        .expect("burma14.tsp missing");
+    let route: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+    let geo_dist = run_tour_distance_from_input(&route, &burma14_input)
+        .expect("GEO tour_distance_from_input must succeed");
+
+    // Build a EUC_2D version and compare
+    let euc_input = burma14_input.replace("GEO", "EUC_2D");
+    let euc_dist = run_tour_distance_from_input(&route, &euc_input)
+        .expect("EUC_2D tour_distance_from_input must succeed");
+
+    assert!(
+        (geo_dist - euc_dist).abs() > 100.0,
+        "GEO ({geo_dist}) and EUC_2D ({euc_dist}) distances must differ significantly for burma14"
     );
 }

--- a/teeline-wasm/wit/world.wit
+++ b/teeline-wasm/wit/world.wit
@@ -111,4 +111,21 @@ world solver {
         route:  list<u32>,
         cities: list<city>,
     ) -> result<f32, string>;
+
+    // ── distance-type-aware variants — parse input internally ─────────────────
+
+    /// Like `compare-tours`, but parses `input` as TSPLIB to use the problem's
+    /// actual distance type (EXPLICIT matrix, GEO, or EUC_2D).
+    export compare-tours-from-input: func(
+        solver-route: list<u32>,
+        opt-route:    list<u32>,
+        input:        string,
+    ) -> result<comparison-stats, string>;
+
+    /// Like `tour-distance`, but parses `input` as TSPLIB to use the problem's
+    /// actual distance type (EXPLICIT matrix, GEO, or EUC_2D).
+    export tour-distance-from-input: func(
+        route: list<u32>,
+        input: string,
+    ) -> result<f32, string>;
 }

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -68,6 +68,7 @@ window.parseFile = parseFile
 // ---- App state ----
 
 let parsedProblem: ParsedProblem | null = null
+let rawInput: string | null = null
 let optTourRoute: number[] | null = null
 let solverConfig: ReturnType<typeof initSolverConfig> | null = null
 
@@ -160,13 +161,23 @@ worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMe
                 }
               }
               worker.addEventListener('message', compareHandler)
-              worker.postMessage({
-                type: 'compare-tours',
-                id: compareId,
-                solverRoute: result.route,
-                optRoute: optTourRoute,
-                cities: parsedProblem!.cities,
-              })
+              if (rawInput) {
+                worker.postMessage({
+                  type: 'compare-tours-from-input',
+                  id: compareId,
+                  solverRoute: result.route,
+                  optRoute: optTourRoute,
+                  input: rawInput,
+                })
+              } else {
+                worker.postMessage({
+                  type: 'compare-tours',
+                  id: compareId,
+                  solverRoute: result.route,
+                  optRoute: optTourRoute,
+                  cities: parsedProblem!.cities,
+                })
+              }
             }
           })
           .catch((err: Error) => {
@@ -180,7 +191,7 @@ worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMe
     // Upload depends on solverConfig.refresh — must be wired after solverConfig exists
     initUpload(
       parseFile,
-      (p) => { parsedProblem = p; solverConfig!.refresh() },
+      (p, input) => { parsedProblem = p; rawInput = input; solverConfig!.refresh() },
       (route) => {
         optTourRoute = route.length > 0 ? route : null
         updateOptRoute(optTourRoute)
@@ -221,6 +232,7 @@ function clearCompareError(): void {
 
 function resetToStep01(): void {
   parsedProblem = null
+  rawInput = null
   optTourRoute = null
   resetUpload()
   ;(document.getElementById('step-01') as HTMLElement).hidden = false

--- a/teeline-web/src/teeline-wasm.d.ts
+++ b/teeline-web/src/teeline-wasm.d.ts
@@ -59,5 +59,8 @@ declare module 'teeline-wasm' {
     optimalOnlyEdges: number
   }
   export function compareTours(solverRoute: Uint32Array, optRoute: Uint32Array, cities: Array<City>): ComparisonStats
+  export function tourDistance(route: Uint32Array, cities: Array<City>): number
+  export function compareToursFromInput(solverRoute: Uint32Array, optRoute: Uint32Array, input: string): ComparisonStats
+  export function tourDistanceFromInput(route: Uint32Array, input: string): number
   export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E }
 }

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -33,7 +33,7 @@ export function resetUpload(): void {
 
 export function initUpload(
   parseFile: (input: string) => Promise<ParsedProblem>,
-  onProblemLoaded?: (problem: ParsedProblem) => void,
+  onProblemLoaded?: (problem: ParsedProblem, rawInput: string) => void,
   onOptTourLoaded?: (route: number[]) => void,
 ): void {
   // DOM elements — all pre-built in index.html
@@ -104,7 +104,7 @@ export function initUpload(
     try {
       const parsed = await parseFile(text)
       showTspLoaded(filename, parsed)
-      onProblemLoaded?.(parsed)
+      onProblemLoaded?.(parsed, text)
     } catch (err) {
       showError(err instanceof Error ? err.message : String(err))
     }

--- a/teeline-web/src/worker.test.ts
+++ b/teeline-web/src/worker.test.ts
@@ -7,11 +7,12 @@ vi.mock('teeline-wasm', () => ({
   listAlgorithms: vi.fn(),
   getVersion: vi.fn(),
   compareTours: vi.fn(),
+  compareToursFromInput: vi.fn(),
 }))
 
 
 
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours } from 'teeline-wasm'
+import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, compareToursFromInput } from 'teeline-wasm'
 import {
   handleMessage,
   type ParseAndSolveRequest,
@@ -20,6 +21,7 @@ import {
   type ListAlgorithmsRequest,
   type GetVersionRequest,
   type CompareToursRequest,
+  type CompareToursFromInputRequest,
   type ComparisonStats,
   type WebMCPSolveRequest,
   type WebMCPListAlgorithmsRequest,
@@ -355,6 +357,59 @@ describe('handleMessage — webmcp-parse', () => {
       expect(res.id).toBe('parse-id-err')
       expect(res.error).toContain('invalid tsplib')
       expect(res.problem).toBeUndefined()
+    }
+  })
+})
+
+describe('handleMessage — compare-tours-from-input', () => {
+  const mockStats: ComparisonStats = {
+    optimalCost: 2085.0,
+    solverCost: 2200.0,
+    gapPct: 5.5,
+    sharedEdges: 10,
+    solverOnlyEdges: 3,
+    optimalOnlyEdges: 4,
+  }
+  const solverRoute = [1, 2, 3]
+  const optRoute    = [1, 3, 2]
+  const tspInput = 'NAME: test\nDIMENSION: 3\nEDGE_WEIGHT_TYPE: EXPLICIT\nNODE_COORD_SECTION\n1 0.0 0.0\n2 1.0 0.0\n3 0.0 1.0\nEOF\n'
+
+  it('returns compare-tours-result with stats when using raw input', () => {
+    vi.mocked(compareToursFromInput).mockReturnValue(mockStats)
+    const req: CompareToursFromInputRequest = {
+      type: 'compare-tours-from-input',
+      id: 'from-input-1',
+      solverRoute,
+      optRoute,
+      input: tspInput,
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('compare-tours-result')
+    if (res.type === 'compare-tours-result') {
+      expect(res.id).toBe('from-input-1')
+      expect(res.stats?.gapPct).toBe(5.5)
+      expect(res.stats?.sharedEdges).toBe(10)
+      expect(res.error).toBeUndefined()
+    }
+  })
+
+  it('returns error when compareToursFromInput throws', () => {
+    vi.mocked(compareToursFromInput).mockImplementation(() => {
+      throw new Error('bad TSPLIB input')
+    })
+    const req: CompareToursFromInputRequest = {
+      type: 'compare-tours-from-input',
+      id: 'from-input-err',
+      solverRoute,
+      optRoute,
+      input: 'garbage',
+    }
+    const res = handleMessage(req)
+    expect(res.type).toBe('compare-tours-result')
+    if (res.type === 'compare-tours-result') {
+      expect(res.id).toBe('from-input-err')
+      expect(res.error).toContain('bad TSPLIB input')
+      expect(res.stats).toBeUndefined()
     }
   })
 })

--- a/teeline-web/src/worker.ts
+++ b/teeline-web/src/worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, type ParsedProblem } from 'teeline-wasm'
+import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, compareToursFromInput, type ParsedProblem } from 'teeline-wasm'
 import type { AlgorithmInfo } from 'teeline-wasm'
 import { defaultSolveOptions, type SolveOptions } from './solver-options'
 
@@ -77,6 +77,14 @@ export interface CompareToursRequest {
   cities: Array<{ id: number; x: number; y: number }>
 }
 
+export interface CompareToursFromInputRequest {
+  type: 'compare-tours-from-input'
+  id: string
+  solverRoute: number[]
+  optRoute: number[]
+  input: string
+}
+
 export interface CompareToursResult {
   type: 'compare-tours-result'
   id: string
@@ -121,7 +129,7 @@ export interface WebMCPParseResult {
   error?: string
 }
 
-type WorkerRequest = SolveRequest | ParseAndSolveRequest | ParseRequest | ListAlgorithmsRequest | GetVersionRequest | CompareToursRequest | WebMCPSolveRequest | WebMCPListAlgorithmsRequest | WebMCPParseRequest
+type WorkerRequest = SolveRequest | ParseAndSolveRequest | ParseRequest | ListAlgorithmsRequest | GetVersionRequest | CompareToursRequest | CompareToursFromInputRequest | WebMCPSolveRequest | WebMCPListAlgorithmsRequest | WebMCPParseRequest
 type WorkerResponse = SolveResult | ParseResult | AlgorithmsResult | VersionResult | SolveError | WorkerReadyMessage | CompareToursResult | WebMCPSolveResult | WebMCPAlgorithmsResult | WebMCPParseResult
 
 export function handleMessage(data: WorkerRequest): WorkerResponse {
@@ -141,6 +149,30 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
       try {
         // compareTours returns ComparisonStats directly (jco throws on WIT Err)
         const s = compareTours(new Uint32Array(req.solverRoute), new Uint32Array(req.optRoute), req.cities)
+        return {
+          type: 'compare-tours-result',
+          id: req.id,
+          stats: {
+            optimalCost: s.optimalCost,
+            solverCost: s.solverCost,
+            gapPct: s.gapPct,
+            sharedEdges: s.sharedEdges,
+            solverOnlyEdges: s.solverOnlyEdges,
+            optimalOnlyEdges: s.optimalOnlyEdges,
+          },
+        }
+      } catch (err) {
+        return {
+          type: 'compare-tours-result',
+          id: req.id,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
+    }
+    if (data.type === 'compare-tours-from-input') {
+      const req = data as CompareToursFromInputRequest
+      try {
+        const s = compareToursFromInput(new Uint32Array(req.solverRoute), new Uint32Array(req.optRoute), req.input)
         return {
           type: 'compare-tours-result',
           id: req.id,


### PR DESCRIPTION
## Summary

The WASM solver currently computes Euclidean distances from city coordinates for all TSPLIB problems, even when the problem specifies `EDGE_WEIGHT_TYPE: EXPLICIT` (pre-computed matrix) or `GEO` (great-circle formula). This makes solver results, optimal comparisons, and gap percentages meaningless for these problems (e.g. gr120 EXPLICIT: solver reports 1805.9 vs optimal 6942).

## Changes

### Core library (`src/tsp/`)
- Added `DistanceType::Explicit` variant with `FromStr` parsing
- Added distance-type-aware tour cost functions: `tour_cost_from_matrix`, `tour_cost_with_type`
- Added distance-type-aware comparison: `compare_tours_from_matrix`, `compare_tours_with_type`
- Extracted shared `build_stats` helper for comparison stats
- Added `geo_distance` to comparison.rs for GEO support
- Updated `distance_matrix.rs` to error on EXPLICIT (must use `new()` with precomputed distances)
- Updated `teeline-api` `distance_type_str` for Explicit variant

### WASM layer (`teeline-wasm/`)
- New WIT exports: `compare-tours-from-input`, `tour-distance-from-input` (parse TSPLIB internally to use the correct distance type)
- `parse()` now returns `distance_type: "EXPLICIT"` for explicit-weight problems
- `parse_and_solve` and `compare` now use `TspLibData::distance_matrix()` instead of always computing Euclidean from coordinates

### Web layer (`teeline-web/`)
- Added `compareToursFromInput`/`tourDistanceFromInput` ambient declarations
- `worker.ts`: handler for `compare-tours-from-input` message type
- `main.ts`: stores raw input, routes EXPLICIT/GEO comparisons through `from-input` variant
- Kept existing `compareTours`/`tourDistance` for backward compatibility

### Tests
- Unit: `DistanceType::from_str("EXPLICIT")`, `tour_cost_from_matrix` (ring6), `tour_cost_with_type` (GEO pair)
- WASM integration: `parse()` returns EXPLICIT for gr17, `parse_and_solve` on EXPLICIT and GEO, `compare_tours_from_input` on ring6, `tour_distance_from_input` on ring6 and burma14
- Vitest: worker handler for `compare-tours-from-input`

Closes #436