### PR TITLE
ci(web): fix astro 7.2+ build OOM by raising Node heap

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -41,6 +41,10 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          # Same as teeline-web.yml: astro 7.2+ builds OOM past the default
+          # ~4 GB Node heap on the runner.
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Deploy to Cloudflare Pages
         run: npx wrangler pages deploy dist/

--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -56,3 +56,7 @@ jobs:
 
       - name: Build
         run: npm run build:check
+        env:
+          # astro 7.2+ static builds exceed the runner's default Node heap
+          # (~4 GB) and abort with "JavaScript heap out of memory" (exit 134).
+          NODE_OPTIONS: --max-old-space-size=6144


### PR DESCRIPTION
## Problem

PR #451 (astro 7.1.6 → 7.2.1) fails CI consistently at the **Build** step with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
##[error]Process completed with exit code 134.
```

## Root cause

astro 7.2.x increased the peak memory of `astro build` for this site (156 static pages, Tailwind v4 via `@tailwindcss/vite`, shiki, sentry-vite-plugin) past the GitHub runner's default Node heap (~4 GB), so the build aborts (exit 134, ~4.05 GB heap). Reproduced locally with `NODE_OPTIONS=--max-old-space-size=4096`:

| astro version | 4 GB heap cap | 6 GB heap cap |
|---|---|---|
| 7.1.6 (current master) | ✅ passes | — |
| 7.2.1 (PR #451) | ❌ OOM | ✅ passes |
| 7.2.2 (latest patch) | ❌ OOM | — |

So it's a memory increase in the 7.2.x line, not a flake, and a patch bump (7.2.2) does not fix it.

## Fix

Raise Node's heap for the build steps in the two workflows that run `astro build`:

- `.github/workflows/teeline-web.yml` → `Build` step: `NODE_OPTIONS: --max-old-space-size=6144`
- `.github/workflows/deploy-web.yml` → `Build` step: same

GitHub ubuntu-latest runners have 7 GB RAM, so 6 GB is safe headroom.

Once merged, PR #451's CI re-runs against the new base and should pass.