### PR TITLE
feat(web): move solver to dedicated /solve/ page (#437)

### DIFF
--- a/teeline-web/src/components/Topbar.astro
+++ b/teeline-web/src/components/Topbar.astro
@@ -48,6 +48,9 @@ import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from '../nav-data'
       </details>
     </li>
     <li>
+      <a href="/solve/">Solver</a>
+    </li>
+    <li>
       <a href="/problems/">Problems</a>
     </li>
     <li>

--- a/teeline-web/src/pages/index.astro
+++ b/teeline-web/src/pages/index.astro
@@ -24,173 +24,6 @@ const jsonLd = {
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>
-  <main class="container">
-    <nav aria-label="Solver steps">
-      <ol class="stepper" role="list">
-        <li class="stepper-step stepper-step--active" aria-current="step">
-          <span class="stepper-number">1</span>
-          <span class="stepper-label">Load Data</span>
-        </li>
-        <li class="stepper-step">
-          <span class="stepper-number">2</span>
-          <span class="stepper-label">Configure</span>
-        </li>
-        <li class="stepper-step">
-          <span class="stepper-number">3</span>
-          <span class="stepper-label">Results</span>
-        </li>
-      </ol>
-    </nav>
-
-    <section id="step-content">
-      <!-- Step 01: Load Data -->
-      <section id="step-01" class="step-panel" aria-labelledby="step-01-heading">
-        <h2 id="step-01-heading">Load Data</h2>
-
-        <div class="drop-zones">
-          <!-- Required .tsp zone -->
-          <div id="zone-tsp" class="drop-zone drop-zone--required" role="region" aria-label="TSP problem file (.tsp)">
-            <div id="zone-tsp-idle" class="drop-zone__idle">
-              <p class="drop-zone__hint">Drag a <strong>.tsp</strong> file here</p>
-              <p class="drop-zone__or"><small>or</small></p>
-              <button type="button" class="outline" id="btn-browse-tsp">Browse…</button>
-              <input id="input-tsp" type="file" accept=".tsp" hidden aria-hidden="true" />
-            </div>
-            <div id="zone-tsp-chip" class="drop-zone__chip" hidden>
-              <span class="chip-icon" aria-hidden="true">✓</span>
-              <span class="chip-name" id="tsp-chip-name"></span>
-              <button type="button" class="outline secondary chip-replace" id="btn-replace-tsp">replace</button>
-            </div>
-          </div>
-
-          <!-- Optional .opt.tour zone -->
-          <div id="zone-opt" class="drop-zone drop-zone--optional" role="region" aria-label="Optimal tour file (.opt.tour, optional)">
-            <div id="zone-opt-idle" class="drop-zone__idle">
-              <p class="drop-zone__hint">Drag a <strong>.opt.tour</strong> file here</p>
-              <p class="drop-zone__or"><small>or</small></p>
-              <button type="button" class="outline" id="btn-browse-opt">Browse…</button>
-              <input id="input-opt" type="file" accept=".opt.tour" hidden aria-hidden="true" />
-              <p class="drop-zone__hint-secondary"><small>optional reference tour</small></p>
-            </div>
-            <div id="zone-opt-chip" class="drop-zone__chip" hidden>
-              <span class="chip-icon" aria-hidden="true">✓</span>
-              <span class="chip-name" id="opt-chip-name"></span>
-              <button type="button" class="outline secondary chip-replace" id="btn-replace-opt">replace</button>
-            </div>
-          </div>
-        </div>
-        <!-- /.drop-zones -->
-
-        <p id="metadata-line" class="metadata-line" hidden></p>
-        <p id="error-line" class="upload-error" hidden></p>
-
-        <fieldset>
-          <legend>Example datasets</legend>
-          <div class="example-buttons">
-            <button type="button" class="outline secondary" data-example="berlin52">berlin52</button>
-            <button type="button" class="outline secondary" data-example="burma14">burma14</button>
-            <button type="button" class="outline secondary" data-example="ulysses22">ulysses22</button>
-          </div>
-        </fieldset>
-
-        <div class="step-actions">
-          <button type="button" id="btn-continue" hidden>Continue →</button>
-        </div>
-      </section>
-
-      <!-- Step 02: Configure -->
-      <section id="step-02" class="step-panel" aria-labelledby="step-02-heading" hidden>
-        <h2 id="step-02-heading">Configure Solver</h2>
-
-        <div class="solver-pills">
-          <button type="button" class="pill outline secondary" data-solver="nn" aria-current="false">NN</button>
-          <button type="button" class="pill outline secondary" data-solver="2opt" aria-current="false">2-opt</button>
-          <button type="button" class="pill outline secondary" data-solver="sa" aria-current="false">SA</button>
-          <button type="button" class="pill outline secondary" data-solver="ga" aria-current="false">GA</button>
-          <button type="button" class="pill outline secondary" data-solver="gec" aria-current="false">GEC</button>
-          <button type="button" class="pill outline secondary" data-solver="aco" aria-current="false">ACO</button>
-          <button type="button" class="pill outline secondary" data-solver="sav" aria-current="false">SAV</button>
-          <select id="solver-select" aria-label="All solvers">
-            <option value="">All solvers…</option>
-          </select>
-        </div>
-
-        <div id="config-panel" class="config-panel">
-          <p class="muted">Select a solver above to see its options.</p>
-        </div>
-
-        <ul class="checklist" id="precondition-list" role="list">
-          <li class="checklist-item" id="check-problem">problem file loaded</li>
-          <li class="checklist-item" id="check-solver">solver selected</li>
-          <li class="checklist-item checklist-item--optional" id="check-optimal">optimal route (optional)</li>
-        </ul>
-
-        <div class="step-actions step-actions--spread">
-          <button type="button" id="btn-change-file" class="outline secondary">← Change file</button>
-          <button type="button" id="btn-run" disabled>Run Solver</button>
-        </div>
-      </section>
-
-      <!-- Step 04: Results -->
-      <section id="step-04" class="step-panel" aria-labelledby="step-04-heading" hidden>
-        <h2 id="step-04-heading">Results</h2>
-
-        <div class="step-04-body">
-          <figure class="tour-figure">
-            <div id="solving-overlay" class="solving-overlay" hidden>
-              <p>Solving…</p>
-            </div>
-            <svg id="tour-svg" class="tour-svg" viewBox="0 0 600 400" role="img" aria-label="TSP tour map"></svg>
-          </figure>
-
-          <div class="step-04-sidebar">
-            <table class="results-table">
-              <thead>
-                <tr>
-                  <th>Tour length</th>
-                  <th>Gap vs optimal</th>
-                  <th>Shared edges</th>
-                  <th>Solver-only</th>
-                  <th>Opt-only</th>
-                  <th>Runtime</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td id="result-total">—</td>
-                  <td id="result-gap">—</td>
-                  <td id="result-shared-edges">—</td>
-                  <td id="result-solver-only-edges">—</td>
-                  <td id="result-optimal-only-edges">—</td>
-                  <td id="result-runtime">—</td>
-                </tr>
-              </tbody>
-            </table>
-
-            <p id="comparison-error" class="comparison-error pico-color-red-500" hidden aria-live="polite"></p>
-
-            <section aria-labelledby="run-history-heading">
-              <h3 id="run-history-heading">Run history</h3>
-              <ol id="run-history-list" class="run-history-list" aria-label="Previous runs"></ol>
-            </section>
-          </div>
-        </div>
-
-        <div id="download-actions" class="download-actions" hidden>
-          <button type="button" id="btn-download-tour" class="outline secondary">⬇ .tour</button>
-          <button type="button" id="btn-download-csv" class="outline secondary">⬇ .csv</button>
-          <button type="button" id="btn-download-json" class="outline secondary">⬇ .json</button>
-          <button type="button" id="btn-download-svg" class="outline secondary">⬇ .svg</button>
-        </div>
-
-        <div class="step-actions step-actions--spread">
-          <button type="button" id="btn-new-dataset" class="outline secondary">← New dataset</button>
-          <button type="button" id="btn-try-again" class="outline secondary">↻ try another solver</button>
-        </div>
-      </section>
-    </section>
-    <!-- /#step-content -->
-  </main>
 
   <header class="container hero">
     <img
@@ -211,6 +44,9 @@ const jsonLd = {
         New to the problem? <a href="/tsp/">Read the TSP overview</a> — history, real-world
         uses, and further reading.
       </p>
+      <p>
+        <a href="/solve/" role="button">▶ Open Solver</a>
+      </p>
     </div>
   </header>
 
@@ -226,50 +62,8 @@ const jsonLd = {
   </section>
 
   <footer id="app-footer" class="container">
-    <span id="wasm-status" class="status-dot status-dot--loading"></span>
-    <span id="wasm-version">Connecting…</span>
+    <div class="footer-links">
+      <a href="/solve/" role="button">Open Solver →</a>
+    </div>
   </footer>
-
-  <script>
-    import '../main.ts'
-  </script>
-
-  <!-- WebMCP tools — hidden forms for AI agent access -->
-  <form id="webmcp-solve" toolname="solveTSP"
-        tooldescription="Solve a TSP problem using a named algorithm. Returns tour cost and city sequence."
-        toolautosubmit hidden>
-    <textarea name="problem" toolparamdescription="TSPLIB-format problem data (NODE_COORD_SECTION etc.)"></textarea>
-    <input name="algorithm" type="text"
-           toolparamdescription="Algorithm ID: nn, 2opt, lk, sa, ga, pso, cs, fpa, or_opt, christofides, gsa, fourier, aco. Default: lk">
-    <input name="epochs" type="number" toolparamdescription="Iteration count. Default: 500">
-    <input name="max_temperature" type="number" toolparamdescription="Max temperature for SA. Default: 1000">
-    <input name="mutation_probability" type="number" toolparamdescription="Mutation rate for GA (0–1). Default: 0.05">
-    <input name="n_nearest" type="number" toolparamdescription="KD-tree candidate list size. Default: 5">
-    <input name="alpha" type="number" toolparamdescription="ACO pheromone influence. Default: 1.0">
-    <input name="beta" type="number" toolparamdescription="ACO heuristic (1/distance) influence, 0–6. Default: 2.0">
-    <input name="evaporation_rate" type="number" toolparamdescription="ACO pheromone evaporation per epoch (0–1). Default: 0.5">
-    <input name="num_ants" type="number" toolparamdescription="ACO colony size (tours per epoch). Default: 25">
-  </form>
-
-  <form id="webmcp-list-algorithms" toolname="listAlgorithms"
-        tooldescription="List all available TSP solving algorithms with metadata."
-        toolautosubmit hidden>
-  </form>
-
-  <form id="webmcp-parse" toolname="parseProblem"
-        tooldescription="Parse a TSPLIB problem string and return full problem data (name, cities, distance type)."
-        toolautosubmit hidden>
-    <textarea name="problem" toolparamdescription="TSPLIB-format problem data"></textarea>
-  </form>
-
-  <form id="webmcp-compare" toolname="compareTours"
-        tooldescription="Compare a solver tour against an optimal tour. Returns gap %, shared edges, and per-tour edge counts."
-        toolautosubmit hidden>
-    <input name="solver_route" type="text"
-           toolparamdescription="JSON array of city IDs in solver tour order, e.g. [1,5,3,...]">
-    <input name="opt_route" type="text"
-           toolparamdescription="JSON array of city IDs in optimal tour order">
-    <input name="cities" type="text"
-           toolparamdescription="JSON array of city objects: [{id,x,y}, ...]">
-  </form>
 </BaseLayout>

--- a/teeline-web/src/pages/problems/[id]/index.astro
+++ b/teeline-web/src/pages/problems/[id]/index.astro
@@ -19,8 +19,8 @@ const canonicalUrl = `https://tspsolver.com${pagePath}`
 
 const sizeIcon = { small: '🟢', medium: '🟡', large: '🟠', xl: '🔴' }[data.sizeGroup] || ''
 const solverLink = data.optimalCost !== null
-  ? `/?dataset=${data.id}&opt=${data.optimalCost}`
-  : `/?dataset=${data.id}`
+  ? `/solve/?dataset=${data.id}&opt=${data.optimalCost}`
+  : `/solve/?dataset=${data.id}`
 
 const jsonLd = {
   '@context': 'https://schema.org',

--- a/teeline-web/src/pages/solve/index.astro
+++ b/teeline-web/src/pages/solve/index.astro
@@ -1,0 +1,240 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import '../../main.css'
+
+const description =
+  "Traveling Salesman Problem solver — upload a TSPLIB .tsp file, pick an algorithm, and get an optimized tour. Runs entirely in-browser via WebAssembly."
+const ogDescription =
+  "Browser-based Traveling Salesman Problem solver. Upload a TSPLIB .tsp file, pick an algorithm and download the optimised tour — runs entirely in-browser via WebAssembly."
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'teeline',
+  description: ogDescription,
+  url: 'https://tspsolver.com/solve/',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Any (runs in-browser via WebAssembly)',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+}
+---
+<BaseLayout title="Solve — Teeline TSP Solver" description={description} ogDescription={ogDescription} path="/solve/">
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  </Fragment>
+  <main class="container">
+    <nav aria-label="Solver steps">
+      <ol class="stepper" role="list">
+        <li class="stepper-step stepper-step--active" aria-current="step">
+          <span class="stepper-number">1</span>
+          <span class="stepper-label">Load Data</span>
+        </li>
+        <li class="stepper-step">
+          <span class="stepper-number">2</span>
+          <span class="stepper-label">Configure</span>
+        </li>
+        <li class="stepper-step">
+          <span class="stepper-number">3</span>
+          <span class="stepper-label">Results</span>
+        </li>
+      </ol>
+    </nav>
+
+    <section id="step-content">
+      <!-- Step 01: Load Data -->
+      <section id="step-01" class="step-panel" aria-labelledby="step-01-heading">
+        <h2 id="step-01-heading">Load Data</h2>
+
+        <div class="drop-zones">
+          <!-- Required .tsp zone -->
+          <div id="zone-tsp" class="drop-zone drop-zone--required" role="region" aria-label="TSP problem file (.tsp)">
+            <div id="zone-tsp-idle" class="drop-zone__idle">
+              <p class="drop-zone__hint">Drag a <strong>.tsp</strong> file here</p>
+              <p class="drop-zone__or"><small>or</small></p>
+              <button type="button" class="outline" id="btn-browse-tsp">Browse…</button>
+              <input id="input-tsp" type="file" accept=".tsp" hidden aria-hidden="true" />
+            </div>
+            <div id="zone-tsp-chip" class="drop-zone__chip" hidden>
+              <span class="chip-icon" aria-hidden="true">✓</span>
+              <span class="chip-name" id="tsp-chip-name"></span>
+              <button type="button" class="outline secondary chip-replace" id="btn-replace-tsp">replace</button>
+            </div>
+          </div>
+
+          <!-- Optional .opt.tour zone -->
+          <div id="zone-opt" class="drop-zone drop-zone--optional" role="region" aria-label="Optimal tour file (.opt.tour, optional)">
+            <div id="zone-opt-idle" class="drop-zone__idle">
+              <p class="drop-zone__hint">Drag a <strong>.opt.tour</strong> file here</p>
+              <p class="drop-zone__or"><small>or</small></p>
+              <button type="button" class="outline" id="btn-browse-opt">Browse…</button>
+              <input id="input-opt" type="file" accept=".opt.tour" hidden aria-hidden="true" />
+              <p class="drop-zone__hint-secondary"><small>optional reference tour</small></p>
+            </div>
+            <div id="zone-opt-chip" class="drop-zone__chip" hidden>
+              <span class="chip-icon" aria-hidden="true">✓</span>
+              <span class="chip-name" id="opt-chip-name"></span>
+              <button type="button" class="outline secondary chip-replace" id="btn-replace-opt">replace</button>
+            </div>
+          </div>
+        </div>
+        <!-- /.drop-zones -->
+
+        <p id="metadata-line" class="metadata-line" hidden></p>
+        <p id="error-line" class="upload-error" hidden></p>
+
+        <fieldset>
+          <legend>Example datasets</legend>
+          <div class="example-buttons">
+            <button type="button" class="outline secondary" data-example="berlin52">berlin52</button>
+            <button type="button" class="outline secondary" data-example="burma14">burma14</button>
+            <button type="button" class="outline secondary" data-example="ulysses22">ulysses22</button>
+          </div>
+        </fieldset>
+
+        <div class="step-actions">
+          <button type="button" id="btn-continue" hidden>Continue →</button>
+        </div>
+      </section>
+
+      <!-- Step 02: Configure -->
+      <section id="step-02" class="step-panel" aria-labelledby="step-02-heading" hidden>
+        <h2 id="step-02-heading">Configure Solver</h2>
+
+        <div class="solver-pills">
+          <button type="button" class="pill outline secondary" data-solver="nn" aria-current="false">NN</button>
+          <button type="button" class="pill outline secondary" data-solver="2opt" aria-current="false">2-opt</button>
+          <button type="button" class="pill outline secondary" data-solver="sa" aria-current="false">SA</button>
+          <button type="button" class="pill outline secondary" data-solver="ga" aria-current="false">GA</button>
+          <button type="button" class="pill outline secondary" data-solver="gec" aria-current="false">GEC</button>
+          <button type="button" class="pill outline secondary" data-solver="aco" aria-current="false">ACO</button>
+          <button type="button" class="pill outline secondary" data-solver="sav" aria-current="false">SAV</button>
+          <select id="solver-select" aria-label="All solvers">
+            <option value="">All solvers…</option>
+          </select>
+        </div>
+
+        <div id="config-panel" class="config-panel">
+          <p class="muted">Select a solver above to see its options.</p>
+        </div>
+
+        <ul class="checklist" id="precondition-list" role="list">
+          <li class="checklist-item" id="check-problem">problem file loaded</li>
+          <li class="checklist-item" id="check-solver">solver selected</li>
+          <li class="checklist-item checklist-item--optional" id="check-optimal">optimal route (optional)</li>
+        </ul>
+
+        <div class="step-actions step-actions--spread">
+          <button type="button" id="btn-change-file" class="outline secondary">← Change file</button>
+          <button type="button" id="btn-run" disabled>Run Solver</button>
+        </div>
+      </section>
+
+      <!-- Step 04: Results -->
+      <section id="step-04" class="step-panel" aria-labelledby="step-04-heading" hidden>
+        <h2 id="step-04-heading">Results</h2>
+
+        <div class="step-04-body">
+          <figure class="tour-figure">
+            <div id="solving-overlay" class="solving-overlay" hidden>
+              <p>Solving…</p>
+            </div>
+            <svg id="tour-svg" class="tour-svg" viewBox="0 0 600 400" role="img" aria-label="TSP tour map"></svg>
+          </figure>
+
+          <div class="step-04-sidebar">
+            <table class="results-table">
+              <thead>
+                <tr>
+                  <th>Tour length</th>
+                  <th>Gap vs optimal</th>
+                  <th>Shared edges</th>
+                  <th>Solver-only</th>
+                  <th>Opt-only</th>
+                  <th>Runtime</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td id="result-total">—</td>
+                  <td id="result-gap">—</td>
+                  <td id="result-shared-edges">—</td>
+                  <td id="result-solver-only-edges">—</td>
+                  <td id="result-optimal-only-edges">—</td>
+                  <td id="result-runtime">—</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p id="comparison-error" class="comparison-error pico-color-red-500" hidden aria-live="polite"></p>
+
+            <section aria-labelledby="run-history-heading">
+              <h3 id="run-history-heading">Run history</h3>
+              <ol id="run-history-list" class="run-history-list" aria-label="Previous runs"></ol>
+            </section>
+          </div>
+        </div>
+
+        <div id="download-actions" class="download-actions" hidden>
+          <button type="button" id="btn-download-tour" class="outline secondary">⬇ .tour</button>
+          <button type="button" id="btn-download-csv" class="outline secondary">⬇ .csv</button>
+          <button type="button" id="btn-download-json" class="outline secondary">⬇ .json</button>
+          <button type="button" id="btn-download-svg" class="outline secondary">⬇ .svg</button>
+        </div>
+
+        <div class="step-actions step-actions--spread">
+          <button type="button" id="btn-new-dataset" class="outline secondary">← New dataset</button>
+          <button type="button" id="btn-try-again" class="outline secondary">↻ try another solver</button>
+        </div>
+      </section>
+    </section>
+    <!-- /#step-content -->
+  </main>
+
+  <footer id="app-footer" class="container">
+    <span id="wasm-status" class="status-dot status-dot--loading"></span>
+    <span id="wasm-version">Connecting…</span>
+  </footer>
+
+  <script>
+    import '../../main.ts'
+  </script>
+
+  <!-- WebMCP tools — hidden forms for AI agent access -->
+  <form id="webmcp-solve" toolname="solveTSP"
+        tooldescription="Solve a TSP problem using a named algorithm. Returns tour cost and city sequence."
+        toolautosubmit hidden>
+    <textarea name="problem" toolparamdescription="TSPLIB-format problem data (NODE_COORD_SECTION etc.)"></textarea>
+    <input name="algorithm" type="text"
+           toolparamdescription="Algorithm ID: nn, 2opt, lk, sa, ga, pso, cs, fpa, or_opt, christofides, gsa, fourier, aco. Default: lk">
+    <input name="epochs" type="number" toolparamdescription="Iteration count. Default: 500">
+    <input name="max_temperature" type="number" toolparamdescription="Max temperature for SA. Default: 1000">
+    <input name="mutation_probability" type="number" toolparamdescription="Mutation rate for GA (0–1). Default: 0.05">
+    <input name="n_nearest" type="number" toolparamdescription="KD-tree candidate list size. Default: 5">
+    <input name="alpha" type="number" toolparamdescription="ACO pheromone influence. Default: 1.0">
+    <input name="beta" type="number" toolparamdescription="ACO heuristic (1/distance) influence, 0–6. Default: 2.0">
+    <input name="evaporation_rate" type="number" toolparamdescription="ACO pheromone evaporation per epoch (0–1). Default: 0.5">
+    <input name="num_ants" type="number" toolparamdescription="ACO colony size (tours per epoch). Default: 25">
+  </form>
+
+  <form id="webmcp-list-algorithms" toolname="listAlgorithms"
+        tooldescription="List all available TSP solving algorithms with metadata."
+        toolautosubmit hidden>
+  </form>
+
+  <form id="webmcp-parse" toolname="parseProblem"
+        tooldescription="Parse a TSPLIB problem string and return full problem data (name, cities, distance type)."
+        toolautosubmit hidden>
+    <textarea name="problem" toolparamdescription="TSPLIB-format problem data"></textarea>
+  </form>
+
+  <form id="webmcp-compare" toolname="compareTours"
+        tooldescription="Compare a solver tour against an optimal tour. Returns gap %, shared edges, and per-tour edge counts."
+        toolautosubmit hidden>
+    <input name="solver_route" type="text"
+           toolparamdescription="JSON array of city IDs in solver tour order, e.g. [1,5,3,...]">
+    <input name="opt_route" type="text"
+           toolparamdescription="JSON array of city IDs in optimal tour order">
+    <input name="cities" type="text"
+           toolparamdescription="JSON array of city objects: [{id,x,y}, ...]">
+  </form>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Moves the solver UI from the home page (`/`) to a dedicated `/solve/` page. The home page now shows only landing content (hero, features, algorithm cards) with a CTA to `/solve/`, so deep links like `/?dataset=berlin52&opt=7542` no longer mix marketing content with the solver stepper.

## Changes

**New: `pages/solve/index.astro`**
- Full solver stepper (Load → Configure → Results)
- Drop zones, solver pills, config panel, checklist
- Results table, run history, download actions
- WebMCP forms + `main.ts` wiring

**Updated: `pages/index.astro`**
- Removed all solver sections and the `main.ts` import
- Kept hero, features, algorithm cards, footer CTA ("Open Solver →")

**Updated: `pages/problems/[id]/index.astro`**
- "Open in Solver" links now point to `/solve/?dataset=<id>` (with `&opt=` preserved)

**Updated: `components/Topbar.astro`**
- Added a "Solver" link to `/solve/`

## Verification

`main.ts`, `upload.ts`, `solver-form.ts`, `results.ts`, and `worker.ts` are unchanged — the `/solve/` page uses the exact same DOM ids, so all wiring works identically.

Verified end-to-end with Playwright against a production build:
- `/solve/` renders the stepper; loading `berlin52` → configure → run NN → results (8980.9, 32ms) works
- `/` renders only landing content with working CTA + nav links
- Problem page "Open in Solver" href resolves to `/solve/?dataset=berlin52`
- `?dataset=ulysses22&opt=7013` auto-loads on `/solve/`, detects GEO, shows "optimal route · 7,013" in the checklist

## Tests

- 258 Vitest tests pass
- `tsc --noEmit` clean
- `npm run build` succeeds (156 pages, incl. `/solve/index.html`)

Closes #437