### PR TITLE
fix(web): Kohonen SOM explainer — white island card for readable text

### DIFF
--- a/teeline-web/src/explainers/som.tsx
+++ b/teeline-web/src/explainers/som.tsx
@@ -247,8 +247,20 @@ export default function SomExplainer() {
 
 const CSS = `
 .som-root {
-  font-family: system-ui, sans-serif;
-  max-width: 860px;
+  --accent: #7c3aed;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #6b7280;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
 }
 
 .som-header {
@@ -259,7 +271,7 @@ const CSS = `
 }
 .som-emoji { font-size: 2rem; line-height: 1; }
 .som-title { margin: 0; font-size: 1.25rem; }
-.som-subtitle { margin: 0; color: #6b7280; font-size: 0.875rem; }
+.som-subtitle { margin: 0; color: var(--muted); font-size: 0.875rem; }
 
 .som-viz-row {
   display: flex;
@@ -405,7 +417,7 @@ const CSS = `
 .som-footer {
   margin-top: 0.75rem;
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: var(--muted);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Problem

The Kohonen (SOM) explainer (`som.tsx`) was the **only** explainer without the white "island" card: it rendered its light-theme palette directly on the dark page background, so dark-gray text (`#374151`, `#6b7280`) — subtitles, phase text, legend, footer — was nearly invisible (dark gray on black). Every other explainer (sa, ga, fourier, lk, two-opt, nn, pso, gsa, tabu, aco, cs, fpa, greedy-edge, savings) wraps its content in the same white card.

## Fix

Give `.som-root` the standard explainer card, matching the other 14 explainers:

```css
.som-root {
  --accent: #7c3aed;
  --bg: #ffffff;
  --panel: #f6f8fa;
  --line: #d0d7de;
  --text: #1f2328;
  --muted: #6b7280;
  font-family: ui-sans-serif, system-ui, ...;
  background: var(--bg);
  color: var(--text);
  border: 1px solid var(--line);
  border-radius: 12px;
  padding: 20px;
  max-width: 760px;
  box-sizing: border-box;
}
```

Also routed the subtitle and footer through `var(--muted)` (was `#6b7280`/`#9ca3af` hardcodes) so muted text matches the other explainers' tone. All inner colors (canvas `#f9fafb`, stats `#f3f4f6`, buttons) already worked on light backgrounds and are unchanged.

## Verification

- `npm run build:check` ✅ (astro check + tsc + astro build)
- `npm test` ✅ 258/258 (incl. som.test.ts)
- Confirmed the new card CSS ships in the production bundle (`dist/assets/som.*.js`)