### PR TITLE
feat(web): add interactive Stochastic Hill Climbing explainer (#433)

### DIFF
--- a/docs/algorithms/stochastic-hill.md
+++ b/docs/algorithms/stochastic-hill.md
@@ -3,7 +3,7 @@ id: "stochastic_hill"
 name: "Stochastic Hill Climbing"
 typeBadge: "Heuristic — local search"
 description: "Iterative improvement with random restarts. Each step applies a random perturbation to the current tour; the new tour is accepted if it is better."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Stochastic Hill Climbing

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -90,6 +90,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of Ant Colony Optimization: watch a colony of ants construct tours probabilistically, biased by a shared pheromone matrix that strengthens on short edges and decays over epochs. Adjust α (pheromone influence), β (heuristic weight), evaporation rate, and colony size.',
     backLabel: 'ACO',
   },
+  stochastic_hill: {
+    title: 'Stochastic Hill Climbing — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of Stochastic Hill Climbing: watch random 2-opt candidates get accepted only when they beat the best tour so far, with random restarts when the search goes stale.',
+    backLabel: 'Stochastic Hill Climbing',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/explainers/stochastic-hill-algo.ts
+++ b/teeline-web/src/explainers/stochastic-hill-algo.ts
@@ -128,14 +128,24 @@ export function randomSuccessor(tour: number[], rng: RngState): {
     if (j - i > 1) break
   }
   const next = reverseSegment(tour, i, j)
-  const removed: [number, number][] = [
-    [tour[(i - 1 + n) % n], tour[i]],
-    [tour[j], tour[(j + 1) % n]],
-  ]
-  const added: [number, number][] = [
-    [tour[(i - 1 + n) % n], tour[j]],
-    [tour[i], tour[(j + 1) % n]],
-  ]
+  let removed: [number, number][]
+  let added: [number, number][]
+  if (i === 0 && j === n - 1) {
+    // Full-tour reversal: both break points sit on the same wrap-around edge,
+    // so report that single edge once (the general formula would duplicate it
+    // and build self-loop "added" edges that never match a real tour edge).
+    removed = [[tour[n - 1], tour[0]]]
+    added = [[tour[n - 1], tour[0]]]
+  } else {
+    removed = [
+      [tour[(i - 1 + n) % n], tour[i]],
+      [tour[j], tour[(j + 1) % n]],
+    ]
+    added = [
+      [tour[(i - 1 + n) % n], tour[j]],
+      [tour[i], tour[(j + 1) % n]],
+    ]
+  }
   return { tour: next, i, j, removed, added, rng: r }
 }
 
