### PR TITLE
feat(web): account-level banned flag

### DIFF
--- a/docs/auth-verification-runbook.md
+++ b/docs/auth-verification-runbook.md
@@ -109,3 +109,33 @@ npx wrangler pages deployment tail --project-name teeline-web <deployment-id>
 - Curl tests to the auth service need the **`Origin` header** (CSRF), and the session cookie is
   `__Host-`/SameSite=Strict — a full sign-in only works from a real browser.
 - Test keys inserted via §2 are **real, working keys** — always clean them up.
+
+## 7. Banning an abusive account
+
+The `banned` flag (migration `0003_add_banned.sql`, column `users.banned`, default 0) is the
+operator tool for abusive users. It does **not** delete the account — it denies access:
+
+- **Login** (`/api/auth/login/complete`) → 403, no session cookie.
+- **Session APIs** (`/api/auth/me`, `/api/auth/keys` create/list/revoke) → 403.
+- **Existing API keys** (`/api/auth/keys/verify`) → 404, so the teeline-api middleware stops
+  authorizing them immediately — no key rotation needed.
+
+Find the user id (WebAuthn userHandle — ask them for it, or look it up in D1), then set the flag:
+
+```bash
+# From teeline-web/ — list users to find the id
+npx wrangler d1 execute teeline-auth --remote --command "SELECT id, display_name, banned, created_at FROM users"
+
+# Ban
+npx wrangler d1 execute teeline-auth --remote --command "UPDATE users SET banned = 1 WHERE id = '<user-id>'"
+
+# Unban (rare; restores access without re-registration)
+npx wrangler d1 execute teeline-auth --remote --command "UPDATE users SET banned = 0 WHERE id = '<user-id>'"
+```
+
+Caveats:
+
+- The flag is **per account**: with open registration a banned user can create a brand-new account
+  with a new passkey. A durable ban would additionally deny-list credential IDs (follow-up).
+- Banning is immediate and idempotent; setting it again (or on a nonexistent id) is a no-op.
+- Banned users keep their rows — deleting the account (`deleteUser`) remains the "GDPR-style" nuke.

--- a/teeline-web/functions/api/auth/handlers.test.ts
+++ b/teeline-web/functions/api/auth/handlers.test.ts
@@ -2,10 +2,10 @@
 // mocked at the verification boundary and the real SQL against the D1 shim.
 // Exercises: challenge lifecycle, atomic user+credential creation, session
 // cookie issuance/validation, counter updates, origin policy.
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
 import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
-import { addCredential, createUser, getChallenge, getCredentialById, getUser } from '../../lib/db'
+import { addCredential, createUser, getChallenge, getCredentialById, getUser, setUserBanned } from '../../lib/db'
 import { createSessionToken } from '../../lib/session'
 import Database from 'better-sqlite3'
 
@@ -23,6 +23,7 @@ import { onRequestPost as loginBegin } from './login/begin'
 import { onRequestPost as loginComplete } from './login/complete'
 import { onRequestGet as me } from './me'
 import { onRequestPost as logout } from './logout'
+import { onRequestGet as listKeys, onRequestPost as createKey } from './keys'
 
 let shim: D1Like
 const env = { SESSION_SECRET: 'test-session-secret', ALLOWED_ORIGINS: 'http://localhost:8788' } as never // DB injected below
