### PR TITLE
fix(web): enable optimal cost comparison for EXPLICIT/GEO problem pages

### DIFF
--- a/teeline-web/src/pages/problems/[id]/index.astro
+++ b/teeline-web/src/pages/problems/[id]/index.astro
@@ -18,8 +18,7 @@ const pagePath = `/problems/${data.id}/`
 const canonicalUrl = `https://tspsolver.com${pagePath}`
 
 const sizeIcon = { small: '🟢', medium: '🟡', large: '🟠', xl: '🔴' }[data.sizeGroup] || ''
-const isCoordinateMetric = !['EXPLICIT', 'MATRIX', 'GEO'].some(t => data.edgeWeightType.toUpperCase().includes(t))
-const solverLink = data.optimalCost !== null && isCoordinateMetric
+const solverLink = data.optimalCost !== null
   ? `/?dataset=${data.id}&opt=${data.optimalCost}`
   : `/?dataset=${data.id}`
 


### PR DESCRIPTION
## Summary

Removes the `isCoordinateMetric` guard in the problem detail page template that suppressed the `?opt=` query parameter for EXPLICIT, MATRIX, and GEO problems.

Since PR #439 correctly computes distances for non-Euclidean distance types via `compare-tours-from-input`, the optimal cost comparison is now correct and the guard is no longer needed.

## What changed

**`teeline-web/src/pages/problems/[id]/index.astro`** — Removed the `isCoordinateMetric` check. Now `optimalCost` is always passed as `?opt=` when non-null, regardless of `edgeWeightType`.

## Affected problem pages

These pages now correctly include the `?opt=<cost>` parameter:

| Problem | Type | Optimal |
|---------|------|---------|
| hk48 | EXPLICIT | 11461 |
| swiss42 | EXPLICIT | 1273 |
| gr96 | GEO | 55209 |
| gr137 | GEO | ... |
| gr202 | GEO | ... |
| gr229 | GEO | ... |
| gr431 | GEO | ... |
| gr666 | GEO | ... |
| ulysses22 | GEO | 7013 |

## Follow-up to

- PR #439 — EXPLICIT/MATRIX + GEO distance support in WASM (#436)