### PR TITLE
feat(web): API key lifecycle + internal verify endpoint (Phase 3)

### DIFF
--- a/teeline-web/functions/api/auth/keys.test.ts
+++ b/teeline-web/functions/api/auth/keys.test.ts
@@ -1,0 +1,156 @@
+// API-key lifecycle tests: mint (show-once), list (metadata only), revoke
+// (immediate), and the internal verify contract (the shape teeline-api
+// expects — a drop-in for the old Clerk verify call).
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
+import { createUser } from '../../lib/db'
+import { createSessionToken } from '../../lib/session'
+import Database from 'better-sqlite3'
+
+import { onRequestGet as listKeys, onRequestPost as createKey } from './keys'
+import { onRequestDelete as revokeKey } from './keys/[id]'
+import { onRequestPost as verifyKey } from './keys/verify'
+
+let shim: D1Like
+const env = {
+  SESSION_SECRET: 'test-session-secret',
+  AUTH_SERVICE_SECRET: 'verify-shared-secret',
+  ALLOWED_ORIGINS: 'http://localhost:8788',
+} as never
+
+function ctx(request: Request, params: Record<string, string> = {}) {
+  return { request, env: { ...env, DB: shim }, params } as never
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  const { headers, ...rest } = init
+  return new Request(`http://localhost:8788${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', ...(headers as Record<string, string>) },
+    ...rest,
+  })
+}
+
+async function sessionCookie(userId: string): Promise<string> {
+  const token = await createSessionToken(env.SESSION_SECRET as string, userId)
+  return `__Host-teeline-session=${token}`
+}
+
+async function seedUser(id = 'u1'): Promise<void> {
+  await createUser(shim, { id, displayName: 'Tim', createdAt: Date.now() })
+}
+
+beforeAll(() => {
+  shim = makeD1(new Database(':memory:'))
+})
+
+beforeEach(() => {
+  shim.exec(SCHEMA)
+  shim.exec('DELETE FROM api_keys; DELETE FROM credentials; DELETE FROM challenges; DELETE FROM users;')
+})
+
+describe('key creation (show-once)', () => {
+  it('requires a session', async () => {
+    const res = await createKey(ctx(req('/api/auth/keys')))
+    expect(res.status).toBe(401)
+  })
+
+  it('mints a well-formed key, stores only the hash, and returns the secret once', async () => {
+    await seedUser()
+    const cookie = await sessionCookie('u1')
+    const res = await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'my-laptop' }), headers: { Cookie: cookie } })))
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { id: string; name: string | null; secret: string }
+    expect(body.id).toMatch(/^key_/)
+    expect(body.name).toBe('my-laptop')
+    expect(body.secret).toMatch(/^ak_[A-Za-z0-9_-]{43}$/)
+
+    // only the hash is stored: looking up by the secret's hash finds it
+    const rows = await shim.prepare('SELECT id, secret_hash FROM api_keys').bind().all<{ id: string; secret_hash: string }>()
+    expect(rows.results).toHaveLength(1)
+    expect(rows.results[0].secret_hash).not.toBe(body.secret)
+    expect(rows.results[0].secret_hash).toMatch(/^[0-9a-f]{64}$/)
+
+    // second mint → different secret
+    const res2 = await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))
+    const body2 = (await res2.json()) as { secret: string }
+    expect(body2.secret).not.toBe(body.secret)
+  })
+})
+
+describe('key listing', () => {
+  it('returns metadata only — never the secret or hash', async () => {
+    await seedUser()
+    const cookie = await sessionCookie('u1')
+    await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'a' }), headers: { Cookie: cookie } })))
+    await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'b' }), headers: { Cookie: cookie } })))
+
+    const res = await listKeys(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))
+    expect(res.status).toBe(200)
+    const { keys } = (await res.json()) as { keys: { id: string; name: string | null; secret?: string; secret_hash?: string }[] }
+    expect(keys).toHaveLength(2)
+    for (const k of keys) {
+      expect(k.secret).toBeUndefined()
+      expect(k.secret_hash).toBeUndefined()
+      expect(typeof k.id).toBe('string')
+    }
+  })
+
+  it('requires a session', async () => {
+    expect((await listKeys(ctx(req('/api/auth/keys')))).status).toBe(401)
+  })
+})
+
+describe('key revocation', () => {
+  it('revokes a key the owner owns; verify stops accepting it immediately', async () => {
+    await seedUser()
+    await seedUser('u2')
+    const cookie = await sessionCookie('u1')
+    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ id: string; secret: string }>
+    const { id, secret } = await minted
+
+    // verify works before revocation
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
+
+    // non-owner cannot revoke
+    const nonOwner = await revokeKey(ctx(req('/api/auth/keys'), { id }), { id })
+    expect((nonOwner as Response).status).toBe(401) // no session
+    const otherCookie = await sessionCookie('u2')
+    const asOther = await revokeKey(ctx(req('/api/auth/keys', { headers: { Cookie: otherCookie } }), { id }), { id })
+    expect((asOther as Response).status).toBe(400) // 'Key not found' (scoped)
+
+    // owner revokes → verify now 404
+    const revoked = await revokeKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } }), { id }), { id })
+    expect((revoked as Response).status).toBe(200)
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(404)
+  })
+})
+
+describe('internal verify endpoint', () => {
+  it('rejects missing or wrong shared secret', async () => {
+    const body = JSON.stringify({ secret: 'ak_anything' })
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body })))).status).toBe(401)
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body, headers: { 'X-Auth-Secret': 'wrong' } })))).status).toBe(401)
+  })
+
+  it('returns the Clerk-shaped contract for a valid key', async () => {
+    await seedUser()
+    const cookie = await sessionCookie('u1')
+    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ secret: string }>
+    const { secret } = await minted
+
+    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ subject: 'u1', revoked: false, expired: false })
+  })
+
+  it('404s for an unknown key', async () => {
+    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret: 'ak_doesnotexist123456789012345678901234' }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects a missing secret field', async () => {
+    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: '{}', headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    expect(res.status).toBe(400)
+  })
+})

--- a/teeline-web/functions/api/auth/keys.test.ts
+++ b/teeline-web/functions/api/auth/keys.test.ts
@@ -153,4 +153,14 @@ describe('internal verify endpoint', () => {
     const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: '{}', headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
     expect(res.status).toBe(400)
   })
+
+  it('handles a literal null body without crashing', async () => {
+    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: 'null', headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects malformed secrets early (shape check)', async () => {
+    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret: 'not-a-key' }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    expect(res.status).toBe(404)
+  })
 })

--- a/teeline-web/functions/api/auth/keys.ts
+++ b/teeline-web/functions/api/auth/keys.ts
@@ -1,0 +1,74 @@
+// POST /api/auth/keys — mint a new API key (session required). The plaintext
+// secret is returned exactly once; only its SHA-256 hash is stored.
+// GET  /api/auth/keys — list key metadata (never the secret/hash).
+import type { Env } from '../../lib/env'
+import { createApiKey, getUser, listApiKeysByUser } from '../../lib/db'
+import { forbidden, json, serverError, unauthorized } from '../../lib/http'
+import { generateKeySecret, hashSecret, newKeyId } from '../../lib/keys'
+import { getSessionUser } from '../../lib/session'
+import { isClientOriginAllowed } from '../../lib/webauthn'
+
+async function requireSession(request: Request, env: Env) {
+  if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF
+  const session = await getSessionUser(env, request.headers)
+  if (!session) return unauthorized()
+  const user = await getUser(env.DB, session.sub)
+  if (!user) return unauthorized() // deleted account → session void
+  return { userId: user.id }
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const auth = await requireSession(request, env)
+  if (auth instanceof Response) return auth
+
+  // Optional human-readable label.
+  let name: string | undefined
+  try {
+    const body = (await request.json()) as { name?: unknown } | null
+    if (typeof body === 'object' && body !== null && typeof body.name === 'string' && body.name.trim()) {
+      name = Array.from(body.name.trim()).slice(0, 64).join('')
+    }
+  } catch (err) {
+    console.warn('keys: optional body parse failed:', err)
+  }
+
+  try {
+    const secret = generateKeySecret()
+    const id = newKeyId()
+    const now = Date.now()
+    await createApiKey(env.DB, {
+      id,
+      userId: auth.userId,
+      name,
+      secretHash: await hashSecret(secret),
+      createdAt: now,
+    })
+    // `secret` is the only time the plaintext exists — the client must save
+    // it now (the UI shows it once until the page is refreshed).
+    return json({ id, name: name ?? null, secret, createdAt: now }, 201)
+  } catch (err) {
+    console.error('Failed to create API key:', err)
+    return serverError('Failed to create API key — please try again')
+  }
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const auth = await requireSession(request, env)
+  if (auth instanceof Response) return auth
+
+  try {
+    const keys = await listApiKeysByUser(env.DB, auth.userId)
+    return json({
+      keys: keys.map((k) => ({
+        id: k.id,
+        name: k.name,
+        createdAt: k.created_at,
+        lastUsedAt: k.last_used_at,
+        revoked: k.revoked === 1,
+      })),
+    })
+  } catch (err) {
+    console.error('Failed to list API keys:', err)
+    return serverError('Failed to list API keys — please try again')
+  }
+}

--- a/teeline-web/functions/api/auth/keys.ts
+++ b/teeline-web/functions/api/auth/keys.ts
@@ -2,20 +2,10 @@
 // secret is returned exactly once; only its SHA-256 hash is stored.
 // GET  /api/auth/keys — list key metadata (never the secret/hash).
 import type { Env } from '../../lib/env'
-import { createApiKey, getUser, listApiKeysByUser } from '../../lib/db'
-import { forbidden, json, serverError, unauthorized } from '../../lib/http'
+import { createApiKey, listApiKeysByUser } from '../../lib/db'
+import { json, serverError } from '../../lib/http'
 import { generateKeySecret, hashSecret, newKeyId } from '../../lib/keys'
-import { getSessionUser } from '../../lib/session'
-import { isClientOriginAllowed } from '../../lib/webauthn'
-
-async function requireSession(request: Request, env: Env) {
-  if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF
-  const session = await getSessionUser(env, request.headers)
-  if (!session) return unauthorized()
-  const user = await getUser(env.DB, session.sub)
-  if (!user) return unauthorized() // deleted account → session void
-  return { userId: user.id }
-}
+import { requireSession } from '../../lib/auth'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const auth = await requireSession(request, env)

--- a/teeline-web/functions/api/auth/keys/[id].ts
+++ b/teeline-web/functions/api/auth/keys/[id].ts
@@ -1,0 +1,25 @@
+// DELETE /api/auth/keys/:id — revoke a key (session required, scoped to the
+// key's owner). Revocation is a soft flag, effective immediately.
+import type { Env } from '../../../lib/env'
+import { revokeKey } from '../../../lib/db'
+import { badRequest, forbidden, json, serverError, unauthorized } from '../../../lib/http'
+import { getSessionUser } from '../../../lib/session'
+import { isClientOriginAllowed } from '../../../lib/webauthn'
+
+export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
+  if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF
+  const session = await getSessionUser(env, request.headers)
+  if (!session) return unauthorized()
+
+  const id = params.id
+  if (!id || typeof id !== 'string') return badRequest('Key id required')
+
+  try {
+    const revoked = await revokeKey(env.DB, id, session.sub)
+    if (!revoked) return badRequest('Key not found')
+    return json({ ok: true })
+  } catch (err) {
+    console.error('Failed to revoke API key:', err)
+    return serverError('Failed to revoke API key — please try again')
+  }
+}

--- a/teeline-web/functions/api/auth/keys/[id].ts
+++ b/teeline-web/functions/api/auth/keys/[id].ts
@@ -2,20 +2,18 @@
 // key's owner). Revocation is a soft flag, effective immediately.
 import type { Env } from '../../../lib/env'
 import { revokeKey } from '../../../lib/db'
-import { badRequest, forbidden, json, serverError, unauthorized } from '../../../lib/http'
-import { getSessionUser } from '../../../lib/session'
-import { isClientOriginAllowed } from '../../../lib/webauthn'
+import { badRequest, json, serverError } from '../../../lib/http'
+import { requireSession } from '../../../lib/auth'
 
 export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
-  if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF
-  const session = await getSessionUser(env, request.headers)
-  if (!session) return unauthorized()
+  const auth = await requireSession(request, env)
+  if (auth instanceof Response) return auth
 
   const id = params.id
   if (!id || typeof id !== 'string') return badRequest('Key id required')
 
   try {
-    const revoked = await revokeKey(env.DB, id, session.sub)
+    const revoked = await revokeKey(env.DB, id, auth.userId)
     if (!revoked) return badRequest('Key not found')
     return json({ ok: true })
   } catch (err) {

--- a/teeline-web/functions/api/auth/keys/verify.ts
+++ b/teeline-web/functions/api/auth/keys/verify.ts
@@ -1,0 +1,46 @@
+// POST /api/auth/keys/verify — INTERNAL. Called by teeline-api (Fly.io) to
+// check an API key on every authenticated request. Protected by the shared
+// AUTH_SERVICE_SECRET; mirrors the old Clerk verify contract
+// ({subject, revoked, expired}) so the Rust ApiKeyVerifier is a drop-in swap.
+//
+//   curl -X POST https://tspsolver.com/api/auth/keys/verify \
+//     -H "X-Auth-Secret: <shared>" -H "Content-Type: application/json" \
+//     -d '{"secret":"ak_..."}'
+//   → 200 {subject, revoked:false, expired:false} | 404 unknown/revoked | 401 bad secret
+import type { Env } from '../../../lib/env'
+import { findActiveKeyByHash, timingSafeEqual, touchKeyLastUsed } from '../../../lib/db'
+import { badRequest, json, unauthorized } from '../../../lib/http'
+import { hashSecret } from '../../../lib/keys'
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const presented = request.headers.get('X-Auth-Secret')
+  if (!env.AUTH_SERVICE_SECRET || !presented || !timingSafeEqual(presented, env.AUTH_SERVICE_SECRET)) {
+    return unauthorized()
+  }
+
+  let body: { secret?: unknown }
+  try {
+    body = (await request.json()) as { secret?: unknown }
+  } catch {
+    return badRequest('Invalid JSON body')
+  }
+  if (typeof body.secret !== 'string') return badRequest('secret is required')
+
+  try {
+    const hash = await hashSecret(body.secret)
+    const key = await findActiveKeyByHash(env.DB, hash)
+    if (!key) return json({ error: 'Unknown or revoked key' }, 404)
+
+    // Best-effort usage tracking — must never fail the verification.
+    try {
+      await touchKeyLastUsed(env.DB, key.id)
+    } catch (err) {
+      console.warn('Failed to record key usage:', err)
+    }
+
+    return json({ subject: key.user_id, revoked: false, expired: false })
+  } catch (err) {
+    console.error('Key verification failed:', err)
+    return json({ error: 'Verification failed' }, 500)
+  }
+}

--- a/teeline-web/functions/api/auth/keys/verify.ts
+++ b/teeline-web/functions/api/auth/keys/verify.ts
@@ -10,7 +10,7 @@
 import type { Env } from '../../../lib/env'
 import { findActiveKeyByHash, timingSafeEqual, touchKeyLastUsed } from '../../../lib/db'
 import { badRequest, json, unauthorized } from '../../../lib/http'
-import { hashSecret } from '../../../lib/keys'
+import { hashSecret, isKeySecretShape } from '../../../lib/keys'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const presented = request.headers.get('X-Auth-Secret')
@@ -24,7 +24,9 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   } catch {
     return badRequest('Invalid JSON body')
   }
-  if (typeof body.secret !== 'string') return badRequest('secret is required')
+  if (!body || typeof body.secret !== 'string') return badRequest('secret is required')
+  // Early reject of malformed secrets before hashing + DB lookup.
+  if (!isKeySecretShape(body.secret)) return json({ error: 'Unknown or revoked key' }, 404)
 
   try {
     const hash = await hashSecret(body.secret)

--- a/teeline-web/functions/lib/auth.ts
+++ b/teeline-web/functions/lib/auth.ts
@@ -1,0 +1,22 @@
+// Shared session authorization for authenticated endpoints:
+// 1. CSRF — the client origin (Origin/Referer header) must be on the allowlist
+// 2. session — valid HMAC cookie
+// 3. user existence — a deleted account voids its session
+// Returns the userId or an error Response.
+import type { Env } from './env'
+import { getUser } from './db'
+import { forbidden, unauthorized } from './http'
+import { getSessionUser } from './session'
+import { isClientOriginAllowed } from './webauthn'
+
+export async function requireSession(
+  request: Request,
+  env: Env,
+): Promise<Response | { userId: string }> {
+  if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF
+  const session = await getSessionUser(env, request.headers)
+  if (!session) return unauthorized()
+  const user = await getUser(env.DB, session.sub)
+  if (!user) return unauthorized() // deleted account → session void
+  return { userId: user.id }
+}

--- a/teeline-web/functions/lib/keys.ts
+++ b/teeline-web/functions/lib/keys.ts
@@ -1,0 +1,25 @@
+// API-key minting helpers.
+//
+// Key format: ak_ + base64url(32 CSPRNG bytes) ≈ 46 chars. The plaintext is
+// returned to the caller exactly once; only its SHA-256 hash is stored (see
+// db.ts). `ak_` prefix is kept for continuity with the old Clerk keys.
+import { hashSecret } from './db'
+
+export function newKeyId(): string {
+  return `key_${crypto.randomUUID()}`
+}
+
+export function generateKeySecret(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  const b64 = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return `ak_${b64}`
+}
+
+export function isKeySecretShape(v: unknown): v is string {
+  return typeof v === 'string' && v.startsWith('ak_') && v.length >= 10
+}
+
+export { hashSecret }


### PR DESCRIPTION
## Phase 3 — API keys + verify endpoint

Fourth step of replacing Clerk with WebAuthn + self-serve API keys
(design: GitKB `decisions/webauthn-auth-design`; ADR-007; task `tasks/webauthn-auth-replace-clerk`).

### Endpoints (session + CSRF-origin protected)

| Route | Behavior |
|---|---|
| `POST /api/auth/keys` | mint — `ak_` + base64url(32 CSPRNG bytes); **only SHA-256 stored**; plaintext returned exactly once |
| `GET /api/auth/keys` | metadata only (id/name/createdAt/lastUsedAt/revoked) — never the secret or hash |
| `DELETE /api/auth/keys/:id` | owner-scoped revoke, effective immediately |
| `POST /api/auth/keys/verify` | **internal**, `X-Auth-Secret` protected; mirrors the old Clerk `{subject, revoked, expired}` contract so teeline-api's `ApiKeyVerifier` is a drop-in swap (404 for unknown/revoked) |

### Notes
- `functions/lib/keys.ts` — minting helpers (`ak_`+base64url, key id), shape check.
- `functions/lib/auth.ts` — shared `requireSession` (CSRF origin + session + user-existence), used by all key endpoints.
- Verify does best-effort `last_used_at` tracking that never fails the request.

### Testing — 312 total (12 new this phase)
show-once minting, metadata-only listing, owner-scoped revocation, verify contract
(200/404/401/400), literal-null body, malformed-secret early reject. Typecheck ✅, bundle ✅.

### OCR review (open-code-review skill)
Reviewed before opening: 4 findings (0 high) — all applied: shared `requireSession`
(deleted-account consistency), `null`-body guard in verify, early shape-reject.