### PR TITLE
feat(web): WebAuthn auth data layer (Phase 1)

### DIFF
--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -50,9 +50,11 @@ jobs:
 
       - name: Build gate (Pages Functions bundle)
         # Compiles teeline-web/functions/* (WebAuthn auth) to catch bundler /
-        # SimpleWebAuthn edge-runtime issues early. Local build only — no
-        # Cloudflare auth required.
-        run: npx wrangler pages functions build --outdir /tmp/teeline-fn-build
+        # SimpleWebAuthn edge-runtime issues early, and type-checks them with
+        # the Workers types. Local build only — no Cloudflare auth required.
+        run: |
+          npx tsc -p functions/tsconfig.json --noEmit
+          npx wrangler pages functions build --outdir /tmp/teeline-fn-build
 
       - name: Lint (tsc)
         run: npx tsc --noEmit

--- a/teeline-web/functions/api/auth/ping.ts
+++ b/teeline-web/functions/api/auth/ping.ts
@@ -4,6 +4,7 @@
 // verifier so the full import graph is exercised by the bundler.
 // Replaced by real WebAuthn routes in Phase 2.
 import { generateRegistrationOptions, verifyRegistrationResponse } from '@simplewebauthn/server'
+import type { Env } from '../../lib/env'
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
@@ -23,13 +24,4 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   } catch (err) {
     return Response.json({ ok: false, error: String(err) }, { status: 500 })
   }
-}
-
-// Env shape for this worker — D1 binding + secrets (moved to a shared .d.ts
-// in Phase 1; inline here so the scaffold type-checks standalone).
-interface Env {
-  DB?: D1Database & { name?: string }
-  AUTH_SERVICE_SECRET?: string
-  SESSION_SECRET?: string
-  ALLOWED_ORIGINS?: string
 }

