### PR TITLE
feat(web): auth hardening — rate limiting + audit logs (Phase 8)

### DIFF
--- a/teeline-web/functions/api/auth/handlers.test.ts
+++ b/teeline-web/functions/api/auth/handlers.test.ts
@@ -34,7 +34,7 @@ function ctx(request: Request) {
 function req(path: string, init: RequestInit = {}): Request {
   return new Request(`http://localhost:8788${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788' },
+    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': '1.2.3.4' },
     ...init,
   })
 }

--- a/teeline-web/functions/api/auth/keys.test.ts
+++ b/teeline-web/functions/api/auth/keys.test.ts
@@ -26,7 +26,7 @@ function req(path: string, init: RequestInit = {}): Request {
   const { headers, ...rest } = init
   return new Request(`http://localhost:8788${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', ...(headers as Record<string, string>) },
+    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': '1.2.3.4', ...(headers as Record<string, string>) },
     ...rest,
   })
 }

--- a/teeline-web/functions/api/auth/keys.ts
+++ b/teeline-web/functions/api/auth/keys.ts
@@ -36,7 +36,8 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       secretHash: await hashSecret(secret),
       createdAt: now,
     })
-    console.log('[audit] api_key_created', JSON.stringify({ keyId: id, userId: auth.userId, at: now }))
+    const clientIp = request.headers.get('CF-Connecting-IP') ?? null
+    console.log('[audit] api_key_created', JSON.stringify({ keyId: id, userId: auth.userId, ip: clientIp, at: now }))
     // `secret` is the only time the plaintext exists — the client must save
     // it now (the UI shows it once until the page is refreshed).
     return json({ id, name: name ?? null, secret, createdAt: now }, 201)

--- a/teeline-web/functions/api/auth/keys.ts
+++ b/teeline-web/functions/api/auth/keys.ts
@@ -6,10 +6,13 @@ import { createApiKey, listApiKeysByUser } from '../../lib/db'
 import { json, serverError } from '../../lib/http'
 import { generateKeySecret, hashSecret, newKeyId } from '../../lib/keys'
 import { requireSession } from '../../lib/auth'
+import { rateLimit } from '../../lib/ratelimit'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const auth = await requireSession(request, env)
   if (auth instanceof Response) return auth
+  const limited = await rateLimit(request, env, 'keys-create', 30)
+  if (limited) return limited
 
   // Optional human-readable label.
   let name: string | undefined
@@ -33,6 +36,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       secretHash: await hashSecret(secret),
       createdAt: now,
     })
+    console.log('[audit] api_key_created', JSON.stringify({ keyId: id, userId: auth.userId, at: now }))
     // `secret` is the only time the plaintext exists — the client must save
     // it now (the UI shows it once until the page is refreshed).
     return json({ id, name: name ?? null, secret, createdAt: now }, 201)

--- a/teeline-web/functions/api/auth/keys/[id].ts
+++ b/teeline-web/functions/api/auth/keys/[id].ts
@@ -4,10 +4,13 @@ import type { Env } from '../../../lib/env'
 import { revokeKey } from '../../../lib/db'
 import { badRequest, json, serverError } from '../../../lib/http'
 import { requireSession } from '../../../lib/auth'
+import { rateLimit } from '../../../lib/ratelimit'
 
 export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
   const auth = await requireSession(request, env)
   if (auth instanceof Response) return auth
+  const limited = await rateLimit(request, env, 'keys-revoke', 60)
+  if (limited) return limited
 
   const id = params.id
   if (!id || typeof id !== 'string') return badRequest('Key id required')
