### PR TITLE
feat(web): add interactive Or-opt explainer (#432)

### DIFF
--- a/docs/algorithms/or-opt.md
+++ b/docs/algorithms/or-opt.md
@@ -3,7 +3,7 @@ id: "or_opt"
 name: "Or-opt"
 typeBadge: "Heuristic — local search"
 description: "Local search algorithm that relocates segments of 1, 2, or 3 consecutive cities to a better position elsewhere in the tour."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Or-opt

--- a/teeline-web/src/explainers/or-opt-algo.ts
+++ b/teeline-web/src/explainers/or-opt-algo.ts
@@ -1,0 +1,276 @@
+// Pure simulation logic for the Or-opt interactive explainer.
+// Rust-faithful model (src/tsp/or_opt.rs):
+//   - each pass scans ALL relocations of segments of length 1, 2 and 3
+//     (Or-1/Or-2/Or-3) and applies the single best-improving move
+//   - reversed insertions are also tried for Or-2/Or-3 (symmetric distances)
+//   - repeats until no relocation improves the tour (local optimum)
+// Move encoding follows the Rust solver exactly: (i, seg_len, j, reversed)
+// with `i` = segment start, `j` = insert after original position j,
+// the forbidden window {prev} ∪ [i, i+seg_len), the −1e-3 float threshold,
+// and the drain/splice index adjustment in applyRelocation.
+// Deterministic — no RNG, so Back/Step replay identically and tests can
+// assert exact sequences. No DOM, fully testable.
+
+export const CITIES: [number, number][] = [
+  [150, 20],   // 0 — top
+  [270, 70],   // 1 — top-right
+  [260, 180],  // 2 — right
+  [180, 280],  // 3 — bottom-right
+  [120, 290],  // 4 — bottom
+  [35, 220],   // 5 — bottom-left
+  [25, 80],    // 6 — left
+  [80, 25],    // 7 — top-left
+  [155, 155],  // 8 — centre
+  [90, 140],   // 9 — inner-left
+]
+export const N_CITIES = CITIES.length
+
+export type Phase = 'idle' | 'candidate' | 'move_applied' | 'local_optimum'
+
+export function dist(i: number, j: number): number {
+  const dx = CITIES[i][0] - CITIES[j][0]
+  const dy = CITIES[i][1] - CITIES[j][1]
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+export function tourLength(tour: number[]): number {
+  let d = 0
+  for (let k = 0; k < tour.length; k++) {
+    d += dist(tour[k], tour[(k + 1) % tour.length])
+  }
+  return d
+}
+
+// ---------------------------------------------------------------
+// The candidate move (Rust find_best_move + apply_relocation port)
+// ---------------------------------------------------------------
+export interface MoveEvent {
+  i: number             // segment start index (original tour indexing)
+  segLen: 1 | 2 | 3
+  j: number             // insert after original position j
+  reversed: boolean     // reversed insertion (Or-2 / Or-3 only)
+  delta: number         // new tour length − old tour length (negative = improvement)
+  segCities: number[]   // cities in the segment, in tour order
+  insertAfter: number   // city the segment lands after (path[j])
+  insertBefore: number  // city the segment lands before (path[(j+1) % n])
+  cutEdges: [number, number][]   // edges removed: prev→first, last→after, x→y
+  pasteEdges: [number, number][] // edges added: prev→after, x→first, last→y (or reversed)
+  improvingGaps: number[]        // original positions j with any improving move (scan ticks)
+}
+
+export interface SimState {
+  phase: Phase
+  tour: number[]
+  bestTour: number[]
+  bestCost: number
+  pass: number          // completed scans (one per applied move + final local-optimum scan)
+  moves: number         // applied relocations
+  pending: MoveEvent | null // candidate awaiting its apply phase
+  lastMove: MoveEvent | null // most recently applied move (for the flash)
+  costHistory: number[] // best cost after each pass (sparkline)
+  step: number
+}
+
+// Rust find_best_move: scan all Or-1/2/3 relocations, return the best
+// improving move (delta < −1e-3) or null. Tie-break order matches Rust:
+// seg_len asc → i asc → j asc → forward before reversed.
+export function scanBestMove(tour: number[]): MoveEvent | null {
+  const n = tour.length
+  const improvingGaps = new Set<number>()
+  // −1e-3 threshold + strictly-lower replacement, same as the solver's
+  // best_delta (f32 rounding guard at large coordinate scales).
+  let bestDelta = -1e-3
+  let best: {
+    i: number
+    segLen: 1 | 2 | 3
+    j: number
+    reversed: boolean
+    delta: number
+  } | null = null
+
+  for (const segLen of [1, 2, 3] as const) {
+    if (n <= segLen + 1) continue
+    for (let i = 0; i < n; i++) {
+      if (i + segLen > n) continue // no wrap-around segments
+      const prev = i === 0 ? n - 1 : i - 1
+      const afterSeg = (i + segLen) % n
+      const a = tour[prev]
+      const firstSeg = tour[i]
+      const lastSeg = tour[i + segLen - 1]
+      const d = tour[afterSeg]
+      const removeGain = dist(a, firstSeg) + dist(lastSeg, d) - dist(a, d)
+
+      for (let j = 0; j < n; j++) {
+        if (j === prev || (j >= i && j < i + segLen)) continue
+        const x = tour[j]
+        const y = tour[(j + 1) % n]
+        const edgeXY = dist(x, y)
+
+        const fwdDelta = -removeGain + dist(x, firstSeg) + dist(lastSeg, y) - edgeXY
+        if (fwdDelta < bestDelta) {
+          bestDelta = fwdDelta
+          best = { i, segLen, j, reversed: false, delta: fwdDelta }
+        }
+        if (fwdDelta < -1e-3) improvingGaps.add(j)
+
+        if (segLen > 1) {
+          const revDelta = -removeGain + dist(x, lastSeg) + dist(firstSeg, y) - edgeXY
+          if (revDelta < bestDelta) {
+            bestDelta = revDelta
+            best = { i, segLen, j, reversed: true, delta: revDelta }
+          }
+          if (revDelta < -1e-3) improvingGaps.add(j)
+        }
+      }
+    }
+  }
+
+  if (!best) return null
+
+  const { i, segLen, j, reversed, delta } = best
+  const segCities = tour.slice(i, i + segLen)
+  const prev = i === 0 ? n - 1 : i - 1
+  const afterSeg = (i + segLen) % n
+  const x = tour[j]
+  const y = tour[(j + 1) % n]
+  const cutEdges: [number, number][] = [
+    [tour[prev], tour[i]],
+    [tour[i + segLen - 1], tour[afterSeg]],
+    [x, y],
+  ]
+  const pasteEdges: [number, number][] = reversed
+    ? [
+        [tour[prev], tour[afterSeg]],
+        [x, tour[i + segLen - 1]],
+        [tour[i], y],
+      ]
+    : [
+        [tour[prev], tour[afterSeg]],
+        [x, tour[i]],
+        [tour[i + segLen - 1], y],
+      ]
+
+  return {
+    i, segLen, j, reversed, delta,
+    segCities,
+    insertAfter: x,
+    insertBefore: y,
+    cutEdges,
+    pasteEdges,
+    improvingGaps: [...improvingGaps].sort((a, b) => a - b),
+  }
+}
+
+// Rust apply_relocation: remove tour[i..i+segLen), insert it after position j
+// (original indexing), reversing the segment when `reversed`.
+export function applyRelocation(
+  tour: number[],
+  i: number,
+  segLen: number,
+  j: number,
+  reversed: boolean,
+): number[] {
+  const seg = tour.slice(i, i + segLen)
+  const rest = [...tour.slice(0, i), ...tour.slice(i + segLen)]
+  const insertAt = j >= i + segLen ? j - segLen + 1 : j + 1
+  const toInsert = reversed ? [...seg].reverse() : seg
+  return [...rest.slice(0, insertAt), ...toInsert, ...rest.slice(insertAt)]
+}
+
+// ---------------------------------------------------------------
+// Scenarios (crafted tours, tuned offline — see or-opt.test.ts pins)
+// ---------------------------------------------------------------
+export interface Scenario {
+  label: string
+  desc: string
+  tour: number[]
+}
+
+export const SCENARIOS: Record<string, Scenario> = {
+  single_segment: {
+    label: 'Single segment',
+    desc: 'The centre city is wedged in the wrong spot — one Or-1 move slides it out',
+    tour: [0, 1, 2, 3, 4, 8, 5, 9, 6, 7],
+  },
+  triplet_move: {
+    label: 'Triplet move',
+    desc: 'A block of 3 cities got folded into the tour — the best move relocates the whole block (Or-3)',
+    tour: [0, 1, 2, 8, 5, 4, 3, 9, 6, 7],
+  },
+  already_optimal: {
+    label: 'Already optimal',
+    desc: 'No improving Or-1/2/3 relocation exists — this tour is the global optimum',
+    tour: [0, 1, 2, 3, 4, 5, 8, 9, 6, 7],
+  },
+  two_opt_stuck: {
+    label: '2-opt stuck',
+    desc: '2-opt calls this a local optimum — but Or-opt still finds an improving relocation',
+    tour: [0, 7, 6, 5, 4, 3, 2, 1, 8, 9],
+  },
+}
+
+export function makeInitState(tour: number[]): SimState {
+  const cost = tourLength(tour)
+  return {
+    phase: 'idle',
+    tour: [...tour],
+    bestTour: [...tour],
+    bestCost: cost,
+    pass: 0,
+    moves: 0,
+    pending: null,
+    lastMove: null,
+    costHistory: [cost],
+    step: 0,
+  }
+}
+
+// One Step press. Two-click model like the 2-opt explainer:
+//   idle | move_applied → 'candidate'   (scan; show best move + faint gaps)
+//   'candidate'          → 'move_applied' (apply the pending relocation)
+// Either scan may instead end in 'local_optimum' when no move improves.
+// Pure function of the input state — no mutation.
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'local_optimum') return { ...state, step: state.step + 1 }
+
+  // Second click — apply the pending move
+  if (state.phase === 'candidate' && state.pending) {
+    const m = state.pending
+    const newTour = applyRelocation(state.tour, m.i, m.segLen, m.j, m.reversed)
+    const cost = tourLength(newTour)
+
+    return {
+      ...state,
+      phase: 'move_applied',
+      tour: newTour,
+      bestTour: cost < state.bestCost ? [...newTour] : state.bestTour,
+      bestCost: Math.min(cost, state.bestCost),
+      pass: state.pass + 1,
+      moves: state.moves + 1,
+      lastMove: m,
+      costHistory: [...state.costHistory, cost],
+      step: state.step + 1,
+    }
+  }
+
+  // First click — scan for the best improving move
+  const move = scanBestMove(state.tour)
+
+  if (!move) {
+    return {
+      ...state,
+      phase: 'local_optimum',
+      pass: state.pass + 1,
+      costHistory: [...state.costHistory, state.bestCost],
+      pending: null,
+      step: state.step + 1,
+    }
+  }
+
+  return {
+    ...state,
+    phase: 'candidate',
+    pending: move,
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/or-opt-algo.ts
+++ b/teeline-web/src/explainers/or-opt-algo.ts
@@ -166,7 +166,7 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
 export function applyRelocation(
   tour: number[],
   i: number,
-  segLen: number,
+  segLen: 1 | 2 | 3,
   j: number,
   reversed: boolean,
 ): number[] {

--- a/teeline-web/src/explainers/or-opt.test.ts
+++ b/teeline-web/src/explainers/or-opt.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, SCENARIOS,
+  dist, tourLength, scanBestMove, applyRelocation, makeInitState, stepOnce,
+} from './or-opt-algo'
+import type { SimState } from './or-opt-algo'
+import { scanOnePass, makeInitState as twoOptInit } from './two-opt-algo'
+
+// True optimum for the shared 10-city layout (see stochastic-hill tests).
+const OPT = 979.0581791448133
+
+// Run to the local optimum; returns the final state.
+function runToOptimum(tour: number[]): SimState {
+  let s = makeInitState(tour)
+  let guard = 200
+  while (s.phase !== 'local_optimum' && guard-- > 0) s = stepOnce(s)
+  expect(s.phase, 'runToOptimum must converge').toBe('local_optimum')
+  return s
+}
+
+// ---------------------------------------------------------------
+describe('dist / tourLength', () => {
+  it('dist is symmetric and non-negative', () => {
+    for (let i = 0; i < N_CITIES; i++) {
+      for (let j = 0; j < N_CITIES; j++) {
+        expect(dist(i, j)).toBeCloseTo(dist(j, i), 10)
+        expect(dist(i, j)).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+
+  it('tourLength matches the known optimum', () => {
+    expect(tourLength([0, 1, 2, 3, 4, 5, 8, 9, 6, 7])).toBeCloseTo(OPT, 6)
+  })
+})
+
+// ---------------------------------------------------------------
+// applyRelocation — direct ports of the Rust unit tests
+// (src/tsp/or_opt.rs apply_relocation_*)
+// ---------------------------------------------------------------
+describe('applyRelocation (ported from Rust)', () => {
+  it('or-1 forward: move city at index 1 to after index 3', () => {
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 1, 3, false)).toEqual([0, 2, 3, 1, 4])
+  })
+
+  it('or-1 backward: move city at index 3 to after index 0', () => {
+    expect(applyRelocation([0, 1, 2, 3, 4], 3, 1, 0, false)).toEqual([0, 3, 1, 2, 4])
+  })
+
+  it('or-2 forward: move pair [1,2] to after index 3', () => {
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, false)).toEqual([0, 3, 1, 2, 4])
+  })
+
+  it('or-2 reversed: move pair [1,2] as [2,1] to after index 3', () => {
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, true)).toEqual([0, 3, 2, 1, 4])
+  })
+
+  it('or-3 forward: move triple [1,2,3] to after index 4', () => {
+    expect(applyRelocation([0, 1, 2, 3, 4, 5], 1, 3, 4, false)).toEqual([0, 4, 1, 2, 3, 5])
+  })
+
+  it('never mutates the input', () => {
+    const tour = [0, 1, 2, 3, 4]
+    const copy = [...tour]
+    applyRelocation(tour, 1, 2, 3, true)
+    expect(tour).toEqual(copy)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('scanBestMove', () => {
+  it('returns null for the already_optimal tour (the global optimum)', () => {
+    expect(scanBestMove(SCENARIOS.already_optimal.tour)).toBeNull()
+  })
+
+  it('returns a negative-delta move for improving tours', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      if (key === 'already_optimal') continue
+      const move = scanBestMove(s.tour)
+      expect(move, `${key} should have an improving move`).not.toBeNull()
+      expect(move!.delta).toBeLessThan(-1e-3)
+      expect(move!.segLen).toBeGreaterThanOrEqual(1)
+      expect(move!.segLen).toBeLessThanOrEqual(3)
+      expect(move!.segCities).toHaveLength(move!.segLen)
+    }
+  })
+
+  it('single_segment: the best move is an Or-1 relocation of the centre city', () => {
+    const move = scanBestMove(SCENARIOS.single_segment.tour)!
+    expect(move.segLen).toBe(1)
+    expect(move.segCities).toEqual([8])
+    expect(move.reversed).toBe(false)
+    // applying it reaches the optimum
+    const after = applyRelocation(SCENARIOS.single_segment.tour, move.i, move.segLen, move.j, move.reversed)
+    expect(tourLength(after)).toBeCloseTo(OPT, 3)
+  })
+
+  it('triplet_move: the best move is an Or-3 relocation (reversed)', () => {
+    const move = scanBestMove(SCENARIOS.triplet_move.tour)!
+    expect(move.segLen).toBe(3)
+    expect(move.segCities).toEqual([8, 5, 4])
+    expect(move.reversed).toBe(true)
+    const after = applyRelocation(SCENARIOS.triplet_move.tour, move.i, move.segLen, move.j, move.reversed)
+    expect(tourLength(after)).toBeCloseTo(OPT, 3)
+  })
+
+  it('reports the cut/paste edges and insertion gap of the best move', () => {
+    const tour = SCENARIOS.single_segment.tour
+    const move = scanBestMove(tour)!
+    expect(move.cutEdges).toHaveLength(3)
+    expect(move.pasteEdges).toHaveLength(3)
+    expect(move.insertAfter).toBe(tour[move.j])
+    expect(move.insertBefore).toBe(tour[(move.j + 1) % N_CITIES])
+    // improvingGaps lists positions with some improving move
+    expect(move.improvingGaps.length).toBeGreaterThan(0)
+    expect(move.improvingGaps).toEqual([...new Set(move.improvingGaps)].sort((a, b) => a - b))
+  })
+
+  it('delta matches the measured cost change (Rust debug assertion)', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      if (key === 'already_optimal') continue
+      const move = scanBestMove(s.tour)!
+      const before = tourLength(s.tour)
+      const after = tourLength(applyRelocation(s.tour, move.i, move.segLen, move.j, move.reversed))
+      expect(after - before, `${key} delta mismatch`).toBeCloseTo(move.delta, 3)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+describe('two_opt_stuck scenario', () => {
+  it('2-opt finds no improving swap, but Or-opt does', () => {
+    const tour = SCENARIOS.two_opt_stuck.tour
+    const { bestDelta } = scanOnePass(twoOptInit(tour))
+    expect(bestDelta).toBeGreaterThanOrEqual(0) // 2-opt is stuck
+    const move = scanBestMove(tour)
+    expect(move).not.toBeNull() // Or-opt still improves
+    expect(move!.delta).toBeLessThan(-1e-3)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('stepOnce phase machine', () => {
+  const s0 = makeInitState(SCENARIOS.single_segment.tour)
+
+  it('idle → candidate scans and shows the move without touching the tour', () => {
+    const s1 = stepOnce(s0)
+    expect(s1.phase).toBe('candidate')
+    expect(s1.pending).not.toBeNull()
+    expect(s1.tour).toEqual(s0.tour)
+    expect(s1.pass).toBe(0)
+    expect(s1.moves).toBe(0)
+    expect(s1.step).toBe(1)
+  })
+
+  it('candidate → move_applied applies the relocation and increments pass/moves', () => {
+    const s1 = stepOnce(s0)
+    const s2 = stepOnce(s1)
+    expect(s2.phase).toBe('move_applied')
+    expect(s2.pass).toBe(1)
+    expect(s2.moves).toBe(1)
+    expect(s2.tour).toEqual(applyRelocation(s0.tour, s1.pending!.i, s1.pending!.segLen, s1.pending!.j, s1.pending!.reversed))
+    expect(s2.costHistory).toHaveLength(2)
+    expect(s2.step).toBe(2)
+  })
+
+  it('already_optimal → local_optimum on the first scan', () => {
+    const s = stepOnce(makeInitState(SCENARIOS.already_optimal.tour))
+    expect(s.phase).toBe('local_optimum')
+    expect(s.pass).toBe(1)
+    expect(s.moves).toBe(0)
+  })
+
+  it('local_optimum is a no-op apart from the step counter', () => {
+    const done = runToOptimum(SCENARIOS.single_segment.tour)
+    const again = stepOnce(done)
+    expect(again.phase).toBe('local_optimum')
+    expect(again.tour).toEqual(done.tour)
+    expect(again.step).toBe(done.step + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('convergence', () => {
+  it('single_segment converges to the optimum in exactly one move', () => {
+    const s = runToOptimum(SCENARIOS.single_segment.tour)
+    expect(s.moves).toBe(1)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('triplet_move converges to the optimum in exactly one move', () => {
+    const s = runToOptimum(SCENARIOS.triplet_move.tour)
+    expect(s.moves).toBe(1)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('two_opt_stuck converges to an optimal tour', () => {
+    const s = runToOptimum(SCENARIOS.two_opt_stuck.tour)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('best cost never increases and costHistory is non-increasing', () => {
+    const s = runToOptimum(SCENARIOS.triplet_move.tour)
+    expect(s.bestCost).toBeLessThanOrEqual(s.costHistory[0])
+    for (let k = 1; k < s.costHistory.length; k++) {
+      expect(s.costHistory[k]).toBeLessThanOrEqual(s.costHistory[k - 1])
+    }
+    // initial + one push per applied move + one final push at the local optimum
+    expect(s.costHistory).toHaveLength(s.moves + 2)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('purity & determinism', () => {
+  it('stepOnce never mutates its input', () => {
+    const s = makeInitState(SCENARIOS.two_opt_stuck.tour)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 12; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same tour produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.two_opt_stuck.tour)
+    const b = makeInitState(SCENARIOS.two_opt_stuck.tour)
+    for (let i = 0; i < 12; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+})

--- a/teeline-web/src/explainers/or-opt.tsx
+++ b/teeline-web/src/explainers/or-opt.tsx
@@ -1,0 +1,497 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES, SCENARIOS,
+  tourLength, makeInitState, stepOnce,
+} from "./or-opt-algo"
+import type { Phase, MoveEvent, Scenario } from "./or-opt-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.single_segment
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+function edgeKey(a: number, b: number): string {
+  return `${Math.min(a, b)}-${Math.max(a, b)}`
+}
+
+function midTick(x1: number, y1: number, x2: number, y2: number): [number, number, number, number] {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const len = Math.hypot(dx, dy) || 1
+  const mx = (x1 + x2) / 2
+  const my = (y1 + y2) / 2
+  const px = (-dy / len) * 6
+  const py = (dx / len) * 6
+  return [mx - px, my - py, mx + px, my + py]
+}
+
+// ---------------------------------------------------------------
+// TourCanvas — current tour with segment/cut/paste highlights,
+// faint scan ticks at improving insertion gaps, and a CSS morph
+// that makes the tour flow to its new shape when a move applies.
+// ---------------------------------------------------------------
+function TourCanvas({ tour, pending, lastMove, phase, morph }: {
+  tour: number[]
+  pending: MoveEvent | null
+  lastMove: MoveEvent | null
+  phase: Phase
+  morph: boolean
+}) {
+  const showCandidate = phase === 'candidate' && pending
+  const showApplied = phase === 'move_applied' && lastMove
+
+  const cutSet = useMemo(() => {
+    const m = showCandidate ? pending : showApplied ? lastMove : null
+    if (!m) return new Set<string>()
+    return new Set(m.cutEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [pending, lastMove, showCandidate, showApplied])
+  const pasteSet = useMemo(() => {
+    const m = showCandidate ? pending : showApplied ? lastMove : null
+    if (!m) return new Set<string>()
+    return new Set(m.pasteEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [pending, lastMove, showCandidate, showApplied])
+
+  const segSet = useMemo(() => {
+    const m = showCandidate ? pending : showApplied ? lastMove : null
+    if (!m) return new Set<number>()
+    return new Set(m.segCities)
+  }, [pending, lastMove, showCandidate, showApplied])
+
+  const edges: Array<{ from: number; to: number; key: string }> = []
+  for (let k = 0; k < tour.length; k++) {
+    const a = tour[k]
+    const b = tour[(k + 1) % tour.length]
+    edges.push({ from: a, to: b, key: edgeKey(a, b) })
+  }
+
+  const ticks: Array<{ key: string; x1: number; y1: number; x2: number; y2: number }> = []
+  if (showCandidate && pending) {
+    for (const j of pending.improvingGaps) {
+      if (j === pending.j) continue // the best gap gets the strong paste highlight
+      const a = tour[j]
+      const b = tour[(j + 1) % tour.length]
+      const [x1, y1, x2, y2] = midTick(CITIES[a][0], CITIES[a][1], CITIES[b][0], CITIES[b][1])
+      ticks.push({ key: `t${j}`, x1, y1, x2, y2 })
+    }
+  }
+
+  return (
+    <svg viewBox="0 0 300 300"
+      className={`or-canvas ${morph && showApplied ? 'or-morph' : ''}`}
+      role="img" aria-label="Or-opt tour">
+      <rect x={0} y={0} width={300} height={300} className="or-bg" />
+
+      {/* Faint ticks at every improving insertion gap (the scan) */}
+      {ticks.map((t) => (
+        <line key={t.key} className="or-scan-tick" x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
+      ))}
+
+      {/* Best insertion gap marker */}
+      {showCandidate && pending && (
+        <line className="or-gap-marker"
+          x1={CITIES[pending.insertAfter][0]} y1={CITIES[pending.insertAfter][1]}
+          x2={CITIES[pending.insertBefore][0]} y2={CITIES[pending.insertBefore][1]} />
+      )}
+
+      <g className="or-tour">
+        {edges.map(({ from, to, key }) => {
+          let cls = 'or-edge'
+          if (cutSet.has(key)) cls += showCandidate ? ' or-cand-cut' : ' or-cut'
+          else if (pasteSet.has(key)) cls += showCandidate ? ' or-cand-paste' : ' or-paste'
+          return <line key={key} className={cls}
+            x1={CITIES[from][0]} y1={CITIES[from][1]}
+            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+        })}
+        {tour.map((id) => (
+          <g key={id}>
+            <circle className={`or-city ${segSet.has(id) ? 'or-city-seg' : ''}`}
+              cx={CITIES[id][0]} cy={CITIES[id][1]} r={segSet.has(id) ? 8 : 6} />
+            <text className="or-label"
+              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Cost sparkline (same pattern as 2-opt / ACO)
+// ---------------------------------------------------------------
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null
+  const W = 300, H = 46
+  const minV = Math.min(...values)
+  const maxV = Math.max(...values)
+  const range = maxV - minV || 1
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W
+    const y = H - ((v - minV) / range) * (H - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="or-spark" aria-label="cost over passes">
+      <rect x={0} y={0} width={W} height={H} className="or-bg" rx={4} />
+      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
+        strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function OrOptExplainer() {
+  const [tour, setTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.tour])
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [pass, setPass] = useState(0)
+  const [moves, setMoves] = useState(0)
+  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.tour))
+  const [pending, setPending] = useState<MoveEvent | null>(null)
+  const [lastMove, setLastMove] = useState<MoveEvent | null>(null)
+  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.tour)])
+  const [step, setStep] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2) // 3x default
+  const [morphOn, setMorphOn] = useState(false) // animate the tour flow on apply, not on Back
+
+  const simRef = useRef(makeInitState(DEFAULT_SCENARIO.tour))
+  const historyRef = useRef<Array<typeof simRef.current>>([])
+  const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
+
+  const reinit = useCallback((scenario: Scenario) => {
+    scenarioRef.current = scenario
+    simRef.current = makeInitState(scenario.tour)
+    historyRef.current = []
+    setTour([...simRef.current.tour])
+    setPhase('idle')
+    setPass(0)
+    setMoves(0)
+    setBestCost(simRef.current.bestCost)
+    setPending(null)
+    setLastMove(null)
+    setCostHistory([simRef.current.bestCost])
+    setStep(0)
+    setRunning(false)
+    setMorphOn(false)
+  }, [])
+
+  const stepForward = useCallback(() => {
+    historyRef.current.push(structuredClone(simRef.current))
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setTour([...next.tour])
+    setPhase(next.phase)
+    setPass(next.pass)
+    setMoves(next.moves)
+    setBestCost(next.bestCost)
+    setPending(next.pending)
+    setLastMove(next.lastMove)
+    setCostHistory([...next.costHistory])
+    setStep(next.step)
+    setMorphOn(next.phase === 'move_applied')
+    if (next.phase === 'local_optimum') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    const prev = h.pop()!
+    simRef.current = prev
+    setTour([...prev.tour])
+    setPhase(prev.phase)
+    setPass(prev.pass)
+    setMoves(prev.moves)
+    setBestCost(prev.bestCost)
+    setPending(prev.pending)
+    setLastMove(prev.lastMove)
+    setCostHistory([...prev.costHistory])
+    setStep(prev.step)
+    setMorphOn(false) // Back restores instantly
+  }, [running])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = SPEEDS[speedIdx]
+    const id = setInterval(stepForward, ms)
+    return () => clearInterval(id)
+  }, [running, speedIdx, stepForward])
+
+  const distance = tourLength(tour)
+
+  // Status chip
+  let chipText = "Click Step to scan for the best Or-1/2/3 relocation"
+  let chipClass = "or-chip or-chip-idle"
+  if (phase === 'candidate' && pending) {
+    const rev = pending.reversed ? ' ↺ reversed' : ''
+    chipText = `Candidate — move ${pending.segCities.join('→')} (k=${pending.segLen}) after ${pending.insertAfter}${rev}  (Δ=${pending.delta.toFixed(0)})`
+    chipClass = "or-chip or-chip-candidate"
+  } else if (phase === 'move_applied' && lastMove) {
+    const rev = lastMove.reversed ? ' ↺ reversed' : ''
+    chipText = `Moved — ${lastMove.segCities.join('→')} relocated after ${lastMove.insertAfter}${rev}  (Δ=${lastMove.delta.toFixed(0)})`
+    chipClass = "or-chip or-chip-applied"
+  } else if (phase === 'local_optimum') {
+    chipText = `Local optimum — no improving Or-1/2/3 relocation exists (${moves} moves, ${pass} passes)`
+    chipClass = "or-chip or-chip-done"
+  }
+
+  return (
+    <div className="or-root">
+      <style>{CSS}</style>
+
+      <header className="or-header">
+        <div className="or-eyebrow">teeline · algorithms/or_opt</div>
+        <h2 className="or-title">Or-opt Local Search</h2>
+        <p className="or-sub">
+          Or-opt relocates <strong>segments of 1–3 consecutive cities</strong> to a better position
+          elsewhere in the tour — a <em>cut-and-paste</em> move, unlike 2-opt's edge reversal.
+          Each pass scans every segment size (Or-1, Or-2, Or-3) and every insertion point, applying
+          the single <strong>best-improving</strong> relocation (reversed insertions are also tried
+          for Or-2/Or-3). Repeats until no relocation improves the tour.
+        </p>
+      </header>
+
+      <div className="or-viz-row">
+        <div className="or-canvas-wrap">
+          <TourCanvas tour={tour} pending={pending} lastMove={lastMove} phase={phase} morph={morphOn} />
+        </div>
+      </div>
+
+      <div className="or-legend">
+        <span><span className="or-swatch or-swatch-normal" /> tour edge</span>
+        <span><span className="or-swatch or-swatch-seg" /> segment (relocating)</span>
+        <span><span className="or-swatch or-swatch-cut" /> cut edge</span>
+        <span><span className="or-swatch or-swatch-paste" /> paste edge</span>
+        <span><span className="or-swatch or-swatch-gap" /> insertion gap</span>
+        <span><span className="or-swatch or-swatch-tick" /> improving gap (scan)</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="or-section-label">Cost over passes</div>
+      <Sparkline values={costHistory} />
+
+      <div className="or-statgrid">
+        <div>
+          <div className="or-statlabel">pass</div>
+          <div className="or-mono">{pass}</div>
+        </div>
+        <div>
+          <div className="or-statlabel">moves</div>
+          <div className="or-mono">{moves}</div>
+        </div>
+        <div>
+          <div className="or-statlabel">best cost</div>
+          <div className="or-mono">{bestCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="or-statlabel">distance</div>
+          <div className="or-mono">{distance.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="or-statlabel">last Δ</div>
+          <div className="or-mono" style={{ color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit' }}>
+            {lastMove ? lastMove.delta.toFixed(0) : '—'}
+          </div>
+        </div>
+        <div>
+          <div className="or-statlabel">step</div>
+          <div className="or-mono">{step}</div>
+        </div>
+      </div>
+
+      <div className="or-config">
+        <div className="or-config-row">
+          <label className="or-label">Speed</label>
+          <div className="or-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l}
+                className={`or-speed-btn ${i === speedIdx ? 'or-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="or-controls">
+        <button className="or-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+          ⏴ Back
+        </button>
+        <button className="or-btn" onClick={stepForward} disabled={running || phase === 'local_optimum'}>
+          ⏵ Step
+        </button>
+        <button className="or-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="or-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+      </div>
+
+      <div className="or-scenarios">
+        <div className="or-section-label">Scenarios</div>
+        <div className="or-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, s]) => (
+            <button key={key} className="or-scenario-btn" title={s.desc}
+              onClick={() => reinit(s)}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="or-footer">
+        <span className="or-mono">cities: {N_CITIES}</span>
+        <span className="or-mono">Or-1/2/3 relocation · best-improvement · runs to local optimum</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.or-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --improve: #16a34a;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 760px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.or-root * { box-sizing: border-box; }
+.or-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.or-header { margin-bottom: 2px; }
+.or-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.or-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.or-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.or-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.or-bg { fill: var(--panel); }
+.or-edge { stroke: #94a3b8; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.or-cand-cut { stroke: #ea580c; stroke-width: 3.5; stroke-dasharray: 6 4; }
+.or-cand-paste { stroke: #16a34a; stroke-width: 3.5; stroke-dasharray: 4 6; }
+.or-cut { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 6 3; }
+.or-paste { stroke: #16a34a; stroke-width: 3.5; }
+.or-scan-tick { stroke: #f59e0b; stroke-width: 2; stroke-dasharray: 2 2; opacity: 0.5; }
+.or-gap-marker { stroke: #16a34a; stroke-width: 2.5; stroke-dasharray: 5 4; opacity: 0.55; }
+.or-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; transition: cx 0.35s ease, cy 0.35s ease; }
+.or-city-seg { fill: #ea580c; stroke: #fff7ed; }
+.or-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+/* Morph: when a move is applied, the whole tour flows to its new shape. */
+.or-morph .or-edge,
+.or-morph .or-cut,
+.or-morph .or-paste,
+.or-morph .or-cand-cut,
+.or-morph .or-cand-paste {
+  transition: x1 0.35s ease, y1 0.35s ease, x2 0.35s ease, y2 0.35s ease;
+}
+
+.or-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.or-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+.or-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.or-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.or-swatch-normal { background: #94a3b8; }
+.or-swatch-seg { background: #ea580c; }
+.or-swatch-cut { background: #ef4444; }
+.or-swatch-paste { background: #16a34a; }
+.or-swatch-gap { background: #16a34a; }
+.or-swatch-tick { background: #f59e0b; }
+
+.or-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.or-chip-idle { background: #f1f5f9; color: var(--muted); }
+.or-chip-candidate { background: #ffedd5; color: #9a3412; }
+.or-chip-applied { background: #dcfce7; color: #166534; }
+.or-chip-done { background: #f1f5f9; color: var(--muted); }
+
+.or-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.or-spark { width: 100%; display: block; border-radius: 6px; }
+
+.or-statgrid {
+  display: flex; flex-wrap: wrap; gap: 14px 22px;
+  font-size: 0.82rem;
+}
+.or-statlabel { color: var(--muted); font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.or-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.or-config-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.or-label {
+  font-size: 0.82rem; font-weight: 500; color: var(--text);
+  min-width: 50px;
+}
+.or-speed-btns { display: flex; gap: 4px; }
+.or-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.or-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.or-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.or-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.or-controls { display: flex; gap: 8px; }
+.or-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.or-btn:hover:not(:disabled) { background: #f0fdf4; }
+.or-btn:disabled { opacity: 0.4; cursor: default; }
+
+.or-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.or-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.or-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.or-scenario-btn:hover { background: #f0fdf4; border-color: var(--accent); }
+
+.or-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/or-opt.tsx
+++ b/teeline-web/src/explainers/or-opt.tsx
@@ -39,22 +39,27 @@ function TourCanvas({ tour, pending, lastMove, phase, morph }: {
   const showCandidate = phase === 'candidate' && pending
   const showApplied = phase === 'move_applied' && lastMove
 
-  const cutSet = useMemo(() => {
-    const m = showCandidate ? pending : showApplied ? lastMove : null
-    if (!m) return new Set<string>()
-    return new Set(m.cutEdges.map(([a, b]) => edgeKey(a, b)))
-  }, [pending, lastMove, showCandidate, showApplied])
-  const pasteSet = useMemo(() => {
-    const m = showCandidate ? pending : showApplied ? lastMove : null
-    if (!m) return new Set<string>()
-    return new Set(m.pasteEdges.map(([a, b]) => edgeKey(a, b)))
+  // The move currently being displayed: the proposed candidate, or the one
+  // just applied.
+  const activeMove = useMemo<MoveEvent | null>(() => {
+    if (showCandidate) return pending
+    if (showApplied) return lastMove
+    return null
   }, [pending, lastMove, showCandidate, showApplied])
 
+  const cutSet = useMemo(() => {
+    if (!activeMove) return new Set<string>()
+    return new Set(activeMove.cutEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [activeMove])
+  const pasteSet = useMemo(() => {
+    if (!activeMove) return new Set<string>()
+    return new Set(activeMove.pasteEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [activeMove])
+
   const segSet = useMemo(() => {
-    const m = showCandidate ? pending : showApplied ? lastMove : null
-    if (!m) return new Set<number>()
-    return new Set(m.segCities)
-  }, [pending, lastMove, showCandidate, showApplied])
+    if (!activeMove) return new Set<number>()
+    return new Set(activeMove.segCities)
+  }, [activeMove])
 
   const edges: Array<{ from: number; to: number; key: string }> = []
   for (let k = 0; k < tour.length; k++) {
@@ -176,6 +181,9 @@ export default function OrOptExplainer() {
   }, [])
 
   const stepForward = useCallback(() => {
+    // Guard against an in-flight interval tick after the run already finished:
+    // stepping a local_optimum state would push a phantom undo entry.
+    if (simRef.current.phase === 'local_optimum') return
     historyRef.current.push(structuredClone(simRef.current))
     const next = stepOnce(simRef.current)
     simRef.current = next
@@ -332,7 +340,7 @@ export default function OrOptExplainer() {
         <div className="or-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
             <button key={key} className="or-scenario-btn" title={s.desc}
-              onClick={() => reinit(s)}>
+              onClick={() => reinit(s)} disabled={running}>
               {s.label}
             </button>
           ))}
@@ -487,7 +495,8 @@ const CSS = `
   border: 1px solid var(--line); background: var(--bg); color: var(--text);
   cursor: pointer; transition: background 0.15s;
 }
-.or-scenario-btn:hover { background: #f0fdf4; border-color: var(--accent); }
+.or-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.or-scenario-btn:disabled { opacity: 0.4; cursor: default; }
 
 .or-footer {
   display: flex; gap: 12px; justify-content: center;

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -96,6 +96,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of Stochastic Hill Climbing: watch random 2-opt candidates get accepted only when they beat the best tour so far, with random restarts when the search goes stale.',
     backLabel: 'Stochastic Hill Climbing',
   },
+  or_opt: {
+    title: 'Or-opt — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of Or-opt: watch segments of 1–3 consecutive cities get cut from one part of the tour and pasted into a better position, with reversed insertions for Or-2/Or-3 and best-improvement passes running to a local optimum.',
+    backLabel: 'Or-opt',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -29,6 +29,7 @@ import GreedyEdgeExplainer from '../../../../explainers/greedy-edge'
 import SavingsExplainer from '../../../../explainers/savings'
 import AcoExplainer from '../../../../explainers/aco'
 import StochasticHillExplainer from '../../../../explainers/stochastic-hill'
+import OrOptExplainer from '../../../../explainers/or-opt'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -71,6 +72,7 @@ const jsonLd = {
     {id === 'savings' && <SavingsExplainer client:visible />}
     {id === 'aco' && <AcoExplainer client:visible />}
     {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
+    {id === 'or_opt' && <OrOptExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
   </main>

--- a/teeline-web/tests/or-opt.spec.ts
+++ b/teeline-web/tests/or-opt.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the Or-opt explainer (/algorithms/or_opt/explainer/).
+// The component hydrates with `client:visible`, so the tests first scroll it
+// into view and probe until the Preact listeners are attached (a click that
+// changes the status chip), then reset to the idle phase.
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.or-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.or-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  // Retry the click until it lands post-hydration (pre-hydration clicks are no-ops).
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('Candidate', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  // back to the idle phase for deterministic tests
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(chip).toContainText('Click Step')
+}
+
+test.describe('or-opt explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/or_opt/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the canvas, stats panel and controls', async ({ page }) => {
+    await expect(page.locator('.or-title')).toHaveText('Or-opt Local Search')
+    await expect(page.locator('.or-canvas')).toBeVisible()
+    await expect(page.locator('.or-section-label', { hasText: 'Cost over passes' })).toBeVisible()
+
+    const stats = page.locator('.or-statgrid')
+    await expect(stats).toContainText('pass')
+    await expect(stats).toContainText('moves')
+    await expect(stats).toContainText('best cost')
+    await expect(stats).toContainText('distance')
+    await expect(stats).toContainText('last Δ')
+    await expect(stats).toContainText('step')
+
+    for (const label of ['Single segment', 'Triplet move', 'Already optimal', '2-opt stuck']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step advances the two-click model (candidate → applied)', async ({ page }) => {
+    const chip = page.locator('.or-chip')
+    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+    const moves = page.locator('.or-statgrid').locator('div', { hasText: /^moves/ }).locator('.or-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    // single_segment scenario: the best move is an Or-1 relocation of city 8
+    await expect(chip).toContainText('Candidate')
+    await expect(chip).toContainText('k=1')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('Moved')
+    await expect(pass).toHaveText('1')
+    await expect(moves).toHaveText('1')
+
+    // sparkline appears once there are ≥ 2 cost samples
+    await expect(page.locator('.or-spark')).toBeVisible()
+  })
+
+  test('Back restores the previous phase', async ({ page }) => {
+    const chip = page.locator('.or-chip')
+    const stepStat = page.locator('.or-statgrid').locator('div', { hasText: /^step/ }).locator('.or-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click() // candidate
+    await page.getByRole('button', { name: 'Step' }).click() // applied
+    await expect(stepStat).toHaveText('2')
+
+    await page.getByRole('button', { name: 'Back' }).click()
+    await expect(chip).toContainText('Candidate') // back to the candidate phase
+    await expect(stepStat).toHaveText('1')
+  })
+
+  test('Run animates passes; Pause and Reset stop and reset', async ({ page }) => {
+    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await expect(pass).not.toHaveText('0', { timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await pass.textContent()
+    await page.waitForTimeout(500)
+    await expect(pass).toHaveText(paused ?? '')
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(pass).toHaveText('0')
+    await expect(page.locator('.or-chip')).toContainText('Click Step')
+  })
+
+  test('already_optimal reaches the local optimum in one Step', async ({ page }) => {
+    await page.getByRole('button', { name: 'Already optimal' }).click()
+    await expect(page.locator('.or-chip')).toContainText('Click Step')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(page.locator('.or-chip')).toContainText('Local optimum')
+  })
+
+  test('scenario buttons restart the run', async ({ page }) => {
+    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(pass).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Triplet move' }).click()
+    await expect(pass).toHaveText('0')
+    await expect(page.locator('.or-chip')).toContainText('Click Step')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(page.locator('.or-chip')).toContainText('k=3')
+  })
+})

--- a/teeline-web/tests/or-opt.spec.ts
+++ b/teeline-web/tests/or-opt.spec.ts
@@ -75,20 +75,32 @@ test.describe('or-opt explainer', () => {
     await expect(stepStat).toHaveText('1')
   })
 
-  test('Run animates passes; Pause and Reset stop and reset', async ({ page }) => {
+  test('Run animates passes to the local optimum; Reset restores idle', async ({ page }) => {
     const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+    const moves = page.locator('.or-statgrid').locator('div', { hasText: /^moves/ }).locator('.or-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
+    // single_segment converges in one pass — watch it advance and finish
     await expect(pass).not.toHaveText('0', { timeout: 10_000 })
-
-    await page.getByRole('button', { name: 'Pause' }).click()
-    const paused = await pass.textContent()
-    await page.waitForTimeout(500)
-    await expect(pass).toHaveText(paused ?? '')
+    await expect(page.locator('.or-chip')).toContainText('Local optimum', { timeout: 10_000 })
+    // one applied move + the final local-optimum scan
+    await expect(pass).toHaveText('2')
+    await expect(moves).toHaveText('1')
 
     await page.getByRole('button', { name: 'Reset' }).click()
     await expect(pass).toHaveText('0')
     await expect(page.locator('.or-chip')).toContainText('Click Step')
+  })
+
+  test('Pause stops the animation mid-run', async ({ page }) => {
+    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    // pause immediately — before or during the first tick, pass is 0 or 1
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await pass.textContent()
+    await page.waitForTimeout(700)
+    await expect(pass).toHaveText(paused ?? '')
   })
 
   test('already_optimal reaches the local optimum in one Step', async ({ page }) => {


### PR DESCRIPTION
## What

Interactive explainer for **Or-opt** at `/algorithms/or_opt/explainer/`, following the established 2-opt/stochastic-hill explainer pattern (pure `*-algo.ts` simulation + Preact `*.tsx` + vitest + Playwright e2e).

**Rust-faithful simulation** (`src/tsp/or_opt.rs`): each pass scans every segment of length 1–3 (Or-1/Or-2/Or-3) and every insertion point, applying the single best-improving relocation; **reversed insertions are also tried for Or-2/Or-3**. Move encoding mirrors the solver exactly: `(i, seg_len, j, reversed)`, the forbidden window `{prev} ∪ [i, i+seg_len)`, the `−1e-3` float threshold, and the drain/splice index adjustment. Deterministic — no RNG, so Back/Step replay identically.

## UI

SVG canvas with the relocating segment in orange, red cut / green paste edges, **faint ticks at every improving insertion gap** (the scan) plus a dashed marker at the best gap, and a **CSS morph** that makes the whole tour flow to its new shape when a move applies (Back restores instantly). Reversed moves show a `↺ reversed` badge. Cost sparkline, stats (pass, moves, best cost, distance, last Δ), speed slider, Back/Step/Run/Pause/Reset, scenario buttons.

## Scenarios (crafted tours, tuned offline — all converge to the 979.1 optimum)

| Scenario | Tour | Best move |
|---|---|---|
| Single segment | `[0,1,2,3,4,8,5,9,6,7]` | Or-1: centre city 8 slides out |
| Triplet move | `[0,1,2,8,5,4,3,9,6,7]` | Or-3 (reversed): block `[8,5,4]` relocates |
| Already optimal | `[0,1,2,3,4,5,8,9,6,7]` | none — the global optimum (Or-opt with reversal always reaches it here) |
| 2-opt stuck | `[0,7,6,5,4,3,2,1,8,9]` | Or-2 (reversed): 2-opt is stuck, Or-opt still improves — the docs' "catches improvements that 2-opt misses" |

The `2-opt stuck` tour is the same tour the 2-opt explainer calls "already 2-optimal" — a nice cross-explainer story.

## Files

- `teeline-web/src/explainers/or-opt-algo.ts` — pure simulation (ports of `find_best_move` / `apply_relocation`)
- `teeline-web/src/explainers/or-opt.tsx` — Preact component
- `teeline-web/src/explainers/or-opt.test.ts` — 25 unit tests (applyRelocation ported from the Rust tests, delta-vs-measured correctness, phase machine, scenario pins)
- `teeline-web/tests/or-opt.spec.ts` — 6 Playwright e2e tests
- `registry.ts`, `[id]/explainer/index.astro`, `docs/algorithms/or-opt.md` — wiring

## Verification

- `vitest run`: 394 tests pass (29 files)
- `astro check` + `tsc --noEmit`: clean
- Playwright e2e (`--project=chrome`): 6/6 new tests pass (12/12 explainer tests overall; pre-existing `webmcp.spec.ts` requires a production build — the dev server doesn't serve the copied WASM)

Closes #432