### PR TITLE
feat(web): add interactive Christofides explainer (#431)

### DIFF
--- a/docs/algorithms/christofides.md
+++ b/docs/algorithms/christofides.md
@@ -3,7 +3,7 @@ id: "christofides"
 name: "Christofides"
 typeBadge: "Heuristic — constructive approximation"
 description: "The only TSP heuristic with a provable worst-case bound: the output tour is always within 1.5× the optimal length, provided the distance matrix satisfies the triangle inequality (TSPLIB EUC_2D instances do; arbitrary FULL_MATRIX instances may not)."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Christofides

--- a/teeline-web/src/explainers/christofides-algo.ts
+++ b/teeline-web/src/explainers/christofides-algo.ts
@@ -1,0 +1,438 @@
+// Pure simulation logic for the Christofides explainer.
+//
+// Rust-faithful (src/tsp/christofides.rs), six deterministic steps:
+//   1. Prim's MST       — min-key vertex first, tie-break by lowest index,
+//                         strictly-less key updates
+//   2. Odd-degree nodes — handshaking lemma: the count is always even
+//   3. Greedy min-weight perfect matching — all C(k,2) pairs sorted
+//                         shortest-first (stable, matching Rust's sort_by),
+//                         match greedily
+//   4. Multigraph union (MST ∪ matching) — all degrees even ⇒ Eulerian
+//   5. Hierholzer's circuit — iterative, pops the last half-edge and
+//                         swap_removes the reverse (parallel edges allowed)
+//   6. Shortcut — keep the first occurrence of each city
+//
+// Teaches the 1.5× proof:
+//   MST ≤ OPT · true-minimum matching ≤ OPT/2 · Euler = MST + matching
+//   · shortcut ≤ Euler (triangle inequality). The solver (and this demo) use
+//   a GREEDY matching, which can exceed the OPT/2 theory line — the panel
+//   shows both the observed greedy cost and the theory line, honestly.
+//
+// Each instance is a small city layout (≤ 10 cities) so the exact OPT can be
+// brute-forced for the ratio meter. No RNG — fully deterministic.
+
+import { CITIES_10, makeDist } from './explainer-cities'
+
+export interface Instance {
+  label: string
+  desc: string
+  cities: [number, number][]
+}
+
+export type Phase = 'mst' | 'odd' | 'matching' | 'euler' | 'shortcut' | 'done'
+
+export const PHASES: Phase[] = ['mst', 'odd', 'matching', 'euler', 'shortcut', 'done']
+
+export interface SimState {
+  phase: Phase
+  cities: [number, number][]
+  n: number
+  // precomputed pipeline (deterministic per instance) — the distance closure
+  // is deliberately NOT stored so the state stays structuredClone-able (Back)
+  mstEdges: [number, number][]
+  odd: number[]
+  matchingEdges: [number, number][]
+  eulerCircuit: number[]
+  shortcutTour: number[]
+  mstCost: number
+  matchingCost: number
+  eulerCost: number
+  tourCost: number
+  opt: number
+  ratio: number
+  nnCost: number       // greedy nearest-neighbor tour (comparison)
+  approx2Cost: number  // doubled-MST tour (comparison)
+  // progressive state
+  mstRevealed: number      // MST edges revealed so far
+  matchingRevealed: number // matching pairs revealed so far
+  walkerPos: number        // index into eulerCircuit (euler phase)
+  shortcutStep: number     // index into eulerCircuit (shortcut phase)
+  kept: number[]           // shortcut: fresh cities so far (in walk order)
+  skipped: number[]        // shortcut: circuit positions that were repeats
+  step: number
+}
+
+// ---------------------------------------------------------------
+// Step 1 — Prim's MST (port of prim_mst)
+// ---------------------------------------------------------------
+export function primMst(n: number, dist: (i: number, j: number) => number): [number, number][] {
+  const inMst = new Array<boolean>(n).fill(false)
+  const key = new Array<number>(n).fill(Infinity)
+  const parent = new Array<number>(n).fill(-1)
+  key[0] = 0
+  const edges: [number, number][] = []
+
+  for (let iter = 0; iter < n; iter++) {
+    // min-key vertex not yet in MST; ties → lowest index (min_by over 0..n)
+    let u = -1
+    let bestKey = Infinity
+    for (let i = 0; i < n; i++) {
+      if (!inMst[i] && key[i] < bestKey) {
+        bestKey = key[i]
+        u = i
+      }
+    }
+    inMst[u] = true
+    if (parent[u] !== -1) edges.push([u, parent[u]] as [number, number])
+
+    for (let v = 0; v < n; v++) {
+      if (!inMst[v]) {
+        const d = dist(u, v)
+        if (d < key[v]) {
+          key[v] = d
+          parent[v] = u
+        }
+      }
+    }
+  }
+  return edges
+}
+
+// ---------------------------------------------------------------
+// Step 2 — odd-degree vertices (port of odd_degree_nodes)
+// ---------------------------------------------------------------
+export function oddDegreeNodes(mstEdges: [number, number][], n: number): number[] {
+  const degree = new Array<number>(n).fill(0)
+  for (const [u, v] of mstEdges) {
+    degree[u]++
+    degree[v]++
+  }
+  return degree.map((d, i) => (d % 2 === 1 ? i : -1)).filter((i) => i >= 0)
+}
+
+// ---------------------------------------------------------------
+// Step 3 — greedy min-weight perfect matching (port of greedy_matching)
+// ---------------------------------------------------------------
+export function greedyMatching(
+  odd: number[],
+  dist: (i: number, j: number) => number,
+  n: number,
+): [number, number][] {
+  const pairs: { d: number; u: number; v: number }[] = []
+  for (let i = 0; i < odd.length; i++) {
+    for (let j = i + 1; j < odd.length; j++) {
+      pairs.push({ d: dist(odd[i], odd[j]), u: odd[i], v: odd[j] })
+    }
+  }
+  // stable sort by weight (Array.prototype.sort is stable — matches Rust sort_by)
+  pairs.sort((a, b) => a.d - b.d)
+
+  const matched = new Array<boolean>(n).fill(false)
+  const result: [number, number][] = []
+  for (const { u, v } of pairs) {
+    if (!matched[u] && !matched[v]) {
+      matched[u] = true
+      matched[v] = true
+      result.push([u, v] as [number, number])
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------
+// Step 4 — multigraph adjacency (port of build_multigraph)
+// ---------------------------------------------------------------
+export function buildMultigraph(
+  n: number,
+  mstEdges: [number, number][],
+  matching: [number, number][],
+): number[][] {
+  const adj: number[][] = Array.from({ length: n }, () => [])
+  for (const [u, v] of [...mstEdges, ...matching]) {
+    adj[u].push(v)
+    adj[v].push(u)
+  }
+  return adj
+}
+
+// ---------------------------------------------------------------
+// Step 5 — Hierholzer's Eulerian circuit (port of hierholzer)
+// ---------------------------------------------------------------
+export function hierholzer(adjIn: number[][], start: number): number[] {
+  // copy — the algorithm consumes the adjacency
+  const adj = adjIn.map((row) => [...row])
+  const stack = [start]
+  const circuit: number[] = []
+
+  while (stack.length > 0) {
+    const v = stack[stack.length - 1]
+    if (adj[v].length > 0) {
+      const u = adj[v].pop()!
+      const pos = adj[u].indexOf(v)
+      if (pos >= 0) adj[u][pos] = adj[u][adj[u].length - 1] // swap_remove
+      adj[u].pop()
+      stack.push(u)
+    } else {
+      circuit.push(stack.pop()!)
+    }
+  }
+  return circuit.reverse()
+}
+
+// ---------------------------------------------------------------
+// Step 6 — shortcut to a Hamiltonian tour (port of shortcut)
+// ---------------------------------------------------------------
+export function shortcut(circuit: number[], n: number): number[] {
+  const seen = new Array<boolean>(n).fill(false)
+  const tour: number[] = []
+  for (const v of circuit) {
+    if (!seen[v]) {
+      seen[v] = true
+      tour.push(v)
+    }
+  }
+  return tour
+}
+
+// ---------------------------------------------------------------
+// Full pipeline (like the Rust solve())
+// ---------------------------------------------------------------
+export function christofidesPipeline(
+  n: number,
+  dist: (i: number, j: number) => number,
+): {
+  mstEdges: [number, number][]
+  odd: number[]
+  matchingEdges: [number, number][]
+  eulerCircuit: number[]
+  shortcutTour: number[]
+} {
+  const mstEdges = primMst(n, dist)
+  const odd = oddDegreeNodes(mstEdges, n)
+  const matchingEdges = greedyMatching(odd, dist, n)
+  const adj = buildMultigraph(n, mstEdges, matchingEdges)
+  const eulerCircuit = hierholzer(adj, 0)
+  const shortcutTour = shortcut(eulerCircuit, n)
+  return { mstEdges, odd, matchingEdges, eulerCircuit, shortcutTour }
+}
+
+// ---------------------------------------------------------------
+// Comparisons — the 2× cousin (doubled MST) and greedy NN
+// ---------------------------------------------------------------
+export function doubledMstTourCost(n: number, dist: (i: number, j: number) => number): number {
+  const mstEdges = primMst(n, dist)
+  // double every MST edge → all degrees even → Eulerian
+  const adj: number[][] = Array.from({ length: n }, () => [])
+  for (const [u, v] of mstEdges) {
+    adj[u].push(v, v)
+    adj[v].push(u, u)
+  }
+  const circuit = hierholzer(adj, 0)
+  const tour = shortcut(circuit, n)
+  return closedTourCost(tour, dist)
+}
+
+export function nearestNeighborTourCost(n: number, dist: (i: number, j: number) => number): number {
+  const visited = new Array<boolean>(n).fill(false)
+  const tour: number[] = []
+  let cur = 0
+  visited[cur] = true
+  tour.push(cur)
+  for (let t = 1; t < n; t++) {
+    let best = -1
+    let bestD = Infinity
+    for (let v = 0; v < n; v++) {
+      if (!visited[v]) {
+        const d = dist(cur, v)
+        if (d < bestD) {
+          bestD = d
+          best = v
+        }
+      }
+    }
+    visited[best] = true
+    tour.push(best)
+    cur = best
+  }
+  return closedTourCost(tour, dist)
+}
+
+export function closedTourCost(tour: number[], dist: (i: number, j: number) => number): number {
+  let d = 0
+  for (let k = 0; k < tour.length; k++) {
+    d += dist(tour[k], tour[(k + 1) % tour.length])
+  }
+  return d
+}
+
+// ---------------------------------------------------------------
+// Exact optimum (brute force over (n-1)! permutations, start fixed at 0)
+// ---------------------------------------------------------------
+export function bruteForceOpt(n: number, dist: (i: number, j: number) => number): number {
+  let best = Infinity
+  const rest = Array.from({ length: n - 1 }, (_, i) => i + 1)
+  const used = new Array<boolean>(rest.length).fill(false)
+  const order: number[] = [0]
+  const search = () => {
+    if (order.length === n) {
+      const d = closedTourCost(order, dist)
+      if (d < best) best = d
+      return
+    }
+    for (let k = 0; k < rest.length; k++) {
+      if (used[k]) continue
+      used[k] = true
+      order.push(rest[k])
+      search()
+      order.pop()
+      used[k] = false
+    }
+  }
+  search()
+  return best
+}
+
+// ---------------------------------------------------------------
+// Scenarios (city layouts, tuned offline — see christofides.test.ts pins)
+// ---------------------------------------------------------------
+export const SCENARIOS: Record<string, Instance> = {
+  balanced: {
+    label: 'Balanced',
+    desc: 'The classic 10-city ring — a typical 1.11× result',
+    cities: CITIES_10,
+  },
+  near_optimal: {
+    label: 'Near-optimal',
+    desc: 'Cities on a circle — Christofides finds the exact optimum (1.00×)',
+    cities: [
+      [280, 150], [255, 226], [190, 274], [110, 274], [45, 226],
+      [20, 150], [45, 74], [110, 26], [190, 26], [255, 74],
+    ],
+  },
+  matching_heavy: {
+    label: 'Matching-heavy',
+    desc: 'Two tight clusters joined by a bridge — the odd-vertex matching is half the tour cost',
+    cities: [
+      [57, 69], [77, 80], [65, 93], [93, 71], [79, 80],
+      [247, 244], [230, 240], [238, 244], [224, 215], [246, 211],
+    ],
+  },
+  clustered: {
+    label: 'Clustered',
+    desc: 'Three clusters — the matching edges bridge between them (the doubled-MST cousin loses here)',
+    cities: [
+      [69, 65], [90, 62], [84, 60],
+      [202, 79], [216, 79], [196, 101],
+      [149, 215], [152, 239], [159, 220], [139, 215],
+    ],
+  },
+  worst_case: {
+    label: 'Worst case',
+    desc: 'A layout where the ratio stretches to 1.39× — the 1.5× bound is real, not hand-wavy',
+    cities: [
+      [155, 192], [60, 131], [170, 148], [187, 60], [148, 139],
+      [105, 224], [108, 20], [52, 220], [148, 262], [165, 174],
+    ],
+  },
+}
+
+export function makeInitState(instance: Instance): SimState {
+  const cities = instance.cities
+  const n = cities.length
+  const dist = makeDist(cities)
+  const { mstEdges, odd, matchingEdges, eulerCircuit, shortcutTour } = christofidesPipeline(n, dist)
+
+  const mstCost = mstEdges.reduce((s, [u, v]) => s + dist(u, v), 0)
+  const matchingCost = matchingEdges.reduce((s, [u, v]) => s + dist(u, v), 0)
+  const eulerCost = mstCost + matchingCost
+  const tourCost = closedTourCost(shortcutTour, dist)
+  const opt = bruteForceOpt(n, dist)
+  const ratio = tourCost / opt
+
+  return {
+    phase: 'mst',
+    cities,
+    n,
+    mstEdges,
+    odd,
+    matchingEdges,
+    eulerCircuit,
+    shortcutTour,
+    mstCost,
+    matchingCost,
+    eulerCost,
+    tourCost,
+    opt,
+    ratio,
+    nnCost: nearestNeighborTourCost(n, dist),
+    approx2Cost: doubledMstTourCost(n, dist),
+    mstRevealed: 0,
+    matchingRevealed: 0,
+    walkerPos: 0,
+    shortcutStep: 0,
+    kept: [eulerCircuit[0]],
+    skipped: [],
+    step: 0,
+  }
+}
+
+// One Step press — advances the current phase's fine-grained animation, then
+// moves to the next phase at each phase boundary. Pure — no mutation.
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'done') return { ...state, step: state.step + 1 }
+
+  // --- MST phase: reveal one Prim edge per step ---
+  if (state.phase === 'mst') {
+    if (state.mstRevealed < state.mstEdges.length) {
+      return { ...state, mstRevealed: state.mstRevealed + 1, step: state.step + 1 }
+    }
+    return { ...state, phase: 'odd', step: state.step + 1 }
+  }
+
+  // --- Odd phase: one step reveals all odd vertices, next advances ---
+  if (state.phase === 'odd') {
+    return { ...state, phase: 'matching', step: state.step + 1 }
+  }
+
+  // --- Matching phase: reveal one pair per step ---
+  if (state.phase === 'matching') {
+    if (state.matchingRevealed < state.matchingEdges.length) {
+      return { ...state, matchingRevealed: state.matchingRevealed + 1, step: state.step + 1 }
+    }
+    return { ...state, phase: 'euler', step: state.step + 1 }
+  }
+
+  // --- Euler phase: walker advances one edge of the circuit ---
+  if (state.phase === 'euler') {
+    if (state.walkerPos < state.eulerCircuit.length - 1) {
+      return { ...state, walkerPos: state.walkerPos + 1, step: state.step + 1 }
+    }
+    return {
+      ...state,
+      phase: 'shortcut',
+      shortcutStep: 1,
+      kept: [state.eulerCircuit[0]],
+      skipped: [],
+      step: state.step + 1,
+    }
+  }
+
+  // --- Shortcut phase: walker re-traverses; fresh cities extend the tour,
+  //     repeats get crossed out ---
+  if (state.phase === 'shortcut') {
+    if (state.shortcutStep >= state.eulerCircuit.length) {
+      return { ...state, phase: 'done', step: state.step + 1 }
+    }
+    const city = state.eulerCircuit[state.shortcutStep]
+    const isFresh = !state.kept.includes(city)
+    return {
+      ...state,
+      shortcutStep: state.shortcutStep + 1,
+      kept: isFresh ? [...state.kept, city] : state.kept,
+      skipped: isFresh ? state.skipped : [...state.skipped, state.shortcutStep],
+      step: state.step + 1,
+    }
+  }
+
+  return { ...state, step: state.step + 1 }
+}

--- a/teeline-web/src/explainers/christofides-algo.ts
+++ b/teeline-web/src/explainers/christofides-algo.ts
@@ -168,9 +168,13 @@ export function hierholzer(adjIn: number[][], start: number): number[] {
     const v = stack[stack.length - 1]
     if (adj[v].length > 0) {
       const u = adj[v].pop()!
+      // swap_remove the reverse half-edge, exactly like Rust's
+      // `if let Some(pos) = adj[u].iter().position(...)` guard.
       const pos = adj[u].indexOf(v)
-      if (pos >= 0) adj[u][pos] = adj[u][adj[u].length - 1] // swap_remove
-      adj[u].pop()
+      if (pos >= 0) {
+        adj[u][pos] = adj[u][adj[u].length - 1]
+        adj[u].pop()
+      }
       stack.push(u)
     } else {
       circuit.push(stack.pop()!)

--- a/teeline-web/src/explainers/christofides.test.ts
+++ b/teeline-web/src/explainers/christofides.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SCENARIOS,
+  primMst, oddDegreeNodes, greedyMatching, buildMultigraph, hierholzer, shortcut,
+  christofidesPipeline, closedTourCost, makeInitState, stepOnce,
+} from './christofides-algo'
+import { makeDist } from './explainer-cities'
+
+// ---------------------------------------------------------------
+// Step 1 — Prim's MST (ported from the Rust unit tests)
+// ---------------------------------------------------------------
+describe('primMst', () => {
+  it('has exactly n-1 edges and spans all nodes', () => {
+    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1]])
+    const edges = primMst(4, dist)
+    expect(edges).toHaveLength(3)
+    const seen = new Set<number>([0])
+    for (const [u, v] of edges) {
+      seen.add(u)
+      seen.add(v)
+    }
+    expect(seen).toEqual(new Set([0, 1, 2, 3]))
+  })
+
+  it('finds the minimal chain MST (weight 4.0)', () => {
+    const dist = makeDist([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+    const edges = primMst(5, dist)
+    const weight = edges.reduce((s, [u, v]) => s + dist(u, v), 0)
+    expect(weight).toBeCloseTo(4.0, 3)
+  })
+})
+
+// ---------------------------------------------------------------
+// Step 2 — odd-degree nodes (ported)
+// ---------------------------------------------------------------
+describe('oddDegreeNodes', () => {
+  it('counts an even number of odd-degree vertices (handshaking lemma)', () => {
+    const mst: [number, number][] = [[0, 1], [1, 2], [1, 3]]
+    const odd = oddDegreeNodes(mst, 4)
+    expect(odd.length % 2).toBe(0)
+  })
+
+  it('finds the endpoints of a path', () => {
+    const mst: [number, number][] = [[0, 1], [1, 2], [2, 3]]
+    expect(oddDegreeNodes(mst, 4).sort()).toEqual([0, 3])
+  })
+})
+
+// ---------------------------------------------------------------
+// Step 3 — greedy matching (ported)
+// ---------------------------------------------------------------
+describe('greedyMatching', () => {
+  it('covers every odd-degree node exactly once', () => {
+    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1], [3, 0]])
+    const mst = primMst(5, dist)
+    const odd = oddDegreeNodes(mst, 5)
+    const matching = greedyMatching(odd, dist, 5)
+    const count = new Array<number>(5).fill(0)
+    for (const [u, v] of matching) {
+      count[u]++
+      count[v]++
+    }
+    for (const pos of odd) {
+      expect(count[pos]).toBe(1)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+// Step 5 — Hierholzer (ported)
+// ---------------------------------------------------------------
+describe('hierholzer', () => {
+  it('circuit length equals edges + 1 and consumes every edge', () => {
+    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1], [3, 0]])
+    const { mstEdges, matchingEdges, eulerCircuit } = christofidesPipeline(5, dist)
+    const totalEdges = mstEdges.length + matchingEdges.length
+    expect(eulerCircuit).toHaveLength(totalEdges + 1)
+    // every consecutive pair in the circuit is an edge of the multigraph
+    const adj = buildMultigraph(5, mstEdges, matchingEdges)
+    const edgeSet = new Set<string>()
+    for (let v = 0; v < 5; v++) {
+      for (const u of adj[v]) {
+        edgeSet.add(`${Math.min(u, v)}-${Math.max(u, v)}`)
+      }
+    }
+    for (let t = 0; t < eulerCircuit.length - 1; t++) {
+      const [a, b] = [eulerCircuit[t], eulerCircuit[t + 1]].sort((x, y) => x - y)
+      expect(edgeSet.has(`${a}-${b}`), `circuit step ${t} must use a real edge`).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+// Step 6 — shortcut (ported)
+// ---------------------------------------------------------------
+describe('shortcut', () => {
+  it('keeps the first occurrence of each city', () => {
+    const circuit = [0, 1, 3, 4, 2, 1, 0]
+    const tour = shortcut(circuit, 5)
+    expect(tour).toHaveLength(5)
+    expect(tour.slice().sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4])
+    expect(tour).toEqual([0, 1, 3, 4, 2])
+  })
+})
+
+// ---------------------------------------------------------------
+// End-to-end pipeline
+// ---------------------------------------------------------------
+describe('christofidesPipeline', () => {
+  it('produces a valid Hamiltonian tour on every scenario', () => {
+    for (const [key, inst] of Object.entries(SCENARIOS)) {
+      const s = makeInitState(inst)
+      expect(s.shortcutTour).toHaveLength(s.n)
+      expect(s.shortcutTour.slice().sort((a, b) => a - b)).toEqual(
+        Array.from({ length: s.n }, (_, i) => i),
+      )
+      // tour cost matches a recomputation
+      expect(closedTourCost(s.shortcutTour, makeDist(inst.cities))).toBeCloseTo(s.tourCost, 6)
+      // ratio ≤ 1.5 on every scenario
+      expect(s.ratio, `${key} ratio must stay within the 1.5× bound`).toBeLessThanOrEqual(1.5)
+    }
+  })
+
+  it('ratio stays ≤ 1.5 across random 10-city instances', () => {
+    let seed = 12345
+    const rnd = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648
+      return seed / 2147483648
+    }
+    for (let t = 0; t < 12; t++) {
+      const cities: [number, number][] = []
+      for (let i = 0; i < 10; i++) {
+        cities.push([Math.round(20 + rnd() * 260), Math.round(20 + rnd() * 260)] as [number, number])
+      }
+      const s = makeInitState({ label: '', desc: '', cities })
+      expect(s.ratio).toBeLessThanOrEqual(1.5)
+      expect(s.ratio).toBeGreaterThanOrEqual(1.0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+// Pinned scenario behaviour
+// ---------------------------------------------------------------
+describe('scenario pins', () => {
+  it('balanced: the classic ring at ~1.11×', () => {
+    const s = makeInitState(SCENARIOS.balanced)
+    expect(s.ratio).toBeCloseTo(1.107, 2)
+  })
+
+  it('near_optimal: the circle layout hits the exact optimum', () => {
+    const s = makeInitState(SCENARIOS.near_optimal)
+    expect(s.ratio).toBeCloseTo(1.0, 3)
+    expect(s.tourCost).toBeCloseTo(s.opt, 3)
+  })
+
+  it('matching_heavy: the matching is about half the tour cost', () => {
+    const s = makeInitState(SCENARIOS.matching_heavy)
+    expect(s.matchingCost / s.tourCost).toBeGreaterThan(0.45)
+  })
+
+  it('worst_case: the ratio stretches toward the bound', () => {
+    const s = makeInitState(SCENARIOS.worst_case)
+    expect(s.ratio).toBeGreaterThan(1.35)
+  })
+
+  it('bruteForceOpt is a true lower bound on every scenario', () => {
+    for (const inst of Object.values(SCENARIOS)) {
+      const s = makeInitState(inst)
+      expect(s.opt).toBeLessThanOrEqual(s.tourCost + 1e-6)
+      expect(s.opt).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+// Phase machine
+// ---------------------------------------------------------------
+describe('stepOnce phase machine', () => {
+  const s0 = makeInitState(SCENARIOS.balanced)
+  const mstSteps = s0.mstEdges.length // reveal all MST edges
+  const matchingSteps = s0.matchingEdges.length
+  const eulerSteps = s0.eulerCircuit.length - 1
+  const shortcutSteps = s0.eulerCircuit.length
+
+  it('starts in the mst phase with nothing revealed', () => {
+    expect(s0.phase).toBe('mst')
+    expect(s0.mstRevealed).toBe(0)
+    expect(s0.step).toBe(0)
+  })
+
+  it('mst phase reveals one edge per step, then advances to odd', () => {
+    let s = s0
+    for (let i = 0; i < mstSteps; i++) {
+      s = stepOnce(s)
+      expect(s.phase).toBe('mst')
+      expect(s.mstRevealed).toBe(i + 1)
+    }
+    s = stepOnce(s)
+    expect(s.phase).toBe('odd')
+  })
+
+  it('odd → matching → euler → shortcut → done in order', () => {
+    let s = s0
+    // walk the whole machine to completion
+    let guard = mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
+    while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+    expect(s.phase).toBe('done')
+    expect(s.kept).toEqual(s.shortcutTour)
+    // skipped visits recorded
+    expect(s.skipped.length).toBeGreaterThan(0)
+  })
+
+  it('shortcut phase builds the tour by skipping repeats', () => {
+    let s = s0
+    let guard = mstSteps + 2 + matchingSteps + 2 + eulerSteps
+    while (s.phase !== 'shortcut' && guard-- > 0) s = stepOnce(s)
+    expect(s.phase).toBe('shortcut')
+    const initial = s
+    s = stepOnce(s) // first shortcut step processes circuit[1]
+    expect(s.shortcutStep).toBe(initial.shortcutStep + 1)
+  })
+
+  it('done is a no-op apart from the step counter', () => {
+    let s = s0
+    let guard = mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
+    while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+    const again = stepOnce(s)
+    expect(again.phase).toBe('done')
+    expect(again.tourCost).toBe(s.tourCost)
+    expect(again.step).toBe(s.step + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+// Purity & determinism
+// ---------------------------------------------------------------
+describe('purity & determinism', () => {
+  it('stepOnce never mutates its input', () => {
+    const s = makeInitState(SCENARIOS.worst_case)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 15; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same instance produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.matching_heavy)
+    const b = makeInitState(SCENARIOS.matching_heavy)
+    for (let i = 0; i < 12; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+
+  it('primitives are pure — hierholzer does not mutate its input adjacency', () => {
+    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1]])
+    const mst = primMst(4, dist)
+    const odd = oddDegreeNodes(mst, 4)
+    const matching = greedyMatching(odd, dist, 4)
+    const adj = buildMultigraph(4, mst, matching)
+    const snapshot = structuredClone(adj)
+    hierholzer(adj, 0)
+    expect(adj).toEqual(snapshot)
+  })
+})

--- a/teeline-web/src/explainers/christofides.tsx
+++ b/teeline-web/src/explainers/christofides.tsx
@@ -1,0 +1,644 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  PHASES, SCENARIOS,
+  makeInitState, stepOnce,
+} from "./christofides-algo"
+import type { Phase, Instance, SimState } from "./christofides-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.balanced
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+const PHASE_LABELS: Record<Phase, string> = {
+  mst: 'MST',
+  odd: 'Odd vertices',
+  matching: 'Matching',
+  euler: 'Euler walk',
+  shortcut: 'Shortcut',
+  done: 'Done',
+}
+
+function edgeKey(a: number, b: number): string {
+  return `${Math.min(a, b)}-${Math.max(a, b)}`
+}
+
+// ---------------------------------------------------------------
+// TourCanvas — the city map with progressive layers:
+// green MST edges, purple dashed matching, the multigraph with a
+// walking dot (euler), and the final tour being carved out (shortcut).
+// ---------------------------------------------------------------
+function TourCanvas({ sim, showMst, showMatch, showTour }: {
+  sim: SimState
+  showMst: boolean
+  showMatch: boolean
+  showTour: boolean
+}) {
+  const { cities, phase } = sim
+  const pos = (i: number) => cities[i]
+
+  const multigraphEdges = useMemo(() => {
+    const list: Array<{ id: number; a: number; b: number; kind: 'mst' | 'match' }> = []
+    for (const [a, b] of sim.mstEdges) list.push({ id: list.length, a, b, kind: 'mst' })
+    for (const [a, b] of sim.matchingEdges) list.push({ id: list.length, a, b, kind: 'match' })
+    return list
+  }, [sim.mstEdges, sim.matchingEdges])
+
+  // multigraph edges the walker has already used, per unordered pair
+  const usedPairs = useMemo(() => {
+    const map = new Map<string, number>()
+    const upto = phase === 'euler'
+      ? sim.walkerPos
+      : phase === 'shortcut' || phase === 'done'
+        ? sim.eulerCircuit.length - 1
+        : 0
+    for (let t = 0; t < upto; t++) {
+      const k = edgeKey(sim.eulerCircuit[t], sim.eulerCircuit[t + 1])
+      map.set(k, (map.get(k) ?? 0) + 1)
+    }
+    return map
+  }, [phase, sim.walkerPos, sim.eulerCircuit])
+
+  const pairCount = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const e of multigraphEdges) {
+      const k = edgeKey(e.a, e.b)
+      map.set(k, (map.get(k) ?? 0) + 1)
+    }
+    return map
+  }, [multigraphEdges])
+
+  const isEdgeUsed = (a: number, b: number) => {
+    const k = edgeKey(a, b)
+    const used = usedPairs.get(k) ?? 0
+    const total = pairCount.get(k) ?? 1
+    return used >= total
+  }
+
+  // final tour edges (built during shortcut; complete at done)
+  const tourEdges: Array<[number, number]> = []
+  const kept = phase === 'done' ? sim.shortcutTour : sim.kept
+  for (let t = 0; t < kept.length - 1; t++) tourEdges.push([kept[t], kept[t + 1]])
+  if (phase === 'done' && kept.length > 1) tourEdges.push([kept[kept.length - 1], kept[0]])
+
+  const skippedSet = new Set(sim.skipped)
+
+  // walker position: euler phase follows walkerPos; shortcut follows shortcutStep
+  const walkerCity = phase === 'euler'
+    ? sim.eulerCircuit[Math.min(sim.walkerPos, sim.eulerCircuit.length - 1)]
+    : phase === 'shortcut'
+      ? sim.eulerCircuit[Math.min(sim.shortcutStep, sim.eulerCircuit.length - 1)]
+      : null
+
+  const constructing = phase === 'mst' || phase === 'odd' || phase === 'matching'
+  const mstShown: [number, number][] = showMst && constructing
+    ? sim.mstEdges.slice(0, phase === 'mst' ? sim.mstRevealed : sim.mstEdges.length)
+    : []
+  const matchShown: [number, number][] = showMatch && phase === 'matching'
+    ? sim.matchingEdges.slice(0, sim.matchingRevealed)
+    : showMatch && (phase === 'euler' || phase === 'shortcut' || phase === 'done')
+      ? sim.matchingEdges
+      : []
+  const showMultigraph = phase === 'euler' || phase === 'shortcut'
+  const showTourLayer = showTour && (phase === 'shortcut' || phase === 'done')
+
+  return (
+    <svg viewBox="0 0 300 300" className="chr-canvas" role="img" aria-label="Christofides construction">
+      <rect x={0} y={0} width={300} height={300} className="chr-bg" />
+
+      {/* Plain construction layers */}
+      {mstShown.map(([a, b]) => (
+        <line key={`m${edgeKey(a, b)}`} className="chr-mst-edge"
+          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
+      ))}
+      {matchShown.map(([a, b]) => (
+        <line key={`p${edgeKey(a, b)}`} className="chr-match-edge"
+          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
+      ))}
+
+      {/* Multigraph (euler/shortcut): used edges fade */}
+      {showMultigraph && multigraphEdges.map((e) => {
+        const used = isEdgeUsed(e.a, e.b)
+        const cls = `chr-multi-edge ${e.kind === 'mst' ? 'chr-multi-mst' : 'chr-multi-match'} ${used ? 'chr-multi-used' : ''}`
+        return <line key={e.id} className={cls}
+          x1={pos(e.a)[0]} y1={pos(e.a)[1]} x2={pos(e.b)[0]} y2={pos(e.b)[1]} />
+      })}
+
+      {/* Final tour (shortcut phase + done) */}
+      {showTourLayer && tourEdges.map(([a, b]) => (
+        <line key={`t${edgeKey(a, b)}`} className="chr-tour-edge"
+          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
+      ))}
+
+      {/* Cities */}
+      {cities.map(([x, y], id) => {
+        const oddHighlight = phase === 'odd' || phase === 'matching'
+        return (
+          <g key={id}>
+            <circle className={`chr-city ${sim.odd.includes(id) && oddHighlight ? 'chr-city-odd' : ''}`}
+              cx={x} cy={y} r={7} />
+            <text className="chr-label" x={x} y={y + 16}>{id}</text>
+          </g>
+        )
+      })}
+
+      {/* Walker dot */}
+      {walkerCity !== null && (
+        <circle className="chr-walker" cx={pos(walkerCity)[0]} cy={pos(walkerCity)[1]} r={5} />
+      )}
+
+      {/* Skipped repeat markers (shortcut) */}
+      {[...skippedSet].map((idx) => {
+        const city = sim.eulerCircuit[idx]
+        const [x, y] = pos(city)
+        return <text key={`sk${idx}`} className="chr-skip" x={x} y={y - 8}>✕</text>
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Ratio meter — observed ratio vs the 1.5× bound
+// ---------------------------------------------------------------
+function RatioMeter({ ratio }: { ratio: number }) {
+  const ratioClamped = Math.min(1.6, Math.max(1.0, ratio))
+  const pct = ((ratioClamped - 1) / 0.6) * 100
+  return (
+    <div className="chr-meter">
+      <div className="chr-meter-track">
+        <div className="chr-meter-fill" style={{ width: `${Math.min(100, pct)}%` }} />
+        <div className="chr-meter-mark chr-meter-mark-opt" />
+        <div className="chr-meter-mark chr-meter-mark-bound" style={{ left: '83.3%' }} />
+        <div className="chr-meter-dot" style={{ left: `${Math.min(100, pct)}%` }} />
+      </div>
+      <div className="chr-meter-labels">
+        <span>1.0× OPT</span>
+        <span>1.5× bound</span>
+      </div>
+      <div className="chr-meter-value">tour = {ratio.toFixed(2)}× optimal</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// Comparison rows — NN / doubled-MST / Christofides
+// ---------------------------------------------------------------
+function CompareRow({ label, cost, opt, best }: { label: string; cost: number; opt: number; best: boolean }) {
+  const ratio = cost / opt
+  const pct = Math.min(100, ((ratio - 1) / 0.6) * 100)
+  return (
+    <div className={`chr-compare-row ${best ? 'chr-compare-best' : ''}`}>
+      <span className="chr-compare-label">{label}</span>
+      <div className="chr-compare-track">
+        <div className="chr-compare-fill" style={{ width: `${Math.max(0, pct)}%` }} />
+      </div>
+      <span className="chr-compare-value">{ratio.toFixed(2)}×</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function ChristofidesExplainer() {
+  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2) // 3x default
+  const [showMstLayer, setShowMstLayer] = useState(true)
+  const [showMatchLayer, setShowMatchLayer] = useState(true)
+  const [showTourLayer, setShowTourLayer] = useState(true)
+
+  const simRef = useRef(sim)
+  const historyRef = useRef<Array<typeof sim>>([])
+  const scenarioRef = useRef<Instance>(DEFAULT_SCENARIO)
+
+  const commit = useCallback((next: SimState) => {
+    simRef.current = next
+    setSim(next)
+  }, [])
+
+  const reinit = useCallback((instance: Instance) => {
+    scenarioRef.current = instance
+    historyRef.current = []
+    commit(makeInitState(instance))
+    setRunning(false)
+  }, [commit])
+
+  const stepForward = useCallback(() => {
+    const cur = simRef.current
+    if (cur.phase === 'done') return
+    historyRef.current.push(structuredClone(cur))
+    const next = stepOnce(cur)
+    simRef.current = next
+    setSim(next)
+    if (next.phase === 'done') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    commit(h.pop()!)
+  }, [running, commit])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepForward, SPEEDS[speedIdx])
+    return () => clearInterval(id)
+  }, [running, speedIdx, stepForward])
+
+  // Phase selector — jump straight to a phase's start (replays deterministically)
+  const jumpTo = useCallback((target: Phase) => {
+    let s = makeInitState(scenarioRef.current)
+    let guard = 600
+    while (s.phase !== target && s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+    historyRef.current = []
+    commit(s)
+    setRunning(false)
+  }, [commit])
+
+  const s = sim
+  const phaseIdx = PHASES.indexOf(s.phase)
+  const matchShare = s.matchingCost / s.tourCost
+
+  // Status chip
+  let chipText = "Step 1 — growing the Minimum Spanning Tree (Prim's)"
+  let chipClass = "chr-chip chr-chip-idle"
+  if (s.phase === 'mst') {
+    chipText = s.mstRevealed === 0
+      ? `MST — click Step to grow the tree (Prim's, cost ${s.mstCost.toFixed(0)})`
+      : s.mstRevealed < s.mstEdges.length
+        ? `MST — added edge ${s.mstEdges[s.mstRevealed - 1][0]}–${s.mstEdges[s.mstRevealed - 1][1]} (${s.mstRevealed}/${s.mstEdges.length})`
+        : `MST complete — cost ${s.mstCost.toFixed(0)} ≤ OPT ${s.opt.toFixed(0)}. Step to find odd-degree vertices`
+  } else if (s.phase === 'odd') {
+    chipText = `Odd-degree vertices: ${s.odd.join(', ')} — always an even count (handshaking lemma)`
+    chipClass = "chr-chip chr-chip-odd"
+  } else if (s.phase === 'matching') {
+    chipText = s.matchingRevealed < s.matchingEdges.length
+      ? `Matching — paired ${s.matchingEdges[s.matchingRevealed - 1][0]}–${s.matchingEdges[s.matchingRevealed - 1][1]} (${s.matchingRevealed}/${s.matchingEdges.length} pairs)`
+      : `Matching complete — cost ${s.matchingCost.toFixed(0)}`
+    chipClass = "chr-chip chr-chip-match"
+  } else if (s.phase === 'euler') {
+    chipText = `Eulerian circuit — walking ${s.eulerCircuit[s.walkerPos - 1] ?? '—'}→${s.eulerCircuit[s.walkerPos]} (${s.walkerPos}/${s.eulerCircuit.length - 1})`
+    chipClass = "chr-chip chr-chip-euler"
+  } else if (s.phase === 'shortcut') {
+    const city = s.eulerCircuit[Math.min(s.shortcutStep, s.eulerCircuit.length - 1)]
+    const fresh = s.kept.includes(city)
+    chipText = fresh
+      ? `Shortcut — ${city} added to the tour`
+      : `Shortcut — ${city} already visited, skipped (✕)`
+    chipClass = "chr-chip chr-chip-shortcut"
+  } else if (s.phase === 'done') {
+    chipText = `Done — tour cost ${s.tourCost.toFixed(0)} = ${s.ratio.toFixed(2)}× OPT (bound 1.5×)`
+    chipClass = "chr-chip chr-chip-done"
+  }
+
+  return (
+    <div className="chr-root">
+      <style>{CSS}</style>
+
+      <header className="chr-header">
+        <div className="chr-eyebrow">teeline · algorithms/christofides</div>
+        <h2 className="chr-title">Christofides — a ≤1.5× Approximation</h2>
+        <p className="chr-sub">
+          The only simple TSP heuristic with a <strong>provable worst-case bound</strong>: the tour is
+          always within 1.5× of optimal. Three ingredients — <strong>MST</strong> (skeleton, ≤ OPT),
+          <strong>matching</strong> on the odd-degree vertices (patch, ≤ OPT/2), and an
+          <strong>Eulerian walk + shortcut</strong> (≤ MST + matching) — add up to the guarantee.
+        </p>
+      </header>
+
+      <div className="chr-viz-row">
+        <div className="chr-canvas-wrap">
+          <TourCanvas sim={s} showMst={showMstLayer} showMatch={showMatchLayer} showTour={showTourLayer} />
+        </div>
+        <div className="chr-side">
+          <div className="chr-section-label">Pipeline</div>
+          <div className="chr-phase-list">
+            {PHASES.map((p, i) => {
+              const done = i < phaseIdx || s.phase === 'done'
+              return (
+                <button key={p} className={`chr-phase-btn ${i === phaseIdx ? 'chr-phase-cur' : ''} ${done ? 'chr-phase-done' : ''}`}
+                  onClick={() => jumpTo(p)} disabled={running}>
+                  <span className="chr-phase-num">{done ? '✓' : i + 1}</span>
+                  {PHASE_LABELS[p]}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="chr-section-label">Approximation ratio</div>
+          <RatioMeter ratio={s.ratio} />
+
+          <div className="chr-section-label">Why ≤ 1.5×?</div>
+          <div className="chr-proof">
+            <div className={`chr-proof-line ${phaseIdx >= 1 ? 'chr-proof-on' : ''}`}>
+              <span className="chr-proof-tag">MST</span> {s.mstCost.toFixed(0)} ≤ OPT {s.opt.toFixed(0)}
+            </div>
+            <div className={`chr-proof-line ${phaseIdx >= 3 ? 'chr-proof-on' : ''}`}>
+              <span className="chr-proof-tag">Match</span> {s.matchingCost.toFixed(0)} {s.matchingCost > s.opt / 2 ? '>' : '≤'} OPT/2 {(s.opt / 2).toFixed(0)}
+              {s.matchingCost > s.opt / 2 && (
+                <span className="chr-proof-note"> greedy &gt; theory — the 1.5× bound assumes the true minimum matching</span>
+              )}
+            </div>
+            <div className={`chr-proof-line ${s.phase === 'done' ? 'chr-proof-on' : ''}`}>
+              <span className="chr-proof-tag">Tour</span> {s.tourCost.toFixed(0)} ≤ MST+matching {s.eulerCost.toFixed(0)} ≤ 1.5·OPT {(1.5 * s.opt).toFixed(0)}
+            </div>
+          </div>
+
+          <div className="chr-section-label">Compare on this instance</div>
+          <div className="chr-compare">
+            <CompareRow label="Nearest neighbour" cost={s.nnCost} opt={s.opt} best={s.nnCost <= s.approx2Cost && s.nnCost <= s.tourCost} />
+            <CompareRow label="Doubled MST (2×)" cost={s.approx2Cost} opt={s.opt} best={s.approx2Cost < s.nnCost && s.approx2Cost <= s.tourCost} />
+            <CompareRow label="Christofides" cost={s.tourCost} opt={s.opt} best={s.tourCost < s.nnCost && s.tourCost < s.approx2Cost} />
+          </div>
+        </div>
+      </div>
+
+      <div className="chr-legend">
+        <span><span className="chr-swatch chr-swatch-mst" /> MST edge</span>
+        <span><span className="chr-swatch chr-swatch-match" /> matching edge</span>
+        <span><span className="chr-swatch chr-swatch-tour" /> final tour</span>
+        <span><span className="chr-swatch chr-swatch-odd" /> odd-degree vertex</span>
+        <span><span className="chr-swatch chr-swatch-walker" /> walker</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="chr-statgrid">
+        <div><div className="chr-statlabel">phase</div><div className="chr-mono">{PHASE_LABELS[s.phase]}</div></div>
+        <div><div className="chr-statlabel">MST cost</div><div className="chr-mono">{s.mstCost.toFixed(0)}</div></div>
+        <div><div className="chr-statlabel">matching cost</div><div className="chr-mono">{s.matchingCost.toFixed(0)} ({Math.round(matchShare * 100)}%)</div></div>
+        <div><div className="chr-statlabel">tour cost</div><div className="chr-mono">{s.tourCost.toFixed(0)}</div></div>
+        <div><div className="chr-statlabel">ratio</div><div className="chr-mono">{s.ratio.toFixed(2)}×</div></div>
+        <div><div className="chr-statlabel">step</div><div className="chr-mono">{s.step}</div></div>
+      </div>
+
+      <div className="chr-config">
+        <div className="chr-config-row">
+          <span className="chr-label">Show</span>
+          <label className="chr-toggle"><input type="checkbox" checked={showMstLayer} onChange={(e) => setShowMstLayer((e.target as HTMLInputElement).checked)} /> MST</label>
+          <label className="chr-toggle"><input type="checkbox" checked={showMatchLayer} onChange={(e) => setShowMatchLayer((e.target as HTMLInputElement).checked)} /> Matching</label>
+          <label className="chr-toggle"><input type="checkbox" checked={showTourLayer} onChange={(e) => setShowTourLayer((e.target as HTMLInputElement).checked)} /> Tour</label>
+        </div>
+        <div className="chr-config-row">
+          <span className="chr-label">Speed</span>
+          <div className="chr-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l} className={`chr-speed-btn ${i === speedIdx ? 'chr-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="chr-controls">
+        <button className="chr-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>⏴ Back</button>
+        <button className="chr-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
+        <button className="chr-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="chr-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+      </div>
+
+      <div className="chr-scenarios">
+        <div className="chr-section-label">Scenarios</div>
+        <div className="chr-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, inst]) => (
+            <button key={key} className="chr-scenario-btn" title={inst.desc}
+              onClick={() => reinit(inst)} disabled={running}>
+              {inst.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="chr-footer">
+        <span className="chr-mono">cities: {s.n}</span>
+        <span className="chr-mono">MST + matching + Euler + shortcut · ≤ 1.5× optimal</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.chr-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 880px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.chr-root * { box-sizing: border-box; }
+.chr-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+.chr-header { margin-bottom: 2px; }
+.chr-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.chr-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.chr-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.chr-canvas {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.chr-bg { fill: var(--panel); }
+.chr-mst-edge { stroke: #16a34a; stroke-width: 2.5; stroke-linecap: round; }
+.chr-match-edge { stroke: #7c3aed; stroke-width: 2.5; stroke-dasharray: 6 4; }
+.chr-multi-edge { stroke-width: 2; stroke-linecap: round; transition: opacity 0.2s; }
+.chr-multi-mst { stroke: #16a34a; }
+.chr-multi-match { stroke: #7c3aed; stroke-dasharray: 6 4; }
+.chr-multi-used { opacity: 0.18; }
+.chr-tour-edge { stroke: #1f2328; stroke-width: 3; stroke-linecap: round; }
+.chr-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
+.chr-city-odd { fill: #ef4444; animation: chr-pulse 1s ease-in-out infinite; }
+.chr-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+.chr-walker { fill: #f59e0b; stroke: #fff; stroke-width: 2; }
+.chr-skip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px; fill: #ef4444; font-weight: 700; text-anchor: middle;
+}
+@keyframes chr-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.chr-viz-row { display: flex; gap: 12px; align-items: stretch; }
+.chr-canvas-wrap { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.chr-side { width: 260px; flex-shrink: 0; display: flex; flex-direction: column; gap: 8px; }
+
+.chr-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+
+.chr-phase-list { display: flex; flex-direction: column; gap: 3px; }
+.chr-phase-btn {
+  display: flex; align-items: center; gap: 8px; text-align: left;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 4px 8px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--muted);
+  cursor: pointer;
+}
+.chr-phase-btn:hover:not(:disabled) { border-color: var(--accent); }
+.chr-phase-btn:disabled { opacity: 0.5; cursor: default; }
+.chr-phase-cur { border-color: var(--accent); color: #115e59; font-weight: 600; background: #f0fdf4; }
+.chr-phase-done { color: #166534; }
+.chr-phase-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--panel); border: 1px solid var(--line);
+  font-size: 0.68rem;
+}
+.chr-phase-done .chr-phase-num { background: #dcfce7; border-color: #86efac; color: #166534; }
+.chr-phase-cur .chr-phase-num { background: #ccfbf1; border-color: var(--accent); }
+
+.chr-meter-track {
+  position: relative; height: 8px; border-radius: 4px;
+  background: linear-gradient(90deg, #bbf7d0, #fef08a 60%, #fecaca);
+  border: 1px solid var(--line);
+}
+.chr-meter-fill { position: absolute; top: 0; left: 0; bottom: 0; border-radius: 4px; background: #0d9488; opacity: 0.25; }
+.chr-meter-dot {
+  position: absolute; top: -3px; width: 12px; height: 12px; margin-left: -6px;
+  border-radius: 50%; background: #0d9488; border: 2px solid #fff;
+}
+.chr-meter-mark {
+  position: absolute; top: -2px; bottom: -2px; width: 2px; background: #64748b;
+}
+.chr-meter-mark-opt { left: 0; }
+.chr-meter-mark-bound { background: #dc2626; }
+.chr-meter-labels {
+  display: flex; justify-content: space-between; font-size: 0.68rem; color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.chr-meter-value {
+  font-size: 0.78rem; font-weight: 600; color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.chr-proof { display: flex; flex-direction: column; gap: 4px; }
+.chr-proof-line {
+  font-size: 0.76rem; color: var(--muted); opacity: 0.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  transition: opacity 0.3s;
+}
+.chr-proof-on { opacity: 1; color: var(--text); }
+.chr-proof-tag {
+  display: inline-block; min-width: 44px; font-weight: 700;
+  color: var(--accent);
+}
+.chr-proof-note { color: #b45309; }
+
+.chr-compare { display: flex; flex-direction: column; gap: 4px; }
+.chr-compare-row {
+  display: flex; align-items: center; gap: 8px; font-size: 0.74rem;
+  padding: 3px 6px; border-radius: 6px;
+}
+.chr-compare-best { background: #f0fdf4; }
+.chr-compare-label { width: 110px; color: var(--muted); flex-shrink: 0; }
+.chr-compare-track {
+  flex: 1; height: 6px; border-radius: 3px; background: var(--panel);
+  border: 1px solid var(--line);
+}
+.chr-compare-fill { height: 100%; border-radius: 3px; background: #94a3b8; }
+.chr-compare-best .chr-compare-fill { background: #0d9488; }
+.chr-compare-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem; width: 48px; text-align: right;
+}
+
+.chr-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.chr-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.chr-swatch-mst { background: #16a34a; }
+.chr-swatch-match { background: #7c3aed; }
+.chr-swatch-tour { background: #1f2328; }
+.chr-swatch-odd { background: #ef4444; }
+.chr-swatch-walker { background: #f59e0b; }
+
+.chr-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.chr-chip-idle { background: #f1f5f9; color: var(--muted); }
+.chr-chip-odd { background: #fee2e2; color: #991b1b; }
+.chr-chip-match { background: #f3e8ff; color: #6b21a8; }
+.chr-chip-euler { background: #ecfdf5; color: #065f46; }
+.chr-chip-shortcut { background: #ffedd5; color: #9a3412; }
+.chr-chip-done { background: #dcfce7; color: #166534; }
+
+.chr-statgrid {
+  display: flex; flex-wrap: wrap; gap: 14px 22px;
+  font-size: 0.82rem;
+}
+.chr-statlabel { color: var(--muted); font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.chr-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.chr-config-row {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+}
+.chr-label { font-size: 0.82rem; font-weight: 500; color: var(--text); }
+.chr-toggle { font-size: 0.78rem; color: var(--text); display: flex; align-items: center; gap: 4px; cursor: pointer; }
+.chr-speed-btns { display: flex; gap: 4px; }
+.chr-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.chr-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.chr-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.chr-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.chr-controls { display: flex; gap: 8px; }
+.chr-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.chr-btn:hover:not(:disabled) { background: #f0fdf4; }
+.chr-btn:disabled { opacity: 0.4; cursor: default; }
+
+.chr-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.chr-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.chr-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.chr-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.chr-scenario-btn:disabled { opacity: 0.4; cursor: default; }
+
+.chr-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/christofides.tsx
+++ b/teeline-web/src/explainers/christofides.tsx
@@ -46,11 +46,14 @@ function TourCanvas({ sim, showMst, showMatch, showTour }: {
   // multigraph edges the walker has already used, per unordered pair
   const usedPairs = useMemo(() => {
     const map = new Map<string, number>()
-    const upto = phase === 'euler'
-      ? sim.walkerPos
-      : phase === 'shortcut' || phase === 'done'
-        ? sim.eulerCircuit.length - 1
-        : 0
+    let upto: number
+    if (phase === 'euler') {
+      upto = sim.walkerPos
+    } else if (phase === 'shortcut' || phase === 'done') {
+      upto = sim.eulerCircuit.length - 1
+    } else {
+      upto = 0
+    }
     for (let t = 0; t < upto; t++) {
       const k = edgeKey(sim.eulerCircuit[t], sim.eulerCircuit[t + 1])
       map.set(k, (map.get(k) ?? 0) + 1)
@@ -83,21 +86,25 @@ function TourCanvas({ sim, showMst, showMatch, showTour }: {
   const skippedSet = new Set(sim.skipped)
 
   // walker position: euler phase follows walkerPos; shortcut follows shortcutStep
-  const walkerCity = phase === 'euler'
-    ? sim.eulerCircuit[Math.min(sim.walkerPos, sim.eulerCircuit.length - 1)]
-    : phase === 'shortcut'
-      ? sim.eulerCircuit[Math.min(sim.shortcutStep, sim.eulerCircuit.length - 1)]
-      : null
+  let walkerCity: number | null = null
+  if (phase === 'euler') {
+    walkerCity = sim.eulerCircuit[Math.min(sim.walkerPos, sim.eulerCircuit.length - 1)]
+  } else if (phase === 'shortcut') {
+    walkerCity = sim.eulerCircuit[Math.min(sim.shortcutStep, sim.eulerCircuit.length - 1)]
+  }
 
   const constructing = phase === 'mst' || phase === 'odd' || phase === 'matching'
-  const mstShown: [number, number][] = showMst && constructing
-    ? sim.mstEdges.slice(0, phase === 'mst' ? sim.mstRevealed : sim.mstEdges.length)
-    : []
-  const matchShown: [number, number][] = showMatch && phase === 'matching'
-    ? sim.matchingEdges.slice(0, sim.matchingRevealed)
-    : showMatch && (phase === 'euler' || phase === 'shortcut' || phase === 'done')
-      ? sim.matchingEdges
-      : []
+  let mstShown: [number, number][] = []
+  if (showMst && constructing) {
+    const limit = phase === 'mst' ? sim.mstRevealed : sim.mstEdges.length
+    mstShown = sim.mstEdges.slice(0, limit)
+  }
+  let matchShown: [number, number][] = []
+  if (showMatch && phase === 'matching') {
+    matchShown = sim.matchingEdges.slice(0, sim.matchingRevealed)
+  } else if (showMatch && (phase === 'euler' || phase === 'shortcut' || phase === 'done')) {
+    matchShown = sim.matchingEdges
+  }
   const showMultigraph = phase === 'euler' || phase === 'shortcut'
   const showTourLayer = showTour && (phase === 'shortcut' || phase === 'done')
 
@@ -167,7 +174,7 @@ function RatioMeter({ ratio }: { ratio: number }) {
       <div className="chr-meter-track">
         <div className="chr-meter-fill" style={{ width: `${Math.min(100, pct)}%` }} />
         <div className="chr-meter-mark chr-meter-mark-opt" />
-        <div className="chr-meter-mark chr-meter-mark-bound" style={{ left: '83.3%' }} />
+        <div className="chr-meter-mark chr-meter-mark-bound" />
         <div className="chr-meter-dot" style={{ left: `${Math.min(100, pct)}%` }} />
       </div>
       <div className="chr-meter-labels">
@@ -263,11 +270,13 @@ export default function ChristofidesExplainer() {
   let chipText = "Step 1 — growing the Minimum Spanning Tree (Prim's)"
   let chipClass = "chr-chip chr-chip-idle"
   if (s.phase === 'mst') {
-    chipText = s.mstRevealed === 0
-      ? `MST — click Step to grow the tree (Prim's, cost ${s.mstCost.toFixed(0)})`
-      : s.mstRevealed < s.mstEdges.length
-        ? `MST — added edge ${s.mstEdges[s.mstRevealed - 1][0]}–${s.mstEdges[s.mstRevealed - 1][1]} (${s.mstRevealed}/${s.mstEdges.length})`
-        : `MST complete — cost ${s.mstCost.toFixed(0)} ≤ OPT ${s.opt.toFixed(0)}. Step to find odd-degree vertices`
+    if (s.mstRevealed === 0) {
+      chipText = `MST — click Step to grow the tree (Prim's, cost ${s.mstCost.toFixed(0)})`
+    } else if (s.mstRevealed < s.mstEdges.length) {
+      chipText = `MST — added edge ${s.mstEdges[s.mstRevealed - 1][0]}–${s.mstEdges[s.mstRevealed - 1][1]} (${s.mstRevealed}/${s.mstEdges.length})`
+    } else {
+      chipText = `MST complete — cost ${s.mstCost.toFixed(0)} ≤ OPT ${s.opt.toFixed(0)}. Step to find odd-degree vertices`
+    }
   } else if (s.phase === 'odd') {
     chipText = `Odd-degree vertices: ${s.odd.join(', ')} — always an even count (handshaking lemma)`
     chipClass = "chr-chip chr-chip-odd"
@@ -391,7 +400,7 @@ export default function ChristofidesExplainer() {
       </div>
 
       <div className="chr-controls">
-        <button className="chr-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>⏴ Back</button>
+        <button className="chr-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
         <button className="chr-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
         <button className="chr-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
           {running ? "⏸ Pause" : "▶ Run"}
@@ -525,7 +534,7 @@ const CSS = `
   position: absolute; top: -2px; bottom: -2px; width: 2px; background: #64748b;
 }
 .chr-meter-mark-opt { left: 0; }
-.chr-meter-mark-bound { background: #dc2626; }
+.chr-meter-mark-bound { left: 83.3%; background: #dc2626; }
 .chr-meter-labels {
   display: flex; justify-content: space-between; font-size: 0.68rem; color: var(--muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -108,6 +108,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of the 3-opt local-search algorithm: watch three edges get removed and the three segments reconnected in one of seven ways, with the chosen reconnection pattern highlighted in a case diagram.',
     backLabel: '3-opt',
   },
+  christofides: {
+    title: 'Christofides — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of the Christofides ≤1.5× approximation: grow the MST, patch the odd-degree vertices with a matching, walk the Eulerian circuit, and shortcut it into a tour — with the proof made visible.',
+    backLabel: 'Christofides',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -31,6 +31,7 @@ import AcoExplainer from '../../../../explainers/aco'
 import StochasticHillExplainer from '../../../../explainers/stochastic-hill'
 import OrOptExplainer from '../../../../explainers/or-opt'
 import ThreeOptExplainer from '../../../../explainers/three-opt'
+import ChristofidesExplainer from '../../../../explainers/christofides'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -75,6 +76,7 @@ const jsonLd = {
     {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
     {id === 'or_opt' && <OrOptExplainer client:visible />}
     {id === '3opt' && <ThreeOptExplainer client:visible />}
+    {id === 'christofides' && <ChristofidesExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
   </main>

--- a/teeline-web/tests/christofides.spec.ts
+++ b/teeline-web/tests/christofides.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the Christofides explainer (/algorithms/christofides/explainer/).
+// The component hydrates with `client:visible`, so the tests first scroll it
+// into view and probe until the Preact listeners are attached (a click that
+// changes the status chip), then reset to the idle phase.
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.chr-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.chr-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('MST —', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  await page.getByRole('button', { name: 'Reset' }).click()
+  await expect(chip).toContainText('grow the tree')
+}
+
+test.describe('christofides explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/christofides/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the canvas, pipeline stepper, ratio meter, proof and compare panels', async ({ page }) => {
+    await expect(page.locator('.chr-title')).toHaveText('Christofides — a ≤1.5× Approximation')
+    await expect(page.locator('.chr-canvas')).toBeVisible()
+
+    // six pipeline phases
+    await expect(page.locator('.chr-phase-btn')).toHaveCount(6)
+
+    // ratio meter + proof + compare
+    await expect(page.locator('.chr-meter')).toBeVisible()
+    await expect(page.locator('.chr-proof')).toBeVisible()
+    await expect(page.locator('.chr-compare-row')).toHaveCount(3)
+
+    const stats = page.locator('.chr-statgrid')
+    await expect(stats).toContainText('MST cost')
+    await expect(stats).toContainText('matching cost')
+    await expect(stats).toContainText('tour cost')
+    await expect(stats).toContainText('ratio')
+
+    for (const label of ['Balanced', 'Near-optimal', 'Matching-heavy', 'Clustered', 'Worst case']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step reveals MST edges one at a time', async ({ page }) => {
+    const chip = page.locator('.chr-chip')
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('added edge')
+    await expect(chip).toContainText('1/9')
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('2/9')
+  })
+
+  test('the phase selector jumps straight to any phase', async ({ page }) => {
+    const chip = page.locator('.chr-chip')
+
+    await page.getByRole('button', { name: 'Odd vertices' }).click()
+    await expect(chip).toContainText('Odd-degree vertices')
+
+    await page.getByRole('button', { name: 'Euler walk' }).click()
+    await expect(chip).toContainText('Eulerian circuit')
+
+    await page.getByRole('button', { name: 'Done' }).click()
+    await expect(chip).toContainText('Done —')
+    await expect(page.locator('.chr-meter-value')).toContainText('× optimal')
+  })
+
+  test('Run animates through the whole pipeline to Done; Reset restores idle', async ({ page }) => {
+    const chip = page.locator('.chr-chip')
+    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await expect(chip).toContainText('Done —', { timeout: 20_000 })
+    await expect(step).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(chip).toContainText('grow the tree')
+    await expect(step).toHaveText('0')
+  })
+
+  test('Pause stops the animation mid-run', async ({ page }) => {
+    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await step.textContent()
+    await page.waitForTimeout(600)
+    await expect(step).toHaveText(paused ?? '')
+  })
+
+  test('Back restores the previous step', async ({ page }) => {
+    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(step).toHaveText('2')
+
+    await page.getByRole('button', { name: 'Back' }).click()
+    await expect(step).toHaveText('1')
+  })
+
+  test('scenario buttons restart the run with their own ratio', async ({ page }) => {
+    await page.getByRole('button', { name: 'Worst case' }).click()
+    await page.getByRole('button', { name: 'Done' }).click()
+    // worst_case is pinned at ~1.39× — the ratio stat reflects it
+    const ratio = page.locator('.chr-statgrid').locator('div', { hasText: /^ratio/ }).locator('.chr-mono')
+    await expect(ratio).toHaveText('1.39×')
+  })
+})


### PR DESCRIPTION
## What

Interactive explainer for **Christofides** at `/algorithms/christofides/explainer/` — the only simple TSP heuristic with a **provable 1.5× bound**, so the explainer's job is to make the *proof* visible, not just the construction.

**Rust-faithful pipeline** (`src/tsp/christofides.rs`), six deterministic phases: Prim's MST → odd-degree vertices → greedy min-weight perfect matching → multigraph union → iterative Hierholzer Eulerian circuit → first-occurrence shortcut. No RNG; `SimState` stores no function references so it stays `structuredClone`-able for Back.

## The teaching core

- **Walking-dot Eulerian animation** — the walker traverses the multigraph with used-edge fading, then the **shortcut phase carves the final tour out of the walk** (repeats crossed out ✕ in real time)
- **Ratio meter** — observed tour/OPT vs the 1.5× bound (OPT brute-forced; every instance ≤ 10 cities)
- **"Why ≤ 1.5×?" panel** — the three inequalities light up with the instance's live numbers: `MST ≤ OPT`, `matching vs OPT/2`, `tour ≤ MST+matching ≤ 1.5·OPT`. It *honestly* shows when the solver's greedy matching exceeds the OPT/2 theory line (the bound assumes the true minimum matching) — a real implementation-vs-textbook nuance
- **Phase selector** (jump to any phase), **layer toggles** (MST / Matching / Tour), **compare panel** (nearest-neighbour, doubled-MST "2× cousin", Christofides) on the same instance

## Scenarios (layouts tuned offline)

| Scenario | Story |
|---|---|
| Balanced | the classic 10-city ring — 1.11× |
| Near-optimal | 10 cities on a circle — Christofides finds the optimum (1.00×); the doubled-MST cousin sits at 1.18× |
| Matching-heavy | two tight clusters joined by a bridge — the matching is ~50% of the tour cost |
| Clustered | three clusters — matching edges bridge between them |
| Worst case | ratio stretches to 1.39× — the bound is real, not hand-wavy |

## Files

- `christofides-algo.ts` — pipeline port + brute-force OPT + NN / doubled-MST comparisons
- `christofides.tsx` — canvas (progressive layers, walker, tour carving), ratio meter, proof panel, compare panel, phase selector, toggles
- `christofides.test.ts` — 22 unit tests (Rust tests ported, ratio ≤ 1.5 property check over random instances, phase machine, purity)
- `tests/christofides.spec.ts` — 7 Playwright e2e
- `registry.ts`, `[id]/explainer/index.astro`, `docs/algorithms/christofides.md` — wiring

## Verification

- `vitest run`: 444 tests pass (31 files)
- `astro check` + `tsc --noEmit`: clean
- Playwright e2e (`--project=chrome`): 7/7 pass

Closes #431