@@ -15,6 +18,7 @@ export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params
   try {
     const revoked = await revokeKey(env.DB, id, auth.userId)
     if (!revoked) return badRequest('Key not found')
+    console.log('[audit] api_key_revoked', JSON.stringify({ keyId: id, userId: auth.userId, at: Date.now() }))
     return json({ ok: true })
   } catch (err) {
     console.error('Failed to revoke API key:', err)

--- a/teeline-web/functions/api/auth/keys/[id].ts
+++ b/teeline-web/functions/api/auth/keys/[id].ts
@@ -18,7 +18,8 @@ export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params
   try {
     const revoked = await revokeKey(env.DB, id, auth.userId)
     if (!revoked) return badRequest('Key not found')
-    console.log('[audit] api_key_revoked', JSON.stringify({ keyId: id, userId: auth.userId, at: Date.now() }))
+    const clientIp = request.headers.get('CF-Connecting-IP') ?? null
+    console.log('[audit] api_key_revoked', JSON.stringify({ keyId: id, userId: auth.userId, ip: clientIp, at: Date.now() }))
     return json({ ok: true })
   } catch (err) {
     console.error('Failed to revoke API key:', err)

--- a/teeline-web/functions/api/auth/keys/verify.ts
+++ b/teeline-web/functions/api/auth/keys/verify.ts
@@ -11,12 +11,16 @@ import type { Env } from '../../../lib/env'
 import { findActiveKeyByHash, timingSafeEqual, touchKeyLastUsed } from '../../../lib/db'
 import { badRequest, json, unauthorized } from '../../../lib/http'
 import { hashSecret, isKeySecretShape } from '../../../lib/keys'
+import { rateLimit } from '../../../lib/ratelimit'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const presented = request.headers.get('X-Auth-Secret')
   if (!env.AUTH_SERVICE_SECRET || !presented || !timingSafeEqual(presented, env.AUTH_SERVICE_SECRET)) {
     return unauthorized()
   }
+  // Generous: teeline-api verifies on every request (its own limit is 100 RPM).
+  const limited = await rateLimit(request, env, 'keys-verify', 600)
+  if (limited) return limited
 
   let body: { secret?: unknown }
   try {

--- a/teeline-web/functions/api/auth/login/begin.ts
+++ b/teeline-web/functions/api/auth/login/begin.ts
@@ -5,10 +5,13 @@ import { generateAuthenticationOptions } from '@simplewebauthn/server'
 import type { Env } from '../../../lib/env'
 import { insertChallenge } from '../../../lib/db'
 import { CHALLENGE_TTL_MS, isClientOriginAllowed, rpIdFor } from '../../../lib/webauthn'
+import { rateLimit } from '../../../lib/ratelimit'
 import { forbidden, json, serverError } from '../../../lib/http'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF: client origin must be on the allowlist
+  const limited = await rateLimit(request, env, 'login-begin', 10)
+  if (limited) return limited
   // Fail fast before the user interacts with the authenticator: login/complete
   // needs SESSION_SECRET to mint the session token.
   if (!env.SESSION_SECRET) return serverError('Auth service not configured')

--- a/teeline-web/functions/api/auth/login/complete.ts
+++ b/teeline-web/functions/api/auth/login/complete.ts
@@ -8,6 +8,7 @@ import type { Env } from '../../../lib/env'
 import { consumeChallenge, getChallenge, getCredentialById, getUser, updateCredentialCounter } from '../../../lib/db'
 import { isClientOriginAllowed, rpIdFor, serverOrigin } from '../../../lib/webauthn'
 import { badRequest, forbidden, json, serverError } from '../../../lib/http'
+import { rateLimit } from '../../../lib/ratelimit'
 import { createSessionToken, sessionCookieHeader } from '../../../lib/session'
 
 type AuthenticationResponse = Parameters<typeof verifyAuthenticationResponse>[0]['response']
@@ -28,6 +29,8 @@ function isAuthenticationCredential(v: unknown): v is AuthenticationResponse {
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF: client origin must be on the allowlist
+  const limited = await rateLimit(request, env, 'login-complete', 10)
+  if (limited) return limited
   if (!env.SESSION_SECRET) return serverError('Auth service not configured')
 
   let body: { nonce?: unknown; credential?: unknown }

--- a/teeline-web/functions/api/auth/ratelimit-handler.test.ts
+++ b/teeline-web/functions/api/auth/ratelimit-handler.test.ts
@@ -1,0 +1,42 @@
+// Handler-level rate limiting: a single IP flooding an auth endpoint gets 429.
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
+import Database from 'better-sqlite3'
+import { onRequestPost as registerBegin } from './register/begin'
+
+let shim: D1Like
+const env = { SESSION_SECRET: 'test-session-secret', ALLOWED_ORIGINS: 'http://localhost:8788' } as never
+
+function ctx(request: Request) {
+  return { request, env: { ...env, DB: shim } } as never
+}
+
+beforeAll(() => {
+  shim = makeD1(new Database(':memory:'))
+})
+
+beforeEach(() => {
+  shim.exec(SCHEMA)
+  shim.exec('DELETE FROM rate_limits; DELETE FROM challenges;')
+})
+
+describe('register/begin rate limit', () => {
+  it('returns 429 once a single IP exceeds 10 requests per minute', async () => {
+    const makeReq = (ip: string) =>
+      new Request('http://localhost:8788/api/auth/register/begin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': ip },
+        body: '{}',
+      })
+
+    for (let i = 0; i < 10; i++) {
+      expect((await registerBegin(ctx(makeReq('9.9.9.9')))).status).toBe(201)
+    }
+    const limited = await registerBegin(ctx(makeReq('9.9.9.9')))
+    expect(limited.status).toBe(429)
+    expect(limited.headers.get('Retry-After')).toBeTruthy()
+
+    // a different IP is unaffected
+    expect((await registerBegin(ctx(makeReq('8.8.8.8')))).status).toBe(201)
+  })
+})

--- a/teeline-web/functions/api/auth/register/begin.ts
+++ b/teeline-web/functions/api/auth/register/begin.ts
@@ -6,10 +6,13 @@ import { generateRegistrationOptions } from '@simplewebauthn/server'
 import type { Env } from '../../../lib/env'
 import { insertChallenge } from '../../../lib/db'
 import { CHALLENGE_TTL_MS, RP_NAME, isClientOriginAllowed, rpIdFor } from '../../../lib/webauthn'
+import { rateLimit } from '../../../lib/ratelimit'
 import { forbidden, json, serverError } from '../../../lib/http'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF: client origin must be on the allowlist
+  const limited = await rateLimit(request, env, 'register-begin', 10)
+  if (limited) return limited
   if (!env.SESSION_SECRET) return serverError('Auth service not configured')
 
   // Optional friendly name; defaults to a generic label. A null/primitive

--- a/teeline-web/functions/api/auth/register/complete.ts
+++ b/teeline-web/functions/api/auth/register/complete.ts
@@ -7,6 +7,7 @@ import type { Env } from '../../../lib/env'
 import { consumeChallenge, createUserWithCredential, getChallenge } from '../../../lib/db'
 import { isClientOriginAllowed, rpIdFor, serverOrigin } from '../../../lib/webauthn'
 import { badRequest, forbidden, json, serverError } from '../../../lib/http'
+import { rateLimit } from '../../../lib/ratelimit'
 import { createSessionToken, sessionCookieHeader } from '../../../lib/session'
 
 type RegistrationResponse = Parameters<typeof verifyRegistrationResponse>[0]['response']
@@ -30,6 +31,8 @@ function isRegistrationCredential(v: unknown): v is RegistrationResponse {
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   if (!isClientOriginAllowed(request, env)) return forbidden() // CSRF: client origin must be on the allowlist
+  const limited = await rateLimit(request, env, 'register-complete', 10)
+  if (limited) return limited
   if (!env.SESSION_SECRET) return serverError('Auth service not configured')
 
   let body: { nonce?: unknown; credential?: unknown }

--- a/teeline-web/functions/lib/ratelimit.test.ts
+++ b/teeline-web/functions/lib/ratelimit.test.ts
@@ -1,0 +1,51 @@
+// Rate limiter tests against the D1 shim (real SQLite).
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { makeD1, SCHEMA, type D1Like } from './test/sqlite-d1'
+import Database from 'better-sqlite3'
+import { checkRateLimit, cleanupRateLimits } from './ratelimit'
+
+let db: D1Like
+
+beforeAll(() => {
+  db = makeD1(new Database(':memory:'))
+})
+
+beforeEach(() => {
+  db.exec(SCHEMA)
+  db.exec('DELETE FROM rate_limits;')
+})
+
+const NOW = 1_752_000_000_000
+
+describe('checkRateLimit', () => {
+  it('allows up to the limit, then denies within the same window', async () => {
+    for (let i = 1; i <= 3; i++) {
+      const r = await checkRateLimit(db, '1.2.3.4', 'login-begin', 3, 60_000, NOW)
+      expect(r.allowed).toBe(true)
+    }
+    const denied = await checkRateLimit(db, '1.2.3.4', 'login-begin', 3, 60_000, NOW)
+    expect(denied.allowed).toBe(false)
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0)
+  })
+
+  it('tracks different scopes and IPs independently', async () => {
+    await checkRateLimit(db, '1.1.1.1', 'register-begin', 1, 60_000, NOW)
+    expect((await checkRateLimit(db, '1.1.1.1', 'login-begin', 1, 60_000, NOW)).allowed).toBe(true)
+    expect((await checkRateLimit(db, '2.2.2.2', 'register-begin', 1, 60_000, NOW)).allowed).toBe(true)
+    expect((await checkRateLimit(db, '1.1.1.1', 'register-begin', 1, 60_000, NOW)).allowed).toBe(false)
+  })
+
+  it('resets the counter in a new window', async () => {
+    await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW)
+    expect((await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW)).allowed).toBe(false)
+    expect((await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW + 60_000)).allowed).toBe(true)
+  })
+
+  it('cleanupRateLimits removes expired windows only', async () => {
+    await checkRateLimit(db, '1.2.3.4', 'scope', 5, 60_000, NOW - 48 * 3600 * 1000) // window older than the 24h cleanup threshold
+    await checkRateLimit(db, '1.2.3.4', 'scope', 5, 60_000, NOW) // current window
+    await cleanupRateLimits(db, NOW)
+    const rows = await db.prepare('SELECT count FROM rate_limits').bind().all<{ count: number }>()
+    expect(rows.results).toHaveLength(1)
+  })
+})

