### PR TITLE
feat(web): interactive API-key page — passkey sign-in + show-once keys (Phase 4)

### DIFF
--- a/teeline-web/Taskfile.yml
+++ b/teeline-web/Taskfile.yml
@@ -7,7 +7,7 @@ tasks:
       - npx wrangler d1 migrations apply teeline-auth --local
 
   dev:
-    desc: Start Astro dev server at http://localhost:4321 (auth Functions need SESSION_SECRET + ALLOWED_ORIGINS=http://localhost:8788 via .dev.vars and a migrated local D1 — run db:migrate:local once)
+    desc: Start Astro dev server at http://localhost:4321 (auth needs wrangler pages dev on :8788 — astro proxies /api/auth — plus SESSION_SECRET + ALLOWED_ORIGINS=http://localhost:8788 via .dev.vars and a migrated local D1: run db:migrate:local once)
     cmds:
       - npm run dev
 

--- a/teeline-web/astro.config.mjs
+++ b/teeline-web/astro.config.mjs
@@ -58,6 +58,13 @@ export default defineConfig({
     ],
     server: {
       proxy: {
+        // Auth service (WebAuthn + API keys) runs as Pages Functions — proxy
+        // them from astro dev to `wrangler pages dev` (port 8788) so the UI
+        // works locally. Production serves functions on the same origin.
+        '/api/auth': {
+          target: 'http://localhost:8788',
+          changeOrigin: true,
+        },
         '/tsplib': {
           target: 'https://static.tspsolver.com',
           changeOrigin: true,

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -16,6 +16,7 @@
         "@fontsource/jetbrains-mono": "^5.3.0",
         "@sentry/browser": "^10.69.0",
         "@sentry/vite-plugin": "^5.4.0",
+        "@simplewebauthn/browser": "13.3.0",
         "@simplewebauthn/server": "13.3.2",
         "astro": "^7.2.1",
         "preact": "^10.29.8",
@@ -3393,6 +3394,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
       "license": "MIT"
     },
     "node_modules/@simplewebauthn/server": {

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -21,6 +21,7 @@
     "@fontsource/jetbrains-mono": "^5.3.0",
     "@sentry/browser": "^10.69.0",
     "@sentry/vite-plugin": "^5.4.0",
+    "@simplewebauthn/browser": "13.3.0",
     "@simplewebauthn/server": "13.3.2",
     "astro": "^7.2.1",
     "preact": "^10.29.8",

--- a/teeline-web/src/auth/api.test.ts
+++ b/teeline-web/src/auth/api.test.ts
@@ -1,0 +1,42 @@
+// apiFetch tests — mocked fetch, node env.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, apiFetch } from './api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(status: number, body: unknown) {
+  const res = new Response(JSON.stringify(body), { status })
+  vi.stubGlobal('fetch', vi.fn(async () => res))
+}
+
+describe('apiFetch', () => {
+  it('returns parsed JSON on success', async () => {
+    stubFetch(200, { ok: true })
+    await expect(apiFetch<{ ok: boolean }>('/api/auth/me')).resolves.toEqual({ ok: true })
+  })
+
+  it('sends same-origin credentials and JSON content type', async () => {
+    stubFetch(200, {})
+    await apiFetch('/api/auth/keys', { method: 'POST', body: '{}' })
+    const [url, init] = vi.mocked(fetch).mock.calls[0]
+    expect(url).toBe('/api/auth/keys')
+    expect((init as RequestInit).credentials).toBe('same-origin')
+    expect(((init as RequestInit).headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  it('throws ApiError with the server error message', async () => {
+    stubFetch(401, { error: 'Unauthorized' })
+    const err = await apiFetch('/api/auth/me').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(401)
+    expect((err as ApiError).message).toBe('Unauthorized')
+  })
+
+  it('falls back to a generic message when the body has no error field', async () => {
+    stubFetch(500, {})
+    const err = await apiFetch('/api/auth/me').catch((e: unknown) => e)
+    expect((err as ApiError).message).toContain('500')
+  })
+})

--- a/teeline-web/src/auth/api.ts
+++ b/teeline-web/src/auth/api.ts
@@ -13,10 +13,15 @@ export class ApiError extends Error {
 }
 
 export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const { headers, ...rest } = init
+  // Destructure `credentials` out so callers cannot override the same-origin
+  // policy enforced below (see header comment).
+  const { headers, credentials: _enforced, ...rest } = init
   const res = await fetch(path, {
     credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json', ...(headers as Record<string, string>) },
+    headers: {
+      'Content-Type': 'application/json',
+      ...Object.fromEntries(new Headers(headers)),
+    },
     ...rest,
   })
 

--- a/teeline-web/src/auth/api.ts
+++ b/teeline-web/src/auth/api.ts
@@ -1,0 +1,36 @@
+// Thin same-origin fetch wrapper for the auth service (/api/auth/*).
+// Cookies (the __Host-teeline-session) are sent same-origin; the browser
+// attaches the Origin header automatically, which the server checks for CSRF.
+
+export class ApiError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}
+
+export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { headers, ...rest } = init
+  const res = await fetch(path, {
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', ...(headers as Record<string, string>) },
+    ...rest,
+  })
+
+  if (!res.ok) {
+    let message = `Request failed (${res.status})`
+    try {
+      const body = (await res.json()) as { error?: string }
+      if (body.error) message = body.error
+    } catch {
+      /* keep the generic message */
+    }
+    throw new ApiError(res.status, message)
+  }
+
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}

--- a/teeline-web/src/auth/webauthn.test.ts
+++ b/teeline-web/src/auth/webauthn.test.ts
@@ -3,8 +3,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { loginWithPasskey, me, registerPasskey } from './webauthn'
 
+const mocks = vi.hoisted(() => ({
+  startRegistration: vi.fn(),
+  startAuthentication: vi.fn(),
+}))
+vi.mock('@simplewebauthn/browser', () => mocks)
+
 afterEach(() => {
   vi.unstubAllGlobals()
+  vi.clearAllMocks()
 })
 
 // fetch stub: route begin/complete based on the URL
@@ -30,52 +37,49 @@ function stubAuthFetch() {
   }))
 }
 
-function stubCredentials() {
-  const credential = {
-    id: 'cred-1',
-    type: 'public-key',
-    rawId: 'raw',
-    response: { clientDataJSON: 'c', attestationObject: 'a' },
-    getClientExtensionResults: () => ({}),
-  } as unknown as PublicKeyCredential
-  const get = vi.fn(async (_opts: CredentialRequestOptions) => credential)
-  const create = vi.fn(async (_opts: CredentialCreationOptions) => credential)
-  vi.stubGlobal('navigator', { credentials: { get, create } })
-  return { get, create }
-}
-
 describe('registerPasskey', () => {
-  it('runs begin → credentials.create → complete and returns the user', async () => {
+  it('runs begin → startRegistration → complete and returns the user', async () => {
     stubAuthFetch()
-    const { create } = stubCredentials()
+    mocks.startRegistration.mockResolvedValue({ id: 'cred-1', rawId: 'raw', type: 'public-key', response: { clientDataJSON: 'c', attestationObject: 'a' }, clientExtensionResults: {} })
     const user = await registerPasskey('Tim')
     expect(user).toMatchObject({ id: 'u1' })
-    expect(create).toHaveBeenCalledTimes(1)
-    const opts = create.mock.calls[0][0] as CredentialCreationOptions
-    expect(opts.publicKey).toBeDefined()
+    expect(mocks.startRegistration).toHaveBeenCalledTimes(1)
+    expect(mocks.startRegistration.mock.calls[0][0].optionsJSON.challenge).toBe('reg-challenge')
   })
 
-  it('throws when the user cancels the ceremony', async () => {
+  it('maps user cancellation to a friendly error', async () => {
     stubAuthFetch()
-    vi.stubGlobal('navigator', { credentials: { get: vi.fn(), create: vi.fn(async () => null) } })
-    await expect(registerPasskey()).rejects.toThrow('cancelled')
+    mocks.startRegistration.mockRejectedValue(new DOMException('The operation either timed out or was not allowed.', 'NotAllowedError'))
+    await expect(registerPasskey()).rejects.toThrow('Passkey creation was cancelled')
+  })
+
+  it('maps unexpected failures to a generic error', async () => {
+    stubAuthFetch()
+    mocks.startRegistration.mockRejectedValue(new Error('boom'))
+    await expect(registerPasskey()).rejects.toThrow('please try again')
   })
 })
 
 describe('loginWithPasskey', () => {
-  it('runs begin → credentials.get → complete and returns the user', async () => {
+  it('runs begin → startAuthentication → complete and returns the user', async () => {
     stubAuthFetch()
-    const { get } = stubCredentials()
+    mocks.startAuthentication.mockResolvedValue({ id: 'cred-1', rawId: 'raw', type: 'public-key', response: { clientDataJSON: 'c', authenticatorData: 'a', signature: 's' }, clientExtensionResults: {} })
     const user = await loginWithPasskey()
     expect(user).toMatchObject({ id: 'u1', displayName: 'Tim' })
-    expect(get).toHaveBeenCalledTimes(1)
+    expect(mocks.startAuthentication).toHaveBeenCalledTimes(1)
+    expect(mocks.startAuthentication.mock.calls[0][0].optionsJSON.challenge).toBe('login-challenge')
+  })
+
+  it('maps user cancellation to a friendly error', async () => {
+    stubAuthFetch()
+    mocks.startAuthentication.mockRejectedValue(new DOMException('aborted', 'AbortError'))
+    await expect(loginWithPasskey()).rejects.toThrow('Passkey sign-in was cancelled')
   })
 })
 
 describe('me', () => {
   it('returns null on 401 (not signed in)', async () => {
     stubAuthFetch()
-    stubCredentials()
     await expect(me()).resolves.toBeNull()
   })
 })

--- a/teeline-web/src/auth/webauthn.test.ts
+++ b/teeline-web/src/auth/webauthn.test.ts
@@ -1,0 +1,81 @@
+// Client WebAuthn ceremony helper tests — navigator.credentials + fetch
+// stubbed, node env. Verifies the begin→create/get→complete wiring.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { loginWithPasskey, me, registerPasskey } from './webauthn'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// fetch stub: route begin/complete based on the URL
+function stubAuthFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+    const path = String(input)
+    if (path.endsWith('/register/begin')) {
+      return new Response(JSON.stringify({ options: { challenge: 'reg-challenge' }, nonce: 'n1' }), { status: 201 })
+    }
+    if (path.endsWith('/register/complete')) {
+      return new Response(JSON.stringify({ id: 'u1', displayName: null, createdAt: 1 }), { status: 201 })
+    }
+    if (path.endsWith('/login/begin')) {
+      return new Response(JSON.stringify({ options: { challenge: 'login-challenge' }, nonce: 'n2' }), { status: 201 })
+    }
+    if (path.endsWith('/login/complete')) {
+      return new Response(JSON.stringify({ id: 'u1', displayName: 'Tim', createdAt: 1 }), { status: 200 })
+    }
+    if (path.endsWith('/me')) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    }
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 })
+  }))
+}
+
+function stubCredentials() {
+  const credential = {
+    id: 'cred-1',
+    type: 'public-key',
+    rawId: 'raw',
+    response: { clientDataJSON: 'c', attestationObject: 'a' },
+    getClientExtensionResults: () => ({}),
+  } as unknown as PublicKeyCredential
+  const get = vi.fn(async (_opts: CredentialRequestOptions) => credential)
+  const create = vi.fn(async (_opts: CredentialCreationOptions) => credential)
+  vi.stubGlobal('navigator', { credentials: { get, create } })
+  return { get, create }
+}
+
+describe('registerPasskey', () => {
+  it('runs begin → credentials.create → complete and returns the user', async () => {
+    stubAuthFetch()
+    const { create } = stubCredentials()
+    const user = await registerPasskey('Tim')
+    expect(user).toMatchObject({ id: 'u1' })
+    expect(create).toHaveBeenCalledTimes(1)
+    const opts = create.mock.calls[0][0] as CredentialCreationOptions
+    expect(opts.publicKey).toBeDefined()
+  })
+
+  it('throws when the user cancels the ceremony', async () => {
+    stubAuthFetch()
+    vi.stubGlobal('navigator', { credentials: { get: vi.fn(), create: vi.fn(async () => null) } })
+    await expect(registerPasskey()).rejects.toThrow('cancelled')
+  })
+})
+
+describe('loginWithPasskey', () => {
+  it('runs begin → credentials.get → complete and returns the user', async () => {
+    stubAuthFetch()
+    const { get } = stubCredentials()
+    const user = await loginWithPasskey()
+    expect(user).toMatchObject({ id: 'u1', displayName: 'Tim' })
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('me', () => {
+  it('returns null on 401 (not signed in)', async () => {
+    stubAuthFetch()
+    stubCredentials()
+    await expect(me()).resolves.toBeNull()
+  })
+})

--- a/teeline-web/src/auth/webauthn.ts
+++ b/teeline-web/src/auth/webauthn.ts
@@ -1,0 +1,69 @@
+// Client-side WebAuthn ceremony helpers — native navigator.credentials, no
+// library needed. The server (Cloudflare Pages Functions) stores the
+// challenge and verifies the attestation/assertion.
+import { ApiError, apiFetch } from './api'
+
+export interface User {
+  id: string
+  displayName: string | null
+  createdAt: number
+}
+
+/** Serialize a PublicKeyCredential to the JSON shape SimpleWebAuthn expects. */
+function credentialToJSON(cred: PublicKeyCredential): unknown {
+  return JSON.parse(JSON.stringify(cred))
+}
+
+/** First-time registration: create a passkey on this origin → session. */
+export async function registerPasskey(displayName?: string): Promise<User> {
+  const { options, nonce } = await apiFetch<{
+    options: PublicKeyCredentialCreationOptions
+    nonce: string
+  }>('/api/auth/register/begin', {
+    method: 'POST',
+    body: JSON.stringify({ displayName }),
+  })
+
+  const credential = await navigator.credentials.create({ publicKey: options })
+  if (!credential) throw new Error('Passkey creation was cancelled')
+  const publicKeyCredential = credential as PublicKeyCredential // WebAuthn create/get with publicKey options returns a PublicKeyCredential
+
+  return apiFetch<User>('/api/auth/register/complete', {
+    method: 'POST',
+    body: JSON.stringify({ nonce, credential: credentialToJSON(publicKeyCredential) }),
+  })
+}
+
+/** Sign in with an existing passkey (discoverable credentials — no username). */
+export async function loginWithPasskey(): Promise<User> {
+  const { options, nonce } = await apiFetch<{
+    options: PublicKeyCredentialRequestOptions
+    nonce: string
+  }>('/api/auth/login/begin', {
+    method: 'POST',
+    body: '{}',
+  })
+
+  const credential = await navigator.credentials.get({ publicKey: options })
+  if (!credential) throw new Error('Passkey sign-in was cancelled')
+  const publicKeyCredential = credential as PublicKeyCredential
+
+  return apiFetch<User>('/api/auth/login/complete', {
+    method: 'POST',
+    body: JSON.stringify({ nonce, credential: credentialToJSON(publicKeyCredential) }),
+  })
+}
+
+/** Current user, or null when not signed in. */
+export async function me(): Promise<User | null> {
+  try {
+    return await apiFetch<User>('/api/auth/me')
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) return null
+    throw err
+  }
+}
+
+export async function logout(): Promise<void> {
+  await apiFetch<void>('/api/auth/logout', { method: 'POST' })
+}

--- a/teeline-web/src/auth/webauthn.ts
+++ b/teeline-web/src/auth/webauthn.ts
@@ -1,6 +1,12 @@
-// Client-side WebAuthn ceremony helpers — native navigator.credentials, no
-// library needed. The server (Cloudflare Pages Functions) stores the
-// challenge and verifies the attestation/assertion.
+// Client-side WebAuthn ceremony helpers.
+//
+// Uses @simplewebauthn/browser — the client half of the same library as the
+// server (Pages Functions). It handles the two fiddly conversions that
+// native navigator.credentials does NOT: decoding the server's base64url
+// JSON options into WebAuthn-native BufferSources (challenge, user.id,
+// allowCredentials ids), and serializing the returned credential back to
+// the base64url JSON the server's verify*Response() expects.
+import { startAuthentication, startRegistration } from '@simplewebauthn/browser'
 import { ApiError, apiFetch } from './api'
 
 export interface User {
@@ -9,48 +15,58 @@ export interface User {
   createdAt: number
 }
 
-/** Serialize a PublicKeyCredential to the JSON shape SimpleWebAuthn expects. */
-function credentialToJSON(cred: PublicKeyCredential): unknown {
-  return JSON.parse(JSON.stringify(cred))
+/** Map common WebAuthn failures to user-friendly messages. */
+async function withCancellation<T>(fn: () => Promise<T>, cancelledMessage: string): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    // User dismissed the prompt or timed out — treat as a graceful cancel.
+    if (err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'AbortError')) {
+      throw new Error(cancelledMessage)
+    }
+    throw new Error('Passkey operation failed — please try again')
+  }
 }
 
 /** First-time registration: create a passkey on this origin → session. */
 export async function registerPasskey(displayName?: string): Promise<User> {
   const { options, nonce } = await apiFetch<{
-    options: PublicKeyCredentialCreationOptions
+    options: Parameters<typeof startRegistration>[0]['optionsJSON']
     nonce: string
   }>('/api/auth/register/begin', {
     method: 'POST',
     body: JSON.stringify({ displayName }),
   })
 
-  const credential = await navigator.credentials.create({ publicKey: options })
-  if (!credential) throw new Error('Passkey creation was cancelled')
-  const publicKeyCredential = credential as PublicKeyCredential // WebAuthn create/get with publicKey options returns a PublicKeyCredential
+  const response = await withCancellation(
+    () => startRegistration({ optionsJSON: options }),
+    'Passkey creation was cancelled',
+  )
 
   return apiFetch<User>('/api/auth/register/complete', {
     method: 'POST',
-    body: JSON.stringify({ nonce, credential: credentialToJSON(publicKeyCredential) }),
+    body: JSON.stringify({ nonce, credential: response }),
   })
 }
 
 /** Sign in with an existing passkey (discoverable credentials — no username). */
 export async function loginWithPasskey(): Promise<User> {
   const { options, nonce } = await apiFetch<{
-    options: PublicKeyCredentialRequestOptions
+    options: Parameters<typeof startAuthentication>[0]['optionsJSON']
     nonce: string
   }>('/api/auth/login/begin', {
     method: 'POST',
-    body: '{}',
+    body: JSON.stringify({}),
   })
 
-  const credential = await navigator.credentials.get({ publicKey: options })
-  if (!credential) throw new Error('Passkey sign-in was cancelled')
-  const publicKeyCredential = credential as PublicKeyCredential
+  const response = await withCancellation(
+    () => startAuthentication({ optionsJSON: options }),
+    'Passkey sign-in was cancelled',
+  )
 
   return apiFetch<User>('/api/auth/login/complete', {
     method: 'POST',
-    body: JSON.stringify({ nonce, credential: credentialToJSON(publicKeyCredential) }),
+    body: JSON.stringify({ nonce, credential: response }),
   })
 }
 

--- a/teeline-web/src/components/ApiKeyManager.tsx
+++ b/teeline-web/src/components/ApiKeyManager.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState } from 'preact/hooks'
+import { ApiError, apiFetch } from '../auth/api'
+import { loginWithPasskey, logout, me, registerPasskey, type User } from '../auth/webauthn'
+
+interface ApiKeyMeta {
+  id: string
+  name: string | null
+  createdAt: number
+  lastUsedAt: number | null
+  revoked: boolean
+}
+
+interface FreshSecret {
+  id: string
+  secret: string
+  name: string | null
+}
+
+type View = 'loading' | 'anonymous' | 'signedin'
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function formatDate(ms: number | null): string {
+  if (!ms) return '—'
+  return new Date(ms).toLocaleString()
+}
+
+/**
+ * The interactive core of /api-key/: passkey sign-in (open registration),
+ * API-key minting with the show-once secret, and key management.
+ *
+ * Show-once: the freshly minted secret lives only in component state — it is
+ * deliberately NOT persisted to sessionStorage/localStorage, so refreshing
+ * the page destroys it (the reminder tells the user to save it first).
+ */
+export default function ApiKeyManager() {
+  const [view, setView] = useState<View>('loading')
+  const [user, setUser] = useState<User | null>(null)
+  const [keys, setKeys] = useState<ApiKeyMeta[]>([])
+  const [fresh, setFresh] = useState<FreshSecret | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refreshKeys = async () => {
+    const { keys } = await apiFetch<{ keys: ApiKeyMeta[] }>('/api/auth/keys')
+    setKeys(keys)
+  }
+
+  const load = async () => {
+    try {
+      const u = await me()
+      if (!u) {
+        setView('anonymous')
+        return
+      }
+      setUser(u)
+      await refreshKeys()
+      setView('signedin')
+    } catch (err) {
+      setError(messageOf(err))
+      setView('anonymous')
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  const run = async (fn: () => Promise<void>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+    } catch (err) {
+      setError(messageOf(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onRegister = () =>
+    run(async () => {
+      const u = await registerPasskey()
+      setUser(u)
+      await refreshKeys()
+      setView('signedin')
+    })
+
+  const onLogin = () =>
+    run(async () => {
+      const u = await loginWithPasskey()
+      setUser(u)
+      await refreshKeys()
+      setView('signedin')
+    })
+
+  const onGenerate = () =>
+    run(async () => {
+      const key = await apiFetch<FreshSecret>('/api/auth/keys', { method: 'POST', body: '{}' })
+      setFresh(key)
+      setCopied(false)
+      await refreshKeys()
+    })
+
+  const onRevoke = (id: string) =>
+    run(async () => {
+      await apiFetch(`/api/auth/keys/${id}`, { method: 'DELETE' })
+      await refreshKeys()
+    })
+
+  const onLogout = () =>
+    run(async () => {
+      await logout()
+      setFresh(null)
+      setUser(null)
+      setKeys([])
+      setView('anonymous')
+    })
+
+  const onCopySecret = async () => {
+    try {
+      await navigator.clipboard.writeText(fresh?.secret ?? '')
+      setCopied(true)
+    } catch {
+      setError('Could not copy automatically — select and copy the key manually.')
+    }
+  }
+
+  if (view === 'loading') {
+    return <p class="text-text-dim">Loading…</p>
+  }
+
+  const btnBase = 'inline-flex items-center justify-center rounded-md px-5 py-2 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50'
+
+  return (
+    <section class="my-6 max-w-2xl">
+      {error && (
+        <p class="mb-4 rounded-md border border-negative/40 bg-negative/10 px-4 py-2 text-sm text-negative" role="alert">
+          {error}
+        </p>
+      )}
+
+      {view === 'anonymous' && (
+        <div class="rounded-lg border border-border bg-surface p-6">
+          <h2 class="mb-1 text-xl font-semibold text-text">Sign in with a passkey</h2>
+          <p class="mb-4 text-sm text-text-dim">
+            No account or password needed. First time here? <strong class="text-text">Create a passkey</strong> —
+            your browser or password manager stores it. Later visits are a single tap.
+          </p>
+          <div class="flex flex-wrap gap-3">
+            <button class={`${btnBase} bg-accent text-white hover:bg-accent/90`} onClick={onRegister} disabled={busy}>
+              {busy ? 'Working…' : 'Create a passkey'}
+            </button>
+            <button
+              class={`${btnBase} border border-border bg-transparent text-text hover:border-accent hover:text-accent`}
+              onClick={onLogin}
+              disabled={busy}
+            >
+              Sign in with passkey
+            </button>
+          </div>
+        </div>
+      )}
+
+      {view === 'signedin' && user && (
+        <div class="rounded-lg border border-border bg-surface p-6">
+          <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 class="text-xl font-semibold text-text">API keys</h2>
+              <p class="text-sm text-text-dim">
+                Signed in as <span class="font-mono text-accent">{user.displayName ?? user.id.slice(0, 8)}</span>
+              </p>
+            </div>
+            <button class={`${btnBase} border border-border px-3 py-1 text-sm text-text-dim hover:text-text`} onClick={onLogout} disabled={busy}>
+              Sign out
+            </button>
+          </div>
+
+          {fresh && (
+            <div class="mb-5 rounded-md border border-positive/50 bg-positive/10 p-4" role="status">
+              <p class="mb-2 text-sm font-semibold text-positive">Your new API key — shown once</p>
+              <code class="block break-all rounded bg-surface-2 px-3 py-2 font-mono text-sm text-text" data-testid="fresh-secret">
+                {fresh.secret}
+              </code>
+              <p class="mt-2 text-sm text-text">
+                <strong>Copy it into your password manager now.</strong> It won't be shown again — after you
+                refresh or leave this page it's gone for good.
+              </p>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <button class={`${btnBase} bg-accent px-4 py-1 text-sm text-white hover:bg-accent/90`} onClick={onCopySecret}>
+                  {copied ? 'Copied!' : 'Copy to clipboard'}
+                </button>
+                <button class={`${btnBase} border border-border px-4 py-1 text-sm text-text hover:border-accent hover:text-accent`} onClick={() => setFresh(null)}>
+                  I've saved it
+                </button>
+              </div>
+            </div>
+          )}
+
+          <button class={`${btnBase} mb-5 bg-accent text-white hover:bg-accent/90`} onClick={onGenerate} disabled={busy}>
+            {busy ? 'Working…' : 'Generate API key'}
+          </button>
+
+          {keys.length === 0 ? (
+            <p class="text-sm text-text-dim">No keys yet — generate one above.</p>
+          ) : (
+            <table class="w-full border-collapse text-sm">
+              <thead>
+                <tr class="text-left text-text-dim">
+                  <th class="border-b border-border py-2 pr-3 font-semibold">Name</th>
+                  <th class="border-b border-border py-2 pr-3 font-semibold">Created</th>
+                  <th class="border-b border-border py-2 pr-3 font-semibold">Last used</th>
+                  <th class="border-b border-border py-2 text-right font-semibold">Revoke</th>
+                </tr>
+              </thead>
+              <tbody>
+                {keys.map((k) => (
+                  <tr key={k.id} class={k.revoked ? 'opacity-50' : ''}>
+                    <td class="border-b border-border py-2 pr-3 font-mono text-text">{k.name ?? k.id.slice(0, 10)}</td>
+                    <td class="border-b border-border py-2 pr-3 text-text-dim">{formatDate(k.createdAt)}</td>
+                    <td class="border-b border-border py-2 pr-3 text-text-dim">{formatDate(k.lastUsedAt)}</td>
+                    <td class="border-b border-border py-2 text-right">
+                      {k.revoked ? (
+                        <span class="text-xs text-text-dim">revoked</span>
+                      ) : (
+                        <button
+                          class="rounded px-2 py-1 text-xs text-negative hover:bg-negative/10 disabled:opacity-50"
+                          onClick={() => onRevoke(k.id)}
+                          disabled={busy}
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/teeline-web/src/components/ApiKeyManager.tsx
+++ b/teeline-web/src/components/ApiKeyManager.tsx
@@ -57,8 +57,13 @@ export default function ApiKeyManager() {
         return
       }
       setUser(u)
-      await refreshKeys()
       setView('signedin')
+      try {
+        await refreshKeys()
+      } catch (err) {
+        // Keys list is non-critical; the user is still authenticated.
+        setError(messageOf(err))
+      }
     } catch (err) {
       setError(messageOf(err))
       setView('anonymous')
@@ -102,11 +107,16 @@ export default function ApiKeyManager() {
       const key = await apiFetch<FreshSecret>('/api/auth/keys', { method: 'POST', body: '{}' })
       setFresh(key)
       setCopied(false)
-      await refreshKeys()
+      try {
+        await refreshKeys()
+      } catch {
+        // Key was created and shown; the list refresh is non-critical.
+      }
     })
 
   const onRevoke = (id: string) =>
     run(async () => {
+      if (!window.confirm('Revoke this API key? This cannot be undone.')) return
       await apiFetch(`/api/auth/keys/${id}`, { method: 'DELETE' })
       await refreshKeys()
     })
@@ -193,6 +203,7 @@ export default function ApiKeyManager() {
                 <button class={`${btnBase} bg-accent px-4 py-1 text-sm text-white hover:bg-accent/90`} onClick={onCopySecret}>
                   {copied ? 'Copied!' : 'Copy to clipboard'}
                 </button>
+                {copied && <span class="sr-only" role="status">API key copied to clipboard</span>}
                 <button class={`${btnBase} border border-border px-4 py-1 text-sm text-text hover:border-accent hover:text-accent`} onClick={() => setFresh(null)}>
                   I've saved it
                 </button>
@@ -230,6 +241,7 @@ export default function ApiKeyManager() {
                           class="rounded px-2 py-1 text-xs text-negative hover:bg-negative/10 disabled:opacity-50"
                           onClick={() => onRevoke(k.id)}
                           disabled={busy}
+                          aria-label={`Revoke key ${k.name ?? k.id.slice(0, 10)}`}
                         >
                           Revoke
                         </button>

--- a/teeline-web/src/pages/api-key/index.astro
+++ b/teeline-web/src/pages/api-key/index.astro
@@ -38,16 +38,6 @@ const jsonLd = {
 
     <ApiKeyManager client:visible />
 
-    <h2>Using your key</h2>
-    <p>Send it as a bearer token on every request:</p>
-    <pre><code>curl -H "Authorization: Bearer ak_your_key_here" \
-  https://api.tspsolver.com/api/v1/solvers</code></pre>
-    <p>
-      An <code>X-Api-Key</code> header works the same way, if that fits your tooling better:
-    </p>
-    <pre><code>curl -H "X-Api-Key: ak_your_key_here" \
-  https://api.tspsolver.com/api/v1/solvers</code></pre>
-
     <h2>Save it now — it's shown once</h2>
     <p>
       Your new key (it looks like <code>ak_&hellip;</code>) is revealed exactly once, right after
@@ -58,6 +48,16 @@ const jsonLd = {
       before you refresh or leave the page. If you lose it, there's no way to recover it — revoke it
       on this page and create a new one.
     </p>
+
+    <h2>Using your key</h2>
+    <p>Send it as a bearer token on every request:</p>
+    <pre><code>curl -H "Authorization: Bearer ak_your_key_here" \
+  https://api.tspsolver.com/api/v1/solvers</code></pre>
+    <p>
+      An <code>X-Api-Key</code> header works the same way, if that fits your tooling better:
+    </p>
+    <pre><code>curl -H "X-Api-Key: ak_your_key_here" \
+  https://api.tspsolver.com/api/v1/solvers</code></pre>
 
     <h2>Managing or revoking a key</h2>
     <p>

--- a/teeline-web/src/pages/api-key/index.astro
+++ b/teeline-web/src/pages/api-key/index.astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import ApiKeyManager from '../../components/ApiKeyManager'
 
-const description = 'How to sign in and generate a personal API key for the Teeline TSP solver REST API.'
+const description = 'Sign in with a passkey and generate a personal API key for the Teeline TSP solver REST API.'
 const canonicalUrl = 'https://tspsolver.com/api-key/'
 
 const jsonLd = {
@@ -31,44 +32,13 @@ const jsonLd = {
     <p>
       The <a href="https://api.tspsolver.com/docs" target="_blank" rel="noopener">Teeline REST API</a>
       requires a personal API key for every endpoint except <code>/api/v1/health</code>.
-      Getting one takes about a minute — no separate Teeline account or password to create,
-      and no request to us.
+      Getting one takes about a minute — no account, no password, no third-party sign-in.
+      Your <strong>passkey</strong> (stored by your browser or password manager) is your identity.
     </p>
 
-    <h2>1. Sign in</h2>
-    <p>
-      Go to <a href="https://accounts.tspsolver.com/sign-in" target="_blank" rel="noopener">accounts.tspsolver.com/sign-in</a>
-      and continue with GitHub, GitLab, Google, or an email address — whichever's easiest.
-      There's nothing to install and no separate signup form.
-    </p>
+    <ApiKeyManager client:visible />
 
-    <h2>2. Create a key</h2>
-    <p>
-      Signing in takes you straight to the <strong>API keys</strong> page. From there:
-    </p>
-    <ol>
-      <li>Click <strong>Add new key</strong>.</li>
-      <li>
-        Give it a name you'll recognize later — e.g. <code>my-laptop</code> or
-        <code>ci-pipeline</code>. An expiration date is optional; leave it blank for a
-        key that never expires.
-      </li>
-      <li>Click <strong>Create key</strong>.</li>
-    </ol>
-
-    <h2>3. Save it now — it's shown once</h2>
-    <p>
-      Your new key (it looks like <code>ak_&hellip;</code>) is revealed exactly once,
-      immediately after you create it. Clerk (the identity provider we use) cannot show it
-      to you again.
-    </p>
-    <p>
-      <strong>Copy it straight into a password manager</strong> (1Password, Bitwarden, or
-      similar) before you navigate away. If you lose it, there's no way to recover it — you'll
-      need to revoke it from the same page and create a new one.
-    </p>
-
-    <h2>4. Use it</h2>
+    <h2>Using your key</h2>
     <p>Send it as a bearer token on every request:</p>
     <pre><code>curl -H "Authorization: Bearer ak_your_key_here" \
   https://api.tspsolver.com/api/v1/solvers</code></pre>
@@ -78,12 +48,21 @@ const jsonLd = {
     <pre><code>curl -H "X-Api-Key: ak_your_key_here" \
   https://api.tspsolver.com/api/v1/solvers</code></pre>
 
+    <h2>Save it now — it's shown once</h2>
+    <p>
+      Your new key (it looks like <code>ak_&hellip;</code>) is revealed exactly once, right after
+      you create it. We only store a fingerprint of it, so it can never be shown to you again.
+    </p>
+    <p>
+      <strong>Copy it straight into a password manager</strong> (1Password, Bitwarden, or similar)
+      before you refresh or leave the page. If you lose it, there's no way to recover it — revoke it
+      on this page and create a new one.
+    </p>
+
     <h2>Managing or revoking a key</h2>
     <p>
-      Sign back in at the same
-      <a href="https://accounts.tspsolver.com/sign-in" target="_blank" rel="noopener">sign-in link</a> any
-      time — you'll land on the API keys page, where you can add more keys or revoke ones
-      you no longer use.
+      Sign back in with your passkey any time — you'll land on your keys, where you can add more
+      or revoke ones you no longer use.
     </p>
 
     <p>


### PR DESCRIPTION
## Phase 4 — the UI

Replaces the static Clerk-instructions page with the real flow you asked for:
**passkey sign-in → Generate API key → shown once → "save it in your password manager".**

### What's in

- **`src/auth/api.ts`** — same-origin fetch wrapper (`ApiError`, credentials enforced).
- **`src/auth/webauthn.ts`** — ceremony helpers built on **`@simplewebauthn/browser`**
  (the client half of the server library): it decodes the server's base64url JSON options into
  native WebAuthn types and serializes the credential response back to JSON — the two conversions
  a hand-rolled `navigator.credentials` path gets wrong.
- **`src/components/ApiKeyManager.tsx`** — Preact island:
  - *anonymous*: **Create a passkey** / **Sign in with passkey** (open registration)
  - *signed in*: **Generate API key** + keys table (name/created/last-used/revoke with
    confirmation) + sign out
  - *generated*: show-once box, copy button, **"Copy it into your password manager now — it won't
    be shown again"**; the secret lives only in component state (refresh wipes it)
- **`src/pages/api-key/index.astro`** — mounts the island (`client:visible`), Clerk references
  removed, "shown once" + curl docs kept.
- **`astro.config.mjs`** — dev proxy `/api/auth` → `wrangler pages dev`.

### open-code-review pass (17 findings — all addressed)

- **2 critical** (real, ceremony-breaking in a browser): options weren't decoded to BufferSource;
  ArrayBuffer fields were lost to `JSON.stringify` — both fixed by using `@simplewebauthn/browser`
- **1 high**: keys-list refresh failure dropped a signed-in user to the anonymous view
- **4 medium**: cancellation → friendly messages; `confirm()` on revoke; credentials override in
  the fetch wrapper; header normalization
- **10 low** (folded in): a11y (`aria-live`/`aria-label`), error-state separation, page ordering

### Verification
astro check 0 errors · **322 tests** (12 new for the client) · bundle ✅
Note: `npm run build:check` needs `NODE_OPTIONS=--max-old-space-size=8192` locally (astro 7.2 heap).

### Next
**Phase 5** — teeline-api `ServiceVerifier` + `TEELINE_AUTH_MODE`, so keys minted by this page
verify against the API (the end-to-end "failing case" until then).