### PR TITLE
feat(web): add interactive 3-opt explainer (#434)

### DIFF
--- a/docs/algorithms/three-opt.md
+++ b/docs/algorithms/three-opt.md
@@ -3,7 +3,7 @@ id: "3opt"
 name: "3-opt"
 typeBadge: "Heuristic — local search"
 description: "Extension of 2-opt that removes three edges per iteration and reconnects the three segments in the best of the eight possible reconnection configurations."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # 3-opt

--- a/teeline-web/src/explainers/or-opt.tsx
+++ b/teeline-web/src/explainers/or-opt.tsx
@@ -332,7 +332,7 @@ export default function OrOptExplainer() {
         <button className="or-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
           {running ? "⏸ Pause" : "▶ Run"}
         </button>
-        <button className="or-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+        <button className="or-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
       </div>
 
       <div className="or-scenarios">

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -102,6 +102,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of Or-opt: watch segments of 1–3 consecutive cities get cut from one part of the tour and pasted into a better position, with reversed insertions for Or-2/Or-3 and best-improvement passes running to a local optimum.',
     backLabel: 'Or-opt',
   },
+  '3opt': {
+    title: '3-opt — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of the 3-opt local-search algorithm: watch three edges get removed and the three segments reconnected in one of seven ways, with the chosen reconnection pattern highlighted in a case diagram.',
+    backLabel: '3-opt',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/explainers/stochastic-hill.tsx
+++ b/teeline-web/src/explainers/stochastic-hill.tsx
@@ -357,7 +357,7 @@ export default function StochasticHillExplainer() {
         <button className="shc-btn" onClick={() => setRunning(!running)} disabled={phase === 'done'}>
           {running ? "⏸ Pause" : "▶ Run"}
         </button>
-        <button className="shc-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+        <button className="shc-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
       </div>
 
       <div className="shc-scenarios">

--- a/teeline-web/src/explainers/stochastic-hill.tsx
+++ b/teeline-web/src/explainers/stochastic-hill.tsx
@@ -170,6 +170,9 @@ export default function StochasticHillExplainer() {
   }, [])
 
   const stepForward = useCallback(() => {
+    // Guard against an in-flight interval tick after the run already finished:
+    // stepping a 'done' state would push a phantom undo entry.
+    if (simRef.current.phase === 'done') return
     historyRef.current.push(structuredClone(simRef.current))
     const next = stepOnce(simRef.current)
     simRef.current = next
@@ -362,7 +365,7 @@ export default function StochasticHillExplainer() {
         <div className="shc-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
             <button key={key} className="shc-scenario-btn" title={s.desc}
-              onClick={() => reinit(s)}>
+              onClick={() => reinit(s)} disabled={running}>
               {s.label}
             </button>
           ))}
@@ -528,7 +531,8 @@ const CSS = `
   border: 1px solid var(--line); background: var(--bg); color: var(--text);
   cursor: pointer; transition: background 0.15s;
 }
-.shc-scenario-btn:hover { background: #f0fdf4; border-color: var(--accent); }
+.shc-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.shc-scenario-btn:disabled { opacity: 0.4; cursor: default; }
 
 .shc-footer {
   display: flex; gap: 12px; justify-content: center;

--- a/teeline-web/src/explainers/three-opt-algo.ts
+++ b/teeline-web/src/explainers/three-opt-algo.ts
@@ -1,0 +1,276 @@
+// Pure simulation logic for the 3-opt interactive explainer.
+// Rust-faithful model (src/tsp/three_opt.rs):
+//   - each pass scans all O(n³) triples of edges (A,B),(C,D),(E,F) and keeps
+//     the single best improving reconnection across the 7 non-identity cases
+//   - cases 1–3 are segment reversals; cases 4–7 swap/reverse the two middle
+//     segments (the moves 2-opt cannot express)
+//   - repeats until no triple yields an improvement (local optimum)
+// Edge sets, case numbering, tie-breaks (first best case per triple, first
+// max-savings move overall) and the degenerate (i==0, k==n-1) skip all mirror
+// the solver. Deterministic — no RNG, so Back/Step replay identically.
+
+export const CITIES: [number, number][] = [
+  [150, 20],   // 0 — top
+  [270, 70],   // 1 — top-right
+  [260, 180],  // 2 — right
+  [180, 280],  // 3 — bottom-right
+  [120, 290],  // 4 — bottom
+  [35, 220],   // 5 — bottom-left
+  [25, 80],    // 6 — left
+  [80, 25],    // 7 — top-left
+  [155, 155],  // 8 — centre
+  [90, 140],   // 9 — inner-left
+]
+export const N_CITIES = CITIES.length
+
+export type Phase = 'idle' | 'candidate' | 'swap_applied' | 'local_optimum'
+
+export function dist(i: number, j: number): number {
+  const dx = CITIES[i][0] - CITIES[j][0]
+  const dy = CITIES[i][1] - CITIES[j][1]
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+export function tourLength(tour: number[]): number {
+  let d = 0
+  for (let k = 0; k < tour.length; k++) {
+    d += dist(tour[k], tour[(k + 1) % tour.length])
+  }
+  return d
+}
+
+// ---------------------------------------------------------------
+// The candidate move (Rust find_best_move + apply_3opt port)
+// ---------------------------------------------------------------
+export type CaseNo = 1 | 2 | 3 | 4 | 5 | 6 | 7
+
+// Case labels (s1 = [B..C], s2 = [D..E]; rev = reversed):
+//   1: rev(s1)        2: rev(s2)        3: rev(s1)+rev(s2)
+//   4: s2+s1          5: s2+rev(s1)     6: rev(s2)+s1    7: rev(s2)+rev(s1)
+export const CASE_LABELS: Record<CaseNo, string> = {
+  1: 'rev s1',
+  2: 'rev s2',
+  3: 'rev s1 · rev s2',
+  4: 'swap s2+s1',
+  5: 's2 + rev s1',
+  6: 'rev s2 + s1',
+  7: 'rev s2 · rev s1',
+}
+
+export interface MoveEvent {
+  i: number             // A = path[i]
+  j: number             // C = path[j]
+  k: number             // E = path[k]
+  caseNo: CaseNo
+  delta: number         // new tour length − old tour length (negative = improvement)
+  removedEdges: [number, number][]  // [A,B], [C,D], [E,F] — the three cut edges
+  addedEdges: [number, number][]    // the three reconnection edges for this case
+}
+
+export interface SimState {
+  phase: Phase
+  tour: number[]
+  bestTour: number[]
+  bestCost: number
+  pass: number          // completed scans (one per applied swap + final scan)
+  swaps: number         // applied 3-opt moves
+  pending: MoveEvent | null
+  lastMove: MoveEvent | null
+  costHistory: number[] // best cost after each pass (sparkline)
+  step: number
+}
+
+// New edge sets for the 7 reconnection cases (Rust reconnection_costs table).
+function addedEdgesForCase(a: number, b: number, c: number, d: number, e: number, f: number, caseNo: CaseNo): [number, number][] {
+  switch (caseNo) {
+    case 1: return [[a, c], [b, d], [e, f]]
+    case 2: return [[a, b], [c, e], [d, f]]
+    case 3: return [[a, c], [b, e], [d, f]]
+    case 4: return [[a, d], [e, b], [c, f]]
+    case 5: return [[a, d], [e, c], [b, f]]
+    case 6: return [[a, e], [d, b], [c, f]]
+    case 7: return [[a, e], [d, c], [b, f]]
+  }
+}
+
+// Rust find_best_move: scan all C(n,3) triples, return the globally best
+// improving 3-opt move or null. Tie-breaks match the solver: per triple the
+// lowest-index best case; overall the first move with the max savings.
+export function scanBestMove(tour: number[]): MoveEvent | null {
+  const n = tour.length
+  let bestMove: { i: number; j: number; k: number; caseNo: CaseNo; delta: number } | null = null
+  let bestSavings = 0
+
+  for (let i = 0; i < n - 2; i++) {
+    const a = tour[i]
+    const b = tour[i + 1]
+    for (let j = i + 1; j < n - 1; j++) {
+      const c = tour[j]
+      const dt = tour[j + 1]
+      for (let k = j + 1; k < n; k++) {
+        // Degenerate triple: the wrap-around edge makes F == A.
+        if (i === 0 && k === n - 1) continue
+        const e = tour[k]
+        const f = tour[(k + 1) % n]
+
+        const orig = dist(a, b) + dist(c, dt) + dist(e, f)
+        const costs: number[] = [
+          dist(a, c) + dist(b, dt) + dist(e, f), // 1
+          dist(a, b) + dist(c, e) + dist(dt, f), // 2
+          dist(a, c) + dist(b, e) + dist(dt, f), // 3
+          dist(a, dt) + dist(e, b) + dist(c, f), // 4
+          dist(a, dt) + dist(c, e) + dist(b, f), // 5
+          dist(a, e) + dist(b, dt) + dist(c, f), // 6
+          dist(a, e) + dist(c, dt) + dist(b, f), // 7
+        ]
+
+        // Best case for this triple: lowest-index minimum below orig.
+        let bestCase = -1
+        let bestCost = Infinity
+        for (let ci = 0; ci < 7; ci++) {
+          if (costs[ci] < orig && costs[ci] < bestCost) {
+            bestCost = costs[ci]
+            bestCase = ci
+          }
+        }
+        if (bestCase >= 0) {
+          const savings = orig - bestCost
+          if (savings > bestSavings) {
+            bestSavings = savings
+            bestMove = { i, j, k, caseNo: (bestCase + 1) as CaseNo, delta: bestCost - orig }
+          }
+        }
+      }
+    }
+  }
+
+  if (!bestMove) return null
+  const { i, j, k, caseNo, delta } = bestMove
+  const a = tour[i]
+  const b = tour[i + 1]
+  const c = tour[j]
+  const d = tour[j + 1]
+  const e = tour[k]
+  const f = tour[(k + 1) % n]
+  return {
+    i, j, k, caseNo, delta,
+    removedEdges: [[a, b], [c, d], [e, f]],
+    addedEdges: addedEdgesForCase(a, b, c, d, e, f, caseNo),
+  }
+}
+
+// Rust apply_3opt: cases 1–3 reverse segments, cases 4–7 swap/reverse the two
+// middle segments into [i+1..=k].
+export function apply3Opt(tour: number[], i: number, j: number, k: number, caseNo: CaseNo): number[] {
+  const rev = (arr: number[]) => [...arr].reverse()
+  const s1 = tour.slice(i + 1, j + 1) // [i+1..=j]
+  const s2 = tour.slice(j + 1, k + 1) // [j+1..=k]
+  const head = tour.slice(0, i + 1)
+  const tail = tour.slice(k + 1)
+  switch (caseNo) {
+    case 1: return [...head, ...rev(s1), ...tour.slice(j + 1)]
+    case 2: return [...tour.slice(0, j + 1), ...rev(s2), ...tail]
+    case 3: return [...head, ...rev(s1), ...rev(s2), ...tail]
+    case 4: return [...head, ...s2, ...s1, ...tail]
+    case 5: return [...head, ...s2, ...rev(s1), ...tail]
+    case 6: return [...head, ...rev(s2), ...s1, ...tail]
+    case 7: return [...head, ...rev(s2), ...rev(s1), ...tail]
+  }
+}
+
+// ---------------------------------------------------------------
+// Scenarios (crafted tours, tuned offline — see three-opt.test.ts pins)
+// ---------------------------------------------------------------
+export interface Scenario {
+  label: string
+  desc: string
+  tour: number[]
+}
+
+export const SCENARIOS: Record<string, Scenario> = {
+  single_3opt: {
+    label: 'Single 3-opt',
+    desc: 'Two blocks are swapped — one 3-opt segment swap (case 4) puts them back',
+    tour: [0, 3, 4, 1, 2, 5, 8, 9, 6, 7],
+  },
+  beyond_2opt: {
+    label: 'Beyond 2-opt',
+    desc: '2-opt calls this a local optimum — a 3-opt segment swap (case 6) still improves it',
+    tour: [0, 7, 6, 5, 4, 3, 2, 1, 8, 9],
+  },
+  already_3optimal: {
+    label: 'Already 3-optimal',
+    desc: 'No improving 3-opt move — the search is stuck 0.1% above the global optimum',
+    tour: [8, 2, 1, 0, 7, 6, 9, 5, 4, 3],
+  },
+  deep_sweep: {
+    label: 'Deep sweep',
+    desc: 'A tangled tour that needs several 3-opt passes to untangle',
+    tour: [4, 0, 9, 3, 6, 1, 8, 2, 5, 7],
+  },
+}
+
+export function makeInitState(tour: number[]): SimState {
+  const cost = tourLength(tour)
+  return {
+    phase: 'idle',
+    tour: [...tour],
+    bestTour: [...tour],
+    bestCost: cost,
+    pass: 0,
+    swaps: 0,
+    pending: null,
+    lastMove: null,
+    costHistory: [cost],
+    step: 0,
+  }
+}
+
+// One Step press. Two-click model like the 2-opt/or-opt explainers:
+//   idle | swap_applied → 'candidate'     (scan; show the best triple + case)
+//   'candidate'          → 'swap_applied' (apply the pending reconnection)
+// Either scan may instead end in 'local_optimum'. Pure — no mutation.
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'local_optimum') return { ...state, step: state.step + 1 }
+
+  // Second click — apply the pending move
+  if (state.phase === 'candidate' && state.pending) {
+    const m = state.pending
+    const newTour = apply3Opt(state.tour, m.i, m.j, m.k, m.caseNo)
+    const cost = tourLength(newTour)
+
+    return {
+      ...state,
+      phase: 'swap_applied',
+      tour: newTour,
+      bestTour: cost < state.bestCost ? [...newTour] : state.bestTour,
+      bestCost: Math.min(cost, state.bestCost),
+      pass: state.pass + 1,
+      swaps: state.swaps + 1,
+      lastMove: m,
+      costHistory: [...state.costHistory, cost],
+      step: state.step + 1,
+    }
+  }
+
+  // First click — scan for the best 3-opt move
+  const move = scanBestMove(state.tour)
+
+  if (!move) {
+    return {
+      ...state,
+      phase: 'local_optimum',
+      pass: state.pass + 1,
+      costHistory: [...state.costHistory, state.bestCost],
+      pending: null,
+      step: state.step + 1,
+    }
+  }
+
+  return {
+    ...state,
+    phase: 'candidate',
+    pending: move,
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/three-opt-algo.ts
+++ b/teeline-web/src/explainers/three-opt-algo.ts
@@ -137,7 +137,11 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
           const savings = orig - bestCost
           if (savings > bestSavings) {
             bestSavings = savings
-            bestMove = { i, j, k, caseNo: (bestCase + 1) as CaseNo, delta: bestCost - orig }
+            const caseNo = (bestCase + 1) as CaseNo
+            if (caseNo < 1 || caseNo > 7) {
+              throw new Error(`3-opt: invalid caseNo ${caseNo}`)
+            }
+            bestMove = { i, j, k, caseNo, delta: bestCost - orig }
           }
         }
       }
@@ -149,13 +153,13 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
   const a = tour[i]
   const b = tour[i + 1]
   const c = tour[j]
-  const d = tour[j + 1]
+  const dt = tour[j + 1]
   const e = tour[k]
   const f = tour[(k + 1) % n]
   return {
     i, j, k, caseNo, delta,
-    removedEdges: [[a, b], [c, d], [e, f]],
-    addedEdges: addedEdgesForCase(a, b, c, d, e, f, caseNo),
+    removedEdges: [[a, b], [c, dt], [e, f]],
+    addedEdges: addedEdgesForCase(a, b, c, dt, e, f, caseNo),
   }
 }
 
@@ -168,8 +172,8 @@ export function apply3Opt(tour: number[], i: number, j: number, k: number, caseN
   const head = tour.slice(0, i + 1)
   const tail = tour.slice(k + 1)
   switch (caseNo) {
-    case 1: return [...head, ...rev(s1), ...tour.slice(j + 1)]
-    case 2: return [...tour.slice(0, j + 1), ...rev(s2), ...tail]
+    case 1: return [...head, ...rev(s1), ...s2, ...tail]
+    case 2: return [...head, ...s1, ...rev(s2), ...tail]
     case 3: return [...head, ...rev(s1), ...rev(s2), ...tail]
     case 4: return [...head, ...s2, ...s1, ...tail]
     case 5: return [...head, ...s2, ...rev(s1), ...tail]

--- a/teeline-web/src/explainers/three-opt.test.ts
+++ b/teeline-web/src/explainers/three-opt.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import {
+  N_CITIES, SCENARIOS, CASE_LABELS,
+  dist, tourLength, scanBestMove, apply3Opt, makeInitState, stepOnce,
+} from './three-opt-algo'
+import type { SimState } from './three-opt-algo'
+import { scanOnePass, makeInitState as twoOptInit } from './two-opt-algo'
+
+// True optimum for the shared 10-city layout (see stochastic-hill tests).
+const OPT = 979.0581791448133
+
+function runToOptimum(tour: number[]): SimState {
+  let s = makeInitState(tour)
+  let guard = 300
+  while (s.phase !== 'local_optimum' && guard-- > 0) s = stepOnce(s)
+  expect(s.phase, 'runToOptimum must converge').toBe('local_optimum')
+  return s
+}
+
+// ---------------------------------------------------------------
+describe('dist / tourLength', () => {
+  it('dist is symmetric and non-negative', () => {
+    for (let i = 0; i < N_CITIES; i++) {
+      for (let j = 0; j < N_CITIES; j++) {
+        expect(dist(i, j)).toBeCloseTo(dist(j, i), 10)
+        expect(dist(i, j)).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+
+  it('tourLength matches the known optimum', () => {
+    expect(tourLength([0, 1, 2, 3, 4, 5, 8, 9, 6, 7])).toBeCloseTo(OPT, 6)
+  })
+})
+
+// ---------------------------------------------------------------
+// apply3Opt — the 7 reconnection cases
+// ---------------------------------------------------------------
+describe('apply3Opt (the 7 cases)', () => {
+  // tour: 0 → [A=1, B=2, C=3, D=4, E=5] → 6  (i=1, j=3, k=5)
+  const tour = [0, 1, 2, 3, 4, 5, 6]
+
+  it('case 1: reverse s1 = [i+1..=j]', () => {
+    // s1 = [2,3] → [3,2]
+    expect(apply3Opt(tour, 1, 3, 5, 1)).toEqual([0, 1, 3, 2, 4, 5, 6])
+  })
+
+  it('case 2: reverse s2 = [j+1..=k]', () => {
+    // s2 = [4,5] → [5,4]
+    expect(apply3Opt(tour, 1, 3, 5, 2)).toEqual([0, 1, 2, 3, 5, 4, 6])
+  })
+
+  it('case 3: reverse both s1 and s2', () => {
+    expect(apply3Opt(tour, 1, 3, 5, 3)).toEqual([0, 1, 3, 2, 5, 4, 6])
+  })
+
+  it('case 4: swap s2 + s1 (kept in order)', () => {
+    expect(apply3Opt(tour, 1, 3, 5, 4)).toEqual([0, 1, 4, 5, 2, 3, 6])
+  })
+
+  it('case 5: s2 + rev(s1)', () => {
+    expect(apply3Opt(tour, 1, 3, 5, 5)).toEqual([0, 1, 4, 5, 3, 2, 6])
+  })
+
+  it('case 6: rev(s2) + s1', () => {
+    expect(apply3Opt(tour, 1, 3, 5, 6)).toEqual([0, 1, 5, 4, 2, 3, 6])
+  })
+
+  it('case 7: rev(s2) + rev(s1)', () => {
+    expect(apply3Opt(tour, 1, 3, 5, 7)).toEqual([0, 1, 5, 4, 3, 2, 6])
+  })
+
+  it('never mutates the input', () => {
+    const t = [0, 1, 2, 3, 4, 5, 6]
+    const copy = [...t]
+    apply3Opt(t, 1, 3, 5, 7)
+    expect(t).toEqual(copy)
+  })
+
+  it('CASE_LABELS covers all 7 cases', () => {
+    expect(Object.keys(CASE_LABELS)).toHaveLength(7)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('scanBestMove', () => {
+  it('returns null for the already_3optimal tour', () => {
+    expect(scanBestMove(SCENARIOS.already_3optimal.tour)).toBeNull()
+  })
+
+  it('returns a negative-delta move for improving tours', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      if (key === 'already_3optimal') continue
+      const move = scanBestMove(s.tour)
+      expect(move, `${key} should have an improving move`).not.toBeNull()
+      expect(move!.delta).toBeLessThan(0)
+      expect(move!.caseNo).toBeGreaterThanOrEqual(1)
+      expect(move!.caseNo).toBeLessThanOrEqual(7)
+      expect(move!.removedEdges).toHaveLength(3)
+      expect(move!.addedEdges).toHaveLength(3)
+    }
+  })
+
+  it('single_3opt: the best move is a case-4 segment swap of two 2-city blocks', () => {
+    const move = scanBestMove(SCENARIOS.single_3opt.tour)!
+    expect(move.caseNo).toBe(4)
+    expect(move.i).toBe(0)
+    expect(move.j).toBe(2)
+    expect(move.k).toBe(4)
+    // applying it reaches the optimum
+    const after = apply3Opt(SCENARIOS.single_3opt.tour, move.i, move.j, move.k, move.caseNo)
+    expect(tourLength(after)).toBeCloseTo(OPT, 3)
+  })
+
+  it('beyond_2opt: 2-opt is stuck, 3-opt still improves (case 6)', () => {
+    const tour = SCENARIOS.beyond_2opt.tour
+    const { bestDelta } = scanOnePass(twoOptInit(tour))
+    expect(bestDelta).toBeGreaterThanOrEqual(0) // 2-opt is stuck
+    const move = scanBestMove(tour)
+    expect(move).not.toBeNull()
+    expect(move!.delta).toBeLessThan(0)
+    expect(move!.caseNo).toBe(6)
+  })
+
+  it('delta matches the measured cost change', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      if (key === 'already_3optimal') continue
+      const move = scanBestMove(s.tour)!
+      const before = tourLength(s.tour)
+      const after = tourLength(apply3Opt(s.tour, move.i, move.j, move.k, move.caseNo))
+      expect(after - before, `${key} delta mismatch`).toBeCloseTo(move.delta, 3)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+describe('stepOnce phase machine', () => {
+  const s0 = makeInitState(SCENARIOS.single_3opt.tour)
+
+  it('idle → candidate scans without touching the tour', () => {
+    const s1 = stepOnce(s0)
+    expect(s1.phase).toBe('candidate')
+    expect(s1.pending).not.toBeNull()
+    expect(s1.tour).toEqual(s0.tour)
+    expect(s1.pass).toBe(0)
+    expect(s1.swaps).toBe(0)
+    expect(s1.step).toBe(1)
+  })
+
+  it('candidate → swap_applied applies and increments pass/swaps', () => {
+    const s1 = stepOnce(s0)
+    const s2 = stepOnce(s1)
+    expect(s2.phase).toBe('swap_applied')
+    expect(s2.pass).toBe(1)
+    expect(s2.swaps).toBe(1)
+    expect(s2.tour).toEqual(apply3Opt(s0.tour, s1.pending!.i, s1.pending!.j, s1.pending!.k, s1.pending!.caseNo))
+    expect(s2.costHistory).toHaveLength(2)
+    expect(s2.step).toBe(2)
+  })
+
+  it('already_3optimal → local_optimum on the first scan', () => {
+    const s = stepOnce(makeInitState(SCENARIOS.already_3optimal.tour))
+    expect(s.phase).toBe('local_optimum')
+    expect(s.pass).toBe(1)
+    expect(s.swaps).toBe(0)
+  })
+
+  it('local_optimum is a no-op apart from the step counter', () => {
+    const done = runToOptimum(SCENARIOS.single_3opt.tour)
+    const again = stepOnce(done)
+    expect(again.phase).toBe('local_optimum')
+    expect(again.tour).toEqual(done.tour)
+    expect(again.step).toBe(done.step + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('convergence', () => {
+  it('single_3opt converges to the optimum in exactly one swap', () => {
+    const s = runToOptimum(SCENARIOS.single_3opt.tour)
+    expect(s.swaps).toBe(1)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('beyond_2opt converges to the optimum in exactly one swap', () => {
+    const s = runToOptimum(SCENARIOS.beyond_2opt.tour)
+    expect(s.swaps).toBe(1)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('already_3optimal stays stuck just above the optimum', () => {
+    const s = runToOptimum(SCENARIOS.already_3optimal.tour)
+    expect(s.swaps).toBe(0)
+    expect(s.bestCost).toBeGreaterThan(OPT)
+    expect(s.bestCost).toBeLessThan(OPT * 1.01)
+  })
+
+  it('deep_sweep needs several passes to converge', () => {
+    const s = runToOptimum(SCENARIOS.deep_sweep.tour)
+    expect(s.swaps).toBeGreaterThanOrEqual(3)
+    expect(s.pass).toBeGreaterThanOrEqual(s.swaps)
+    expect(s.bestCost).toBeCloseTo(OPT, 3)
+  })
+
+  it('best cost never increases and costHistory is non-increasing', () => {
+    const s = runToOptimum(SCENARIOS.deep_sweep.tour)
+    expect(s.bestCost).toBeLessThanOrEqual(s.costHistory[0])
+    for (let k = 1; k < s.costHistory.length; k++) {
+      expect(s.costHistory[k]).toBeLessThanOrEqual(s.costHistory[k - 1])
+    }
+    // initial + one push per swap + one final push at the local optimum
+    expect(s.costHistory).toHaveLength(s.swaps + 2)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('purity & determinism', () => {
+  it('stepOnce never mutates its input', () => {
+    const s = makeInitState(SCENARIOS.deep_sweep.tour)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 20; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same tour produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.deep_sweep.tour)
+    const b = makeInitState(SCENARIOS.deep_sweep.tour)
+    for (let i = 0; i < 20; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+
+  it('all scenario tours are valid permutations', () => {
+    for (const [key, s] of Object.entries(SCENARIOS)) {
+      const sorted = s.tour.slice().sort((a, b) => a - b)
+      expect(sorted, `${key} must be a permutation`).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+    }
+  })
+})

--- a/teeline-web/src/explainers/three-opt.tsx
+++ b/teeline-web/src/explainers/three-opt.tsx
@@ -234,11 +234,12 @@ export default function ThreeOptExplainer() {
   }, [running, speedIdx, stepForward])
 
   const distance = tourLength(tour)
-  const activeCase = phase === 'candidate' && pending
-    ? pending.caseNo
-    : phase === 'swap_applied' && lastMove
-      ? lastMove.caseNo
-      : null
+  let activeCase: CaseNo | null = null
+  if (phase === 'candidate' && pending) {
+    activeCase = pending.caseNo
+  } else if (phase === 'swap_applied' && lastMove) {
+    activeCase = lastMove.caseNo
+  }
 
   // Status chip
   let chipText = "Click Step to scan triples for the best 3-opt reconnection"
@@ -351,7 +352,7 @@ export default function ThreeOptExplainer() {
         <button className="t3-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
           {running ? "⏸ Pause" : "▶ Run"}
         </button>
-        <button className="t3-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+        <button className="t3-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
       </div>
 
       <div className="t3-scenarios">

--- a/teeline-web/src/explainers/three-opt.tsx
+++ b/teeline-web/src/explainers/three-opt.tsx
@@ -1,0 +1,542 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  CITIES, N_CITIES, SCENARIOS, CASE_LABELS,
+  tourLength, makeInitState, stepOnce,
+} from "./three-opt-algo"
+import type { Phase, MoveEvent, Scenario, CaseNo } from "./three-opt-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.single_3opt
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const CASES: CaseNo[] = [1, 2, 3, 4, 5, 6, 7]
+
+function edgeKey(a: number, b: number): string {
+  return `${Math.min(a, b)}-${Math.max(a, b)}`
+}
+
+// ---------------------------------------------------------------
+// Reconnection pattern diagram — the 7 ways to reconnect the three
+// segments (a "truth table" of which pairs get joined). Nodes A–F sit
+// on a hexagon; removed edges (AB, CD, EF) are faint, the case's three
+// new edges are orange. The active case is highlighted.
+// ---------------------------------------------------------------
+const NODE_POS: Record<string, [number, number]> = {
+  A: [24, 4],
+  B: [41, 13],
+  C: [41, 27],
+  D: [24, 36],
+  E: [7, 27],
+  F: [7, 13],
+}
+const REMOVED_LABEL_PAIRS: [string, string][] = [['A', 'B'], ['C', 'D'], ['E', 'F']]
+
+function caseLabelPairs(caseNo: CaseNo): [string, string][] {
+  switch (caseNo) {
+    case 1: return [['A', 'C'], ['B', 'D'], ['E', 'F']]
+    case 2: return [['A', 'B'], ['C', 'E'], ['D', 'F']]
+    case 3: return [['A', 'C'], ['B', 'E'], ['D', 'F']]
+    case 4: return [['A', 'D'], ['E', 'B'], ['C', 'F']]
+    case 5: return [['A', 'D'], ['E', 'C'], ['B', 'F']]
+    case 6: return [['A', 'E'], ['D', 'B'], ['C', 'F']]
+    case 7: return [['A', 'E'], ['D', 'C'], ['B', 'F']]
+  }
+}
+
+function PatternCell({ caseNo, active }: { caseNo: CaseNo; active: boolean }) {
+  const pairs = caseLabelPairs(caseNo)
+  return (
+    <div className={`t3-pattern-cell ${active ? 't3-pattern-active' : ''}`} title={CASE_LABELS[caseNo]}>
+      <svg viewBox="0 0 48 40" className="t3-pattern-svg" aria-label={`case ${caseNo}: ${CASE_LABELS[caseNo]}`}>
+        {REMOVED_LABEL_PAIRS.map(([a, b]) => (
+          <line key={`r${a}${b}`} className="t3-pattern-removed"
+            x1={NODE_POS[a][0]} y1={NODE_POS[a][1]}
+            x2={NODE_POS[b][0]} y2={NODE_POS[b][1]} />
+        ))}
+        {pairs.map(([a, b]) => (
+          <line key={`n${a}${b}`} className="t3-pattern-new"
+            x1={NODE_POS[a][0]} y1={NODE_POS[a][1]}
+            x2={NODE_POS[b][0]} y2={NODE_POS[b][1]} />
+        ))}
+        {Object.entries(NODE_POS).map(([label, [x, y]]) => (
+          <text key={label} className="t3-pattern-node" x={x} y={y}>{label}</text>
+        ))}
+      </svg>
+      <div className="t3-pattern-case">{caseNo}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// TourCanvas — the current tour with 3 removed / 3 added edges and a
+// CSS morph that makes the tour flow to its new shape on apply.
+// ---------------------------------------------------------------
+function TourCanvas({ tour, pending, lastMove, phase, morph }: {
+  tour: number[]
+  pending: MoveEvent | null
+  lastMove: MoveEvent | null
+  phase: Phase
+  morph: boolean
+}) {
+  const showCandidate = phase === 'candidate' && pending
+  const showApplied = phase === 'swap_applied' && lastMove
+
+  const activeMove = useMemo<MoveEvent | null>(() => {
+    if (showCandidate) return pending
+    if (showApplied) return lastMove
+    return null
+  }, [pending, lastMove, showCandidate, showApplied])
+
+  const removedSet = useMemo(() => {
+    if (!activeMove) return new Set<string>()
+    return new Set(activeMove.removedEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [activeMove])
+  const addedSet = useMemo(() => {
+    if (!activeMove) return new Set<string>()
+    return new Set(activeMove.addedEdges.map(([a, b]) => edgeKey(a, b)))
+  }, [activeMove])
+
+  const edges: Array<{ from: number; to: number; key: string }> = []
+  for (let k = 0; k < tour.length; k++) {
+    const a = tour[k]
+    const b = tour[(k + 1) % tour.length]
+    edges.push({ from: a, to: b, key: edgeKey(a, b) })
+  }
+
+  return (
+    <svg viewBox="0 0 300 300"
+      className={`t3-canvas ${morph && showApplied ? 't3-morph' : ''}`}
+      role="img" aria-label="3-opt tour">
+      <rect x={0} y={0} width={300} height={300} className="t3-bg" />
+      <g className="t3-tour">
+        {edges.map(({ from, to, key }) => {
+          let cls = 't3-edge'
+          if (addedSet.has(key)) cls += showCandidate ? ' t3-cand-new' : ' t3-new'
+          else if (removedSet.has(key)) cls += showCandidate ? ' t3-cand-removed' : ' t3-removed'
+          return <line key={key} className={cls}
+            x1={CITIES[from][0]} y1={CITIES[from][1]}
+            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+        })}
+        {tour.map((id) => (
+          <g key={id}>
+            <circle className="t3-city"
+              cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
+            <text className="t3-label"
+              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Cost sparkline (same pattern as 2-opt / or-opt)
+// ---------------------------------------------------------------
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null
+  const W = 300, H = 46
+  const minV = Math.min(...values)
+  const maxV = Math.max(...values)
+  const range = maxV - minV || 1
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W
+    const y = H - ((v - minV) / range) * (H - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="t3-spark" aria-label="cost over passes">
+      <rect x={0} y={0} width={W} height={H} className="t3-bg" rx={4} />
+      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
+        strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function ThreeOptExplainer() {
+  const [tour, setTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.tour])
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [pass, setPass] = useState(0)
+  const [swaps, setSwaps] = useState(0)
+  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.tour))
+  const [pending, setPending] = useState<MoveEvent | null>(null)
+  const [lastMove, setLastMove] = useState<MoveEvent | null>(null)
+  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.tour)])
+  const [step, setStep] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2) // 3x default
+  const [morphOn, setMorphOn] = useState(false) // animate on apply, not on Back
+
+  const simRef = useRef(makeInitState(DEFAULT_SCENARIO.tour))
+  const historyRef = useRef<Array<typeof simRef.current>>([])
+  const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
+
+  const reinit = useCallback((scenario: Scenario) => {
+    scenarioRef.current = scenario
+    simRef.current = makeInitState(scenario.tour)
+    historyRef.current = []
+    setTour([...simRef.current.tour])
+    setPhase('idle')
+    setPass(0)
+    setSwaps(0)
+    setBestCost(simRef.current.bestCost)
+    setPending(null)
+    setLastMove(null)
+    setCostHistory([simRef.current.bestCost])
+    setStep(0)
+    setRunning(false)
+    setMorphOn(false)
+  }, [])
+
+  const stepForward = useCallback(() => {
+    // Guard against an in-flight interval tick after the run already finished.
+    if (simRef.current.phase === 'local_optimum') return
+    historyRef.current.push(structuredClone(simRef.current))
+    const next = stepOnce(simRef.current)
+    simRef.current = next
+    setTour([...next.tour])
+    setPhase(next.phase)
+    setPass(next.pass)
+    setSwaps(next.swaps)
+    setBestCost(next.bestCost)
+    setPending(next.pending)
+    setLastMove(next.lastMove)
+    setCostHistory([...next.costHistory])
+    setStep(next.step)
+    setMorphOn(next.phase === 'swap_applied')
+    if (next.phase === 'local_optimum') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    const prev = h.pop()!
+    simRef.current = prev
+    setTour([...prev.tour])
+    setPhase(prev.phase)
+    setPass(prev.pass)
+    setSwaps(prev.swaps)
+    setBestCost(prev.bestCost)
+    setPending(prev.pending)
+    setLastMove(prev.lastMove)
+    setCostHistory([...prev.costHistory])
+    setStep(prev.step)
+    setMorphOn(false)
+  }, [running])
+
+  useEffect(() => {
+    if (!running) return
+    const ms = SPEEDS[speedIdx]
+    const id = setInterval(stepForward, ms)
+    return () => clearInterval(id)
+  }, [running, speedIdx, stepForward])
+
+  const distance = tourLength(tour)
+  const activeCase = phase === 'candidate' && pending
+    ? pending.caseNo
+    : phase === 'swap_applied' && lastMove
+      ? lastMove.caseNo
+      : null
+
+  // Status chip
+  let chipText = "Click Step to scan triples for the best 3-opt reconnection"
+  let chipClass = "t3-chip t3-chip-idle"
+  if (phase === 'candidate' && pending) {
+    const [[a, b], [c, d], [e, f]] = pending.removedEdges
+    chipText = `Candidate — remove ${a}→${b} · ${c}→${d} · ${e}→${f}, case ${pending.caseNo} (${CASE_LABELS[pending.caseNo]})  (Δ=${pending.delta.toFixed(0)})`
+    chipClass = "t3-chip t3-chip-candidate"
+  } else if (phase === 'swap_applied' && lastMove) {
+    chipText = `Applied — case ${lastMove.caseNo} (${CASE_LABELS[lastMove.caseNo]})  (Δ=${lastMove.delta.toFixed(0)})`
+    chipClass = "t3-chip t3-chip-applied"
+  } else if (phase === 'local_optimum') {
+    chipText = `Local optimum — no improving 3-opt move (${swaps} swaps, ${pass} passes)`
+    chipClass = "t3-chip t3-chip-done"
+  }
+
+  return (
+    <div className="t3-root">
+      <style>{CSS}</style>
+
+      <header className="t3-header">
+        <div className="t3-eyebrow">teeline · algorithms/3opt</div>
+        <h2 className="t3-title">3-opt Local Search</h2>
+        <p className="t3-sub">
+          3-opt removes <strong>three edges</strong> and reconnects the three resulting segments in
+          one of <strong>seven ways</strong> (2-opt only has one). Cases 1–3 reverse segments; cases
+          4–7 <em>swap</em> segments — the moves 2-opt cannot express. Each pass scans all triples
+          and applies the single <strong>best-improving</strong> reconnection, repeating until no
+          triple yields an improvement.
+        </p>
+      </header>
+
+      <div className="t3-viz-row">
+        <div className="t3-canvas-wrap">
+          <TourCanvas tour={tour} pending={pending} lastMove={lastMove} phase={phase} morph={morphOn} />
+        </div>
+        <div className="t3-pattern-wrap">
+          <div className="t3-section-label">Reconnection patterns</div>
+          <div className="t3-pattern-grid">
+            {CASES.map((c) => (
+              <PatternCell key={c} caseNo={c} active={activeCase === c} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="t3-legend">
+        <span><span className="t3-swatch t3-swatch-normal" /> tour edge</span>
+        <span><span className="t3-swatch t3-swatch-removed" /> removed</span>
+        <span><span className="t3-swatch t3-swatch-new" /> new edge</span>
+        <span><span className="t3-swatch t3-swatch-pattern" /> chosen pattern</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="t3-section-label">Cost over passes</div>
+      <Sparkline values={costHistory} />
+
+      <div className="t3-statgrid">
+        <div>
+          <div className="t3-statlabel">pass</div>
+          <div className="t3-mono">{pass}</div>
+        </div>
+        <div>
+          <div className="t3-statlabel">swaps</div>
+          <div className="t3-mono">{swaps}</div>
+        </div>
+        <div>
+          <div className="t3-statlabel">best cost</div>
+          <div className="t3-mono">{bestCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="t3-statlabel">distance</div>
+          <div className="t3-mono">{distance.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="t3-statlabel">last Δ</div>
+          <div className="t3-mono" style={{ color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit' }}>
+            {lastMove ? lastMove.delta.toFixed(0) : '—'}
+          </div>
+        </div>
+        <div>
+          <div className="t3-statlabel">step</div>
+          <div className="t3-mono">{step}</div>
+        </div>
+      </div>
+
+      <div className="t3-config">
+        <div className="t3-config-row">
+          <label className="t3-label">Speed</label>
+          <div className="t3-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l}
+                className={`t3-speed-btn ${i === speedIdx ? 't3-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="t3-controls">
+        <button className="t3-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+          ⏴ Back
+        </button>
+        <button className="t3-btn" onClick={stepForward} disabled={running || phase === 'local_optimum'}>
+          ⏵ Step
+        </button>
+        <button className="t3-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="t3-btn" onClick={() => reinit(scenarioRef.current)}>↺ Reset</button>
+      </div>
+
+      <div className="t3-scenarios">
+        <div className="t3-section-label">Scenarios</div>
+        <div className="t3-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, s]) => (
+            <button key={key} className="t3-scenario-btn" title={s.desc}
+              onClick={() => reinit(s)} disabled={running}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="t3-footer">
+        <span className="t3-mono">cities: {N_CITIES}</span>
+        <span className="t3-mono">O(n³) triple scan · 7 reconnections · best-improvement</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.t3-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --improve: #16a34a;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 820px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.t3-root * { box-sizing: border-box; }
+.t3-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.t3-header { margin-bottom: 2px; }
+.t3-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.t3-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.t3-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.t3-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.t3-bg { fill: var(--panel); }
+.t3-edge { stroke: #94a3b8; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.t3-cand-removed { stroke: #ea580c; stroke-width: 3.5; stroke-dasharray: 6 4; }
+.t3-cand-new { stroke: #16a34a; stroke-width: 3.5; stroke-dasharray: 4 6; }
+.t3-removed { stroke: #ef4444; stroke-width: 3.5; stroke-dasharray: 6 3; }
+.t3-new { stroke: #16a34a; stroke-width: 3.5; }
+.t3-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; transition: cx 0.35s ease, cy 0.35s ease; }
+.t3-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+/* Morph: when a swap is applied, the whole tour flows to its new shape. */
+.t3-morph .t3-edge,
+.t3-morph .t3-removed,
+.t3-morph .t3-new,
+.t3-morph .t3-cand-removed,
+.t3-morph .t3-cand-new {
+  transition: x1 0.35s ease, y1 0.35s ease, x2 0.35s ease, y2 0.35s ease;
+}
+
+.t3-viz-row { display: flex; gap: 10px; align-items: stretch; }
+.t3-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+
+.t3-pattern-wrap { width: 168px; flex-shrink: 0; display: flex; flex-direction: column; gap: 6px; }
+.t3-pattern-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 4px; }
+.t3-pattern-cell {
+  border: 1px solid var(--line); border-radius: 6px; padding: 2px;
+  background: var(--bg); display: flex; flex-direction: column; align-items: center;
+}
+.t3-pattern-active {
+  border-color: #ea580c; background: #fff7ed;
+  box-shadow: 0 0 0 1px #ea580c;
+}
+.t3-pattern-svg { width: 100%; display: block; }
+.t3-pattern-removed { stroke: #94a3b8; stroke-width: 1; stroke-dasharray: 2 2; opacity: 0.6; }
+.t3-pattern-new { stroke: #ea580c; stroke-width: 1.6; }
+.t3-pattern-node {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 6px; fill: #374151; text-anchor: middle; dominant-baseline: central;
+}
+.t3-pattern-case {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.7rem; color: var(--muted);
+}
+
+.t3-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.t3-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.t3-swatch-normal { background: #94a3b8; }
+.t3-swatch-removed { background: #ef4444; }
+.t3-swatch-new { background: #16a34a; }
+.t3-swatch-pattern { background: #ea580c; }
+
+.t3-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.t3-chip-idle { background: #f1f5f9; color: var(--muted); }
+.t3-chip-candidate { background: #ffedd5; color: #9a3412; }
+.t3-chip-applied { background: #dcfce7; color: #166534; }
+.t3-chip-done { background: #f1f5f9; color: var(--muted); }
+
+.t3-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.t3-spark { width: 100%; display: block; border-radius: 6px; }
+
+.t3-statgrid {
+  display: flex; flex-wrap: wrap; gap: 14px 22px;
+  font-size: 0.82rem;
+}
+.t3-statlabel { color: var(--muted); font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.t3-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.t3-config-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.t3-label {
+  font-size: 0.82rem; font-weight: 500; color: var(--text);
+  min-width: 50px;
+}
+.t3-speed-btns { display: flex; gap: 4px; }
+.t3-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.t3-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.t3-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.t3-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.t3-controls { display: flex; gap: 8px; }
+.t3-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.t3-btn:hover:not(:disabled) { background: #f0fdf4; }
+.t3-btn:disabled { opacity: 0.4; cursor: default; }
+
+.t3-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.t3-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.t3-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer; transition: background 0.15s;
+}
+.t3-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.t3-scenario-btn:disabled { opacity: 0.4; cursor: default; }
+
+.t3-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -30,6 +30,7 @@ import SavingsExplainer from '../../../../explainers/savings'
 import AcoExplainer from '../../../../explainers/aco'
 import StochasticHillExplainer from '../../../../explainers/stochastic-hill'
 import OrOptExplainer from '../../../../explainers/or-opt'
+import ThreeOptExplainer from '../../../../explainers/three-opt'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -73,6 +74,7 @@ const jsonLd = {
     {id === 'aco' && <AcoExplainer client:visible />}
     {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
     {id === 'or_opt' && <OrOptExplainer client:visible />}
+    {id === '3opt' && <ThreeOptExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
   </main>

--- a/teeline-web/tests/three-opt.spec.ts
+++ b/teeline-web/tests/three-opt.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the 3-opt explainer (/algorithms/3opt/explainer/).
+// The component hydrates with `client:visible`, so the tests first scroll it
+// into view and probe until the Preact listeners are attached (a click that
+// changes the status chip), then reset to the idle phase.
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.t3-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.t3-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  // Retry the click until it lands post-hydration (pre-hydration clicks are no-ops).
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('Candidate', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  // back to the idle phase for deterministic tests
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(chip).toContainText('Click Step')
+}
+
+test.describe('3-opt explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/3opt/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the canvas, pattern diagram, stats and controls', async ({ page }) => {
+    await expect(page.locator('.t3-title')).toHaveText('3-opt Local Search')
+    await expect(page.locator('.t3-canvas')).toBeVisible()
+
+    // the 7-reconnection pattern diagram
+    await expect(page.locator('.t3-pattern-grid')).toBeVisible()
+    await expect(page.locator('.t3-pattern-cell')).toHaveCount(7)
+
+    const stats = page.locator('.t3-statgrid')
+    await expect(stats).toContainText('pass')
+    await expect(stats).toContainText('swaps')
+    await expect(stats).toContainText('best cost')
+    await expect(stats).toContainText('distance')
+    await expect(stats).toContainText('last Δ')
+    await expect(stats).toContainText('step')
+
+    for (const label of ['Single 3-opt', 'Beyond 2-opt', 'Already 3-optimal', 'Deep sweep']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step shows the candidate with the chosen reconnection pattern highlighted, then applies', async ({ page }) => {
+    const chip = page.locator('.t3-chip')
+    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+    const swaps = page.locator('.t3-statgrid').locator('div', { hasText: /^swaps/ }).locator('.t3-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    // single_3opt scenario: the best move is a case-4 segment swap
+    await expect(chip).toContainText('Candidate')
+    await expect(chip).toContainText('case 4')
+    await expect(page.locator('.t3-pattern-active')).toHaveCount(1)
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('Applied')
+    await expect(pass).toHaveText('1')
+    await expect(swaps).toHaveText('1')
+
+    // sparkline appears once there are ≥ 2 cost samples
+    await expect(page.locator('.t3-spark')).toBeVisible()
+  })
+
+  test('Back restores the previous phase', async ({ page }) => {
+    const chip = page.locator('.t3-chip')
+    const stepStat = page.locator('.t3-statgrid').locator('div', { hasText: /^step/ }).locator('.t3-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click() // candidate
+    await page.getByRole('button', { name: 'Step' }).click() // applied
+    await expect(stepStat).toHaveText('2')
+
+    await page.getByRole('button', { name: 'Back' }).click()
+    await expect(chip).toContainText('Candidate') // back to the candidate phase
+    await expect(stepStat).toHaveText('1')
+  })
+
+  test('Run animates the deep sweep to the local optimum; Reset restores idle', async ({ page }) => {
+    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+    const swaps = page.locator('.t3-statgrid').locator('div', { hasText: /^swaps/ }).locator('.t3-mono')
+
+    await page.getByRole('button', { name: 'Deep sweep' }).click()
+    await page.getByRole('button', { name: 'Run' }).click()
+    // deep_sweep needs several passes to converge
+    await expect(page.locator('.t3-chip')).toContainText('Local optimum', { timeout: 15_000 })
+    await expect(swaps).not.toHaveText('0')
+    await expect(pass).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(pass).toHaveText('0')
+    await expect(page.locator('.t3-chip')).toContainText('Click Step')
+  })
+
+  test('Pause stops the animation mid-run', async ({ page }) => {
+    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await pass.textContent()
+    await page.waitForTimeout(700)
+    await expect(pass).toHaveText(paused ?? '')
+  })
+
+  test('already_3optimal reaches the local optimum in one Step', async ({ page }) => {
+    await page.getByRole('button', { name: 'Already 3-optimal' }).click()
+    await expect(page.locator('.t3-chip')).toContainText('Click Step')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(page.locator('.t3-chip')).toContainText('Local optimum')
+  })
+
+  test('scenario buttons restart the run', async ({ page }) => {
+    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(pass).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Beyond 2-opt' }).click()
+    await expect(pass).toHaveText('0')
+    await expect(page.locator('.t3-chip')).toContainText('Click Step')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    // beyond_2opt: the best move is a case-6 segment swap
+    await expect(page.locator('.t3-chip')).toContainText('case 6')
+  })
+})


### PR DESCRIPTION
## What

Interactive explainer for **3-opt** at `/algorithms/3opt/explainer/`, following the established 2-opt/or-opt/stochastic-hill explainer pattern (pure `*-algo.ts` simulation + Preact `*.tsx` + vitest + Playwright e2e). Stacked on the or-opt branch (#469) so the two PRs merge cleanly; only the last three commits belong to this PR.

**Rust-faithful simulation** (`src/tsp/three_opt.rs`): each pass scans all O(n³) triples of edges `(A,B),(C,D),(E,F)` and applies the single best-improving reconnection across the **7 non-identity cases**. Edge sets, case numbering, tie-breaks (first best case per triple, first max-savings move overall) and the degenerate `(i==0, k==n-1)` skip mirror the solver exactly. Deterministic — no RNG, so Back/Step replay identically.

## UI

- SVG canvas with the 3 removed edges (orange dashed → red on apply) and 3 new edges (green)
- **7-cell reconnection-pattern diagram** — a hexagon "truth table" of which pairs get joined (nodes A–F, faint removed edges, the case's new edges in orange), with the chosen case highlighted
- CSS morph on apply (Back restores instantly), cost sparkline, stats (pass, swaps, best cost, distance, last Δ), Back/Step/Run/Pause/Reset, speed slider, scenario buttons

## Scenarios (crafted tours, tuned offline)

| Scenario | Tour | Story |
|---|---|---|
| Single 3-opt | `[0,3,4,1,2,5,8,9,6,7]` | two 2-city blocks swapped — best move is **case 4** (swap s2+s1), 1 swap to optimum |
| Beyond 2-opt | `[0,7,6,5,4,3,2,1,8,9]` | the 2-opt explainer's "two_optimal" tour — 2-opt stuck, **case 6** swap improves |
| Already 3-optimal | `[8,2,1,0,7,6,9,5,4,3]` | a genuine **non-optimal** 3-opt local optimum, stuck 0.13% above the global optimum |
| Deep sweep | `[4,0,9,3,6,1,8,2,5,7]` | tangled tour — 4 swaps / 5 passes to converge |

Note: the issue's hand-written pattern list doesn't match the solver's actual 7 reconnections, so the diagram and algo follow the Rust table exactly.

## Also included

- **fix(web)**: the stochastic-hill explainer's Run race (same phantom undo-entry bug ocr caught on or-opt) — early-return guard in `stepForward` + scenario buttons disabled while running.

## Files

- `teeline-web/src/explainers/three-opt-algo.ts`, `three-opt.tsx`, `three-opt.test.ts` (28 unit tests)
- `teeline-web/tests/three-opt.spec.ts` (7 Playwright e2e)
- `registry.ts`, `[id]/explainer/index.astro`, `docs/algorithms/three-opt.md` — wiring

## Verification

- `vitest run`: 422 tests pass (30 files)
- `astro check` + `tsc --noEmit`: clean
- Playwright e2e (`--project=chrome`): 13/13 (7 new 3-opt + 6 stochastic-hill with the race fix)

Closes #434