--- a/teeline-web/functions/lib/ratelimit.ts
+++ b/teeline-web/functions/lib/ratelimit.ts
@@ -1,0 +1,73 @@
+// Fixed-window per-IP rate limiter backed by D1.
+//
+// The window is derived from the clock, so a request that lands in a new
+// window starts a fresh counter. The increment is atomic (INSERT ... ON
+// CONFLICT DO UPDATE), which keeps the count correct under concurrency.
+// Approximation is fine for a limiter: we read the count right after the
+// atomic increment rather than using RETURNING (broader D1 compatibility).
+import type { Env } from './env'
+import { json } from './http'
+
+export interface RateLimitResult {
+  allowed: boolean
+  retryAfterSeconds: number
+}
+
+export async function checkRateLimit(
+  db: D1Database,
+  ip: string,
+  scope: string,
+  limit: number,
+  windowMs: number,
+  now: number = Date.now(),
+): Promise<RateLimitResult> {
+  const windowStart = Math.floor(now / windowMs) * windowMs
+  const key = `${scope}:${ip}:${windowStart}`
+
+  await db
+    .prepare(
+      `INSERT INTO rate_limits (key, count, window_start) VALUES (?1, 1, ?2)
+       ON CONFLICT(key) DO UPDATE SET count = count + 1`,
+    )
+    .bind(key, windowStart)
+    .run()
+
+  const row = await db
+    .prepare('SELECT count FROM rate_limits WHERE key = ?1')
+    .bind(key)
+    .first<{ count: number }>()
+
+  const count = row?.count ?? 1
+  return {
+    allowed: count <= limit,
+    retryAfterSeconds: Math.max(1, Math.ceil((windowStart + windowMs - now) / 1000)),
+  }
+}
+
+/** Opportunistic cleanup of expired windows — call occasionally, never block. */
+export async function cleanupRateLimits(db: D1Database, now: number = Date.now()): Promise<void> {
+  await db.prepare('DELETE FROM rate_limits WHERE window_start < ?1').bind(now - 24 * 3600 * 1000).run()
+}
+
+/**
+ * Enforces a per-IP limit for the calling handler. Returns a 429 Response
+ * when the limit is exceeded, otherwise null (proceed).
+ */
+export async function rateLimit(
+  request: Request,
+  env: Env,
+  scope: string,
+  limit: number,
+  windowMs: number = 60_000,
+): Promise<Response | null> {
+  const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown'
+  const { allowed, retryAfterSeconds } = await checkRateLimit(env.DB, ip, scope, limit, windowMs)
+  if (allowed) {
+    // ~1% of requests also sweep stale windows.
+    if (Math.random() < 0.01) {
+      cleanupRateLimits(env.DB).catch(() => {})
+    }
+    return null
+  }
+  return json({ error: 'Too many requests' }, 429, { 'Retry-After': String(retryAfterSeconds) })
+}

