### PR TITLE
fix(web): local build OOM — heap bump in Taskfile build tasks

### DIFF
--- a/teeline-web/Taskfile.yml
+++ b/teeline-web/Taskfile.yml
@@ -31,6 +31,11 @@ tasks:
 
   build:
     desc: Type-check and build production bundle to dist/
+    # astro 7.2 static builds exceed Node's default ~4 GB heap and OOM
+    # (exit 134). CI sets NODE_OPTIONS=6144 per-step; the local task needs
+    # its own bump so `task web:build` works out of the box.
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     cmds:
       - npm run build
 
@@ -62,12 +67,16 @@ tasks:
 
   deploy:preview:
     desc: Build and deploy to CF Pages preview (current branch)
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     cmds:
       - npm run build
       - npx wrangler pages deploy dist/
 
   deploy:release:
     desc: Build and deploy to CF Pages production (master branch)
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     cmds:
       - npm run build
       - npx wrangler pages deploy dist/ --branch master


### PR DESCRIPTION
## Problem

`task web:build` fails with exit 134 (V8 heap OOM) during `astro build`. Astro 7.2 static builds exceed Node's default ~4 GB heap. CI was already fixed per-step with `NODE_OPTIONS=--max-old-space-size=6144` in teeline-web.yml / deploy-web.yml, but the local Taskfile build task ran `npm run build` without a bump, so the OOM hit every local build.

## Fix

Add `env: NODE_OPTIONS: --max-old-space-size=8192` to the `build`, `deploy:preview`, and `deploy:release` tasks in `teeline-web/Taskfile.yml`. CI is unaffected (it calls `npm run build` directly with its own env, not the task).

## Verification

`task web:build` from repo root now completes: astro check 0 errors, 156 pages built in ~45s, copy-wasm runs, exit 0.