--- a/teeline-web/functions/lib/db.test.ts
+++ b/teeline-web/functions/lib/db.test.ts
@@ -1,0 +1,213 @@
+// Data-layer tests against real SQLite (better-sqlite3) behind a minimal
+// D1-compatible shim. D1 *is* SQLite, so the SQL in db.ts runs unchanged
+// (numbered ?NNN params are normalized to anonymous ? — same bind order).
+//
+// Why not miniflare's D1 emulation: the workerd build shipped with
+// wrangler 4.119 fails to start with `cloudflare-internal:d1-api` wrapped
+// bindings (workers-sdk#4077 / #10114). better-sqlite3 is deterministic,
+// fast and CI-friendly; the real D1 path is exercised by the deploy-time
+// migrations and the Phase 3 verify e2e.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+import {
+  addCredential,
+  consumeChallenge,
+  createApiKey,
+  createUser,
+  deleteUser,
+  findActiveKeyByHash,
+  getChallenge,
+  getCredentialById,
+  getUser,
+  hashSecret,
+  insertChallenge,
+  listApiKeysByUser,
+  listCredentialsByUser,
+  revokeKey,
+  timingSafeEqual,
+  touchKeyLastUsed,
+  updateCredentialCounter,
+} from './db'
+
+const SCHEMA = readFileSync(join(import.meta.dirname, '../../migrations/0001_init.sql'), 'utf8')
+
+// ---- Minimal D1-compatible shim over better-sqlite3 ---------------------
+
+type D1Like = {
+  exec(sql: string): void
+  prepare(sql: string): {
+    bind(...params: unknown[]): {
+      first<T>(col?: string): T | null
+      all<T>(): { results: T[] }
+      run(): { meta: { changes: number } }
+    }
+  }
+  batch(stmts: { run(): { meta: { changes: number } } }[]): { meta: { changes: number } }[]
+}
+
+function makeD1(db: Database.Database): D1Like {
+  return {
+    exec(sql) {
+      db.exec(sql)
+    },
+    prepare(sql) {
+      // D1's ?NNN numbering → SQLite anonymous ? (identical bind order;
+      // db.ts never reuses a numbered param, so this is lossless).
+      const stmt = db.prepare(sql.replace(/\?(\d+)/g, '?'))
+      return {
+        bind(...params) {
+          return {
+            first<T>(): T | null {
+              return (stmt.get(...params) as T | undefined) ?? null
+            },
+            all<T>(): { results: T[] } {
+              return { results: stmt.all(...params) as T[] }
+            },
+            run() {
+              const info = stmt.run(...params)
+              return { meta: { changes: info.changes } }
+            },
+          }
+        },
+      }
+    },
+    batch(stmts) {
+      return db.transaction(() => stmts.map((s) => s.run()))()
+    },
+  }
+}
+
+let db: D1Like
+
+beforeAll(() => {
+  db = makeD1(new Database(':memory:'))
+})
+
+beforeEach(() => {
+  // Fresh schema per test; the SQL is idempotent (IF NOT EXISTS), which also
+  // proves re-applying migrations is safe.
+  db.exec(SCHEMA)
+  db.exec('DELETE FROM api_keys; DELETE FROM credentials; DELETE FROM challenges; DELETE FROM users;')
+})
+
+const NOW = 1_752_000_000_000
+
+describe('users', () => {
+  it('creates and reads a user', async () => {
+    await createUser(db as never, { id: 'u1', displayName: 'Tim', createdAt: NOW })
+    const u = await getUser(db as never, 'u1')
+    expect(u).toMatchObject({ id: 'u1', display_name: 'Tim', created_at: NOW })
+  })
+
+  it('returns null for a missing user', async () => {
+    expect(await getUser(db as never, 'nope')).toBeNull()
+  })
+
+  it('deleteUser wipes user, credentials and keys atomically', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk', counter: 0, createdAt: NOW })
+    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: await hashSecret('ak_x'), createdAt: NOW })
+    await deleteUser(db as never, 'u1')
+    expect(await getUser(db as never, 'u1')).toBeNull()
+    expect(await getCredentialById(db as never, 'c1')).toBeNull()
+    expect(await listApiKeysByUser(db as never, 'u1')).toEqual([])
+  })
+})
+
+describe('credentials', () => {
+  it('adds, lists and looks up by id (login path)', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk1', counter: 1, transports: ['internal'], createdAt: NOW })
+    await addCredential(db as never, { id: 'c2', userId: 'u1', publicKey: 'pk2', counter: 2, createdAt: NOW })
+
+    const byUser = await listCredentialsByUser(db as never, 'u1')
+    expect(byUser.map((c) => c.id)).toEqual(['c1', 'c2'])
+    expect(byUser[0].transports).toBe(JSON.stringify(['internal']))
+
+    const found = await getCredentialById(db as never, 'c2')
+    expect(found?.user_id).toBe('u1')
+    expect(await getCredentialById(db as never, 'ghost')).toBeNull()
+  })
+
+  it('updates the counter atomically', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk', counter: 0, createdAt: NOW })
+    await updateCredentialCounter(db as never, 'c1', 7)
+    expect((await getCredentialById(db as never, 'c1'))?.counter).toBe(7)
+  })
+})
+
+describe('api keys', () => {
+  it('creates, lists metadata and finds by hash', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    const secret = 'ak_abc123'
+    await createApiKey(db as never, { id: 'k1', userId: 'u1', name: 'laptop', secretHash: await hashSecret(secret), createdAt: NOW })
+
+    const keys = await listApiKeysByUser(db as never, 'u1')
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({ id: 'k1', name: 'laptop', revoked: 0 })
+    // secret_hash is present (needed for verify) but callers must never expose it
+    expect(keys[0].secret_hash).toBe(await hashSecret(secret))
+
+    const found = await findActiveKeyByHash(db as never, await hashSecret(secret))
+    expect(found?.user_id).toBe('u1')
+    expect(await findActiveKeyByHash(db as never, await hashSecret('ak_wrong'))).toBeNull()
+  })
+
+  it('revoke hides the key from verify immediately, scoped to owner', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    await createUser(db as never, { id: 'u2', createdAt: NOW })
+    const secret = 'ak_xyz'
+    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: await hashSecret(secret), createdAt: NOW })
+
+    // non-owner cannot revoke
+    expect(await revokeKey(db as never, 'k1', 'u2')).toBe(false)
+    expect(await findActiveKeyByHash(db as never, await hashSecret(secret))).not.toBeNull()
+
+    // owner revokes → verify path immediately returns nothing
+    expect(await revokeKey(db as never, 'k1', 'u1')).toBe(true)
+    expect(await findActiveKeyByHash(db as never, await hashSecret(secret))).toBeNull()
+  })
+
+  it('touchKeyLastUsed records usage', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: 'h', createdAt: NOW })
+    await touchKeyLastUsed(db as never, 'k1', 123)
+    expect((await listApiKeysByUser(db as never, 'u1'))[0].last_used_at).toBe(123)
+  })
+})
+
+describe('challenges', () => {
+  it('insert, read and single-use consume', async () => {
+    await insertChallenge(db as never, { id: 'ch1', type: 'register', challenge: 'abc', userHandle: 'uh', expiresAt: NOW + 300_000 })
+    const c = await getChallenge(db as never, 'ch1')
+    expect(c).toMatchObject({ id: 'ch1', type: 'register', challenge: 'abc', user_handle: 'uh' })
+
+    expect(await consumeChallenge(db as never, 'ch1')).toBe(true)
+    expect(await consumeChallenge(db as never, 'ch1')).toBe(false) // replay fails
+    expect(await getChallenge(db as never, 'ch1')).toBeNull()
+  })
+
+  it('login challenge stores a user_id', async () => {
+    await insertChallenge(db as never, { id: 'ch2', type: 'login', challenge: 'def', userId: 'u1', expiresAt: NOW + 300_000 })
+    expect((await getChallenge(db as never, 'ch2'))?.user_id).toBe('u1')
+  })
+})
+
+describe('crypto helpers', () => {
+  it('hashSecret is deterministic SHA-256 hex', async () => {
+    const h = await hashSecret('ak_secret')
+    expect(h).toMatch(/^[0-9a-f]{64}$/)
+    expect(await hashSecret('ak_secret')).toBe(h)
+    expect(await hashSecret('ak_secret2')).not.toBe(h)
+  })
+
+  it('timingSafeEqual compares in constant time', () => {
+    expect(timingSafeEqual('abc', 'abc')).toBe(true)
+    expect(timingSafeEqual('abc', 'abd')).toBe(false)
+    expect(timingSafeEqual('abc', 'abcd')).toBe(false) // length mismatch short-circuits
+    expect(timingSafeEqual('', '')).toBe(true)
+  })
+})