--- a/teeline-web/functions/lib/ratelimit.ts
+++ b/teeline-web/functions/lib/ratelimit.ts
@@ -1,10 +1,13 @@
 // Fixed-window per-IP rate limiter backed by D1.
 //
 // The window is derived from the clock, so a request that lands in a new
-// window starts a fresh counter. The increment is atomic (INSERT ... ON
-// CONFLICT DO UPDATE), which keeps the count correct under concurrency.
-// Approximation is fine for a limiter: we read the count right after the
-// atomic increment rather than using RETURNING (broader D1 compatibility).
+// window starts a fresh counter. The increment + read run as one D1 batch
+// (atomic), so the count we read includes this request's increment — no
+// TOCTOU gap that could allow a bypass or cause false rejections.
+//
+// Failure mode: the limiter is a SECONDARY defense (auth endpoints already
+// require WebAuthn/session verification), so a D1 error fails OPEN (request
+// allowed) rather than locking everyone out during an outage.
 import type { Env } from './env'
 import { json } from './http'
 
@@ -24,19 +27,22 @@ export async function checkRateLimit(
   const windowStart = Math.floor(now / windowMs) * windowMs
   const key = `${scope}:${ip}:${windowStart}`
 
-  await db
-    .prepare(
-      `INSERT INTO rate_limits (key, count, window_start) VALUES (?1, 1, ?2)
-       ON CONFLICT(key) DO UPDATE SET count = count + 1`,
-    )
-    .bind(key, windowStart)
-    .run()
+  // Atomic: the SELECT runs in the same transaction as the increment.
+  const results = await db.batch([
+    db
+      .prepare(
+        `INSERT INTO rate_limits (key, count, window_start) VALUES (?1, 1, ?2)
+         ON CONFLICT(key) DO UPDATE SET count = count + 1`,
+      )
+      .bind(key, windowStart),
+    db.prepare('SELECT count FROM rate_limits WHERE key = ?1').bind(key),
+  ])
 
-  const row = await db
-    .prepare('SELECT count FROM rate_limits WHERE key = ?1')
-    .bind(key)
-    .first<{ count: number }>()
-
+  const row = (results[1] as { results: { count: number }[] }).results[0] ?? undefined
+  if (!row) {
+    // INSERT succeeded but the row isn't visible — unexpected; don't mask it.
+    console.warn('[rate-limit] INSERT succeeded but SELECT returned no row for key:', key)
+  }
   const count = row?.count ?? 1
   return {
     allowed: count <= limit,
@@ -51,7 +57,8 @@ export async function cleanupRateLimits(db: D1Database, now: number = Date.now()
 
 /**
  * Enforces a per-IP limit for the calling handler. Returns a 429 Response
- * when the limit is exceeded, otherwise null (proceed).
+ * when the limit is exceeded, otherwise null (proceed). Fails open (null)
+ * when the limiter itself errors — see the module comment.
  */
 export async function rateLimit(
   request: Request,
@@ -60,14 +67,28 @@ export async function rateLimit(
   limit: number,
   windowMs: number = 60_000,
 ): Promise<Response | null> {
-  const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown'
-  const { allowed, retryAfterSeconds } = await checkRateLimit(env.DB, ip, scope, limit, windowMs)
-  if (allowed) {
-    // ~1% of requests also sweep stale windows.
-    if (Math.random() < 0.01) {
-      cleanupRateLimits(env.DB).catch(() => {})
-    }
+  const ip = request.headers.get('CF-Connecting-IP')
+  if (!ip) {
+    // Cloudflare always sets this header at the edge; its absence means the
+    // request didn't come through CF — refuse rather than collapse all such
+    // requests into one shared bucket (a trivial DoS vector).
+    return json({ error: 'Unable to determine client IP' }, 400)
+  }
+
+  // ~1% of requests also sweep stale windows, regardless of allow/deny.
+  if (Math.random() < 0.01) {
+    cleanupRateLimits(env.DB).catch((err) => console.error('[rate-limit] cleanup failed:', err))
+  }
+
+  let allowed: boolean
+  let retryAfterSeconds: number
+  try {
+    ;({ allowed, retryAfterSeconds } = await checkRateLimit(env.DB, ip, scope, limit, windowMs))
+  } catch (err) {
+    console.error('[rate-limit] D1 error, failing open:', err)
     return null
   }
+
+  if (allowed) return null
   return json({ error: 'Too many requests' }, 429, { 'Retry-After': String(retryAfterSeconds) })
 }

--- a/teeline-web/functions/lib/test/sqlite-d1.ts
+++ b/teeline-web/functions/lib/test/sqlite-d1.ts
@@ -29,7 +29,7 @@ export type D1Like = {
       run(): { meta: { changes: number; last_row_id: number } }
     }
   }
-  batch(stmts: { run(): { meta: { changes: number; last_row_id: number } } }[]): { meta: { changes: number; last_row_id: number } }[]
+  batch(stmts: { _isSelect?: boolean; all?<T>(): { results: T[] }; run?(): { meta: { changes: number } } }[]): unknown[]
 }
 
 export function makeD1(db: Database.Database): D1Like {
@@ -46,9 +46,14 @@ export function makeD1(db: Database.Database): D1Like {
         throw new Error(`sqlite-d1 shim: reused numbered param in SQL: ${sql}`)
       }
       const stmt = db.prepare(sql.replace(/\?(\d+)/g, '?'))
+      // Real D1 batch executes each statement and returns per-statement
+      // results; better-sqlite3 needs .all() for SELECTs and .run() for
+      // writes, so the bound object carries the hint for batch().
+      const isSelect = /^\s*SELECT/i.test(sql)
       return {
         bind(...params) {
           return {
+            _isSelect: isSelect,
             first<T>(col?: string): T | null {
               const row = stmt.get(...params) as Record<string, unknown> | undefined
               if (row === undefined) return null
@@ -67,7 +72,7 @@ export function makeD1(db: Database.Database): D1Like {
       }
     },
     batch(stmts) {
-      return db.transaction(() => stmts.map((s) => s.run()))()
+      return db.transaction(() => stmts.map((s) => (s._isSelect ? s.all() : s.run())))()
     },
   }
 }

--- a/teeline-web/migrations/0002_rate_limits.sql
+++ b/teeline-web/migrations/0002_rate_limits.sql
@@ -1,0 +1,9 @@
+-- Per-IP fixed-window rate limiting for the auth endpoints.
+-- Rows are keyed by '{scope}:{ip}:{windowStart}'; the counter is incremented
+-- atomically per request. Old windows are cleaned up opportunistically.
+CREATE TABLE IF NOT EXISTS rate_limits (
+  key          TEXT PRIMARY KEY,
+  count        INTEGER NOT NULL,
+  window_start INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rate_limits_window ON rate_limits(window_start);


### PR DESCRIPTION
## Phase 8 — hardening (final phase)

### What's in

- **Per-IP rate limiting** on all auth endpoints — `migrations/0002_rate_limits.sql` +
  `functions/lib/ratelimit.ts`: fixed-window limiter backed by D1, **atomic** (increment + read in
  one D1 batch), `Retry-After` on 429, opportunistic stale-window cleanup, **fails open** on D1
  errors (it's a secondary defense), headerless requests refused (no shared 'unknown' bucket).
  Limits: register/login begin+complete **10/min**, keys create **30/min**, keys revoke **60/min**,
  keys verify **600/min** (teeline-api calls it per request; its own limit is 100 RPM).
- **Audit logs** on key mint/revoke (`[audit] api_key_created/revoked` with keyId, userId, client
  IP, timestamp — never the secret).
- **Tests**: 5 new (limiter semantics: allow/deny, per-IP+scope isolation, window reset, cleanup,
  handler-level 429) — 327 total.

### open-code-review — 7 findings, all applied
- **2 high**: TOCTOU in the increment+read → now one atomic D1 batch; unhandled D1 errors → deliberate fail-open.
- **2 medium**: headerless-request shared bucket → refuse (400); cleanup only ran on allowed requests → now always.
- **3 low**: cleanup error logging, missing-row warn, client IP in audit logs.

### Verification
327 unit tests ✅ · functions + web typecheck ✅ · functions bundle ✅ · **e2e passes** (the flow
still works with the limiter active under `wrangler pages dev`).