### PR TITLE
feat(web): Playwright WebAuthn e2e + fix client user-envelope bug (Phase 6)

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,43 @@
+name: web-e2e
+
+# Browser-level e2e for the WebAuthn auth service (register → mint → verify →
+# revoke) against the local Pages stack with a virtual authenticator.
+# Runs only the web side (wrangler pages dev + local D1) — no Cloudflare auth,
+# no Rust build required.
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - 'teeline-web/**'
+      - '.github/workflows/web-e2e.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'teeline-web/**'
+      - '.github/workflows/web-e2e.yml'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: teeline-web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: teeline-web
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: teeline-web
+        run: npx playwright install chromium
+
+      - name: Run auth e2e
+        working-directory: teeline-web
+        run: npm run test:e2e:auth

--- a/teeline-web/.gitignore
+++ b/teeline-web/.gitignore
@@ -30,3 +30,5 @@ test-results/
 
 # Wrangler local state (Pages Functions dev)
 .wrangler
+.dev.vars
+.e2e-state

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
     "deploy": "npm run build && wrangler pages deploy dist/"
   },
   "dependencies": {

--- a/teeline-web/playwright.auth.config.ts
+++ b/teeline-web/playwright.auth.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Auth-service e2e: runs against the FULL local stack via `wrangler pages dev`
+// (static site + Pages Functions + local D1), unlike the main config which
+// uses `astro dev`. WebAuthn requires Chromium + a CDP virtual authenticator.
+export default defineConfig({
+  testDir: './tests/auth',
+  timeout: 60_000,
+  workers: 1,
+  use: {
+    baseURL: 'http://localhost:8788',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command:
+      'bash -c "mkdir -p .e2e-state && printf \'SESSION_SECRET=e2e-session-secret\\nAUTH_SERVICE_SECRET=e2e-shared-secret\\nALLOWED_ORIGINS=http://localhost:8788\\n\' > .dev.vars && NODE_OPTIONS=--max-old-space-size=8192 npm run build && npx wrangler d1 migrations apply teeline-auth --local && npx wrangler pages dev --port 8788"',
+    url: 'http://localhost:8788/api-key/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    // Keep wrangler's log/registry state inside the project (works on
+    // read-only homes; harmless on CI).
+    env: {
+      WRANGLER_LOG_PATH: '.e2e-state/wrangler.log',
+      XDG_CONFIG_HOME: '.e2e-state/config',
+      XDG_CACHE_HOME: '.e2e-state/cache',
+      HOME: '.e2e-state/home',
+    },
+  },
+})

--- a/teeline-web/playwright.auth.config.ts
+++ b/teeline-web/playwright.auth.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   ],
   webServer: {
     command:
-      'bash -c "mkdir -p .e2e-state && printf \'SESSION_SECRET=e2e-session-secret\\nAUTH_SERVICE_SECRET=e2e-shared-secret\\nALLOWED_ORIGINS=http://localhost:8788\\n\' > .dev.vars && NODE_OPTIONS=--max-old-space-size=8192 npm run build && npx wrangler d1 migrations apply teeline-auth --local && npx wrangler pages dev --port 8788"',
+      'bash -c "mkdir -p .e2e-state && printf \'SESSION_SECRET=e2e-session-secret\\nAUTH_SERVICE_SECRET=e2e-shared-secret\\nALLOWED_ORIGINS=http://localhost:8788\\n\' > .dev.vars && NODE_OPTIONS=--max-old-space-size=8192 npm run build:check && npx wrangler d1 migrations apply teeline-auth --local && npx wrangler pages dev --port 8788"',
     url: 'http://localhost:8788/api-key/',
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,

--- a/teeline-web/playwright.config.ts
+++ b/teeline-web/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
+  // tests/auth runs under playwright.auth.config.ts (wrangler pages dev +
+  // WebAuthn virtual authenticator) — not the astro dev server here.
+  testIgnore: '**/auth/**',
   timeout: 30_000,
   use: {
     baseURL: 'http://localhost:4321',

--- a/teeline-web/src/auth/webauthn.test.ts
+++ b/teeline-web/src/auth/webauthn.test.ts
@@ -22,13 +22,13 @@ function stubAuthFetch() {
       return new Response(JSON.stringify({ options: { challenge: 'reg-challenge' }, nonce: 'n1' }), { status: 201 })
     }
     if (path.endsWith('/register/complete')) {
-      return new Response(JSON.stringify({ id: 'u1', displayName: null, createdAt: 1 }), { status: 201 })
+      return new Response(JSON.stringify({ user: { id: 'u1', displayName: null, createdAt: 1 } }), { status: 201 })
     }
     if (path.endsWith('/login/begin')) {
       return new Response(JSON.stringify({ options: { challenge: 'login-challenge' }, nonce: 'n2' }), { status: 201 })
     }
     if (path.endsWith('/login/complete')) {
-      return new Response(JSON.stringify({ id: 'u1', displayName: 'Tim', createdAt: 1 }), { status: 200 })
+      return new Response(JSON.stringify({ user: { id: 'u1', displayName: 'Tim', createdAt: 1 } }), { status: 200 })
     }
     if (path.endsWith('/me')) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })

--- a/teeline-web/src/auth/webauthn.ts
+++ b/teeline-web/src/auth/webauthn.ts
@@ -43,10 +43,11 @@ export async function registerPasskey(displayName?: string): Promise<User> {
     'Passkey creation was cancelled',
   )
 
-  return apiFetch<User>('/api/auth/register/complete', {
+  const { user } = await apiFetch<{ user: User }>('/api/auth/register/complete', {
     method: 'POST',
     body: JSON.stringify({ nonce, credential: response }),
   })
+  return user
 }
 
 /** Sign in with an existing passkey (discoverable credentials — no username). */