@@ -41,13 +42,11 @@ function req(path: string, init: RequestInit = {}): Request {
 
 const NOW = Date.now()
 
-beforeAll(() => {
-  shim = makeD1(new Database(':memory:'))
-})
-
 beforeEach(() => {
+  // Fresh in-memory DB per test — migrations are not idempotent (0003 is a
+  // plain ALTER TABLE ADD COLUMN).
+  shim = makeD1(new Database(':memory:'))
   shim.exec(SCHEMA)
-  shim.exec('DELETE FROM api_keys; DELETE FROM credentials; DELETE FROM challenges; DELETE FROM users;')
   vi.clearAllMocks()
   mocks.generateRegistrationOptions.mockResolvedValue({ challenge: 'reg-challenge' })
   mocks.generateAuthenticationOptions.mockResolvedValue({ challenge: 'login-challenge', rpId: 'localhost', allowCredentials: [], userVerification: 'preferred' })
@@ -143,6 +142,21 @@ describe('login', () => {
     )
     expect(res.status).toBe(400)
   })
+
+  it('denies a banned user (403) but still advances the credential counter', async () => {
+    await seedUser()
+    await setUserBanned(shim, 'u1', true)
+    const beginRes = await loginBegin(ctx(req('/api/auth/login/begin', { body: '{}' })))
+    const { nonce } = (await beginRes.json()) as { nonce: string }
+
+    const res = await loginComplete(
+      ctx(req('/api/auth/login/complete', { body: JSON.stringify({ nonce, credential: { id: 'cred-1', response: { clientDataJSON: 'client', authenticatorData: 'auth', signature: 'sig' } } }) })),
+    )
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Set-Cookie')).toBeNull() // no session for a banned user
+    // counter advanced anyway so an eventual unban doesn't hit a stale counter
+    expect((await getCredentialById(shim, 'cred-1'))?.counter).toBe(9)
+  })
 })
 
 describe('session endpoints', () => {
@@ -158,6 +172,28 @@ describe('session endpoints', () => {
   it('me rejects a missing or tampered cookie', async () => {
     expect((await me(ctx(new Request('http://localhost:8788/api/auth/me')))).status).toBe(401)
     expect((await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: '__Host-teeline-session=tampered' } })))).status).toBe(401)
+  })
+
+  it('me rejects a banned user (403) despite a valid cookie', async () => {
+    await createUser(shim, { id: 'u1', displayName: 'Tim', createdAt: NOW })
+    const token = await createSessionToken(env.SESSION_SECRET as string, 'u1', NOW)
+    const cookie = `__Host-teeline-session=${token}`
+    expect((await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: cookie } })))).status).toBe(200)
+
+    await setUserBanned(shim, 'u1', true)
+    const res = await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: cookie } })))
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Set-Cookie')).toBeNull() // no session slide for a banned user
+  })
+
+  it('banned users cannot mint or list API keys (requireSession 403)', async () => {
+    await createUser(shim, { id: 'u1', displayName: 'Tim', createdAt: NOW })
+    const token = await createSessionToken(env.SESSION_SECRET as string, 'u1', NOW)
+    const cookie = `__Host-teeline-session=${token}`
+    await setUserBanned(shim, 'u1', true)
+
+    expect((await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).status).toBe(403)
+    expect((await listKeys(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).status).toBe(403)
   })
 
   it('logout clears the cookie', async () => {

--- a/teeline-web/functions/api/auth/keys.test.ts
+++ b/teeline-web/functions/api/auth/keys.test.ts
@@ -1,9 +1,9 @@
 // API-key lifecycle tests: mint (show-once), list (metadata only), revoke
 // (immediate), and the internal verify contract (the shape teeline-api
 // expects — a drop-in for the old Clerk verify call).
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
-import { createUser } from '../../lib/db'
+import { createUser, setUserBanned } from '../../lib/db'
 import { createSessionToken } from '../../lib/session'
 import Database from 'better-sqlite3'
 
@@ -40,13 +40,11 @@ async function seedUser(id = 'u1'): Promise<void> {
   await createUser(shim, { id, displayName: 'Tim', createdAt: Date.now() })
 }
 
-beforeAll(() => {
-  shim = makeD1(new Database(':memory:'))
-})
-
 beforeEach(() => {
+  // Fresh in-memory DB per test — migrations are not idempotent (0003 is a
+  // plain ALTER TABLE ADD COLUMN).
+  shim = makeD1(new Database(':memory:'))
   shim.exec(SCHEMA)
-  shim.exec('DELETE FROM api_keys; DELETE FROM credentials; DELETE FROM challenges; DELETE FROM users;')
 })
 
 describe('key creation (show-once)', () => {
@@ -142,6 +140,22 @@ describe('internal verify endpoint', () => {
     const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
     expect(res.status).toBe(200)
     expect(await res.json()).toMatchObject({ subject: 'u1', revoked: false, expired: false })
+  })
+
+  it('404s for a key owned by a banned user (ban kills existing keys)', async () => {
+    await seedUser()
+    const cookie = await sessionCookie('u1')
+    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ secret: string }>
+    const { secret } = await minted
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
+
+    // operator bans the account → the key stops verifying immediately
+    await setUserBanned(shim, 'u1', true)
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(404)
+
+    // unban restores it (flag is a toggle, not a deletion)
+    await setUserBanned(shim, 'u1', false)
+    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
   })
 
   it('404s for an unknown key', async () => {

--- a/teeline-web/functions/api/auth/login/complete.ts
+++ b/teeline-web/functions/api/auth/login/complete.ts
@@ -99,6 +99,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     // rejected a lower counter, so persisting the new one is safe and atomic.
     await updateCredentialCounter(env.DB, credential.id, verification.authenticationInfo.newCounter)
 
+    // Banned account: the ceremony succeeded but access is denied. The counter
+    // is updated above so an eventual unban leaves the credential usable.
+    if (user.banned) return forbidden('Account is banned')
+
     const token = await createSessionToken(env.SESSION_SECRET, user.id)
     return json(
       { user: { id: user.id, displayName: user.display_name, createdAt: user.created_at } },

--- a/teeline-web/functions/api/auth/me.ts
+++ b/teeline-web/functions/api/auth/me.ts
@@ -2,7 +2,7 @@
 // session cookie forward when it's past the halfway point of its lifetime.
 import type { Env } from '../../lib/env'
 import { getUser } from '../../lib/db'
-import { json, serverError, unauthorized } from '../../lib/http'
+import { json, forbidden, serverError, unauthorized } from '../../lib/http'
 import { createSessionToken, getSessionUser, sessionCookieHeader, shouldRefreshSession } from '../../lib/session'
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
@@ -17,6 +17,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     return serverError('Failed to load user — please try again')
   }
   if (!user) return unauthorized() // account deleted → session is void
+  if (user.banned) return forbidden('Account is banned') // banned account → deny, no session slide
 
   const headers: Record<string, string> = {}
   if (shouldRefreshSession(session) && env.SESSION_SECRET) {

--- a/teeline-web/functions/api/auth/ratelimit-handler.test.ts
+++ b/teeline-web/functions/api/auth/ratelimit-handler.test.ts
@@ -1,5 +1,5 @@
 // Handler-level rate limiting: a single IP flooding an auth endpoint gets 429.
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
 import Database from 'better-sqlite3'
 import { onRequestPost as registerBegin } from './register/begin'
@@ -11,13 +11,11 @@ function ctx(request: Request) {
   return { request, env: { ...env, DB: shim } } as never
 }
 
-beforeAll(() => {
-  shim = makeD1(new Database(':memory:'))
-})
-
 beforeEach(() => {
+  // Fresh in-memory DB per test — migrations are not idempotent (0003 is a
+  // plain ALTER TABLE ADD COLUMN).
+  shim = makeD1(new Database(':memory:'))
   shim.exec(SCHEMA)
-  shim.exec('DELETE FROM rate_limits; DELETE FROM challenges;')
 })
 
 describe('register/begin rate limit', () => {

--- a/teeline-web/functions/lib/auth.ts
+++ b/teeline-web/functions/lib/auth.ts
@@ -2,6 +2,7 @@
 // 1. CSRF — the client origin (Origin/Referer header) must be on the allowlist
 // 2. session — valid HMAC cookie
 // 3. user existence — a deleted account voids its session
+// 4. not banned — an operator-banned account is denied (403)
 // Returns the userId or an error Response.
 import type { Env } from './env'
 import { getUser } from './db'
@@ -18,5 +19,6 @@ export async function requireSession(
   if (!session) return unauthorized()
   const user = await getUser(env.DB, session.sub)
   if (!user) return unauthorized() // deleted account → session void
+  if (user.banned) return forbidden('Account is banned') // banned account → deny session APIs
   return { userId: user.id }
 }

--- a/teeline-web/functions/lib/db.test.ts
+++ b/teeline-web/functions/lib/db.test.ts
@@ -8,7 +8,7 @@
 // pages dev`'s local D1 *does* work — this only affects the library path.
 // better-sqlite3 is deterministic, fast and CI-friendly; the real D1 path is
 // exercised by the deploy-time migrations and the Phase 3 verify e2e.
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   addCredential,
   consumeChallenge,
@@ -24,6 +24,7 @@ import {
   listApiKeysByUser,
   listCredentialsByUser,
   revokeKey,
+  setUserBanned,
   timingSafeEqual,
   touchKeyLastUsed,
   updateCredentialCounter,
@@ -34,15 +35,11 @@ import Database from 'better-sqlite3'
 
 let db: D1Like
 
-beforeAll(() => {
-  db = makeD1(new Database(':memory:'))
-})
-
 beforeEach(() => {
-  // Fresh schema per test; the SQL is idempotent (IF NOT EXISTS), which also
-  // proves re-applying migrations is safe.
+  // Fresh in-memory DB per test. Migrations are applied once per DB — they
+  // are NOT idempotent (0003 is a plain ALTER TABLE ADD COLUMN).
+  db = makeD1(new Database(':memory:'))
   db.exec(SCHEMA)
-  db.exec('DELETE FROM api_keys; DELETE FROM credentials; DELETE FROM challenges; DELETE FROM users;')
 })
 
 const NOW = 1_752_000_000_000
@@ -66,6 +63,17 @@ describe('users', () => {
     expect(await getUser(db as never, 'u1')).toBeNull()
     expect(await getCredentialById(db as never, 'c1')).toBeNull()
     expect(await listApiKeysByUser(db as never, 'u1')).toEqual([])
+  })
+
+  it('new users default to not banned; setUserBanned flips the flag', async () => {
+    await createUser(db as never, { id: 'u1', createdAt: NOW })
+    expect((await getUser(db as never, 'u1'))?.banned).toBe(0)
+    expect(await setUserBanned(db as never, 'u1', true)).toBe(true)
+    expect((await getUser(db as never, 'u1'))?.banned).toBe(1)
+    expect(await setUserBanned(db as never, 'u1', false)).toBe(true)
+    expect((await getUser(db as never, 'u1'))?.banned).toBe(0)
+    // unknown user → no-op
+    expect(await setUserBanned(db as never, 'ghost', true)).toBe(false)
   })
 })
 

--- a/teeline-web/functions/lib/db.ts
+++ b/teeline-web/functions/lib/db.ts
@@ -14,6 +14,9 @@ export interface UserRow {
   id: string
   display_name: string | null
   created_at: number
+  // Operator-set ban flag: banned users cannot log in and their API keys
+  // stop verifying (findActiveKeyByHash joins users and filters banned).
+  banned: number
 }
 
 export interface CredentialRow {
@@ -45,8 +48,12 @@ export interface ChallengeRow {
 }
 
 const USER_COLS = 'id, display_name, created_at'
+// SELECT list includes the ban flag (INSERTs omit it — the column defaults to 0).
+const USER_SELECT_COLS = 'id, display_name, created_at, banned'
 const CRED_COLS = 'id, user_id, public_key, counter, transports, created_at'
 const KEY_COLS = 'id, user_id, name, secret_hash, created_at, last_used_at, revoked'
+// Same columns, qualified for the api_keys↔users JOIN in findActiveKeyByHash.
+const KEY_COLS_ALIASED = 'k.id, k.user_id, k.name, k.secret_hash, k.created_at, k.last_used_at, k.revoked'
 
 // ---- Users ---------------------------------------------------------------
 
@@ -62,9 +69,16 @@ export async function createUser(
 
 export async function getUser(db: D1Database, id: string): Promise<UserRow | null> {
   return (
-    (await db.prepare(`SELECT ${USER_COLS} FROM users WHERE id = ?1`).bind(id).first<UserRow>()) ??
+    (await db.prepare(`SELECT ${USER_SELECT_COLS} FROM users WHERE id = ?1`).bind(id).first<UserRow>()) ??
     null
   )
+}
+
+// Operator hook: set or clear the ban flag. Returns false when the user
+// doesn't exist. Banned users can't log in and their keys stop verifying.
+export async function setUserBanned(db: D1Database, id: string, banned: boolean): Promise<boolean> {
+  const res = await db.prepare('UPDATE users SET banned = ?1 WHERE id = ?2').bind(banned ? 1 : 0, id).run()
+  return res.meta.changes > 0
 }
 
 // Operator reset: passkey loss = account loss. Wipes user + credentials + keys
@@ -160,11 +174,17 @@ export async function listApiKeysByUser(db: D1Database, userId: string): Promise
 }
 
 // Verify path: hash lookup, revoked keys are invisible (revocation is a soft
-// flag, effective immediately — no cache to invalidate).
+// flag, effective immediately — no cache to invalidate). Also invisible: keys
+// owned by a banned user — banning an account kills its existing keys in the
+// same query, no per-key bookkeeping.
 export async function findActiveKeyByHash(db: D1Database, secretHash: string): Promise<ApiKeyRow | null> {
   return (
     (await db
-      .prepare(`SELECT ${KEY_COLS} FROM api_keys WHERE secret_hash = ?1 AND revoked = 0`)
+      .prepare(
+        `SELECT ${KEY_COLS_ALIASED}
+         FROM api_keys k JOIN users u ON u.id = k.user_id
+         WHERE k.secret_hash = ?1 AND k.revoked = 0 AND u.banned = 0`,
+      )
       .bind(secretHash)
       .first<ApiKeyRow>()) ?? null
   )

--- a/teeline-web/functions/lib/http.ts
+++ b/teeline-web/functions/lib/http.ts
@@ -17,8 +17,8 @@ export function badRequest(message: string): Response {
   return json({ error: message }, 400)
 }
 
-export function forbidden(): Response {
-  return json({ error: 'Forbidden' }, 403)
+export function forbidden(message = 'Forbidden'): Response {
+  return json({ error: message }, 403)
 }
 
 export function unauthorized(): Response {

--- a/teeline-web/functions/lib/ratelimit.test.ts
+++ b/teeline-web/functions/lib/ratelimit.test.ts
@@ -1,18 +1,16 @@
 // Rate limiter tests against the D1 shim (real SQLite).
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { makeD1, SCHEMA, type D1Like } from './test/sqlite-d1'
 import Database from 'better-sqlite3'
 import { checkRateLimit, cleanupRateLimits } from './ratelimit'
 
 let db: D1Like
 
-beforeAll(() => {
-  db = makeD1(new Database(':memory:'))
-})
-
 beforeEach(() => {
+  // Fresh in-memory DB per test — migrations are not idempotent (0003 is a
+  // plain ALTER TABLE ADD COLUMN).
+  db = makeD1(new Database(':memory:'))
   db.exec(SCHEMA)
-  db.exec('DELETE FROM rate_limits;')
 })
 
 const NOW = 1_752_000_000_000

--- a/teeline-web/migrations/0003_add_banned.sql
+++ b/teeline-web/migrations/0003_add_banned.sql
@@ -1,0 +1,5 @@
+-- Account-level ban flag (operator-set). Banned users cannot log in and
+-- their existing API keys stop verifying. Note: with open registration a
+-- banned user could create a fresh account; a durable ban would additionally
+-- deny-list credential IDs (follow-up).
+ALTER TABLE users ADD COLUMN banned INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## What

Adds an operator-set `banned` flag on auth accounts (migration `0003_add_banned.sql`) so an abusive user's account can be blocked without deleting data.

## Behavior

A banned user is denied everywhere:

- **Login** (`/api/auth/login/complete`) → `403 Account is banned`, no session cookie. The credential counter still advances so an eventual unban doesn't hit a stale counter.
- **Session APIs** (`/api/auth/me`, `/api/auth/keys` create/list/revoke via `requireSession`) → `403`.
- **Existing API keys** (`/api/auth/keys/verify`) → `404`, via a `JOIN users ... AND u.banned = 0` in `findActiveKeyByHash`. Keys stop authorizing immediately, no rotation needed, and the verify response doesn't leak ban status.

## Operator workflow

```bash
npx wrangler d1 execute teeline-auth --remote --command "UPDATE users SET banned = 1 WHERE id = '<user-id>'"
```

Documented in `docs/auth-verification-runbook.md` §7.

## Tests

- `db.test.ts`: `banned` defaults to 0; `setUserBanned` flips it; unknown id is a no-op.
- `keys.test.ts`: a banned user's key 404s on verify; unban restores it.
- `handlers.test.ts`: banned login → 403 (no cookie, counter still advanced); banned `me` → 403 (no slide); banned `requireSession` (keys create/list) → 403.
- All 332 tests pass; `tsc -p functions` and `wrangler pages functions build` green.

## Caveat

Open registration means a banned user can create a brand-new account with a new passkey. A durable ban would additionally deny-list credential IDs — noted as a follow-up in the migration comment and runbook.