### PR TITLE
feat(web): scaffold WebAuthn auth service (Phase 0)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -46,6 +46,16 @@ jobs:
           # ~4 GB Node heap on the runner.
           NODE_OPTIONS: --max-old-space-size=6144
 
+      - name: Apply D1 migrations
+        # Applies teeline-web/migrations/* to the remote teeline-auth D1 DB
+        # BEFORE deploy, so the deployed Functions always see the schema they
+        # expect. Idempotent (d1_migrations table tracks applied migrations);
+        # no-op when nothing new.
+        run: npx wrangler d1 migrations apply teeline-auth --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy to Cloudflare Pages
         run: npx wrangler pages deploy dist/
         env:

--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build gate (Pages Functions bundle)
+        # Compiles teeline-web/functions/* (WebAuthn auth) to catch bundler /
+        # SimpleWebAuthn edge-runtime issues early. Local build only — no
+        # Cloudflare auth required.
+        run: npx wrangler pages functions build --outdir /tmp/teeline-fn-build
+
       - name: Lint (tsc)
         run: npx tsc --noEmit
 

--- a/teeline-web/.gitignore
+++ b/teeline-web/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 # Sentry Config File
 .env.sentry-build-plugin
 test-results/
+
+# Wrangler local state (Pages Functions dev)
+.wrangler

--- a/teeline-web/functions/api/auth/ping.ts
+++ b/teeline-web/functions/api/auth/ping.ts
@@ -1,0 +1,35 @@
+// Phase 0 scaffold: proves the Pages Functions pipeline AND that
+// @simplewebauthn/server (pinned 13.3.2) bundles + runs on the Workers
+// runtime (ESM build; WebCrypto). Imports both the option generator and the
+// verifier so the full import graph is exercised by the bundler.
+// Replaced by real WebAuthn routes in Phase 2.
+import { generateRegistrationOptions, verifyRegistrationResponse } from '@simplewebauthn/server'
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const opts = await generateRegistrationOptions({
+      rpName: 'Teeline',
+      rpID: 'tspsolver.com',
+      userName: 'probe',
+      userID: new Uint8Array(16),
+    })
+    return Response.json({
+      ok: true,
+      service: 'webauthn-auth',
+      hasDbBinding: !!context.env.DB,
+      challengeLength: opts.challenge.length,
+      verifierLoaded: typeof verifyRegistrationResponse === 'function',
+    })
+  } catch (err) {
+    return Response.json({ ok: false, error: String(err) }, { status: 500 })
+  }
+}
+
+// Env shape for this worker — D1 binding + secrets (moved to a shared .d.ts
+// in Phase 1; inline here so the scaffold type-checks standalone).
+interface Env {
+  DB?: D1Database & { name?: string }
+  AUTH_SERVICE_SECRET?: string
+  SESSION_SECRET?: string
+  ALLOWED_ORIGINS?: string
+}