--- a/teeline-web/functions/lib/db.ts
+++ b/teeline-web/functions/lib/db.ts
@@ -1,0 +1,219 @@
+// Data access layer for the WebAuthn auth service (Cloudflare D1).
+//
+// Every function takes the D1 handle explicitly (no module globals), which
+// keeps the layer unit-testable against miniflare's local D1 emulation and
+// the real binding identical in production.
+//
+// Schema: migrations/0001_init.sql
+//   users        — one row per passkey account (id = WebAuthn userHandle)
+//   credentials  — WebAuthn public keys; counter updated atomically
+//   api_keys     — SHA-256 hashes only; plaintext shown exactly once
+//   challenges   — WebAuthn ceremony state; TTL + single-use
+
+export interface UserRow {
+  id: string
+  display_name: string | null
+  created_at: number
+}
+
+export interface CredentialRow {
+  id: string
+  user_id: string
+  public_key: string
+  counter: number
+  transports: string | null
+  created_at: number
+}
+
+export interface ApiKeyRow {
+  id: string
+  user_id: string
+  name: string | null
+  secret_hash: string
+  created_at: number
+  last_used_at: number | null
+  revoked: number
+}
+
+export interface ChallengeRow {
+  id: string
+  type: 'register' | 'login'
+  challenge: string
+  user_id: string | null
+  user_handle: string | null
+  expires_at: number
+}
+
+const USER_COLS = 'id, display_name, created_at'
+const CRED_COLS = 'id, user_id, public_key, counter, transports, created_at'
+const KEY_COLS = 'id, user_id, name, secret_hash, created_at, last_used_at, revoked'
+
+// ---- Users ---------------------------------------------------------------
+
+export async function createUser(
+  db: D1Database,
+  user: { id: string; displayName?: string; createdAt: number },
+): Promise<void> {
+  await db
+    .prepare(`INSERT INTO users (${USER_COLS}) VALUES (?1, ?2, ?3)`)
+    .bind(user.id, user.displayName ?? null, user.createdAt)
+    .run()
+}
+
+export async function getUser(db: D1Database, id: string): Promise<UserRow | null> {
+  return (
+    (await db.prepare(`SELECT ${USER_COLS} FROM users WHERE id = ?1`).bind(id).first<UserRow>()) ??
+    null
+  )
+}
+
+// Operator reset: passkey loss = account loss. Wipes user + credentials + keys
+// atomically (D1 batch runs in one transaction).
+export async function deleteUser(db: D1Database, id: string): Promise<void> {
+  await db.batch([
+    db.prepare('DELETE FROM api_keys WHERE user_id = ?1').bind(id),
+    db.prepare('DELETE FROM credentials WHERE user_id = ?1').bind(id),
+    db.prepare('DELETE FROM users WHERE id = ?1').bind(id),
+  ])
+}
+
+// ---- Credentials ---------------------------------------------------------
+
+export async function addCredential(
+  db: D1Database,
+  c: {
+    id: string
+    userId: string
+    publicKey: string
+    counter: number
+    transports?: string[]
+    createdAt: number
+  },
+): Promise<void> {
+  await db
+    .prepare(`INSERT INTO credentials (${CRED_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`)
+    .bind(c.id, c.userId, c.publicKey, c.counter, c.transports ? JSON.stringify(c.transports) : null, c.createdAt)
+    .run()
+}
+
+export async function listCredentialsByUser(db: D1Database, userId: string): Promise<CredentialRow[]> {
+  return (
+    await db
+      .prepare(`SELECT ${CRED_COLS} FROM credentials WHERE user_id = ?1 ORDER BY created_at`)
+      .bind(userId)
+      .all<CredentialRow>()
+  ).results
+}
+
+// Discoverable-credential login: the client sends only the credential id, so
+// we look the credential up across all users.
+export async function getCredentialById(db: D1Database, id: string): Promise<CredentialRow | null> {
+  return (
+    (await db.prepare(`SELECT ${CRED_COLS} FROM credentials WHERE id = ?1`).bind(id).first<CredentialRow>()) ??
+    null
+  )
+}
+
+// Single-statement update = atomic; prevents lost counter increments under
+// concurrent assertions (the counter is the anti-clone bookkeeping).
+export async function updateCredentialCounter(db: D1Database, id: string, counter: number): Promise<void> {
+  await db.prepare('UPDATE credentials SET counter = ?1 WHERE id = ?2').bind(counter, id).run()
+}
+
+// ---- API keys ------------------------------------------------------------
+
+export async function createApiKey(
+  db: D1Database,
+  k: { id: string; userId: string; name?: string; secretHash: string; createdAt: number },
+): Promise<void> {
+  await db
+    .prepare(`INSERT INTO api_keys (${KEY_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, NULL, 0)`)
+    .bind(k.id, k.userId, k.name ?? null, k.secretHash, k.createdAt)
+    .run()
+}
+
+// Metadata only — the secret itself is never stored, so it can never be listed.
+export async function listApiKeysByUser(db: D1Database, userId: string): Promise<ApiKeyRow[]> {
+  return (
+    await db
+      .prepare(`SELECT ${KEY_COLS} FROM api_keys WHERE user_id = ?1 ORDER BY created_at DESC`)
+      .bind(userId)
+      .all<ApiKeyRow>()
+  ).results
+}
+
+// Verify path: hash lookup, revoked keys are invisible (revocation is a soft
+// flag, effective immediately — no cache to invalidate).
+export async function findActiveKeyByHash(db: D1Database, secretHash: string): Promise<ApiKeyRow | null> {
+  return (
+    (await db
+      .prepare(`SELECT ${KEY_COLS} FROM api_keys WHERE secret_hash = ?1 AND revoked = 0`)
+      .bind(secretHash)
+      .first<ApiKeyRow>()) ?? null
+  )
+}
+
+// Scoped to the key's owner so one user can't revoke another's key.
+export async function revokeKey(db: D1Database, id: string, userId: string): Promise<boolean> {
+  const res = await db
+    .prepare('UPDATE api_keys SET revoked = 1 WHERE id = ?1 AND user_id = ?2')
+    .bind(id, userId)
+    .run()
+  return res.meta.changes > 0
+}
+
+export async function touchKeyLastUsed(db: D1Database, id: string, at: number = Date.now()): Promise<void> {
+  await db.prepare('UPDATE api_keys SET last_used_at = ?1 WHERE id = ?2').bind(at, id).run()
+}
+
+// ---- Challenges ----------------------------------------------------------
+
+export async function insertChallenge(
+  db: D1Database,
+  c: {
+    id: string
+    type: 'register' | 'login'
+    challenge: string
+    userId?: string
+    userHandle?: string
+    expiresAt: number
+  },
+): Promise<void> {
+  await db
+    .prepare('INSERT INTO challenges (id, type, challenge, user_id, user_handle, expires_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)')
+    .bind(c.id, c.type, c.challenge, c.userId ?? null, c.userHandle ?? null, c.expiresAt)
+    .run()
+}
+
+export async function getChallenge(db: D1Database, id: string): Promise<ChallengeRow | null> {
+  return (
+    (await db
+      .prepare('SELECT id, type, challenge, user_id, user_handle, expires_at FROM challenges WHERE id = ?1')
+      .bind(id)
+      .first<ChallengeRow>()) ?? null
+  )
+}
+
+// Single-use: DELETE is the consume step; returns false on a second attempt.
+export async function consumeChallenge(db: D1Database, id: string): Promise<boolean> {
+  const res = await db.prepare('DELETE FROM challenges WHERE id = ?1').bind(id).run()
+  return res.meta.changes > 0
+}
+
+// ---- Crypto helpers ------------------------------------------------------
+
+// SHA-256 hex of a secret. API keys are stored hashed; the plaintext exists
+// only in the one HTTPS response that mints it.
+export async function hashSecret(secret: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret))
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// Constant-time comparison for equal-length strings (hash comparison — we
+// never compare raw secrets, only their digests).
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let out = 0
+  for (let i = 0; i < a.length; i++) out |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return out === 0
+}