@@ -267,19 +277,20 @@ export function stepOnce(state: SimState): SimState {
     const epoch = state.epoch + 1
     const accepted = p.accepted
     const restart = p.restart
-    const tour = accepted
-      ? p.candidateTour
-      : restart && p.restartTour
-        ? p.restartTour
-        : state.tour
+
+    let phase: Phase
+    let tour: number[]
+    if (accepted) {
+      phase = epoch >= state.maxEpochs ? 'done' : 'accepted'
+      tour = p.candidateTour
+    } else if (restart && p.restartTour) {
+      phase = epoch >= state.maxEpochs ? 'done' : 'restart'
+      tour = p.restartTour
+    } else {
+      phase = epoch >= state.maxEpochs ? 'done' : 'rejected'
+      tour = state.tour
+    }
     const bestCost = accepted ? p.candidateCost : state.bestCost
-    const phase: Phase = epoch >= state.maxEpochs
-      ? 'done'
-      : accepted
-        ? 'accepted'
-        : restart
-          ? 'restart'
-          : 'rejected'
 
     return {
       ...state,
@@ -289,7 +300,7 @@ export function stepOnce(state: SimState): SimState {
       bestCost,
       currentCost: tourLength(tour),
       epoch,
-      nStale: accepted ? 0 : restart ? 0 : state.nStale + 1,
+      nStale: accepted || restart ? 0 : state.nStale + 1,
       restarts: state.restarts + (restart ? 1 : 0),
       acceptedCount: state.acceptedCount + (accepted ? 1 : 0),
       rejectedCount: state.rejectedCount + (!accepted && !restart ? 1 : 0),

--- a/teeline-web/src/explainers/stochastic-hill-algo.ts
+++ b/teeline-web/src/explainers/stochastic-hill-algo.ts
@@ -1,0 +1,334 @@
+// Pure simulation logic for the Stochastic Hill Climbing interactive explainer.
+// Rust-faithful model (src/tsp/stochastic_hill.rs + src/tsp/route.rs):
+//   - the tour starts as a random shuffle of the 8 cities
+//   - each epoch draws ONE random 2-opt candidate (random non-adjacent pair,
+//     inclusive segment reversal) from the current tour
+//   - the candidate is accepted ONLY if it beats the best-so-far cost, so the
+//     current tour equals the best tour except right after a restart, when a
+//     fresh random tour is shown until it either beats the best or the search
+//     goes stale again
+//   - when the number of consecutive rejections exceeds `patience`, the
+//     current tour is shuffled again (the best tour survives)
+// All randomness comes from a pure counter-based RNG (seed + counter) stored
+// inside SimState, so Back/Step replay identically and tests can assert exact
+// sequences. No DOM, fully testable.
+
+// 8 cities in a rough ring (the 10-city layout minus the two inner points) —
+// small enough that a full scenario run stays short, which suits an explainer
+// whose job is to show the mechanics (random 2-opt, accept-if-better,
+// restart-when-stale), not to solve the instance.
+export const CITIES: [number, number][] = [
+  [150, 20],   // 0 — top
+  [270, 70],   // 1 — top-right
+  [260, 180],  // 2 — right
+  [180, 280],  // 3 — bottom-right
+  [120, 290],  // 4 — bottom
+  [35, 220],   // 5 — bottom-left
+  [25, 80],    // 6 — left
+  [80, 25],    // 7 — top-left
+]
+export const N_CITIES = CITIES.length
+
+export type Phase = 'idle' | 'propose' | 'accepted' | 'rejected' | 'restart' | 'done'
+
+// ---------------------------------------------------------------
+// Seeded RNG — pure (seed, counter) → [0, 1), so it can be
+// structuredClone'd as part of SimState and replay identically.
+// ---------------------------------------------------------------
+export interface RngState {
+  seed: number
+  counter: number
+}
+
+export function makeRng(seed: number): RngState {
+  return { seed: seed >>> 0, counter: 0 }
+}
+
+export function nextRand(rng: RngState): { value: number; rng: RngState } {
+  // mulberry32-style scramble of (seed + counter·φ), pure w.r.t. its inputs.
+  let t = (rng.seed + Math.imul(rng.counter, 0x6d2b79f5)) >>> 0
+  t = Math.imul(t ^ (t >>> 15), t | 1)
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+  return {
+    value: ((t ^ (t >>> 14)) >>> 0) / 4294967296,
+    rng: { seed: rng.seed, counter: rng.counter + 1 },
+  }
+}
+
+// ---------------------------------------------------------------
+// Geometry (same 10-city set as the 2-opt and NN explainers)
+// ---------------------------------------------------------------
+export function dist(i: number, j: number): number {
+  const dx = CITIES[i][0] - CITIES[j][0]
+  const dy = CITIES[i][1] - CITIES[j][1]
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+export function tourLength(tour: number[]): number {
+  let d = 0
+  for (let k = 0; k < tour.length; k++) {
+    d += dist(tour[k], tour[(k + 1) % tour.length])
+  }
+  return d
+}
+
+// ---------------------------------------------------------------
+// Moves — Rust route.rs semantics
+// ---------------------------------------------------------------
+export function seededShuffle(rng: RngState): { tour: number[]; rng: RngState } {
+  const tour = Array.from({ length: N_CITIES }, (_, i) => i)
+  let r = rng
+  for (let i = N_CITIES - 1; i > 0; i--) {
+    const { value, rng: r2 } = nextRand(r)
+    r = r2
+    const j = Math.floor(value * (i + 1))
+    ;[tour[i], tour[j]] = [tour[j], tour[i]]
+  }
+  return { tour, rng: r }
+}
+
+// Reverse the inclusive segment [i..=j] on a copy (Rust swap_cities — the
+// "2-OPT keeps changes more stable" reversal).
+export function reverseSegment(tour: number[], i: number, j: number): number[] {
+  const next = [...tour]
+  let left = i
+  let right = j
+  while (left < right) {
+    ;[next[left], next[right]] = [next[right], next[left]]
+    left++
+    right--
+  }
+  return next
+}
+
+// Rust random_successor(): draw a random pair with positions > 1 apart (the
+// wrap pair (0, n−1) is allowed), then reverse the inclusive segment [i..=j].
+// Returns the candidate tour plus the removed/added edge pairs for display.
+export function randomSuccessor(tour: number[], rng: RngState): {
+  tour: number[]
+  i: number
+  j: number
+  removed: [number, number][]
+  added: [number, number][]
+  rng: RngState
+} {
+  const n = tour.length
+  let r = rng
+  let i = 0
+  let j = 0
+  for (let tries = 0; tries < 10; tries++) {
+    const a = nextRand(r)
+    r = a.rng
+    const b = nextRand(r)
+    r = b.rng
+    const lo = Math.floor(a.value * n)
+    const hi = Math.floor(b.value * n)
+    i = Math.min(lo, hi)
+    j = Math.max(lo, hi)
+    if (j - i > 1) break
+  }
+  const next = reverseSegment(tour, i, j)
+  const removed: [number, number][] = [
+    [tour[(i - 1 + n) % n], tour[i]],
+    [tour[j], tour[(j + 1) % n]],
+  ]
+  const added: [number, number][] = [
+    [tour[(i - 1 + n) % n], tour[j]],
+    [tour[i], tour[(j + 1) % n]],
+  ]
+  return { tour: next, i, j, removed, added, rng: r }
+}
+
+// ---------------------------------------------------------------
+// Scenario + simulation state
+// ---------------------------------------------------------------
+export interface Scenario {
+  label: string
+  desc: string
+  seed: number
+  // Optional crafted starting tour (Rust's init_tour path — used by the
+  // "quick convergence" scenario, whose premise is a *good* start). When
+  // omitted the tour starts as a seeded random shuffle, like the solver's
+  // default `shuffle` auto-seed.
+  initTour?: number[]
+  epochs: number
+  patience: number
+}
+
+export interface CandidateEvent {
+  i: number
+  j: number
+  removed: [number, number][]
+  added: [number, number][]
+  delta: number            // candidateCost − currentCost (visual Δ on screen)
+  candidateTour: number[]
+  candidateCost: number
+  accepted: boolean        // candidateCost < bestCost (Rust: < best_distance)
+  restart: boolean         // this rejection pushes nStale past patience
+  restartTour: number[] | null // fresh random tour if restarting
+}
+
+export interface SimState {
+  phase: Phase
+  tour: number[]           // current tour (== bestTour except right after a restart)
+  bestTour: number[]
+  bestCost: number
+  currentCost: number
+  epoch: number            // completed candidate evaluations (verdicts)
+  nStale: number           // consecutive rejections since last accept/restart
+  restarts: number
+  acceptedCount: number
+  rejectedCount: number
+  maxEpochs: number
+  patience: number
+  rng: RngState
+  pending: CandidateEvent | null // drawn candidate awaiting its verdict phase
+  costHistory: number[]    // best cost after each epoch (sparkline)
+  step: number
+}
+
+// Seeds tuned so each scenario reliably behaves as its name suggests
+// (see stochastic-hill.test.ts for the assertions that pin them):
+//   quick  — seed 371 + a crafted start (the optimal perimeter with its head
+//            segment reversed, [2,1,0,3,4,5,6,7], 1.36× optimal): reaches the
+//            optimum (827.8) at epoch 15, ZERO restarts
+//   rugged — seed 917: 9 restarts, ends at 1.65× the optimum
+//   needle — seed 1548: the optimum is only found at epoch 37, after 4
+//            restarts have wandered through mediocre local optima
+export const SCENARIOS: Record<string, Scenario> = {
+  quick_convergence: {
+    label: 'Quick convergence',
+    desc: 'A good starting tour — a few improving moves reach the optimum, no restarts',
+    seed: 371,
+    initTour: [2, 1, 0, 3, 4, 5, 6, 7],
+    epochs: 30,
+    patience: 25,
+  },
+  rugged_landscape: {
+    label: 'Rugged landscape',
+    desc: 'Many mediocre local optima — the search keeps stalling and restarting',
+    seed: 917,
+    epochs: 50,
+    patience: 5,
+  },
+  needle_in_haystack: {
+    label: 'Needle in haystack',
+    desc: 'One good optimum hidden among many — only a rare restart finds it',
+    seed: 1548,
+    epochs: 60,
+    patience: 6,
+  },
+}
+
+export function makeInitState(scenario: Scenario): SimState {
+  const rng = makeRng(scenario.seed)
+  let rng2 = rng
+  let tour: number[]
+  if (scenario.initTour) {
+    tour = [...scenario.initTour]
+  } else {
+    const s = seededShuffle(rng2)
+    tour = s.tour
+    rng2 = s.rng
+  }
+  const cost = tourLength(tour)
+  return {
+    phase: 'idle',
+    tour,
+    bestTour: [...tour],
+    bestCost: cost,
+    currentCost: cost,
+    epoch: 0,
+    nStale: 0,
+    restarts: 0,
+    acceptedCount: 0,
+    rejectedCount: 0,
+    maxEpochs: scenario.epochs,
+    patience: scenario.patience,
+    rng: rng2,
+    pending: null,
+    costHistory: [cost],
+    step: 0,
+  }
+}
+
+// One Step press. Two phases per step (like 2-opt's candidate/apply):
+//   idle | verdict-phase  → 'propose'   (draw a random candidate, tour unchanged)
+//   'propose'             → verdict phase ('accepted' | 'rejected' | 'restart',
+//                            or 'done' when the epoch cap is hit)
+// Everything is a pure function of the input state — no mutation, fully
+// deterministic for a given seed.
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'done') return { ...state, step: state.step + 1 }
+
+  // Phase 2 — apply the pending verdict
+  if (state.phase === 'propose' && state.pending) {
+    const p = state.pending
+    const epoch = state.epoch + 1
+    const accepted = p.accepted
+    const restart = p.restart
+    const tour = accepted
+      ? p.candidateTour
+      : restart && p.restartTour
+        ? p.restartTour
+        : state.tour
+    const bestCost = accepted ? p.candidateCost : state.bestCost
+    const phase: Phase = epoch >= state.maxEpochs
+      ? 'done'
+      : accepted
+        ? 'accepted'
+        : restart
+          ? 'restart'
+          : 'rejected'
+
+    return {
+      ...state,
+      phase,
+      tour,
+      bestTour: accepted ? [...p.candidateTour] : state.bestTour,
+      bestCost,
+      currentCost: tourLength(tour),
+      epoch,
+      nStale: accepted ? 0 : restart ? 0 : state.nStale + 1,
+      restarts: state.restarts + (restart ? 1 : 0),
+      acceptedCount: state.acceptedCount + (accepted ? 1 : 0),
+      rejectedCount: state.rejectedCount + (!accepted && !restart ? 1 : 0),
+      costHistory: [...state.costHistory, bestCost],
+      step: state.step + 1,
+    }
+  }
+
+  // Phase 1 — draw the next random candidate
+  if (state.epoch >= state.maxEpochs) {
+    return { ...state, phase: 'done', step: state.step + 1 }
+  }
+  const { tour: candidateTour, i, j, removed, added, rng } = randomSuccessor(state.tour, state.rng)
+  const candidateCost = tourLength(candidateTour)
+  const delta = candidateCost - state.currentCost
+  const accepted = candidateCost < state.bestCost
+  const staleAfter = state.nStale + 1
+  const restart = !accepted && staleAfter > state.patience
+
+  let rng2 = rng
+  let restartTour: number[] | null = null
+  if (restart) {
+    const s = seededShuffle(rng2)
+    restartTour = s.tour
+    rng2 = s.rng
+  }
+
+  return {
+    ...state,
+    phase: 'propose',
+    rng: rng2,
+    pending: {
+      i, j, removed, added, delta,
+      candidateTour,
+      candidateCost,
+      accepted,
+      restart,
+      restartTour,
+    },
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/stochastic-hill.test.ts
+++ b/teeline-web/src/explainers/stochastic-hill.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, SCENARIOS,
+  dist, tourLength, makeRng, nextRand, seededShuffle,
+  reverseSegment, randomSuccessor, makeInitState, stepOnce,
+} from './stochastic-hill-algo'
+import type { SimState } from './stochastic-hill-algo'
+
+// True optimum for the shared 8-city layout (brute-forced; verified below).
+const OPT = 827.774076596031
+
+function runToDone(seed: number, epochs: number, patience: number, initTour?: number[]): SimState {
+  let s = makeInitState({ label: '', desc: '', seed, epochs, patience, initTour })
+  let guard = epochs + 1000
+  while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+  expect(s.phase, 'runToDone must reach done').toBe('done')
+  return s
+}
+
+function isPermutation(tour: number[]): boolean {
+  const sorted = tour.slice().sort((a, b) => a - b)
+  return sorted.every((v, i) => v === i) && tour.length === N_CITIES
+}
+
+// ---------------------------------------------------------------
+describe('dist', () => {
+  it('is symmetric', () => {
+    for (let i = 0; i < N_CITIES; i++) {
+      for (let j = 0; j < N_CITIES; j++) {
+        expect(dist(i, j)).toBeCloseTo(dist(j, i), 10)
+      }
+    }
+  })
+
+  it('is zero for the same city and positive otherwise', () => {
+    expect(dist(0, 0)).toBe(0)
+    expect(dist(0, 1)).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('tourLength', () => {
+  it('is finite and positive for a valid tour', () => {
+    const len = tourLength([0, 1, 2, 3, 4, 5, 6, 7])
+    expect(len).toBeGreaterThan(0)
+    expect(Number.isFinite(len)).toBe(true)
+  })
+
+  it('matches the brute-forced optimum for the perimeter tour', () => {
+    expect(tourLength([0, 1, 2, 3, 4, 5, 6, 7])).toBeCloseTo(OPT, 6)
+  })
+
+  it('matches the known length of the crafted quick-start tour', () => {
+    expect(tourLength(SCENARIOS.quick_convergence.initTour!)).toBeCloseTo(1128.8, 1)
+  })
+})
+
+describe('OPT is the true optimum (brute force)', () => {
+  it('no permutation of the 8 cities is shorter', () => {
+    let best = Infinity
+    const perm = Array.from({ length: N_CITIES - 1 }, (_, i) => i + 1)
+    const used = new Array<boolean>(perm.length).fill(false)
+    const order: number[] = [0]
+    const search = () => {
+      if (order.length === N_CITIES) {
+        const d = tourLength(order)
+        if (d < best) best = d
+        return
+      }
+      for (let k = 0; k < perm.length; k++) {
+        if (used[k]) continue
+        used[k] = true
+        order.push(perm[k])
+        search()
+        order.pop()
+        used[k] = false
+      }
+    }
+    search()
+    expect(best).toBeCloseTo(OPT, 6)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('seeded RNG', () => {
+  it('produces values in [0, 1)', () => {
+    let rng = makeRng(42)
+    for (let i = 0; i < 200; i++) {
+      const { value, rng: r2 } = nextRand(rng)
+      rng = r2
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThan(1)
+    }
+  })
+
+  it('is deterministic — same seed and counter give the same value', () => {
+    const a = nextRand(makeRng(7))
+    const b = nextRand(makeRng(7))
+    expect(a.value).toBe(b.value)
+    expect(a.rng).toEqual(b.rng)
+  })
+
+  it('advances the counter and (almost surely) changes the value', () => {
+    const a = nextRand(makeRng(7))
+    const b = nextRand(a.rng)
+    expect(a.rng.counter).toBe(1)
+    expect(b.rng.counter).toBe(2)
+    expect(b.value).not.toBe(a.value)
+  })
+
+  it('different seeds give different sequences', () => {
+    const a = nextRand(makeRng(1))
+    const b = nextRand(makeRng(2))
+    expect(a.value).not.toBe(b.value)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('seededShuffle', () => {
+  it('returns a permutation of all cities', () => {
+    const { tour } = seededShuffle(makeRng(123))
+    expect(isPermutation(tour)).toBe(true)
+  })
+
+  it('is reproducible for the same seed', () => {
+    const a = seededShuffle(makeRng(123))
+    const b = seededShuffle(makeRng(123))
+    expect(a.tour).toEqual(b.tour)
+    expect(a.rng).toEqual(b.rng)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('reverseSegment', () => {
+  it('reverses the inclusive segment [i..=j]', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7]
+    expect(reverseSegment(tour, 2, 5)).toEqual([0, 1, 5, 4, 3, 2, 6, 7])
+  })
+
+  it('does not mutate the input', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7]
+    const copy = [...tour]
+    reverseSegment(tour, 1, 6)
+    expect(tour).toEqual(copy)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('randomSuccessor', () => {
+  it('returns a valid permutation and a non-adjacent pair', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7]
+    const { tour: next, i, j, rng } = randomSuccessor(tour, makeRng(99))
+    expect(isPermutation(next)).toBe(true)
+    expect(i).toBeLessThan(j)
+    expect(j - i).toBeGreaterThan(1)
+    expect(next).toEqual(reverseSegment(tour, i, j))
+    expect(rng.counter).toBeGreaterThan(0)
+  })
+
+  it('reports the removed/added edges of the reversal', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7]
+    const n = tour.length
+    const { i, j, removed, added } = randomSuccessor(tour, makeRng(99))
+    expect(removed).toEqual([
+      [tour[(i - 1 + n) % n], tour[i]],
+      [tour[j], tour[(j + 1) % n]],
+    ])
+    expect(added).toEqual([
+      [tour[(i - 1 + n) % n], tour[j]],
+      [tour[i], tour[(j + 1) % n]],
+    ])
+  })
+})
+
+// ---------------------------------------------------------------
+describe('SCENARIOS', () => {
+  it('every tour (init or shuffle) is a valid permutation', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      const init = makeInitState(s)
+      expect(isPermutation(init.tour), `${key} tour must be a permutation`).toBe(true)
+      if (s.initTour) {
+        expect(isPermutation(s.initTour), `${key} initTour must be a permutation`).toBe(true)
+      }
+    }
+  })
+
+  it('quick_convergence starts from the crafted near-optimal tour', () => {
+    const s = makeInitState(SCENARIOS.quick_convergence)
+    expect(s.tour).toEqual([2, 1, 0, 3, 4, 5, 6, 7])
+    expect(s.bestCost).toBeCloseTo(1128.8, 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('makeInitState', () => {
+  it('starts idle with zeroed counters and best == current', () => {
+    const s = makeInitState(SCENARIOS.rugged_landscape)
+    expect(s.phase).toBe('idle')
+    expect(s.epoch).toBe(0)
+    expect(s.nStale).toBe(0)
+    expect(s.restarts).toBe(0)
+    expect(s.acceptedCount).toBe(0)
+    expect(s.rejectedCount).toBe(0)
+    expect(s.step).toBe(0)
+    expect(s.pending).toBeNull()
+    expect(s.bestTour).toEqual(s.tour)
+    expect(s.currentCost).toBeCloseTo(s.bestCost, 10)
+    expect(s.costHistory).toEqual([s.bestCost])
+  })
+
+  it('copies the tour (no shared reference)', () => {
+    const s = makeInitState(SCENARIOS.quick_convergence)
+    const original = s.tour[0]
+    s.tour[0] = 999
+    expect(s.bestTour[0]).toBe(original)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('stepOnce phase machine', () => {
+  const s0 = makeInitState(SCENARIOS.quick_convergence)
+
+  it('idle → propose draws a candidate without touching the tour', () => {
+    const s1 = stepOnce(s0)
+    expect(s1.phase).toBe('propose')
+    expect(s1.pending).not.toBeNull()
+    expect(s1.tour).toEqual(s0.tour)
+    expect(s1.epoch).toBe(0)
+    expect(s1.step).toBe(1)
+  })
+
+  it('propose → verdict applies and increments the epoch', () => {
+    const s1 = stepOnce(s0)
+    const s2 = stepOnce(s1)
+    expect(['accepted', 'rejected', 'restart', 'done']).toContain(s2.phase)
+    expect(s2.epoch).toBe(1)
+    expect(s2.step).toBe(2)
+    expect(s2.costHistory).toHaveLength(2)
+  })
+
+  it('an accepted verdict adopts the candidate tour and cost', () => {
+    // step until we observe an acceptance
+    let s = stepOnce(s0)
+    let guard = 200
+    while (guard-- > 0 && s.phase !== 'done') {
+      const next = stepOnce(s)
+      if (next.phase !== 'propose' && next.pending?.accepted) {
+        expect(next.tour).toEqual(next.pending.candidateTour)
+        expect(next.bestCost).toBeCloseTo(next.pending.candidateCost, 10)
+        expect(next.currentCost).toBeCloseTo(next.pending.candidateCost, 10)
+        expect(next.nStale).toBe(0)
+        return
+      }
+      s = next
+    }
+    expect.unreachable('expected at least one acceptance in the quick run')
+  })
+
+  it('a rejected verdict leaves the tour unchanged and counts the stale move', () => {
+    let s = stepOnce(s0)
+    let guard = 200
+    while (guard-- > 0 && s.phase !== 'done') {
+      const next = stepOnce(s)
+      if (next.phase !== 'propose' && next.pending && !next.pending.accepted && !next.pending.restart) {
+        expect(next.tour).toEqual(s.tour)
+        expect(next.bestCost).toBe(s.bestCost)
+        expect(next.nStale).toBe(s.nStale + 1)
+        return
+      }
+      s = next
+    }
+    expect.unreachable('expected at least one rejection in the quick run')
+  })
+
+  it('done is a no-op apart from the step counter', () => {
+    const done = runToDone(SCENARIOS.quick_convergence.seed, 10, 5, SCENARIOS.quick_convergence.initTour)
+    const again = stepOnce(done)
+    expect(again.phase).toBe('done')
+    expect(again.epoch).toBe(done.epoch)
+    expect(again.tour).toEqual(done.tour)
+    expect(again.step).toBe(done.step + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('Rust-faithful acceptance (candidate must beat best-so-far)', () => {
+  it('every accepted verdict beats the previous best', () => {
+    let s = makeInitState(SCENARIOS.needle_in_haystack)
+    let guard = 1000
+    while (s.phase !== 'done' && guard-- > 0) {
+      const next = stepOnce(s)
+      if (next.phase !== 'propose' && next.pending?.accepted) {
+        expect(next.pending.candidateCost).toBeLessThan(s.bestCost)
+      }
+      s = next
+    }
+  })
+
+  it('after a restart, a candidate can improve the current tour yet still be rejected (delta<0, not accepted)', () => {
+    // needle seed 1548 restarts several times; on the climb after a restart the
+    // fresh random tour is worse than best, so a delta<0 candidate may still
+    // not beat best — the Rust-faithful quirk.
+    let s = makeInitState(SCENARIOS.needle_in_haystack)
+    let sawRestart = false
+    let sawQuirk = false
+    let guard = 1000
+    while (s.phase !== 'done' && guard-- > 0) {
+      const next = stepOnce(s)
+      if (next.phase === 'restart') sawRestart = true
+      if (next.phase === 'propose' && next.pending && sawRestart) {
+        if (next.pending.delta < 0 && !next.pending.accepted) sawQuirk = true
+      }
+      s = next
+    }
+    expect(sawRestart).toBe(true)
+    expect(sawQuirk, 'expected a delta<0-but-rejected candidate after a restart').toBe(true)
+  })
+
+  it('acceptedCount + rejectedCount + restarts == epoch (verdicts partition)', () => {
+    const s = runToDone(SCENARIOS.rugged_landscape.seed, 30, 5)
+    expect(s.acceptedCount + s.rejectedCount + s.restarts).toBe(s.epoch)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('restart logic', () => {
+  it('restarts only after patience+1 consecutive rejections and keeps the best', () => {
+    // Rugged seed 917 restarts a lot; check one restart event precisely.
+    let s = makeInitState(SCENARIOS.rugged_landscape)
+    let guard = 1000
+    while (s.phase !== 'done' && guard-- > 0) {
+      const next = stepOnce(s)
+      if (next.phase === 'restart') {
+        expect(next.pending?.restart).toBe(true)
+        expect(next.pending?.restartTour).not.toBeNull()
+        expect(next.tour).toEqual(next.pending!.restartTour)
+        expect(next.bestCost).toBe(s.bestCost) // best survives
+        expect(next.bestTour).toEqual(s.bestTour)
+        expect(next.nStale).toBe(0)
+        expect(next.restarts).toBe(s.restarts + 1)
+        return
+      }
+      s = next
+    }
+    expect.unreachable('expected at least one restart in the rugged run')
+  })
+
+  it('never restarts on an accepted move (acceptance resets staleness)', () => {
+    let s = makeInitState(SCENARIOS.needle_in_haystack)
+    let guard = 1000
+    while (s.phase !== 'done' && guard-- > 0) {
+      const next = stepOnce(s)
+      if (next.phase !== 'propose' && next.pending?.accepted) {
+        expect(next.phase).not.toBe('restart')
+        expect(next.nStale).toBe(0)
+      }
+      s = next
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+describe('cost bookkeeping', () => {
+  it('best cost never increases and costHistory is non-increasing', () => {
+    const s = runToDone(SCENARIOS.needle_in_haystack.seed, 40, 6)
+    expect(s.bestCost).toBeLessThanOrEqual(s.costHistory[0])
+    for (let k = 1; k < s.costHistory.length; k++) {
+      expect(s.costHistory[k]).toBeLessThanOrEqual(s.costHistory[k - 1])
+    }
+    expect(s.costHistory).toHaveLength(s.epoch + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('pinned scenario behaviour', () => {
+  it('quick_convergence: reaches the optimum with no restarts, first improvement at epoch 1', () => {
+    const s = runToDone(SCENARIOS.quick_convergence.seed, SCENARIOS.quick_convergence.epochs, SCENARIOS.quick_convergence.patience, SCENARIOS.quick_convergence.initTour)
+    expect(s.restarts).toBeLessThanOrEqual(1)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+    expect(s.acceptedCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('rugged_landscape: many restarts and a poor final result', () => {
+    const s = runToDone(SCENARIOS.rugged_landscape.seed, SCENARIOS.rugged_landscape.epochs, SCENARIOS.rugged_landscape.patience)
+    expect(s.restarts).toBeGreaterThanOrEqual(6)
+    expect(s.bestCost).toBeGreaterThanOrEqual(OPT * 1.2)
+  })
+
+  it('needle_in_haystack: the optimum is found, but only after several restarts', () => {
+    const scenario = SCENARIOS.needle_in_haystack
+    let s = makeInitState(scenario)
+    let finalBestEpoch = 0
+    let restartsBeforeFinal = 0
+    let guard = 2000
+    while (s.phase !== 'done' && guard-- > 0) {
+      const before = s
+      s = stepOnce(s)
+      if (before.phase === 'propose' && s.phase !== 'propose' && s.bestCost < before.bestCost) {
+        finalBestEpoch = s.epoch
+        restartsBeforeFinal = s.restarts
+      }
+    }
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+    expect(s.restarts).toBeGreaterThanOrEqual(4)
+    expect(finalBestEpoch).toBeGreaterThanOrEqual(35)
+    expect(restartsBeforeFinal).toBeGreaterThanOrEqual(2)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('determinism & purity', () => {
+  it('stepOnce is pure — the input state is never mutated', () => {
+    const s = makeInitState(SCENARIOS.rugged_landscape)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 20; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same seed produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.rugged_landscape)
+    const b = makeInitState(SCENARIOS.rugged_landscape)
+    for (let i = 0; i < 30; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+})

--- a/teeline-web/src/explainers/stochastic-hill.test.ts
+++ b/teeline-web/src/explainers/stochastic-hill.test.ts
@@ -170,6 +170,19 @@ describe('randomSuccessor', () => {
       [tour[i], tour[(j + 1) % n]],
     ])
   })
+
+  it('handles the (0, n−1) full-tour reversal with a single wrap edge (no self-loops)', () => {
+    const tour = [0, 1, 2, 3, 4, 5, 6, 7]
+    const n = tour.length
+    let hit: { removed: [number, number][]; added: [number, number][] } | null = null
+    for (let seed = 1; seed <= 5000 && !hit; seed++) {
+      const { i, j, removed, added } = randomSuccessor(tour, makeRng(seed))
+      if (i === 0 && j === n - 1) hit = { removed, added }
+    }
+    expect(hit, 'expected a seed producing the (0, n−1) full-tour reversal').not.toBeNull()
+    expect(hit!.removed).toEqual([[tour[n - 1], tour[0]]])
+    expect(hit!.added).toEqual([[tour[n - 1], tour[0]]])
+  })
 })
 
 // ---------------------------------------------------------------

--- a/teeline-web/src/explainers/stochastic-hill.tsx
+++ b/teeline-web/src/explainers/stochastic-hill.tsx
@@ -1,0 +1,535 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES, SCENARIOS,
+  tourLength, makeInitState, stepOnce,
+} from "./stochastic-hill-algo"
+import type { Phase, CandidateEvent, Scenario } from "./stochastic-hill-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.quick_convergence
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+function sameTour(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}
+
+function edgeKey(a: number, b: number): string {
+  return `${Math.min(a, b)}-${Math.max(a, b)}`
+}
+
+// ---------------------------------------------------------------
+// TourCanvas — ghost best tour behind the current tour, with
+// candidate/verdict edge highlighting and a restart fade.
+// ---------------------------------------------------------------
+function TourCanvas({ tour, bestTour, pending, phase }: {
+  tour: number[]
+  bestTour: number[]
+  pending: CandidateEvent | null
+  phase: Phase
+}) {
+  const showGhost = !sameTour(bestTour, tour)
+
+  const removedSet = useMemo(() => {
+    if (!pending) return new Set<string>()
+    return new Set(pending.removed.map(([a, b]) => edgeKey(a, b)))
+  }, [pending])
+  const addedSet = useMemo(() => {
+    if (!pending) return new Set<string>()
+    return new Set(pending.added.map(([a, b]) => edgeKey(a, b)))
+  }, [pending])
+
+  const edges: Array<{ from: number; to: number; key: string }> = []
+  for (let k = 0; k < tour.length; k++) {
+    const a = tour[k]
+    const b = tour[(k + 1) % tour.length]
+    edges.push({ from: a, to: b, key: edgeKey(a, b) })
+  }
+
+  const isPropose = phase === 'propose' && pending
+  const isAccepted = phase === 'accepted' && pending
+  const isRejected = phase === 'rejected' && pending
+  const isRestarting = phase === 'restart'
+
+  return (
+    <svg viewBox="0 0 300 300" className={`shc-canvas ${isAccepted ? 'shc-glow' : ''}`}
+      role="img" aria-label="Stochastic hill climbing tour">
+      <rect x={0} y={0} width={300} height={300} className="shc-bg" />
+
+      {/* Ghost of the best tour found so far (visible when it differs — i.e. after a restart) */}
+      {showGhost && (
+        <g className="shc-ghost">
+          {bestTour.map((_id, k) => {
+            const a = bestTour[k]
+            const b = bestTour[(k + 1) % bestTour.length]
+            return <line key={`g${edgeKey(a, b)}`} className="shc-edge-ghost"
+              x1={CITIES[a][0]} y1={CITIES[a][1]}
+              x2={CITIES[b][0]} y2={CITIES[b][1]} />
+          })}
+        </g>
+      )}
+
+      <g className={isRestarting ? 'shc-restarting' : ''}>
+        {edges.map(({ from, to, key }) => {
+          let cls = 'shc-edge'
+          if (isPropose) {
+            if (removedSet.has(key)) cls += ' shc-cand-removed'
+            else if (addedSet.has(key)) cls += ' shc-cand-added'
+          } else if (isAccepted) {
+            if (removedSet.has(key)) cls += ' shc-removed'
+            else if (addedSet.has(key)) cls += ' shc-added'
+          } else if (isRejected) {
+            if (removedSet.has(key)) cls += ' shc-rejected'
+          }
+          return <line key={key} className={cls}
+            x1={CITIES[from][0]} y1={CITIES[from][1]}
+            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+        })}
+        {tour.map((id) => (
+          <g key={id}>
+            <circle className="shc-city"
+              cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
+            <text className="shc-label"
+              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Best-cost sparkline (same pattern as 2-opt / ACO)
+// ---------------------------------------------------------------
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null
+  const W = 300, H = 46
+  const minV = Math.min(...values)
+  const maxV = Math.max(...values)
+  const range = maxV - minV || 1
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W
+    const y = H - ((v - minV) / range) * (H - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="shc-spark" aria-label="best cost over epochs">
+      <rect x={0} y={0} width={W} height={H} className="shc-bg" rx={4} />
+      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
+        strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function StochasticHillExplainer() {
+  const [tour, setTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.initTour!])
+  const [bestTour, setBestTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.initTour!])
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [epoch, setEpoch] = useState(0)
+  const [nStale, setNStale] = useState(0)
+  const [restarts, setRestarts] = useState(0)
+  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.initTour!))
+  const [currentCost, setCurrentCost] = useState(() => tourLength(DEFAULT_SCENARIO.initTour!))
+  const [acceptedCount, setAcceptedCount] = useState(0)
+  const [rejectedCount, setRejectedCount] = useState(0)
+  const [pending, setPending] = useState<CandidateEvent | null>(null)
+  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.initTour!)])
+  const [step, setStep] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(3) // 4x default — 8-city runs are short; keep them snappy
+  const [epochsInput, setEpochsInput] = useState(DEFAULT_SCENARIO.epochs)
+  const [patienceInput, setPatienceInput] = useState(DEFAULT_SCENARIO.patience)
+
+  const simRef = useRef(makeInitState(DEFAULT_SCENARIO))
+  const historyRef = useRef<Array<typeof simRef.current>>([])
+  const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
+
+  const reinit = useCallback((scenario: Scenario) => {
+    scenarioRef.current = scenario
+    simRef.current = makeInitState(scenario)
+    historyRef.current = []
+    setTour([...simRef.current.tour])
+    setBestTour([...simRef.current.bestTour])
+    setPhase('idle')
+    setEpoch(0)
+    setNStale(0)
+    setRestarts(0)
+    setBestCost(simRef.current.bestCost)
+    setCurrentCost(simRef.current.currentCost)
+    setAcceptedCount(0)
+    setRejectedCount(0)
+    setPending(null)
+    setCostHistory([simRef.current.bestCost])
+    setStep(0)
+    setRunning(false)
+    setEpochsInput(scenario.epochs)
+    setPatienceInput(scenario.patience)
+  }, [])
+
+  const step_fn = useCallback(() => {
+    historyRef.current.push(structuredClone(simRef.current))
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setTour([...next.tour])
+    setBestTour([...next.bestTour])
+    setPhase(next.phase)
+    setEpoch(next.epoch)
+    setNStale(next.nStale)
+    setRestarts(next.restarts)
+    setBestCost(next.bestCost)
+    setCurrentCost(next.currentCost)
+    setAcceptedCount(next.acceptedCount)
+    setRejectedCount(next.rejectedCount)
+    setPending(next.pending)
+    setCostHistory([...next.costHistory])
+    setStep(next.step)
+    if (next.phase === 'done') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    const prev = h.pop()!
+    simRef.current = prev
+    setTour([...prev.tour])
+    setBestTour([...prev.bestTour])
+    setPhase(prev.phase)
+    setEpoch(prev.epoch)
+    setNStale(prev.nStale)
+    setRestarts(prev.restarts)
+    setBestCost(prev.bestCost)
+    setCurrentCost(prev.currentCost)
+    setAcceptedCount(prev.acceptedCount)
+    setRejectedCount(prev.rejectedCount)
+    setPending(prev.pending)
+    setCostHistory([...prev.costHistory])
+    setStep(prev.step)
+  }, [running])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = SPEEDS[speedIdx]
+    const id = setInterval(step_fn, ms)
+    return () => clearInterval(id)
+  }, [running, speedIdx, step_fn])
+
+  // Restart-pace params are per-scenario defaults, user-adjustable; changing
+  // them restarts the run with the new values (keeps the current scenario).
+  const applyParams = useCallback((epochs: number, patience: number) => {
+    const sc = scenarioRef.current
+    reinit({
+      ...sc,
+      epochs: Math.max(1, Math.min(500, Math.floor(epochs))),
+      patience: Math.max(1, Math.min(100, Math.floor(patience))),
+    })
+  }, [reinit])
+
+  const acceptRate = acceptedCount + rejectedCount > 0
+    ? Math.round((acceptedCount / (acceptedCount + rejectedCount)) * 100)
+    : null
+
+  // Status chip
+  let chipText = "Click Step to draw a random 2-opt candidate"
+  let chipClass = "shc-chip shc-chip-idle"
+  if (phase === 'propose' && pending) {
+    chipText = `Candidate — reverse ${pending.i}…${pending.j}  (Δ=${pending.delta.toFixed(0)}, ${pending.accepted ? 'beats best' : 'won’t beat best'})`
+    chipClass = "shc-chip shc-chip-candidate"
+  } else if (phase === 'accepted' && pending) {
+    chipText = `Accepted — new best ${bestCost.toFixed(0)}  (Δ=${pending.delta.toFixed(0)})`
+    chipClass = "shc-chip shc-chip-accepted"
+  } else if (phase === 'rejected' && pending) {
+    chipText = `Rejected — Δ=${pending.delta.toFixed(0)}, candidate ${pending.candidateCost.toFixed(0)} ≥ best ${bestCost.toFixed(0)}  (${nStale} stale)`
+    chipClass = "shc-chip shc-chip-rejected"
+  } else if (phase === 'restart') {
+    chipText = "Restarting… search went stale — fresh random tour appears (best survives)"
+    chipClass = "shc-chip shc-chip-restart"
+  } else if (phase === 'done') {
+    chipText = `Done — ${epoch} epochs · ${restarts} restarts · best ${bestCost.toFixed(0)}`
+    chipClass = "shc-chip shc-chip-done"
+  }
+
+  return (
+    <div className="shc-root">
+      <style>{CSS}</style>
+
+      <header className="shc-header">
+        <div className="shc-eyebrow">teeline · algorithms/stochastic_hill</div>
+        <h2 className="shc-title">Stochastic Hill Climbing</h2>
+        <p className="shc-sub">
+          Each step draws a <strong>random 2-opt candidate</strong> — a random segment reversal.
+          The candidate is accepted only if it <strong>beats the best tour found so far</strong>;
+          otherwise it is rejected and the tour stays. When the search goes stale (too many
+          rejections in a row), it <strong>restarts from a fresh random tour</strong> — the best
+          tour survives. Random restarts are what rescue the search from mediocre local optima.
+        </p>
+      </header>
+
+      <div className="shc-viz-row">
+        <div className="shc-canvas-wrap">
+          <TourCanvas tour={tour} bestTour={bestTour} pending={pending} phase={phase} />
+        </div>
+      </div>
+
+      <div className="shc-legend">
+        <span><span className="shc-swatch shc-swatch-normal" /> tour edge</span>
+        <span><span className="shc-swatch shc-swatch-ghost" /> best tour (ghost)</span>
+        <span><span className="shc-swatch shc-swatch-cand-rm" /> candidate (remove)</span>
+        <span><span className="shc-swatch shc-swatch-cand-ad" /> candidate (add)</span>
+        <span><span className="shc-swatch shc-swatch-removed" /> removed</span>
+        <span><span className="shc-swatch shc-swatch-added" /> new edge</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="shc-section-label">Best cost over epochs</div>
+      <Sparkline values={costHistory} />
+
+      <div className="shc-statgrid">
+        <div>
+          <div className="shc-statlabel">epoch</div>
+          <div className="shc-mono">{epoch}</div>
+        </div>
+        <div>
+          <div className="shc-statlabel">restarts</div>
+          <div className="shc-mono">{restarts}</div>
+        </div>
+        <div>
+          <div className="shc-statlabel">best cost</div>
+          <div className="shc-mono">{bestCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="shc-statlabel">current cost</div>
+          <div className="shc-mono">{currentCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="shc-statlabel">accept rate</div>
+          <div className="shc-mono">{acceptRate === null ? '—' : `${acceptRate}%`}</div>
+        </div>
+        <div>
+          <div className="shc-statlabel">step</div>
+          <div className="shc-mono">{step}</div>
+        </div>
+      </div>
+
+      <div className="shc-config">
+        <div className="shc-config-row">
+          <label className="shc-label" htmlFor="shc-epochs">Epochs</label>
+          <input id="shc-epochs" className="shc-input" type="number" min={1} max={500}
+            value={epochsInput}
+            onInput={(e) => setEpochsInput(Number((e.target as HTMLInputElement).value))}
+            onBlur={() => applyParams(epochsInput, patienceInput)} />
+          <label className="shc-label" htmlFor="shc-patience">Restart patience</label>
+          <input id="shc-patience" className="shc-input" type="number" min={1} max={100}
+            value={patienceInput}
+            onInput={(e) => setPatienceInput(Number((e.target as HTMLInputElement).value))}
+            onBlur={() => applyParams(epochsInput, patienceInput)} />
+        </div>
+        <div className="shc-config-row">
+          <label className="shc-label">Speed</label>
+          <div className="shc-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l}
+                className={`shc-speed-btn ${i === speedIdx ? 'shc-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="shc-controls">
+        <button className="shc-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+          ⏴ Back
+        </button>
+        <button className="shc-btn" onClick={step_fn} disabled={running || phase === 'done'}>
+          ⏵ Step
+        </button>
+        <button className="shc-btn" onClick={() => setRunning(!running)} disabled={phase === 'done'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="shc-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+      </div>
+
+      <div className="shc-scenarios">
+        <div className="shc-section-label">Scenarios</div>
+        <div className="shc-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, s]) => (
+            <button key={key} className="shc-scenario-btn" title={s.desc}
+              onClick={() => reinit(s)}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="shc-footer">
+        <span className="shc-mono">cities: {N_CITIES}</span>
+        <span className="shc-mono">random 2-opt · accept only if &lt; best · random restart</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.shc-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --improve: #16a34a;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.shc-root * { box-sizing: border-box; }
+.shc-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.shc-header { margin-bottom: 2px; }
+.shc-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.shc-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.shc-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.shc-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+  transition: box-shadow 0.3s ease;
+}
+.shc-glow { box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.35); }
+.shc-bg { fill: var(--panel); }
+.shc-edge { stroke: #94a3b8; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.shc-edge-ghost { stroke: #64748b; stroke-width: 1.5; stroke-dasharray: 2 4; opacity: 0.35; }
+.shc-cand-removed { stroke: #ea580c; stroke-width: 3.5; stroke-dasharray: 6 4; }
+.shc-cand-added { stroke: #16a34a; stroke-width: 3.5; stroke-dasharray: 4 6; }
+.shc-removed { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 6 3; }
+.shc-added { stroke: #16a34a; stroke-width: 3.5; }
+.shc-rejected { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 3 3; animation: shc-flash-red 0.6s ease; }
+.shc-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
+.shc-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+@keyframes shc-flash-red {
+  0% { opacity: 0.3; }
+  50% { opacity: 1; }
+  100% { opacity: 1; }
+}
+@keyframes shc-fade {
+  0% { opacity: 1; }
+  45% { opacity: 0.12; }
+  55% { opacity: 0.12; }
+  100% { opacity: 1; }
+}
+.shc-restarting { animation: shc-fade 1.1s ease-in-out; }
+
+.shc-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.shc-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+.shc-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.shc-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.shc-swatch-normal { background: #94a3b8; }
+.shc-swatch-ghost { background: #64748b; }
+.shc-swatch-cand-rm { background: #ea580c; }
+.shc-swatch-cand-ad { background: #16a34a; }
+.shc-swatch-removed { background: #ef4444; }
+.shc-swatch-added { background: #16a34a; }
+
+.shc-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.shc-chip-idle { background: #f1f5f9; color: var(--muted); }
+.shc-chip-candidate { background: #ffedd5; color: #9a3412; }
+.shc-chip-accepted { background: #dcfce7; color: #166534; }
+.shc-chip-rejected { background: #fee2e2; color: #991b1b; }
+.shc-chip-restart { background: #ede9fe; color: #5b21b6; }
+.shc-chip-done { background: #f1f5f9; color: var(--muted); }
+
+.shc-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.shc-spark { width: 100%; display: block; border-radius: 6px; }
+
+.shc-statgrid {
+  display: flex; flex-wrap: wrap; gap: 14px 22px;
+  font-size: 0.82rem;
+}
+.shc-statlabel { color: var(--muted); font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.shc-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.shc-config-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.shc-label {
+  font-size: 0.82rem; font-weight: 500; color: var(--text);
+}
+.shc-input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem; width: 72px; padding: 4px 6px;
+  border: 1px solid var(--line); border-radius: 5px; background: var(--bg); color: var(--text);
+}
+.shc-speed-btns { display: flex; gap: 4px; }
+.shc-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.shc-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.shc-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.shc-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.shc-controls { display: flex; gap: 8px; }
+.shc-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.shc-btn:hover:not(:disabled) { background: #f0fdf4; }
+.shc-btn:disabled { opacity: 0.4; cursor: default; }
+
+.shc-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.shc-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.shc-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.shc-scenario-btn:hover { background: #f0fdf4; border-color: var(--accent); }
+
+.shc-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/stochastic-hill.tsx
+++ b/teeline-web/src/explainers/stochastic-hill.tsx
@@ -169,7 +169,7 @@ export default function StochasticHillExplainer() {
     setPatienceInput(scenario.patience)
   }, [])
 
-  const step_fn = useCallback(() => {
+  const stepForward = useCallback(() => {
     historyRef.current.push(structuredClone(simRef.current))
     const next = stepOnce(simRef.current)
     simRef.current = next
@@ -212,19 +212,22 @@ export default function StochasticHillExplainer() {
   useEffect(() => {
     if (!running) return
     const ms = SPEEDS[speedIdx]
-    const id = setInterval(step_fn, ms)
+    const id = setInterval(stepForward, ms)
     return () => clearInterval(id)
-  }, [running, speedIdx, step_fn])
+  }, [running, speedIdx, stepForward])
 
   // Restart-pace params are per-scenario defaults, user-adjustable; changing
   // them restarts the run with the new values (keeps the current scenario).
   const applyParams = useCallback((epochs: number, patience: number) => {
     const sc = scenarioRef.current
-    reinit({
-      ...sc,
-      epochs: Math.max(1, Math.min(500, Math.floor(epochs))),
-      patience: Math.max(1, Math.min(100, Math.floor(patience))),
-    })
+    // Math.floor(x) || 1 guards against NaN (a partially-typed number input
+    // like "-" or ".") and 0 — either would otherwise break the epoch cap /
+    // restart threshold (e.g. maxEpochs: NaN never triggers 'done').
+    const clampedEpochs = Math.max(1, Math.min(500, Math.floor(epochs) || 1))
+    const clampedPatience = Math.max(1, Math.min(100, Math.floor(patience) || 1))
+    setEpochsInput(clampedEpochs)
+    setPatienceInput(clampedPatience)
+    reinit({ ...sc, epochs: clampedEpochs, patience: clampedPatience })
   }, [reinit])
 
   const acceptRate = acceptedCount + rejectedCount > 0
@@ -345,7 +348,7 @@ export default function StochasticHillExplainer() {
         <button className="shc-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
           ⏴ Back
         </button>
-        <button className="shc-btn" onClick={step_fn} disabled={running || phase === 'done'}>
+        <button className="shc-btn" onClick={stepForward} disabled={running || phase === 'done'}>
           ⏵ Step
         </button>
         <button className="shc-btn" onClick={() => setRunning(!running)} disabled={phase === 'done'}>

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -28,6 +28,7 @@ import FourierExplainer from '../../../../explainers/fourier'
 import GreedyEdgeExplainer from '../../../../explainers/greedy-edge'
 import SavingsExplainer from '../../../../explainers/savings'
 import AcoExplainer from '../../../../explainers/aco'
+import StochasticHillExplainer from '../../../../explainers/stochastic-hill'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -69,6 +70,7 @@ const jsonLd = {
     {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
     {id === 'savings' && <SavingsExplainer client:visible />}
     {id === 'aco' && <AcoExplainer client:visible />}
+    {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
   </main>

--- a/teeline-web/tests/explainer-stochastic-hill.spec.ts
+++ b/teeline-web/tests/explainer-stochastic-hill.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the Stochastic Hill Climbing explainer
+// (/algorithms/stochastic_hill/explainer/). The component hydrates with
+// `client:visible`, so the tests first scroll it into view and probe until
+// the Preact listeners are attached (a click that changes the status chip),
+// then reset to the idle phase.
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.shc-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.shc-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  // Retry the click until it lands post-hydration (pre-hydration clicks are no-ops).
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('Candidate', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  // back to the idle phase for deterministic tests
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(chip).toContainText('Click Step')
+}
+
+test.describe('stochastic hill explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/stochastic_hill/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the canvas, stats panel and controls', async ({ page }) => {
+    await expect(page.locator('.shc-title')).toHaveText('Stochastic Hill Climbing')
+    await expect(page.locator('.shc-canvas')).toBeVisible()
+    // sparkline section label is present; the line itself appears after the
+    // first verdict (needs ≥ 2 cost samples)
+    await expect(page.locator('.shc-section-label', { hasText: 'Best cost over epochs' })).toBeVisible()
+
+    // stats panel
+    const stats = page.locator('.shc-statgrid')
+    await expect(stats).toContainText('epoch')
+    await expect(stats).toContainText('restarts')
+    await expect(stats).toContainText('best cost')
+    await expect(stats).toContainText('current cost')
+    await expect(stats).toContainText('accept rate')
+
+    // all three scenario buttons
+    for (const label of ['Quick convergence', 'Rugged landscape', 'Needle in haystack']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step advances the two-phase machine (propose → verdict)', async ({ page }) => {
+    const chip = page.locator('.shc-chip')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('Candidate')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    // verdict chip: accepted, rejected or restarting
+    await expect(chip).toContainText(/Accepted|Rejected|Restarting/)
+    // sparkline appears once there are ≥ 2 best-cost samples
+    await expect(page.locator('.shc-spark')).toBeVisible()
+
+    // epoch advanced by exactly one verdict
+    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+    await expect(epoch).toHaveText('1')
+  })
+
+  test('Back restores the previous phase', async ({ page }) => {
+    const chip = page.locator('.shc-chip')
+    const stepStat = page.locator('.shc-statgrid').locator('div', { hasText: /^step/ }).locator('.shc-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click() // propose
+    await page.getByRole('button', { name: 'Step' }).click() // verdict
+    await expect(stepStat).toHaveText('2')
+
+    await page.getByRole('button', { name: 'Back' }).click()
+    await expect(chip).toContainText('Candidate') // back to the propose phase
+    await expect(stepStat).toHaveText('1')
+  })
+
+  test('Run animates epochs; Pause and Reset stop and reset', async ({ page }) => {
+    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+    const run = page.getByRole('button', { name: 'Run' })
+
+    await run.click()
+    await expect(epoch).not.toHaveText('0', { timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await epoch.textContent()
+    await page.waitForTimeout(500)
+    await expect(epoch).toHaveText(paused ?? '')
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(epoch).toHaveText('0')
+    await expect(page.locator('.shc-chip')).toContainText('Click Step')
+  })
+
+  test('scenario buttons restart the run with their own parameters', async ({ page }) => {
+    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+    const restarts = page.locator('.shc-statgrid').locator('div', { hasText: /^restarts/ }).locator('.shc-mono')
+
+    await page.getByRole('button', { name: 'Rugged landscape' }).click()
+    await expect(epoch).toHaveText('0')
+    await expect(restarts).toHaveText('0')
+    await expect(page.locator('.shc-chip')).toContainText('Click Step')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(page.locator('.shc-chip')).toContainText('Candidate')
+  })
+
+  test('epochs / restart-patience inputs commit on blur and restart the run', async ({ page }) => {
+    const epochsInput = page.locator('#shc-epochs')
+    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+
+    // advance a few steps first
+    await page.getByRole('button', { name: 'Run' }).click()
+    await expect(epoch).not.toHaveText('0', { timeout: 10_000 })
+    await page.getByRole('button', { name: 'Pause' }).click()
+
+    await epochsInput.fill('20')
+    await epochsInput.blur()
+    // changing parameters restarts the run
+    await expect(epoch).toHaveText('0')
+    await expect(epochsInput).toHaveValue('20')
+  })
+})


### PR DESCRIPTION
## What

Interactive explainer for **Stochastic Hill Climbing** at `/algorithms/stochastic_hill/explainer/`, following the established 2-opt/NN explainer pattern (pure `*-algo.ts` simulation + Preact `*.tsx` + vitest + Playwright e2e).

**Rust-faithful simulation** (`src/tsp/stochastic_hill.rs`): each epoch draws one random 2-opt candidate (random non-adjacent pair, inclusive segment reversal — `route.rs` `swap_cities`); the candidate is accepted **only if it beats the best-so-far cost**, so `current == best` except right after a restart, when a fresh random tour is shown until it beats the best or the search goes stale again (`nStale > patience` → shuffle, best survives).

**8 cities in a ring** (10-city layout minus the two inner points) so a full scenario run stays short — the point is explaining the mechanics (random 2-opt, accept-if-better, restart-when-stale), not solving the instance.

**Deterministic**: all randomness comes from a pure counter-based RNG (seed + counter) stored inside `SimState`, so Back/Step replay identically and tests assert exact sequences.

## Scenarios (seeds tuned offline)

| Scenario | Start | Behaviour |
|---|---|---|
| Quick convergence | crafted `[2,1,0,3,4,5,6,7]` (1.36×opt) | reaches the optimum (827.8) at epoch 15, **0 restarts** |
| Rugged landscape | random shuffle | **9 restarts**, ends at 1.65×opt |
| Needle in haystack | random shuffle | optimum only at epoch 37, **after 4 restarts** |

## UI

SVG canvas with a dim ghost of the best tour behind the current one, orange-dashed candidate edges, red/green verdict flashes, restart fade-in of a new random tour, best-cost sparkline, stats (epochs, restarts, best/current cost, acceptance rate), epochs + restart-patience inputs, speed slider, Back/Step/Run/Pause/Reset, scenario buttons.

## Files

- `teeline-web/src/explainers/stochastic-hill-algo.ts` — pure simulation
- `teeline-web/src/explainers/stochastic-hill.tsx` — Preact component
- `teeline-web/src/explainers/stochastic-hill.test.ts` — 36 unit tests
- `teeline-web/tests/explainer-stochastic-hill.spec.ts` — 6 Playwright e2e tests
- `teeline-web/src/explainers/registry.ts`, `teeline-web/src/pages/algorithms/[id]/explainer/index.astro`, `docs/algorithms/stochastic-hill.md` — wiring

## Verification

- `vitest run`: 368 tests pass (28 files)
- `astro check` + `tsc --noEmit`: clean
- Playwright e2e (`--project=chrome`): 6/6 pass against the Astro dev server

Closes #433