--- a/teeline-web/migrations/0001_init.sql
+++ b/teeline-web/migrations/0001_init.sql
@@ -1,0 +1,42 @@
+-- WebAuthn auth schema (design: decisions/webauthn-auth-design)
+-- users: one row per passkey account (userHandle = users.id)
+CREATE TABLE IF NOT EXISTS users (
+  id           TEXT PRIMARY KEY,          -- uuid v4 (WebAuthn userHandle)
+  display_name TEXT,                      -- optional, set at registration
+  created_at   INTEGER NOT NULL
+);
+
+-- credentials: WebAuthn public keys; counter must be updated atomically
+-- (anti-clone detection — SimpleWebAuthn validates, we persist the new value)
+CREATE TABLE IF NOT EXISTS credentials (
+  id         TEXT PRIMARY KEY,            -- base64url credentialId
+  user_id    TEXT NOT NULL REFERENCES users(id),
+  public_key TEXT NOT NULL,               -- base64url COSE public key
+  counter    INTEGER NOT NULL DEFAULT 0,
+  transports TEXT,                        -- JSON array
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_credentials_user ON credentials(user_id);
+
+-- api_keys: only SHA-256 hashes at rest; plaintext shown exactly once
+CREATE TABLE IF NOT EXISTS api_keys (
+  id           TEXT PRIMARY KEY,          -- "key_" + uuid (management id)
+  user_id      TEXT NOT NULL REFERENCES users(id),
+  name         TEXT,                      -- optional label ("my-laptop")
+  secret_hash  TEXT NOT NULL,             -- SHA-256(secret), hex
+  created_at   INTEGER NOT NULL,
+  last_used_at INTEGER,
+  revoked      INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_keys_user ON api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_keys_hash ON api_keys(secret_hash);
+
+-- challenges: WebAuthn ceremony state; TTL 300 s, single-use (DELETE on consume)
+CREATE TABLE IF NOT EXISTS challenges (
+  id          TEXT PRIMARY KEY,           -- random nonce returned to client
+  type        TEXT NOT NULL,              -- 'register' | 'login'
+  challenge   TEXT NOT NULL,
+  user_id     TEXT,                       -- NULL for register (no user yet)
+  user_handle TEXT,                       -- register only
+  expires_at  INTEGER NOT NULL
+);

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -16,6 +16,7 @@
         "@fontsource/jetbrains-mono": "^5.3.0",
         "@sentry/browser": "^10.69.0",
         "@sentry/vite-plugin": "^5.4.0",
+        "@simplewebauthn/server": "13.3.2",
         "astro": "^7.2.1",
         "preact": "^10.29.8",
         "tailwindcss": "^4.3.3",
@@ -1585,6 +1586,12 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2200,6 +2207,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
@@ -2246,6 +2259,174 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.9.0.tgz",
+      "integrity": "sha512-ErGsrDbWYhMu/H43L3qohwCwPrjdinn8GGm4Q52evA1u2juJxqkPXv+26vBC35hhMoUkzYIOTLrFzSbXanRU+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.0.tgz",
+      "integrity": "sha512-VKQz6sJYgSxtGaK6UdnNBUx7hmSdg0K331qrEWh5qxpQsyZGWBjxbq05AJ2bTWWjd7d+nJIxFzwvsR5T7DWC/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "@peculiar/asn1-x509-attr": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.0.tgz",
+      "integrity": "sha512-SbxRzHiWnRdiDuiiji/RLsJxu2au4hmSZSKK7GQOgNr2BVvheAlFQST9qqzRchUcZ6wvcyRuPXIfYXVzLoZ/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.0.tgz",
+      "integrity": "sha512-vNspHtTd9h6e8c2lMW+B/VHEUD+HRFV0fj/Gvz7SaJbwiecA8dxd96UTFPYI1PR8k7qwjjW9AFEyI+LuyVi4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.0.tgz",
+      "integrity": "sha512-A6bX+gZr69U38Pg1mWvPrM1eRba6L6kLR8iVG+bJtKj3qSv2rSNmlXLtej7ZOkEWt6xL6PiJD73uFEdQI3BXCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.0",
+        "@peculiar/asn1-pkcs8": "^2.9.0",
+        "@peculiar/asn1-rsa": "^2.9.0",
+        "@peculiar/asn1-schema": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.0.tgz",
+      "integrity": "sha512-1JH4FliKQ3trkMD17X+bKGsph5TsiM+AiiqnVKr1wxA/GoUSDHiWG/zROzLAbDIA7eclBCjQsp8hrBEJk7LRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.0.tgz",
+      "integrity": "sha512-igArY6bpCI6tOPm2EU9QPrXuKq2s1iraLCTym4UlooYdzcRDIPCRUN9TAEcqZ5rZhA+HiPdFKTbDP9vneN/tsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.0",
+        "@peculiar/asn1-pfx": "^2.9.0",
+        "@peculiar/asn1-pkcs8": "^2.9.0",
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "@peculiar/asn1-x509-attr": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.0.tgz",
+      "integrity": "sha512-vOD7Q4UmQWhlMYuWJawS2sD+/JcPKJNtyQuFZx09r+KFhm5/HxfGak63y/m56cpBjmb5k6PeRlQf1fvLQAieUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.0.tgz",
+      "integrity": "sha512-AKvPMOM7LfK0uFe1m7o7+veOa8xQGPqsqOrKi3QKgCElzwjGp39mbhr2g7mt/v/mXQHiIvJmDj5cJS173x8Q9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.0.tgz",
+      "integrity": "sha512-b9Na83rhRFQBd5CuMmuEqokYhmyWUbG7mNZl/thGhBwLpCdiZ85TZ3WFhF7OVgOekC5uKhLk4C3HKtdiScCMdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.0.tgz",
+      "integrity": "sha512-f+u+EyGjfPvPzvr0+rlh/TFEO7LWt84mEwQynCUYr4F6urf/8s6+ESJ23qfSn1aamkZR6AuBNaC62iEsGvp0+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.0",
+        "@peculiar/asn1-x509": "^2.9.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -3205,6 +3386,25 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.2.tgz",
+      "integrity": "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -4009,6 +4209,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -6369,6 +6583,24 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -6387,6 +6619,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/regex": {
       "version": "6.1.0",
@@ -6920,8 +7158,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -21,6 +21,7 @@
     "@fontsource/jetbrains-mono": "^5.3.0",
     "@sentry/browser": "^10.69.0",
     "@sentry/vite-plugin": "^5.4.0",
+    "@simplewebauthn/server": "13.3.2",
     "astro": "^7.2.1",
     "preact": "^10.29.8",
     "tailwindcss": "^4.3.3",

--- a/teeline-web/wrangler.toml
+++ b/teeline-web/wrangler.toml
@@ -1,3 +1,19 @@
 name = "teeline-web"
 pages_build_output_dir = "dist"
 compatibility_date = "2026-05-29"
+
+# ---- WebAuthn auth (Phase 0 scaffold) ----
+# D1 binding for the auth service (users / credentials / api_keys / challenges).
+# database_id is created under your Cloudflare account with:
+#   wrangler d1 create teeline-auth
+# then paste the returned id below (the placeholder breaks remote deploys).
+[[d1_databases]]
+binding = "DB"
+database_name = "teeline-auth"
+database_id = "REPLACE_WITH_REAL_D1_DATABASE_ID"
+migrations_dir = "migrations"
+
+# Secrets (set via Cloudflare dashboard / `wrangler pages secret put`):
+#   AUTH_SERVICE_SECRET — shared secret between teeline-api and the verify endpoint
+#   SESSION_SECRET      — HMAC key for the session cookie
+#   ALLOWED_ORIGINS     — comma-separated origins allowed for WebAuthn (dev override)

--- a/teeline-web/wrangler.toml
+++ b/teeline-web/wrangler.toml
@@ -4,13 +4,10 @@ compatibility_date = "2026-05-29"
 
 # ---- WebAuthn auth (Phase 0 scaffold) ----
 # D1 binding for the auth service (users / credentials / api_keys / challenges).
-# database_id is created under your Cloudflare account with:
-#   wrangler d1 create teeline-auth
-# then paste the returned id below (the placeholder breaks remote deploys).
 [[d1_databases]]
 binding = "DB"
 database_name = "teeline-auth"
-database_id = "REPLACE_WITH_REAL_D1_DATABASE_ID"
+database_id = "86f65990-077e-42cc-b94a-4d4c7abf548f"
 migrations_dir = "migrations"
 
 # Secrets (set via Cloudflare dashboard / `wrangler pages secret put`):


### PR DESCRIPTION
## Phase 0 — Auth service scaffold

First step of replacing Clerk with WebAuthn + self-serve API keys
(design: GitKB `decisions/webauthn-auth-design`, ADR-007; task: `tasks/webauthn-auth-replace-clerk`).

### What's in

- **Pages Functions skeleton** — `teeline-web/functions/api/auth/ping.ts`: a canary that imports
  `@simplewebauthn/server` (13.3.2, pinned) and generates a real registration challenge, proving the
  library **bundles and runs on the Workers runtime** (WebCrypto path) — the key risk of the whole
  migration.
- **D1 binding** in `wrangler.toml` (`teeline-auth`) + `migrations_dir`; verified locally:
  `wrangler pages dev` exposes `env.DB` in local mode.
- **Schema** — `migrations/0001_init.sql`: `users`, `credentials` (atomic WebAuthn counters),
  `api_keys` (SHA-256 hashes only), `challenges` (TTL, single-use).
- **CI build gate** — `teeline-web.yml` gains a "Build gate (Pages Functions bundle)" step
  (`wrangler pages functions build`) to catch edge-bundling regressions (SimpleWebAuthn included).
- `.gitignore`: ignore wrangler local state.

### Database (already done — nothing to do)

- `wrangler d1 create teeline-auth` already ran (region WEUR); `database_id` wired into
  `wrangler.toml` (commit `e7ac459`).
- Remote migrations applied: `0001_init.sql` ✅ — tables `users`, `credentials`, `api_keys`,
  `challenges` live in D1.

### Verified locally

```
GET /api/auth/ping → {"ok":true,"service":"webauthn-auth","hasDbBinding":true,
                      "challengeLength":43,"verifierLoaded":true}
```
Existing `functions/tunnel.js` (Sentry proxy) unaffected.