--- a/teeline-web/functions/lib/env.ts
+++ b/teeline-web/functions/lib/env.ts
@@ -1,0 +1,9 @@
+// Shared Env shape for the WebAuthn auth Pages Functions.
+// Bindings come from wrangler.toml; secrets are set on the Pages project
+// (AUTH_SERVICE_SECRET, SESSION_SECRET) and ALLOWED_ORIGINS is a dev override.
+export interface Env {
+  DB: D1Database
+  AUTH_SERVICE_SECRET?: string
+  SESSION_SECRET?: string
+  ALLOWED_ORIGINS?: string
+}

--- a/teeline-web/functions/tsconfig.json
+++ b/teeline-web/functions/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -24,9 +24,11 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@cloudflare/workers-types": "5.20260815.1",
         "@playwright/test": "^1.62.1",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
+        "better-sqlite3": "11.10.0",
         "typescript": "6.0.3",
         "vitest": "4.1.10",
         "wrangler": "4.119.0"
@@ -1045,6 +1047,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260815.1.tgz",
+      "integrity": "sha512-btpW8rEgeJKcxDlBWKxzjLLUHxzUWqXZY8O+DmM6NcSHadUQN5I71z6Q/yAKCTJyGS7adBpXzlsZSFbosLnECQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4404,6 +4413,27 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -4414,6 +4444,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blake3-wasm": {
@@ -4472,6 +4536,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4548,6 +4637,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -4775,6 +4871,32 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -4951,6 +5073,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
@@ -5058,6 +5190,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5179,6 +5321,13 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5224,6 +5373,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5272,6 +5428,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -5467,6 +5630,41 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -6032,6 +6230,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "5.20260801.0-alpha",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.0-alpha.tgz",
@@ -6065,6 +6276,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -6073,6 +6294,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -6114,6 +6342,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/neotraverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
@@ -6134,6 +6369,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -6234,6 +6482,16 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
@@ -6524,6 +6782,34 @@
         "preact": ">=10 || >= 11.0.0-0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.9.6",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -6583,6 +6869,17 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
@@ -6606,6 +6903,37 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -6734,6 +7062,27 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/satteri": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
@@ -6858,6 +7207,53 @@
         "kolorist": "^1.6.0"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6952,6 +7348,16 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6992,6 +7398,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strnum": {
@@ -7065,6 +7481,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/teeline-wasm": {
@@ -7177,6 +7623,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
@@ -8153,6 +8612,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -29,9 +29,11 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@cloudflare/workers-types": "5.20260815.1",
     "@playwright/test": "^1.62.1",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
+    "better-sqlite3": "11.10.0",
     "typescript": "6.0.3",
     "vitest": "4.1.10",
     "wrangler": "4.119.0"

--- a/teeline-web/vitest.config.ts
+++ b/teeline-web/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     // node env (default) — tests import only DOM-free modules
     // Playwright tests live in tests/ — excluded by not matching this pattern
-    include: ['src/**/*.test.ts'],
+    // functions/** tests use miniflare's local D1 emulation (node env)
+    include: ['src/**/*.test.ts', 'functions/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Phase 1 — Data layer

Second step of replacing Clerk with WebAuthn + self-serve API keys
(design: GitKB `decisions/webauthn-auth-design`; ADR-007; task `tasks/webauthn-auth-replace-clerk`).

### What's in

- **`functions/lib/db.ts`** — D1 data access for `users` / `credentials` / `api_keys` / `challenges`:
  - atomic WebAuthn **counter** updates (anti-clone bookkeeping)
  - API keys stored as **SHA-256 hashes only** (`hashSecret` + constant-time `timingSafeEqual`)
  - **revocation** is a soft flag, scoped to the key's owner, effective immediately
  - **single-use challenges** (DELETE-on-consume, replay fails) with TTL expiry
  - `deleteUser` = atomic operator reset (batch) — the documented recovery path
- **`functions/lib/env.ts`** — shared binding types; the Phase 0 `ping.ts` canary now imports it.
- **`functions/tsconfig.json`** + `@cloudflare/workers-types` — the Functions code is type-checked
  (the web tsconfig only covers `src/`); CI build gate now runs `tsc -p functions/tsconfig.json`.
- **`functions/lib/db.test.ts`** — 12 unit tests over **real SQLite** (`better-sqlite3`) behind a
  minimal D1-compatible shim (`?NNN` → `?` normalization; identical bind order).

### Testing note

Miniflare's D1 **local emulation was dropped**: the workerd build shipped with wrangler 4.119
fails to start D1 wrapped bindings (`cloudflare-internal:d1-api`, workers-sdk#4077/#10114).
Since D1 *is* SQLite, `better-sqlite3` runs the same SQL unchanged — deterministic, fast,
CI-friendly. The real D1 path is covered by deploy-time migrations and will be exercised by the
Phase 3 verify e2e.

### Verified

- `tsc -p functions/tsconfig.json --noEmit` ✅
- `npm test` — **270 passed** (258 existing + 12 new) ✅
- `wrangler pages functions build` ✅