@@ -64,16 +65,18 @@ export async function loginWithPasskey(): Promise<User> {
     'Passkey sign-in was cancelled',
   )
 
-  return apiFetch<User>('/api/auth/login/complete', {
+  const { user } = await apiFetch<{ user: User }>('/api/auth/login/complete', {
     method: 'POST',
     body: JSON.stringify({ nonce, credential: response }),
   })
+  return user
 }
 
 /** Current user, or null when not signed in. */
 export async function me(): Promise<User | null> {
   try {
-    return await apiFetch<User>('/api/auth/me')
+    const { user } = await apiFetch<{ user: User }>('/api/auth/me')
+    return user
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) return null
     throw err

--- a/teeline-web/tests/auth/auth-flow.spec.ts
+++ b/teeline-web/tests/auth/auth-flow.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Page } from '@playwright/test'
+
+// The full passkey → API-key loop against the local Pages stack
+// (wrangler pages dev + local D1). WebAuthn is simulated with a CDP virtual
+// authenticator (CTAP2, resident keys, user verification).
+async function setupVirtualAuthenticator(page: Page): Promise<void> {
+  const client = await page.context().newCDPSession(page)
+  await client.send('WebAuthn.enable')
+  await client.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  })
+}
+
+test('register → mint → show-once → refresh wipes → login → revoke → verify', async ({ page, request }) => {
+  await setupVirtualAuthenticator(page)
+
+  // ---- anonymous state ----
+  await page.goto('/api-key/')
+  await expect(page.getByRole('button', { name: 'Create a passkey' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Sign in with passkey' })).toBeVisible()
+
+  // ---- register (open registration: first passkey becomes the account) ----
+  await page.getByRole('button', { name: 'Create a passkey' }).click()
+  await expect(page.getByRole('heading', { name: 'API keys' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+
+  // ---- mint an API key ----
+  await page.getByRole('button', { name: 'Generate API key' }).click()
+  const secretBox = page.getByTestId('fresh-secret')
+  await expect(secretBox).toBeVisible()
+  const secret = (await secretBox.textContent())?.trim() ?? ''
+  expect(secret).toMatch(/^ak_[A-Za-z0-9_-]{43}$/)
+
+  // ---- show-once: a refresh destroys the secret (not persisted) ----
+  await page.reload()
+  await expect(page.getByTestId('fresh-secret')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+
+  // the key is listed (metadata only)
+  await expect(page.locator('tbody tr')).toHaveCount(1)
+
+  // ---- the minted key verifies against the auth service (full loop) ----
+  const verify = await request.post('/api/auth/keys/verify', {
+    headers: { 'X-Auth-Secret': 'e2e-shared-secret' },
+    data: { secret },
+  })
+  expect(verify.status()).toBe(200)
+  const body = (await verify.json()) as { subject: string; revoked: boolean; expired: boolean }
+  expect(body).toMatchObject({ revoked: false, expired: false })
+  expect(typeof body.subject).toBe('string')
+
+  // a wrong secret still fails closed
+  const badVerify = await request.post('/api/auth/keys/verify', {
+    headers: { 'X-Auth-Secret': 'e2e-shared-secret' },
+    data: { secret: 'ak_notminted000000000000000000000000000' },
+  })
+  expect(badVerify.status()).toBe(404)
+
+  // ---- sign out, sign back in with the same passkey ----
+  await page.getByRole('button', { name: 'Sign out' }).click()
+  await expect(page.getByRole('button', { name: 'Sign in with passkey' })).toBeVisible()
+  await page.getByRole('button', { name: 'Sign in with passkey' }).click()
+  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+  await expect(page.locator('tbody tr')).toHaveCount(1)
+
+  // ---- revoke (destructive → confirm dialog) ----
+  page.once('dialog', (dialog) => dialog.accept())
+  await page.getByRole('button', { name: /Revoke key/ }).click()
+  // soft revoke: the key stays listed, marked as revoked, no revoke button
+  await expect(page.getByText('revoked')).toBeVisible()
+  await expect(page.getByRole('button', { name: /Revoke key/ })).toHaveCount(0)
+
+  // the revoked key no longer verifies
+  const revokedVerify = await request.post('/api/auth/keys/verify', {
+    headers: { 'X-Auth-Secret': 'e2e-shared-secret' },
+    data: { secret },
+  })
+  expect(revokedVerify.status()).toBe(404)
+})


### PR DESCRIPTION
## Phase 6 — browser-level e2e for the auth service

Runs the **full passkey → API-key loop** in a real Chromium with a CDP **virtual authenticator**
against the complete local stack (`wrangler pages dev` + local D1) — no Cloudflare auth needed.

### What's in

- **`playwright.auth.config.ts`** — dedicated config: `build → wrangler d1 migrations apply
  --local → wrangler pages dev :8788`, `.dev.vars` test secrets, chromium-only (WebAuthn requires
  CDP), wrangler state kept in-project.
- **`tests/auth/auth-flow.spec.ts`** — the full flow:
  register (virtual authenticator) → **Generate API key** → show-once secret (`ak_…`) → **refresh
  wipes it** → the minted key **verifies** against `/api/auth/keys/verify` (200) → sign out → sign
  back in with the same passkey → keys listed → **revoke** (confirm dialog) → verify now 404; wrong
  key 404.
- **`web-e2e.yml`** — CI workflow (npm ci, `playwright install chromium`, `npm run test:e2e:auth`).
- Main playwright config excludes `tests/auth` (runs under its own config).

### Bug the e2e caught (production-breaking)

The client helpers returned the **whole `{ user: … }` response envelope** instead of the `User`
object, so right after registration the signed-in view crashed on `user.id.slice(...)` — the live
`/api-key/` breaks on first registration. `webauthn.ts` now unwraps `{ user }`; the client unit
tests were masking it (mocks returned the bare user, not the envelope) — now corrected.

### Verification
- e2e passes locally (1 test, ~4s after stack startup) ✅
- 322 unit tests · web + functions typecheck ✅ · functions bundle ✅