### PR TITLE
feat(web): add interactive Bellman-Held-Karp explainer (#429)

### DIFF
--- a/docs/algorithms/bellman-held-karp.md
+++ b/docs/algorithms/bellman-held-karp.md
@@ -3,7 +3,7 @@ id: "bhk"
 name: "Bellman–Held–Karp"
 typeBadge: "Exact"
 description: "Dynamic programming algorithm that solves TSP exactly. It builds up solutions for subsets of cities, combining the optimal sub-tour results to find the globally optimal tour. Returns the provably shortest Hamiltonian circuit."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Bellman–Held–Karp

--- a/docs/algorithms/branch-bound.md
+++ b/docs/algorithms/branch-bound.md
@@ -3,7 +3,7 @@ id: "branch_bound"
 name: "Branch and Bound"
 typeBadge: "Exact"
 description: "Systematic enumeration of candidate tours that prunes any branch whose lower-bound cost already exceeds the best complete tour found so far."
-hasExplainer: false
+hasExplainer: true
 ---
 
 # Branch and Bound

--- a/teeline-web/src/components/ExplainerSidebar.astro
+++ b/teeline-web/src/components/ExplainerSidebar.astro
@@ -4,7 +4,7 @@
 // sidebar, linking to /algorithms/<id>/explainer/. Built from the registry so
 // it stays in sync with EXPLAINER_META automatically.
 import { EXPLAINER_META } from '../explainers/registry'
-import { SOLVER_GROUPS, SOLVER_META } from '../nav-data'
+import { SOLVER_GROUPS } from '../nav-data'
 
 interface Props {
   currentId: string | null
@@ -24,7 +24,6 @@ const { currentId } = Astro.props
           <ul class="m-0 list-none p-0">
             {explainerIds.map((id) => {
               const label = EXPLAINER_META[id].backLabel
-              const meta = SOLVER_META[id]
               const isCurrent = id === currentId
               return (
                 <li class={isCurrent ? 'border-l-2 border-accent bg-accent-dim' : ''}>

--- a/teeline-web/src/components/ExplainerSidebar.astro
+++ b/teeline-web/src/components/ExplainerSidebar.astro
@@ -1,0 +1,44 @@
+---
+// Server-rendered sidebar for the interactive explainer pages: lists every
+// solver that HAS an explainer, grouped by the same categories as the docs
+// sidebar, linking to /algorithms/<id>/explainer/. Built from the registry so
+// it stays in sync with EXPLAINER_META automatically.
+import { EXPLAINER_META } from '../explainers/registry'
+import { SOLVER_GROUPS, SOLVER_META } from '../nav-data'
+
+interface Props {
+  currentId: string | null
+}
+
+const { currentId } = Astro.props
+---
+<ul class="m-0 list-none p-0">
+  <li class="px-4 pb-1 pt-2 font-sans text-xs font-semibold tracking-wide text-text">Explorers</li>
+  {
+    SOLVER_GROUPS.map((g) => {
+      const explainerIds = g.ids.filter((id) => id in EXPLAINER_META)
+      if (explainerIds.length === 0) return null
+      return (
+        <li class="mb-1">
+          <span class="block px-4 pb-1 pt-2 font-sans text-[0.7rem] font-bold uppercase tracking-wider text-text-dim">{g.label}</span>
+          <ul class="m-0 list-none p-0">
+            {explainerIds.map((id) => {
+              const label = EXPLAINER_META[id].backLabel
+              const meta = SOLVER_META[id]
+              const isCurrent = id === currentId
+              return (
+                <li class={isCurrent ? 'border-l-2 border-accent bg-accent-dim' : ''}>
+                  {isCurrent ? (
+                    <span aria-current="page" class="block px-4 py-1 text-sm font-semibold text-accent">{label}</span>
+                  ) : (
+                    <a href={`/algorithms/${id}/explainer/`} class="block px-4 py-1 text-sm text-text no-underline hover:bg-surface-2 hover:text-accent">{label}</a>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </li>
+      )
+    })
+  }
+</ul>

--- a/teeline-web/src/explainers/bhk-algo.ts
+++ b/teeline-web/src/explainers/bhk-algo.ts
@@ -1,0 +1,236 @@
+// Pure simulation logic for the Bellman-Held-Karp explainer.
+//
+// Rust-faithful model (src/tsp/bellman_karp.rs) with a cleaner convention:
+// the start city is city 0 and the DP lives on the OTHER n-1 cities (1..n-1),
+// indexed by bitmask subsets. dp[mask][i] = minimum cost of a path that starts
+// at city 0, visits exactly the cities in `mask`, and ends at city i:
+//   base:  dp[{i}][i] = d(0, i)
+//   step:  dp[mask][i] = min over j in mask\{i} of dp[mask\{i}][j] + d(j, i)
+// Answer: min over i of dp[full][i] + d(i, 0).
+// The predecessor choice is recorded per cell so the optimal route can be
+// read back and each cell can explain its computation.
+//
+// n = 6 per scenario → the table is 5 rows × 32 subsets, easy to scan.
+// Deterministic — no RNG; SimState holds only plain data (cloneable for Back).
+
+export type Phase = 'forward' | 'readback' | 'done'
+
+export interface Scenario {
+  label: string
+  desc: string
+  cities: [number, number][]
+}
+
+export interface SimState {
+  phase: Phase
+  cities: [number, number][]
+  n: number            // total cities (city 0 = start)
+  m: number            // n-1 (DP cities 1..n-1)
+  dm: number[][]       // distance matrix (plain numbers)
+  // DP table: rows = end city index (0..m-1 ↔ city i+1), cols = mask
+  table: number[][]    // ∞ until computed
+  pred: number[][]     // predecessor city (index into rows) per computed cell, -1 if none
+  // fill order (deterministic): masks by popcount ascending, then value
+  fillOrder: { mask: number; row: number }[]
+  fillPtr: number
+  // optimal route (computed when forward completes)
+  optCost: number | null
+  route: number[] | null       // city ids, [0, c1, ..., cn-1]
+  readback: number[]           // city ids revealed so far (from the end backwards)
+  readbackPtr: number
+  lastEvent: string | null
+  step: number
+}
+
+export const SCENARIOS: Record<string, Scenario> = {
+  grid_6: {
+    label: '6-city grid',
+    desc: 'The familiar compact grid — a clean DP table to scan',
+    cities: [[60, 60], [240, 60], [240, 240], [60, 240], [150, 60], [150, 240]],
+  },
+  circle_6: {
+    label: 'Circle',
+    desc: 'Six cities on a circle — the optimal route is the perimeter',
+    cities: [[270, 150], [210, 254], [90, 254], [30, 150], [90, 46], [210, 46]],
+  },
+  clusters_6: {
+    label: 'Two clusters',
+    desc: 'Two tight triples far apart — the DP must bridge them twice',
+    cities: [[60, 60], [90, 60], [60, 90], [240, 240], [210, 240], [240, 210]],
+  },
+}
+
+const INF = Infinity
+
+export function makeDm(cities: [number, number][]): number[][] {
+  const n = cities.length
+  const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
+      dm[i][j] = d
+      dm[j][i] = d
+    }
+  }
+  return dm
+}
+
+export function popcount(x: number): number {
+  let c = 0
+  while (x > 0) {
+    x &= x - 1
+    c++
+  }
+  return c
+}
+
+// Deterministic fill order: subset size ascending (starting at size 2 — the
+// size-1 base cells are pre-filled in makeInitState), then mask value, then row.
+export function computeFillOrder(m: number): { mask: number; row: number }[] {
+  const order: { mask: number; row: number }[] = []
+  const full = (1 << m) - 1
+  for (let size = 2; size <= m; size++) {
+    for (let mask = 1; mask <= full; mask++) {
+      if (popcount(mask) !== size) continue
+      for (let row = 0; row < m; row++) {
+        if (mask & (1 << row)) order.push({ mask, row })
+      }
+    }
+  }
+  return order
+}
+
+export function makeInitState(scenario: Scenario): SimState {
+  const cities = scenario.cities
+  const n = cities.length
+  const m = n - 1
+  const dm = makeDm(cities)
+  const size = 1 << m
+  const table: number[][] = Array.from({ length: m }, () => new Array(size).fill(INF))
+  const pred: number[][] = Array.from({ length: m }, () => new Array(size).fill(-1))
+
+  // base cells: dp[{i}][i] = d(0, city i+1)
+  for (let row = 0; row < m; row++) {
+    table[row][1 << row] = dm[0][row + 1]
+  }
+
+  return {
+    phase: 'forward',
+    cities,
+    n,
+    m,
+    dm,
+    table,
+    pred,
+    fillOrder: computeFillOrder(m),
+    fillPtr: 0,
+    optCost: null,
+    route: null,
+    readback: [],
+    readbackPtr: 0,
+    lastEvent: null,
+    step: 0,
+  }
+}
+
+// Compute one DP cell (mask, row) from its predecessors; record the argmin.
+function fillCell(state: SimState, mask: number, row: number): { value: number; via: number } {
+  const rest = mask & ~(1 << row)
+  const city = row + 1
+  let best = INF
+  let via = -1
+  for (let j = 0; j < state.m; j++) {
+    if ((rest & (1 << j)) === 0) continue
+    const v = state.table[j][rest] + state.dm[j + 1][city]
+    if (v < best) {
+      best = v
+      via = j
+    }
+  }
+  return { value: best, via }
+}
+
+// The optimal route: end city e = argmin_i table[i][full] + d(i+1, 0),
+// then read predecessors back to the start.
+export function computeRoute(state: SimState): { cost: number; route: number[] } {
+  const full = (1 << state.m) - 1
+  let best = INF
+  let end = -1
+  for (let i = 0; i < state.m; i++) {
+    const v = state.table[i][full] + state.dm[i + 1][0]
+    if (v < best) {
+      best = v
+      end = i
+    }
+  }
+  const routeRev = [end + 1]
+  let cur = end
+  let mask = full
+  while (mask !== 0) {
+    const via = state.pred[cur][mask]
+    if (via < 0) break
+    mask &= ~(1 << cur)
+    cur = via
+    if (mask !== 0) routeRev.push(via + 1)
+  }
+  const route = [0, ...routeRev.reverse()]
+  return { cost: best, route }
+}
+
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'done') return { ...state, step: state.step + 1 }
+
+  // ----- readback: reveal one city of the optimal route per step -----
+  if (state.phase === 'readback') {
+    if (state.readbackPtr >= (state.route?.length ?? 0) - 1) {
+      return { ...state, phase: 'done', lastEvent: `Done — optimal tour ${state.route!.join('→')} = ${state.optCost!.toFixed(1)}`, step: state.step + 1 }
+    }
+    // the end city is seeded; each step reveals the next city back toward the start
+    const city = state.route![state.route!.length - 1 - state.readbackPtr]
+    return {
+      ...state,
+      readback: [...state.readback, city],
+      readbackPtr: state.readbackPtr + 1,
+      lastEvent: `Read-back — optimal tour passes ${city} next (${state.readbackPtr + 1}/${state.n - 1} revealed)`,
+      step: state.step + 1,
+    }
+  }
+
+  // ----- forward: fill the next cell -----
+  if (state.fillPtr >= state.fillOrder.length) {
+    // forward complete → compute the optimal route, start read-back
+    const { cost, route } = computeRoute(state)
+    return {
+      ...state,
+      phase: 'readback',
+      optCost: cost,
+      route,
+      readback: [route[route.length - 1]],
+      readbackPtr: 1,
+      lastEvent: `DP complete — optimal cost ${cost.toFixed(1)}. Step to read the route back`,
+      step: state.step + 1,
+    }
+  }
+
+  const { mask, row } = state.fillOrder[state.fillPtr]
+  const { value, via } = fillCell(state, mask, row)
+
+  const table = state.table.map((r, ri) => (ri === row ? [...r] : r))
+  const pred = state.pred.map((r, ri) => (ri === row ? [...r] : r))
+  table[row][mask] = value
+  pred[row][mask] = via
+
+  const sizeLabel = mask.toString(2).padStart(state.m, '0')
+  const event = value === INF
+    ? `Cell (${sizeLabel}, end ${row + 1}) — unreachable`
+    : `dp[${sizeLabel}][${row + 1}] = ${value.toFixed(1)} via city ${via + 1}`
+
+  return {
+    ...state,
+    table,
+    pred,
+    fillPtr: state.fillPtr + 1,
+    lastEvent: event,
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/bhk-algo.ts
+++ b/teeline-web/src/explainers/bhk-algo.ts
@@ -13,6 +13,9 @@
 // n = 6 per scenario → the table is 5 rows × 32 subsets, easy to scan.
 // Deterministic — no RNG; SimState holds only plain data (cloneable for Back).
 
+import { makeDm } from './explainer-cities'
+export { makeDm }
+
 export type Phase = 'forward' | 'readback' | 'done'
 
 export interface Scenario {
@@ -61,19 +64,6 @@ export const SCENARIOS: Record<string, Scenario> = {
 }
 
 const INF = Infinity
-
-export function makeDm(cities: [number, number][]): number[][] {
-  const n = cities.length
-  const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
-  for (let i = 0; i < n; i++) {
-    for (let j = i + 1; j < n; j++) {
-      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
-      dm[i][j] = d
-      dm[j][i] = d
-    }
-  }
-  return dm
-}
 
 export function popcount(x: number): number {
   let c = 0
@@ -163,6 +153,7 @@ export function computeRoute(state: SimState): { cost: number; route: number[] }
       end = i
     }
   }
+  if (end < 0) return { cost: best, route: [0] } // no complete tour found
   const routeRev = [end + 1]
   let cur = end
   let mask = full

--- a/teeline-web/src/explainers/bhk.test.ts
+++ b/teeline-web/src/explainers/bhk.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SCENARIOS, makeInitState, stepOnce, makeDm, popcount, computeFillOrder,
+} from './bhk-algo'
+import type { SimState } from './bhk-algo'
+
+// Brute-force optimum over the same instance (fixed start at city 0).
+function bruteForce(cities: [number, number][]): number {
+  const n = cities.length
+  const dm = makeDm(cities)
+  const rest = Array.from({ length: n - 1 }, (_, i) => i + 1)
+  const used = new Array<boolean>(rest.length).fill(false)
+  const order: number[] = [0]
+  let best = Infinity
+  const search = () => {
+    if (order.length === n) {
+      let d = 0
+      for (let k = 0; k < n; k++) d += dm[order[k]][order[(k + 1) % n]]
+      if (d < best) best = d
+      return
+    }
+    for (let i = 0; i < rest.length; i++) {
+      if (used[i]) continue
+      used[i] = true
+      order.push(rest[i])
+      search()
+      order.pop()
+      used[i] = false
+    }
+  }
+  search()
+  return best
+}
+
+function runToDone(scenario: (typeof SCENARIOS)[string]): SimState {
+  let s = makeInitState(scenario)
+  let guard = 1000
+  while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+  expect(s.phase).toBe('done')
+  return s
+}
+
+// ---------------------------------------------------------------
+describe('primitives', () => {
+  it('popcount counts set bits', () => {
+    expect(popcount(0)).toBe(0)
+    expect(popcount(1)).toBe(1)
+    expect(popcount(7)).toBe(3)
+    expect(popcount(31)).toBe(5)
+  })
+
+  it('fill order goes by subset size ascending, then mask, then row', () => {
+    const order = computeFillOrder(3)
+    const sizes = order.map((o) => popcount(o.mask))
+    for (let k = 1; k < sizes.length; k++) {
+      expect(sizes[k]).toBeGreaterThanOrEqual(sizes[k - 1])
+    }
+    // every (mask, row in mask) cell appears exactly once
+    const keys = new Set(order.map((o) => `${o.mask}:${o.row}`))
+    expect(keys.size).toBe(order.length)
+    // sizes 2..3 only: 3×2 + 1×3 = 9 cells (size-1 base cells are pre-filled)
+    expect(order).toHaveLength(9)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('makeInitState', () => {
+  it('sets the base cells dp[{i}][i] = d(0, i+1)', () => {
+    const s = makeInitState(SCENARIOS.grid_6)
+    for (let row = 0; row < s.m; row++) {
+      expect(s.table[row][1 << row]).toBeCloseTo(s.dm[0][row + 1], 10)
+    }
+    expect(s.phase).toBe('forward')
+    expect(s.fillPtr).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('stepOnce forward', () => {
+  it('fills one cell per step and records the predecessor', () => {
+    let s = makeInitState(SCENARIOS.grid_6)
+    s = stepOnce(s) // first size-2 cell
+    expect(s.fillPtr).toBe(1)
+    expect(s.lastEvent).toContain('via city')
+    const cell = s.fillOrder[0]
+    expect(s.table[cell.row][cell.mask]).not.toBe(Infinity)
+    expect(s.pred[cell.row][cell.mask]).toBeGreaterThanOrEqual(0)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('readback', () => {
+  it('reveals the route from the end back to the start', () => {
+    const s0 = makeInitState(SCENARIOS.grid_6)
+    let s = s0
+    let guard = 100
+    while (s.phase !== 'readback' && guard-- > 0) s = stepOnce(s)
+    expect(s.phase).toBe('readback')
+    expect(s.optCost).not.toBeNull()
+    expect(s.route).toHaveLength(6)
+    expect(s.route![0]).toBe(0)
+    // readback seeds the end city
+    expect(s.readback[0]).toBe(s.route![5])
+    // stepping reveals the rest in reverse order
+    const next = stepOnce(s)
+    expect(next.readback).toHaveLength(2)
+    expect(next.readback[1]).toBe(s.route![4])
+  })
+})
+
+// ---------------------------------------------------------------
+describe('correctness', () => {
+  it('every scenario finds the exact optimum and a valid route', () => {
+    for (const [key, sc] of Object.entries(SCENARIOS)) {
+      const s = runToDone(sc)
+      expect(s.optCost, `${key} must match brute force`).toBeCloseTo(bruteForce(sc.cities), 6)
+      expect([...s.route!].sort((a, b) => a - b), `${key} route must be a permutation`).toEqual(
+        Array.from({ length: sc.cities.length }, (_, i) => i),
+      )
+    }
+  })
+
+  it('computeRoute on the finished table matches the closed tour length', () => {
+    const s = runToDone(SCENARIOS.clusters_6)
+    const dm = s.dm
+    const route = s.route!
+    let d = 0
+    for (let k = 0; k < route.length; k++) d += dm[route[k]][route[(k + 1) % route.length]]
+    expect(d).toBeCloseTo(s.optCost!, 6)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('purity & determinism', () => {
+  it('stepOnce never mutates its input', () => {
+    const s = makeInitState(SCENARIOS.clusters_6)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 20; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same scenario produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.grid_6)
+    const b = makeInitState(SCENARIOS.grid_6)
+    for (let i = 0; i < 20; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+})

--- a/teeline-web/src/explainers/bhk.tsx
+++ b/teeline-web/src/explainers/bhk.tsx
@@ -1,0 +1,478 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  SCENARIOS, makeInitState, stepOnce, popcount,
+} from "./bhk-algo"
+import type { Phase, Scenario, SimState } from "./bhk-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.grid_6
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+const INF = Infinity
+
+// ---------------------------------------------------------------
+// DpTable — rows = end city, columns = subset bitmask. Base cells
+// pre-filled; the next cell to compute is ringed; click a cell to
+// inspect its computation. Read-back cells turn gold.
+// ---------------------------------------------------------------
+function DpTable({ sim, selected, onSelect }: {
+  sim: SimState
+  selected: { mask: number; row: number } | null
+  onSelect: (mask: number, row: number) => void
+}) {
+  const m = sim.m
+  const full = (1 << m) - 1
+
+  // cells of the optimal route (mask, row) — gold in readback/done
+  const routeCells = useMemo(() => {
+    const cells = new Set<string>()
+    if (!sim.route) return cells
+    let mask = full
+    for (let k = sim.route.length - 1; k >= 1; k--) {
+      const city = sim.route[k]
+      const row = city - 1
+      if (mask & (1 << row)) cells.add(`${mask}:${row}`)
+      mask &= ~(1 << row)
+    }
+    return cells
+  }, [sim.route, full])
+
+  const nextCell = sim.fillPtr < sim.fillOrder.length ? sim.fillOrder[sim.fillPtr] : null
+
+  return (
+    <div className="bhk-table-scroll">
+      <table className="bhk-table">
+        <thead>
+          <tr>
+            <th className="bhk-th bhk-th-row">end \ subset</th>
+            {Array.from({ length: full }, (_, i) => i + 1).map((mask) => (
+              <th key={mask} className="bhk-th">{mask.toString(2).padStart(m, '0')}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: m }, (_, row) => (
+            <tr key={row}>
+              <th className="bhk-th bhk-th-row">{row + 1}</th>
+              {Array.from({ length: full }, (_, i) => i + 1).map((mask) => {
+                const val = sim.table[row][mask]
+                const isSel = selected?.mask === mask && selected?.row === row
+                const isNext = nextCell?.mask === mask && nextCell?.row === row
+                const isRoute = routeCells.has(`${mask}:${row}`)
+                const isBase = popcount(mask) === 1 && (mask & (1 << row)) !== 0
+                const cls = [
+                  'bhk-cell',
+                  val === INF ? 'bhk-cell-empty' : '',
+                  isBase ? 'bhk-cell-base' : '',
+                  isRoute ? 'bhk-cell-route' : '',
+                  isNext ? 'bhk-cell-next' : '',
+                  isSel ? 'bhk-cell-sel' : '',
+                ].join(' ').trim()
+                return (
+                  <td key={mask} className={cls} onClick={() => onSelect(mask, row)}>
+                    {val === INF ? '·' : val.toFixed(0)}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// CityMap — current subset (forward) or revealed route (read-back)
+// ---------------------------------------------------------------
+function CityMap({ sim }: { sim: SimState }) {
+  const m = sim.m
+  const n = sim.n
+  const inReadback = sim.phase === 'readback' || sim.phase === 'done'
+
+  let subset = new Set<number>([0])
+  if (inReadback) {
+    subset = new Set([0, ...sim.readback])
+  } else if (sim.fillPtr < sim.fillOrder.length) {
+    const { mask } = sim.fillOrder[sim.fillPtr]
+    subset = new Set([0])
+    for (let i = 0; i < m; i++) if (mask & (1 << i)) subset.add(i + 1)
+  }
+
+  const routeEdges: Array<[number, number]> = []
+  if (inReadback && sim.readback.length >= 2) {
+    const pts = [0, ...sim.readback]
+    for (let k = 0; k < pts.length - 1; k++) routeEdges.push([pts[k], pts[k + 1]])
+    if (sim.phase === 'done') routeEdges.push([pts[pts.length - 1], 0])
+  }
+
+  return (
+    <svg viewBox="0 0 300 300" className="bhk-map" role="img" aria-label="Current subset on the map">
+      <rect x={0} y={0} width={300} height={300} className="bhk-bg" />
+      {routeEdges.map(([a, b]) => (
+        <line key={`${a}-${b}`} className="bhk-map-edge"
+          x1={sim.cities[a][0]} y1={sim.cities[a][1]}
+          x2={sim.cities[b][0]} y2={sim.cities[b][1]} />
+      ))}
+      {Array.from({ length: n }, (_, i) => i).map((i) => {
+        const inSub = subset.has(i)
+        const cls = i === 0 ? 'bhk-city-start' : inSub ? 'bhk-city' : 'bhk-city-dim'
+        return (
+          <g key={i}>
+            <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
+            <text className="bhk-label" x={sim.cities[i][0]} y={sim.cities[i][1] + 16}>{i}</text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function BhkExplainer() {
+  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2)
+  const [selected, setSelected] = useState<{ mask: number; row: number } | null>(null)
+
+  const simRef = useRef(sim)
+  const historyRef = useRef<Array<typeof sim>>([])
+  const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
+
+  const commit = useCallback((next: SimState) => {
+    simRef.current = next
+    setSim(next)
+  }, [])
+
+  const reinit = useCallback((scenario: Scenario) => {
+    scenarioRef.current = scenario
+    historyRef.current = []
+    setSelected(null)
+    commit(makeInitState(scenario))
+    setRunning(false)
+  }, [commit])
+
+  const stepForward = useCallback(() => {
+    const cur = simRef.current
+    if (cur.phase === 'done') return
+    historyRef.current.push(structuredClone(cur))
+    const next = stepOnce(cur)
+    simRef.current = next
+    setSim(next)
+    if (next.phase === 'done') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    commit(h.pop()!)
+  }, [running, commit])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepForward, SPEEDS[speedIdx])
+    return () => clearInterval(id)
+  }, [running, speedIdx, stepForward])
+
+  // jump to a phase (forward start / read-back start / done)
+  const jumpTo = useCallback((target: Phase) => {
+    let s = makeInitState(scenarioRef.current)
+    let guard = 600
+    while (s.phase !== target && s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+    if (s.phase !== target && target !== 'done') s = stepOnce(s)
+    historyRef.current = []
+    commit(s)
+    setRunning(false)
+  }, [commit])
+
+  const s = sim
+  const full = (1 << s.m) - 1
+  const currentMask = s.fillPtr < s.fillOrder.length ? s.fillOrder[s.fillPtr].mask : full
+  const selectedCell = selected && selected.mask >= 1 && selected.mask <= full
+    ? { value: s.table[selected.row][selected.mask], mask: selected.mask, row: selected.row }
+    : null
+
+  // cell info text
+  let cellInfo = 'click a cell to see how its value was computed'
+  if (selectedCell) {
+    const { value, mask, row } = selectedCell
+    if (value === INF) {
+      cellInfo = `dp[${mask.toString(2).padStart(s.m, '0')}][${row + 1}] — not computed (city ${row + 1} not in subset)`
+    } else if (popcount(mask) === 1) {
+      cellInfo = `base — dp[{${row + 1}}][${row + 1}] = d(0, ${row + 1}) = ${value.toFixed(1)}`
+    } else {
+      const rest = mask & ~(1 << row)
+      const via = s.pred[row][mask]
+      cellInfo = `dp[${mask.toString(2).padStart(s.m, '0')}][${row + 1}] = dp[${rest.toString(2).padStart(s.m, '0')}][${via + 1}] + d(${via + 1}, ${row + 1}) = ${value.toFixed(1)}`
+    }
+  }
+
+  let chipText = s.lastEvent ?? 'Bellman-Held-Karp — the DP table fills subset by subset'
+  let chipClass = "bhk-chip bhk-chip-idle"
+  if (s.phase === 'done') chipClass = "bhk-chip bhk-chip-done"
+  else if (s.phase === 'readback') chipClass = "bhk-chip bhk-chip-readback"
+  else if (chipText.includes('dp[')) chipClass = "bhk-chip bhk-chip-cell"
+
+  return (
+    <div className="bhk-root">
+      <style>{CSS}</style>
+
+      <header className="bhk-header">
+        <div className="bhk-eyebrow">teeline · algorithms/bhk</div>
+        <h2 className="bhk-title">Bellman-Held-Karp — exact dynamic programming</h2>
+        <p className="bhk-sub">
+          BHK fills a table of <strong>subset costs</strong>: <code>dp[mask][i]</code> is the cheapest
+          path from city 0 that visits exactly the cities in <code>mask</code> and ends at city{' '}
+          <code>i</code>. Every cell is built from one smaller subset plus one edge — then the optimal
+          route is <strong>read back</strong> through the recorded predecessors.
+        </p>
+      </header>
+
+      <div className="bhk-viz-row">
+        <div className="bhk-side">
+          <div className="bhk-section-label">DP table — rows end city, columns subset</div>
+          <DpTable sim={s} selected={selected} onSelect={(mask, row) => setSelected({ mask, row })} />
+          <div className="bhk-section-label" style={{ marginTop: 6 }}>Subset on the map</div>
+          <CityMap sim={s} />
+        </div>
+        <div className="bhk-panel">
+          <div className="bhk-section-label">Cell info</div>
+          <div className="bhk-cellinfo">{cellInfo}</div>
+
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>Optimal</div>
+          <div className="bhk-best">
+            <span className="bhk-mono">{s.optCost === null ? '— (after the table fills)' : s.route!.join(' → ') + ' = ' + s.optCost.toFixed(1)}</span>
+          </div>
+
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>Stats</div>
+          <div className="bhk-statgrid">
+            <div><div className="bhk-statlabel">subset size</div><div className="bhk-mono">{popcount(currentMask)}</div></div>
+            <div><div className="bhk-statlabel">bits set</div><div className="bhk-mono">{currentMask.toString(2).padStart(s.m, '0')}</div></div>
+            <div><div className="bhk-statlabel">phase</div><div className="bhk-mono">{s.phase}</div></div>
+            <div><div className="bhk-statlabel">step</div><div className="bhk-mono">{s.step}</div></div>
+          </div>
+
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>Mode</div>
+          <div className="bhk-mode-row">
+            <button className={`bhk-mode-btn ${s.phase === 'forward' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('forward')} disabled={running}>Forward</button>
+            <button className={`bhk-mode-btn ${s.phase === 'readback' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('readback')} disabled={running}>Read-back</button>
+            <button className={`bhk-mode-btn ${s.phase === 'done' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('done')} disabled={running}>Done</button>
+          </div>
+        </div>
+      </div>
+
+      <div className="bhk-legend">
+        <span><span className="bhk-swatch bhk-swatch-base" /> base cell</span>
+        <span><span className="bhk-swatch bhk-swatch-filled" /> filled</span>
+        <span><span className="bhk-swatch bhk-swatch-next" /> next cell</span>
+        <span><span className="bhk-swatch bhk-swatch-route" /> optimal route</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="bhk-config">
+        <div className="bhk-config-row">
+          <span className="bhk-label">Speed</span>
+          <div className="bhk-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l} className={`bhk-speed-btn ${i === speedIdx ? 'bhk-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="bhk-controls">
+        <button className="bhk-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
+        <button className="bhk-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
+        <button className="bhk-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="bhk-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+      </div>
+
+      <div className="bhk-scenarios">
+        <div className="bhk-section-label">Scenarios</div>
+        <div className="bhk-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, sc]) => (
+            <button key={key} className="bhk-scenario-btn" title={sc.desc}
+              onClick={() => reinit(sc)} disabled={running}>
+              {sc.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="bhk-footer">
+        <span className="bhk-mono">cities: {s.n}</span>
+        <span className="bhk-mono">{'dp[mask][i] = min_j dp[mask∖{i}][j] + d(j, i)'}</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.bhk-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 940px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.bhk-root * { box-sizing: border-box; }
+.bhk-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
+}
+
+.bhk-header { margin-bottom: 2px; }
+.bhk-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.bhk-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.bhk-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+.bhk-sub code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  background: var(--panel); padding: 1px 4px; border-radius: 4px;
+}
+
+.bhk-viz-row { display: flex; gap: 12px; align-items: stretch; }
+.bhk-side { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.bhk-panel { width: 260px; flex-shrink: 0; display: flex; flex-direction: column; }
+
+.bhk-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+
+.bhk-table-scroll { overflow: auto; max-height: 320px; border: 1px solid var(--line); border-radius: 8px; }
+.bhk-table { border-collapse: collapse; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.72rem; }
+.bhk-th {
+  position: sticky; top: 0; background: var(--panel); color: var(--muted);
+  font-weight: 600; padding: 3px 5px; border-bottom: 1px solid var(--line); font-size: 0.66rem;
+}
+.bhk-th-row { left: 0; text-align: left; }
+.bhk-cell {
+  padding: 3px 5px; text-align: center; min-width: 40px;
+  border-right: 1px solid #eef1f4; cursor: pointer;
+}
+.bhk-cell:hover { background: #f0fdf4; }
+.bhk-cell-empty { color: #cbd5e1; }
+.bhk-cell-base { background: #fef9c3; }
+.bhk-cell-route { background: #fef3c7; outline: 1px solid #f59e0b; }
+.bhk-cell-next { outline: 2px solid var(--accent); }
+.bhk-cell-sel { background: #ccfbf1; }
+
+.bhk-map {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.bhk-bg { fill: var(--panel); }
+.bhk-map-edge { stroke: #0d9488; stroke-width: 2.5; stroke-linecap: round; }
+.bhk-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
+.bhk-city-start { fill: #0d9488; stroke: #fff; stroke-width: 1.5; }
+.bhk-city-dim { fill: #d1d5db; stroke: #fff; stroke-width: 1.5; }
+.bhk-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+.bhk-cellinfo {
+  font-size: 0.76rem; padding: 6px 8px; background: var(--panel);
+  border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  min-height: 48px;
+}
+.bhk-best { font-size: 0.76rem; padding: 4px 8px; background: #fefce8; border-radius: 6px; }
+
+.bhk-statgrid { display: flex; flex-wrap: wrap; gap: 10px 16px; font-size: 0.8rem; }
+.bhk-statlabel { color: var(--muted); font-size: 0.7em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.bhk-mode-row { display: flex; gap: 6px; }
+.bhk-mode-btn {
+  flex: 1; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.76rem; padding: 4px 6px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text); cursor: pointer;
+}
+.bhk-mode-btn:hover:not(:disabled) { background: #f0fdf4; }
+.bhk-mode-btn:disabled { opacity: 0.5; cursor: default; }
+.bhk-mode-cur { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.bhk-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.bhk-swatch {
+  display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+  margin-right: 4px; vertical-align: middle;
+}
+.bhk-swatch-base { background: #eab308; }
+.bhk-swatch-filled { background: #16a34a; }
+.bhk-swatch-next { background: #0d9488; }
+.bhk-swatch-route { background: #f59e0b; }
+
+.bhk-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.bhk-chip-idle { background: #f1f5f9; color: var(--muted); }
+.bhk-chip-cell { background: #ccfbf1; color: #115e59; }
+.bhk-chip-readback { background: #fef3c7; color: #92400e; }
+.bhk-chip-done { background: #dcfce7; color: #166534; }
+
+.bhk-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.bhk-config-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.bhk-label { font-size: 0.82rem; font-weight: 500; color: var(--text); }
+.bhk-speed-btns { display: flex; gap: 4px; }
+.bhk-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bhk-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.bhk-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.bhk-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.bhk-controls { display: flex; gap: 8px; }
+.bhk-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bhk-btn:hover:not(:disabled) { background: #f0fdf4; }
+.bhk-btn:disabled { opacity: 0.4; cursor: default; }
+
+.bhk-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.bhk-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.bhk-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bhk-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.bhk-scenario-btn:disabled { opacity: 0.4; cursor: default; }
+
+.bhk-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/bhk.tsx
+++ b/teeline-web/src/explainers/bhk.tsx
@@ -22,6 +22,7 @@ function DpTable({ sim, selected, onSelect }: {
 }) {
   const m = sim.m
   const full = (1 << m) - 1
+  const masks = Array.from({ length: full }, (_, i) => i + 1)
 
   // cells of the optimal route (mask, row) — gold in readback/done
   const routeCells = useMemo(() => {
@@ -45,7 +46,7 @@ function DpTable({ sim, selected, onSelect }: {
         <thead>
           <tr>
             <th className="bhk-th bhk-th-row">end \ subset</th>
-            {Array.from({ length: full }, (_, i) => i + 1).map((mask) => (
+            {masks.map((mask) => (
               <th key={mask} className="bhk-th">{mask.toString(2).padStart(m, '0')}</th>
             ))}
           </tr>
@@ -54,7 +55,7 @@ function DpTable({ sim, selected, onSelect }: {
           {Array.from({ length: m }, (_, row) => (
             <tr key={row}>
               <th className="bhk-th bhk-th-row">{row + 1}</th>
-              {Array.from({ length: full }, (_, i) => i + 1).map((mask) => {
+              {masks.map((mask) => {
                 const val = sim.table[row][mask]
                 const isSel = selected?.mask === mask && selected?.row === row
                 const isNext = nextCell?.mask === mask && nextCell?.row === row
@@ -116,7 +117,9 @@ function CityMap({ sim }: { sim: SimState }) {
       ))}
       {Array.from({ length: n }, (_, i) => i).map((i) => {
         const inSub = subset.has(i)
-        const cls = i === 0 ? 'bhk-city-start' : inSub ? 'bhk-city' : 'bhk-city-dim'
+        let cls = 'bhk-city-dim'
+        if (i === 0) cls = 'bhk-city-start'
+        else if (inSub) cls = 'bhk-city'
         return (
           <g key={i}>
             <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
@@ -138,7 +141,7 @@ export default function BhkExplainer() {
   const [selected, setSelected] = useState<{ mask: number; row: number } | null>(null)
 
   const simRef = useRef(sim)
-  const historyRef = useRef<Array<typeof sim>>([])
+  const historyRef = useRef<SimState[]>([])
   const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
 
   const commit = useCallback((next: SimState) => {
@@ -190,7 +193,7 @@ export default function BhkExplainer() {
   const s = sim
   const full = (1 << s.m) - 1
   const currentMask = s.fillPtr < s.fillOrder.length ? s.fillOrder[s.fillPtr].mask : full
-  const selectedCell = selected && selected.mask >= 1 && selected.mask <= full
+  const selectedCell = selected && selected.mask >= 1 && selected.mask <= full && selected.row >= 0 && selected.row < s.m
     ? { value: s.table[selected.row][selected.mask], mask: selected.mask, row: selected.row }
     : null
 

--- a/teeline-web/src/explainers/branch-bound-algo.ts
+++ b/teeline-web/src/explainers/branch-bound-algo.ts
@@ -85,6 +85,7 @@ export function mstCost(ids: number[], dm: number[][]): number {
         u = i
       }
     }
+    if (u === -1) return total // disconnected — no further edges can be added
     inTree[u] = true
     total += key[u]
     for (let v = 0; v < n; v++) {
@@ -174,7 +175,10 @@ export function stepOnce(state: SimState): SimState {
   const top = state.nodes[topId]
   const prev = top.path[top.path.length - 1]
 
-  // Candidates not yet branched: unvisited sorted by distance from prev
+  // Candidates not yet branched: unvisited sorted by distance from the
+  // previous city. This equals the solver's bound-ascending order — for a
+  // fixed node the MST({start} ∪ unvisited) term is the same for every
+  // candidate, so the lower bound differs only in the added edge.
   const childCount = state.nodes.filter((nd) => nd.parent === topId).length
   const candidates = [...top.unvisited].sort((a, b) => state.dm[prev][a] - state.dm[prev][b])
 
@@ -186,7 +190,7 @@ export function stepOnce(state: SimState): SimState {
     const id = state.nodes.length
 
     if (unvisited.length === 0) {
-      // Leaf — a complete tour
+      // Leaf — a complete tour. bestTour stores the closed cycle (start re-appended).
       const tourCost = cost + state.dm[c][state.startCity]
       const isBest = state.bestCost === null || tourCost < state.bestCost
       const node: BnBNode = {
@@ -199,7 +203,7 @@ export function stepOnce(state: SimState): SimState {
         nodes: [...state.nodes, node],
         leaves: state.leaves + 1,
         bestCost: isBest ? tourCost : state.bestCost,
-        bestTour: isBest ? path : state.bestTour,
+        bestTour: isBest ? [...path, state.startCity] : state.bestTour,
         lastEvent: isBest
           ? `New best — complete tour ${path.join('→')} costs ${tourCost.toFixed(0)}`
           : `Leaf — tour ${path.join('→')} costs ${tourCost.toFixed(0)} (not better than ${state.bestCost?.toFixed(0) ?? '∞'})`,

--- a/teeline-web/src/explainers/branch-bound-algo.ts
+++ b/teeline-web/src/explainers/branch-bound-algo.ts
@@ -1,0 +1,252 @@
+// Pure simulation logic for the Branch & Bound explainer.
+//
+// Rust-faithful model (src/tsp/branch_bound.rs), simplified for teaching:
+//   - depth-first search with full branching (the solver additionally restricts
+//     candidates to the n_nearest geometric neighbours — omitted here so the
+//     tree shows every branch)
+//   - lower bound per node: LB = running_cost + MST({start} ∪ unvisited)
+//     (the solver's bound: the completion must span {start} ∪ unvisited, so its
+//     cost is at least the MST of that set — a valid lower bound)
+//   - children are ordered by bound ascending (most promising first), and a
+//     child is pruned immediately when LB ≥ best tour found so far
+//   - a complete tour is a leaf; if it beats `best` it becomes the new best
+// The search runs on ≤ 6 cities per scenario so the tree stays renderable.
+// Deterministic — no RNG; SimState holds only plain data (cloneable for Back).
+
+export type NodeStatus = 'open' | 'explored' | 'pruned' | 'leaf' | 'best'
+
+export interface BnBNode {
+  id: number
+  parent: number | null
+  depth: number          // path length (k)
+  path: number[]         // partial tour (visited city ids in order)
+  cost: number           // running cost of the partial tour
+  unvisited: number[]
+  lb: number             // cost + MST({start} ∪ unvisited)
+  status: NodeStatus
+}
+
+export type Phase = 'searching' | 'done'
+
+export interface SimState {
+  phase: Phase
+  cities: [number, number][]
+  n: number
+  startCity: number
+  dm: number[][]          // distance matrix (plain numbers — cloneable)
+  nodes: BnBNode[]
+  stack: number[]         // DFS stack (node ids)
+  current: number | null  // node being expanded (top of stack)
+  bestCost: number | null
+  bestTour: number[] | null
+  explored: number        // nodes pushed onto the stack
+  pruned: number          // children filtered by LB ≥ best
+  leaves: number          // complete tours evaluated
+  lastEvent: string | null
+  step: number
+}
+
+export interface Scenario {
+  label: string
+  desc: string
+  cities: [number, number][]
+}
+
+// ---------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------
+export function makeDm(cities: [number, number][]): number[][] {
+  const n = cities.length
+  const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
+      dm[i][j] = d
+      dm[j][i] = d
+    }
+  }
+  return dm
+}
+
+// Prim's MST cost over the given city id set (dm is indexed by city id).
+export function mstCost(ids: number[], dm: number[][]): number {
+  const n = ids.length
+  if (n <= 1) return 0
+  const inTree = new Array<boolean>(n).fill(false)
+  const key = new Array<number>(n).fill(Infinity)
+  key[0] = 0
+  let total = 0
+  for (let iter = 0; iter < n; iter++) {
+    let u = -1
+    let best = Infinity
+    for (let i = 0; i < n; i++) {
+      if (!inTree[i] && key[i] < best) {
+        best = key[i]
+        u = i
+      }
+    }
+    inTree[u] = true
+    total += key[u]
+    for (let v = 0; v < n; v++) {
+      if (!inTree[v]) {
+        const d = dm[ids[u]][ids[v]]
+        if (d < key[v]) key[v] = d
+      }
+    }
+  }
+  return total
+}
+
+// ---------------------------------------------------------------
+// Scenario layouts (6 cities — tuned offline, see tests)
+// ---------------------------------------------------------------
+export const SCENARIOS: Record<string, Scenario> = {
+  small_grid: {
+    label: 'Small grid',
+    desc: 'A compact 6-city instance — the tree completes quickly and shows the full search',
+    cities: [[60, 60], [240, 60], [240, 240], [60, 240], [150, 60], [150, 240]],
+  },
+  good_bound: {
+    label: 'Good bound',
+    desc: 'A layout where the MST bound is tight — pruning cuts the tree to a couple of dozen nodes',
+    cities: [[36, 189], [238, 108], [166, 57], [235, 123], [159, 67], [172, 178]],
+  },
+  worst_case: {
+    label: 'Worst case',
+    desc: 'A scattered layout with a weak bound — the search nearly enumerates the whole tree',
+    cities: [[221, 167], [83, 178], [184, 162], [197, 243], [263, 44], [188, 171]],
+  },
+  early_best: {
+    label: 'Early best',
+    desc: 'Cities on a circle — the first complete tour is already optimal, so almost everything prunes away',
+    cities: [[270, 150], [210, 254], [90, 254], [30, 150], [90, 46], [210, 46]],
+  },
+}
+
+// ---------------------------------------------------------------
+// makeInitState + stepOnce
+// ---------------------------------------------------------------
+export function makeInitState(scenario: Scenario): SimState {
+  const cities = scenario.cities
+  const n = cities.length
+  const dm = makeDm(cities)
+  const startCity = 0
+  const unvisited = Array.from({ length: n }, (_, i) => i).filter((i) => i !== startCity)
+  const root: BnBNode = {
+    id: 0,
+    parent: null,
+    depth: 1,
+    path: [startCity],
+    cost: 0,
+    unvisited,
+    lb: mstCost([startCity, ...unvisited], dm),
+    status: 'open',
+  }
+  return {
+    phase: 'searching',
+    cities,
+    n,
+    startCity,
+    dm,
+    nodes: [root],
+    stack: [0],
+    current: 0,
+    bestCost: null,
+    bestTour: null,
+    explored: 1,
+    pruned: 0,
+    leaves: 0,
+    lastEvent: null,
+    step: 0,
+  }
+}
+
+// One search step: expand the frontier node's next candidate (create a child,
+// prune it if its bound cannot beat the best, or backtrack when exhausted).
+export function stepOnce(state: SimState): SimState {
+  if (state.phase === 'done') return { ...state, step: state.step + 1 }
+
+  if (state.stack.length === 0) {
+    return { ...state, phase: 'done', current: null, lastEvent: 'Search complete — optimal tour found', step: state.step + 1 }
+  }
+
+  const topId = state.stack[state.stack.length - 1]
+  const top = state.nodes[topId]
+  const prev = top.path[top.path.length - 1]
+
+  // Candidates not yet branched: unvisited sorted by distance from prev
+  const childCount = state.nodes.filter((nd) => nd.parent === topId).length
+  const candidates = [...top.unvisited].sort((a, b) => state.dm[prev][a] - state.dm[prev][b])
+
+  if (childCount < candidates.length) {
+    const c = candidates[childCount]
+    const path = [...top.path, c]
+    const cost = top.cost + state.dm[prev][c]
+    const unvisited = top.unvisited.filter((u) => u !== c)
+    const id = state.nodes.length
+
+    if (unvisited.length === 0) {
+      // Leaf — a complete tour
+      const tourCost = cost + state.dm[c][state.startCity]
+      const isBest = state.bestCost === null || tourCost < state.bestCost
+      const node: BnBNode = {
+        id, parent: topId, depth: path.length, path, cost, unvisited,
+        lb: tourCost,
+        status: isBest ? 'best' : 'leaf',
+      }
+      return {
+        ...state,
+        nodes: [...state.nodes, node],
+        leaves: state.leaves + 1,
+        bestCost: isBest ? tourCost : state.bestCost,
+        bestTour: isBest ? path : state.bestTour,
+        lastEvent: isBest
+          ? `New best — complete tour ${path.join('→')} costs ${tourCost.toFixed(0)}`
+          : `Leaf — tour ${path.join('→')} costs ${tourCost.toFixed(0)} (not better than ${state.bestCost?.toFixed(0) ?? '∞'})`,
+        step: state.step + 1,
+      }
+    }
+
+    // Interior child: bound = cost + MST({start} ∪ unvisited)
+    const lb = cost + mstCost([state.startCity, ...unvisited], state.dm)
+    if (state.bestCost !== null && lb >= state.bestCost) {
+      // Pruned immediately — cannot beat the best tour
+      const node: BnBNode = {
+        id, parent: topId, depth: path.length, path, cost, unvisited, lb, status: 'pruned',
+      }
+      return {
+        ...state,
+        nodes: [...state.nodes, node],
+        pruned: state.pruned + 1,
+        lastEvent: `Pruned — bound ${lb.toFixed(0)} ≥ best ${state.bestCost.toFixed(0)} (city ${c} after ${prev})`,
+        step: state.step + 1,
+      }
+    }
+
+    const node: BnBNode = {
+      id, parent: topId, depth: path.length, path, cost, unvisited, lb, status: 'open',
+    }
+    return {
+      ...state,
+      nodes: [...state.nodes, node],
+      stack: [...state.stack, id],
+      current: id,
+      explored: state.explored + 1,
+      lastEvent: `Expanded — added ${c} after ${prev} (bound ${lb.toFixed(0)})`,
+      step: state.step + 1,
+    }
+  }
+
+  // All candidates processed — backtrack
+  const rest = state.stack.slice(0, -1)
+  const parent = rest.length > 0 ? rest[rest.length - 1] : null
+  return {
+    ...state,
+    stack: rest,
+    current: parent,
+    // mark this node explored (it stays in the tree, but no longer frontier)
+    nodes: state.nodes.map((nd) => (nd.id === topId ? { ...nd, status: 'explored' as NodeStatus } : nd)),
+    lastEvent: `Backtracked — no better branch under ${top.path.join('→')}`,
+    step: state.step + 1,
+  }
+}

--- a/teeline-web/src/explainers/branch-bound-algo.ts
+++ b/teeline-web/src/explainers/branch-bound-algo.ts
@@ -13,6 +13,9 @@
 // The search runs on ≤ 6 cities per scenario so the tree stays renderable.
 // Deterministic — no RNG; SimState holds only plain data (cloneable for Back).
 
+import { makeDm } from './explainer-cities'
+export { makeDm }
+
 export type NodeStatus = 'open' | 'explored' | 'pruned' | 'leaf' | 'best'
 
 export interface BnBNode {
@@ -55,19 +58,6 @@ export interface Scenario {
 // ---------------------------------------------------------------
 // Primitives
 // ---------------------------------------------------------------
-export function makeDm(cities: [number, number][]): number[][] {
-  const n = cities.length
-  const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
-  for (let i = 0; i < n; i++) {
-    for (let j = i + 1; j < n; j++) {
-      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
-      dm[i][j] = d
-      dm[j][i] = d
-    }
-  }
-  return dm
-}
-
 // Prim's MST cost over the given city id set (dm is indexed by city id).
 export function mstCost(ids: number[], dm: number[][]): number {
   const n = ids.length
@@ -199,7 +189,7 @@ export function stepOnce(state: SimState): SimState {
         nodes: [...state.nodes, node],
         leaves: state.leaves + 1,
         bestCost: isBest ? tourCost : state.bestCost,
-        bestTour: isBest ? path : state.bestTour,
+        bestTour: isBest ? [...path, state.startCity] : state.bestTour,
         lastEvent: isBest
           ? `New best — complete tour ${path.join('→')} costs ${tourCost.toFixed(0)}`
           : `Leaf — tour ${path.join('→')} costs ${tourCost.toFixed(0)} (not better than ${state.bestCost!.toFixed(0)})`,

--- a/teeline-web/src/explainers/branch-bound-algo.ts
+++ b/teeline-web/src/explainers/branch-bound-algo.ts
@@ -85,7 +85,6 @@ export function mstCost(ids: number[], dm: number[][]): number {
         u = i
       }
     }
-    if (u === -1) return total // disconnected — no further edges can be added
     inTree[u] = true
     total += key[u]
     for (let v = 0; v < n; v++) {
@@ -175,10 +174,7 @@ export function stepOnce(state: SimState): SimState {
   const top = state.nodes[topId]
   const prev = top.path[top.path.length - 1]
 
-  // Candidates not yet branched: unvisited sorted by distance from the
-  // previous city. This equals the solver's bound-ascending order — for a
-  // fixed node the MST({start} ∪ unvisited) term is the same for every
-  // candidate, so the lower bound differs only in the added edge.
+  // Candidates not yet branched: unvisited sorted by distance from prev
   const childCount = state.nodes.filter((nd) => nd.parent === topId).length
   const candidates = [...top.unvisited].sort((a, b) => state.dm[prev][a] - state.dm[prev][b])
 
@@ -190,7 +186,7 @@ export function stepOnce(state: SimState): SimState {
     const id = state.nodes.length
 
     if (unvisited.length === 0) {
-      // Leaf — a complete tour. bestTour stores the closed cycle (start re-appended).
+      // Leaf — a complete tour
       const tourCost = cost + state.dm[c][state.startCity]
       const isBest = state.bestCost === null || tourCost < state.bestCost
       const node: BnBNode = {
@@ -203,10 +199,10 @@ export function stepOnce(state: SimState): SimState {
         nodes: [...state.nodes, node],
         leaves: state.leaves + 1,
         bestCost: isBest ? tourCost : state.bestCost,
-        bestTour: isBest ? [...path, state.startCity] : state.bestTour,
+        bestTour: isBest ? path : state.bestTour,
         lastEvent: isBest
           ? `New best — complete tour ${path.join('→')} costs ${tourCost.toFixed(0)}`
-          : `Leaf — tour ${path.join('→')} costs ${tourCost.toFixed(0)} (not better than ${state.bestCost?.toFixed(0) ?? '∞'})`,
+          : `Leaf — tour ${path.join('→')} costs ${tourCost.toFixed(0)} (not better than ${state.bestCost!.toFixed(0)})`,
         step: state.step + 1,
       }
     }

--- a/teeline-web/src/explainers/branch-bound.test.ts
+++ b/teeline-web/src/explainers/branch-bound.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SCENARIOS, makeInitState, stepOnce,
+  mstCost, makeDm,
+} from './branch-bound-algo'
+import type { SimState } from './branch-bound-algo'
+
+// Brute-force optimum over the same instance (fixed start at 0).
+function bruteForce(cities: [number, number][]): number {
+  const n = cities.length
+  const dm = makeDm(cities)
+  const rest = Array.from({ length: n - 1 }, (_, i) => i + 1)
+  const used = new Array<boolean>(rest.length).fill(false)
+  const order: number[] = [0]
+  let best = Infinity
+  const search = () => {
+    if (order.length === n) {
+      let d = 0
+      for (let k = 0; k < n; k++) d += dm[order[k]][order[(k + 1) % n]]
+      if (d < best) best = d
+      return
+    }
+    for (let i = 0; i < rest.length; i++) {
+      if (used[i]) continue
+      used[i] = true
+      order.push(rest[i])
+      search()
+      order.pop()
+      used[i] = false
+    }
+  }
+  search()
+  return best
+}
+
+function runToDone(scenario: (typeof SCENARIOS)[string]): SimState {
+  let s = makeInitState(scenario)
+  let guard = 5000
+  while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+  expect(s.phase).toBe('done')
+  return s
+}
+
+// ---------------------------------------------------------------
+describe('mstCost', () => {
+  it('is zero for a single node', () => {
+    expect(mstCost([0], makeDm([[0, 0], [1, 0]]))).toBe(0)
+  })
+
+  it('finds the minimal chain MST', () => {
+    const dm = makeDm([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+    expect(mstCost([0, 1, 2, 3, 4], dm)).toBeCloseTo(4, 6)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('makeInitState', () => {
+  it('creates the root node with the MST bound', () => {
+    const s = makeInitState(SCENARIOS.small_grid)
+    expect(s.phase).toBe('searching')
+    expect(s.nodes).toHaveLength(1)
+    expect(s.stack).toEqual([0])
+    expect(s.current).toBe(0)
+    expect(s.bestCost).toBeNull()
+    expect(s.step).toBe(0)
+    // root bound = MST over all 6 cities
+    expect(s.nodes[0].lb).toBeCloseTo(mstCost([0, 1, 2, 3, 4, 5], s.dm), 6)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('stepOnce', () => {
+  it('expands the root into its first child and pushes it', () => {
+    const s0 = makeInitState(SCENARIOS.small_grid)
+    const s1 = stepOnce(s0)
+    expect(s1.nodes).toHaveLength(2)
+    expect(s1.stack).toEqual([0, 1])
+    expect(s1.current).toBe(1)
+    expect(s1.nodes[1].depth).toBe(2)
+    expect(s1.nodes[1].path).toHaveLength(2)
+    expect(s1.lastEvent).toContain('Expanded')
+  })
+
+  it('a complete tour at a leaf becomes the new best', () => {
+    // early_best: the first leaf (a full tour) is reached quickly
+    let s = makeInitState(SCENARIOS.early_best)
+    let guard = 20
+    while (s.bestCost === null && guard-- > 0) s = stepOnce(s)
+    expect(s.bestCost).not.toBeNull()
+    expect(s.bestTour).toHaveLength(6)
+    expect(s.nodes.some((nd) => nd.status === 'best')).toBe(true)
+  })
+
+  it('prunes children whose bound cannot beat the best', () => {
+    let s = makeInitState(SCENARIOS.early_best)
+    let guard = 100
+    while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
+    expect(s.pruned).toBeGreaterThan(0)
+    expect(s.nodes.some((nd) => nd.status === 'pruned')).toBe(true)
+  })
+
+  it('done is a no-op apart from the step counter', () => {
+    const done = runToDone(SCENARIOS.small_grid)
+    const again = stepOnce(done)
+    expect(again.phase).toBe('done')
+    expect(again.nodes).toEqual(done.nodes)
+    expect(again.step).toBe(done.step + 1)
+  })
+})
+
+// ---------------------------------------------------------------
+describe('correctness & scenario pins', () => {
+  const pins: Record<string, { nodes: number; leaves: number }> = {
+    small_grid: { nodes: 42, leaves: 2 },
+    good_bound: { nodes: 26, leaves: 2 },
+    worst_case: { nodes: 298, leaves: 98 },
+    early_best: { nodes: 66, leaves: 4 },
+  }
+
+  it('every scenario finds the exact optimum (verified against brute force)', () => {
+    for (const [key, sc] of Object.entries(SCENARIOS)) {
+      const s = runToDone(sc)
+      expect(s.bestCost, `${key} must find the optimum`).toBeCloseTo(bruteForce(sc.cities), 6)
+      expect([...s.bestTour!].sort((a, b) => a - b), `${key} best tour must be a permutation`).toEqual(
+        Array.from({ length: sc.cities.length }, (_, i) => i),
+      )
+    }
+  })
+
+  it('node/leaf counts are pinned per scenario', () => {
+    for (const [key, sc] of Object.entries(SCENARIOS)) {
+      const s = runToDone(sc)
+      expect(s.nodes.length, `${key} node count`).toBe(pins[key].nodes)
+      expect(s.leaves, `${key} leaf count`).toBe(pins[key].leaves)
+    }
+  })
+
+  it('every node has a valid bound and parent linkage', () => {
+    const s = runToDone(SCENARIOS.small_grid)
+    for (const nd of s.nodes) {
+      expect(nd.lb).toBeGreaterThan(0)
+      if (nd.parent !== null) {
+        const parent = s.nodes[nd.parent]
+        expect(parent.depth).toBe(nd.depth - 1)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------
+describe('purity & determinism', () => {
+  it('stepOnce never mutates its input', () => {
+    const s = makeInitState(SCENARIOS.worst_case)
+    const snapshot = structuredClone(s)
+    let cur = s
+    for (let i = 0; i < 20; i++) cur = stepOnce(cur)
+    expect(s).toEqual(snapshot)
+  })
+
+  it('two runs from the same scenario produce identical sequences', () => {
+    const a = makeInitState(SCENARIOS.worst_case)
+    const b = makeInitState(SCENARIOS.worst_case)
+    for (let i = 0; i < 20; i++) {
+      const na = stepOnce(a)
+      const nb = stepOnce(b)
+      expect(na).toEqual(nb)
+      Object.assign(a, na)
+      Object.assign(b, nb)
+    }
+  })
+})

--- a/teeline-web/src/explainers/branch-bound.test.ts
+++ b/teeline-web/src/explainers/branch-bound.test.ts
@@ -87,7 +87,7 @@ describe('stepOnce', () => {
     let guard = 20
     while (s.bestCost === null && guard-- > 0) s = stepOnce(s)
     expect(s.bestCost).not.toBeNull()
-    expect(s.bestTour).toHaveLength(6)
+    expect(s.bestTour).toHaveLength(7) // closed cycle: start + 5 cities + start
     expect(s.nodes.some((nd) => nd.status === 'best')).toBe(true)
   })
 
@@ -121,8 +121,11 @@ describe('correctness & scenario pins', () => {
     for (const [key, sc] of Object.entries(SCENARIOS)) {
       const s = runToDone(sc)
       expect(s.bestCost, `${key} must find the optimum`).toBeCloseTo(bruteForce(sc.cities), 6)
-      expect([...s.bestTour!].sort((a, b) => a - b), `${key} best tour must be a permutation`).toEqual(
-        Array.from({ length: sc.cities.length }, (_, i) => i),
+      // bestTour is the closed cycle: starts and ends at city 0, middle is a permutation
+      expect(s.bestTour![0], `${key} cycle must start at city 0`).toBe(0)
+      expect(s.bestTour![s.bestTour!.length - 1], `${key} cycle must end at city 0`).toBe(0)
+      expect([...s.bestTour!.slice(1, -1)].sort((a, b) => a - b), `${key} middle must be a permutation`).toEqual(
+        Array.from({ length: sc.cities.length - 1 }, (_, i) => i + 1),
       )
     }
   })

--- a/teeline-web/src/explainers/branch-bound.tsx
+++ b/teeline-web/src/explainers/branch-bound.tsx
@@ -90,7 +90,9 @@ function CityMap({ sim, node }: { sim: SimState; node: BnBNode | null }) {
       ))}
       {Array.from({ length: n }, (_, i) => i).map((i) => {
         const inPath = path.includes(i)
-        const cls = inPath ? 'bb-city' : unvisited.has(i) ? 'bb-city-unvisited' : 'bb-city-gray'
+        let cls = 'bb-city-gray'
+        if (inPath) cls = 'bb-city'
+        else if (unvisited.has(i)) cls = 'bb-city-unvisited'
         return (
           <g key={i}>
             <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
@@ -112,7 +114,7 @@ export default function BranchBoundExplainer() {
   const [selectedId, setSelectedId] = useState<number | null>(null)
 
   const simRef = useRef(sim)
-  const historyRef = useRef<Array<typeof sim>>([])
+  const historyRef = useRef<SimState[]>([])
   const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
 
   const commit = useCallback((next: SimState) => {
@@ -133,10 +135,9 @@ export default function BranchBoundExplainer() {
     if (cur.phase === 'done') return
     historyRef.current.push(structuredClone(cur))
     const next = stepOnce(cur)
-    simRef.current = next
-    setSim(next)
+    commit(next)
     if (next.phase === 'done') setRunning(false)
-  }, [])
+  }, [commit])
 
   const stepBack = useCallback(() => {
     const h = historyRef.current
@@ -159,7 +160,7 @@ export default function BranchBoundExplainer() {
   let chipText = s.lastEvent ?? 'Branch & Bound — the search tree grows as we step'
   let chipClass = "bb-chip bb-chip-idle"
   if (s.phase === 'done') {
-    chipText = `Done — optimal tour ${s.bestTour!.join('→')} costs ${s.bestCost!.toFixed(0)} (${s.nodes.length} nodes, ${s.pruned} pruned)`
+    chipText = `Done — optimal tour ${s.bestTour?.join('→') ?? '—'} costs ${s.bestCost?.toFixed(0) ?? '—'} (${s.nodes.length} nodes, ${s.pruned} pruned)`
     chipClass = "bb-chip bb-chip-done"
   } else if (chipText.startsWith('New best')) {
     chipClass = "bb-chip bb-chip-best"
@@ -190,7 +191,7 @@ export default function BranchBoundExplainer() {
         <div className="bb-side">
           <div className="bb-section-label">Search tree</div>
           <SearchTree sim={s} selectedId={selectedId} onSelect={setSelectedId} />
-          <div className="bb-section-label bb-mt6">Tour at selected node</div>
+          <div className="bb-section-label" style={{ marginTop: 6 }}>Tour at selected node</div>
           <CityMap sim={s} node={infoNode} />
         </div>
         <div className="bb-panel">
@@ -213,12 +214,12 @@ export default function BranchBoundExplainer() {
             )}
           </div>
 
-          <div className="bb-section-label bb-mt10">Best tour</div>
+          <div className="bb-section-label" style={{ marginTop: 10 }}>Best tour</div>
           <div className="bb-best">
             <span className="bb-mono">{s.bestCost === null ? '— (none yet)' : s.bestTour!.join(' → ') + ' = ' + s.bestCost.toFixed(1)}</span>
           </div>
 
-          <div className="bb-section-label bb-mt10">Stats</div>
+          <div className="bb-section-label" style={{ marginTop: 10 }}>Stats</div>
           <div className="bb-statgrid">
             <div><div className="bb-statlabel">nodes</div><div className="bb-mono">{s.nodes.length}</div></div>
             <div><div className="bb-statlabel">explored</div><div className="bb-mono">{s.explored}</div></div>
@@ -321,8 +322,6 @@ const CSS = `
 .bb-panel { width: 250px; flex-shrink: 0; display: flex; flex-direction: column; }
 
 .bb-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-.bb-mt6 { margin-top: 6px; }
-.bb-mt10 { margin-top: 10px; }
 
 .bb-tree-scroll {
   overflow: auto; max-height: 300px;

--- a/teeline-web/src/explainers/branch-bound.tsx
+++ b/teeline-web/src/explainers/branch-bound.tsx
@@ -190,7 +190,7 @@ export default function BranchBoundExplainer() {
         <div className="bb-side">
           <div className="bb-section-label">Search tree</div>
           <SearchTree sim={s} selectedId={selectedId} onSelect={setSelectedId} />
-          <div className="bb-section-label" style={{ marginTop: 6 }}>Tour at selected node</div>
+          <div className="bb-section-label bb-mt6">Tour at selected node</div>
           <CityMap sim={s} node={infoNode} />
         </div>
         <div className="bb-panel">
@@ -213,12 +213,12 @@ export default function BranchBoundExplainer() {
             )}
           </div>
 
-          <div className="bb-section-label" style={{ marginTop: 10 }}>Best tour</div>
+          <div className="bb-section-label bb-mt10">Best tour</div>
           <div className="bb-best">
             <span className="bb-mono">{s.bestCost === null ? '— (none yet)' : s.bestTour!.join(' → ') + ' = ' + s.bestCost.toFixed(1)}</span>
           </div>
 
-          <div className="bb-section-label" style={{ marginTop: 10 }}>Stats</div>
+          <div className="bb-section-label bb-mt10">Stats</div>
           <div className="bb-statgrid">
             <div><div className="bb-statlabel">nodes</div><div className="bb-mono">{s.nodes.length}</div></div>
             <div><div className="bb-statlabel">explored</div><div className="bb-mono">{s.explored}</div></div>
@@ -321,6 +321,8 @@ const CSS = `
 .bb-panel { width: 250px; flex-shrink: 0; display: flex; flex-direction: column; }
 
 .bb-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.bb-mt6 { margin-top: 6px; }
+.bb-mt10 { margin-top: 10px; }
 
 .bb-tree-scroll {
   overflow: auto; max-height: 300px;

--- a/teeline-web/src/explainers/branch-bound.tsx
+++ b/teeline-web/src/explainers/branch-bound.tsx
@@ -1,0 +1,445 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import {
+  SCENARIOS, makeInitState, stepOnce,
+} from "./branch-bound-algo"
+import type { Scenario, SimState, BnBNode } from "./branch-bound-algo"
+
+const DEFAULT_SCENARIO = SCENARIOS.small_grid
+const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
+const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+
+// ---------------------------------------------------------------
+// SearchTree — horizontal tree: root on the left, children to the
+// right. Pruned nodes red with a strike, best leaf gold, the active
+// path green; clicking a node pins it in the info panel.
+// ---------------------------------------------------------------
+function SearchTree({ sim, selectedId, onSelect }: {
+  sim: SimState
+  selectedId: number | null
+  onSelect: (id: number) => void
+}) {
+  const X = 78
+  const Y = 16
+
+  const { nodes, stack } = sim
+  const onStack = useMemo(() => new Set(stack), [stack])
+  const maxDepth = useMemo(() => nodes.reduce((m, nd) => Math.max(m, nd.depth), 1), [nodes])
+  const width = maxDepth * X + 70
+  const height = Math.max(40, nodes.length * Y + 24)
+
+  return (
+    <div className="bb-tree-scroll">
+      <svg viewBox={`0 0 ${width} ${height}`} className="bb-tree" role="img" aria-label="Branch and bound search tree">
+        {/* edges */}
+        {nodes.map((nd) => {
+          if (nd.parent === null) return null
+          const p = nodes[nd.parent]
+          const x1 = p.depth * X
+          const y1 = p.id * Y + Y / 2
+          const x2 = nd.depth * X - 6
+          const y2 = nd.id * Y + Y / 2
+          const cls = `bb-edge ${onStack.has(nd.id) ? 'bb-edge-active' : ''}`
+          return <line key={`e${nd.id}`} className={cls} x1={x1} y1={y1} x2={x2} y2={y2} />
+        })}
+        {/* nodes */}
+        {nodes.map((nd) => {
+          const x = nd.depth * X
+          const y = nd.id * Y
+          const cls = [
+            'bb-node',
+            nd.status === 'pruned' ? 'bb-node-pruned' : '',
+            nd.status === 'best' ? 'bb-node-best' : '',
+            nd.status === 'leaf' ? 'bb-node-leaf' : '',
+            onStack.has(nd.id) && nd.status === 'open' ? 'bb-node-open' : '',
+            nd.id === sim.current ? 'bb-node-current' : '',
+            selectedId === nd.id ? 'bb-node-selected' : '',
+          ].join(' ').trim()
+          const label = nd.path[nd.path.length - 1]
+          return (
+            <g key={nd.id} className={cls} onClick={() => onSelect(nd.id)}>
+              <rect x={x - 24} y={y} width={48} height={Y - 3} rx={3} />
+              <text x={x} y={y + 11} className="bb-node-city">{label}</text>
+              <text x={x + 6} y={y + 11} className="bb-node-lb">{nd.lb.toFixed(0)}</text>
+              {nd.status === 'pruned' && <text x={x + 22} y={y + 8} className="bb-node-x">✕</text>}
+              <title>{`path ${nd.path.join('→')} · bound ${nd.lb.toFixed(0)} · ${nd.status}`}</title>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------
+// CityMap — partial tour of the pinned/active node, unvisited gray
+// ---------------------------------------------------------------
+function CityMap({ sim, node }: { sim: SimState; node: BnBNode | null }) {
+  const path = node ? node.path : sim.bestTour ?? []
+  const unvisited = node ? new Set(node.unvisited) : new Set<number>()
+  const n = sim.n
+  const edges: Array<[number, number]> = []
+  for (let k = 0; k < path.length - 1; k++) edges.push([path[k], path[k + 1]])
+
+  return (
+    <svg viewBox="0 0 300 300" className="bb-map" role="img" aria-label="Partial tour at the selected node">
+      <rect x={0} y={0} width={300} height={300} className="bb-bg" />
+      {edges.map(([a, b]) => (
+        <line key={`${a}-${b}`} className="bb-map-edge"
+          x1={sim.cities[a][0]} y1={sim.cities[a][1]}
+          x2={sim.cities[b][0]} y2={sim.cities[b][1]} />
+      ))}
+      {Array.from({ length: n }, (_, i) => i).map((i) => {
+        const inPath = path.includes(i)
+        const cls = inPath ? 'bb-city' : unvisited.has(i) ? 'bb-city-unvisited' : 'bb-city-gray'
+        return (
+          <g key={i}>
+            <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
+            <text className="bb-label" x={sim.cities[i][0]} y={sim.cities[i][1] + 16}>{i}</text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------
+export default function BranchBoundExplainer() {
+  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [running, setRunning] = useState(false)
+  const [speedIdx, setSpeedIdx] = useState(2)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  const simRef = useRef(sim)
+  const historyRef = useRef<Array<typeof sim>>([])
+  const scenarioRef = useRef<Scenario>(DEFAULT_SCENARIO)
+
+  const commit = useCallback((next: SimState) => {
+    simRef.current = next
+    setSim(next)
+  }, [])
+
+  const reinit = useCallback((scenario: Scenario) => {
+    scenarioRef.current = scenario
+    historyRef.current = []
+    setSelectedId(null)
+    commit(makeInitState(scenario))
+    setRunning(false)
+  }, [commit])
+
+  const stepForward = useCallback(() => {
+    const cur = simRef.current
+    if (cur.phase === 'done') return
+    historyRef.current.push(structuredClone(cur))
+    const next = stepOnce(cur)
+    simRef.current = next
+    setSim(next)
+    if (next.phase === 'done') setRunning(false)
+  }, [])
+
+  const stepBack = useCallback(() => {
+    const h = historyRef.current
+    if (h.length === 0 || running) return
+    commit(h.pop()!)
+  }, [running, commit])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(stepForward, SPEEDS[speedIdx])
+    return () => clearInterval(id)
+  }, [running, speedIdx, stepForward])
+
+  const s = sim
+  const selectedNode = selectedId !== null ? s.nodes.find((nd) => nd.id === selectedId) ?? null : null
+  const activeNode = s.current !== null ? s.nodes[s.current] : null
+  const infoNode = selectedNode ?? activeNode
+
+  // Status chip
+  let chipText = s.lastEvent ?? 'Branch & Bound — the search tree grows as we step'
+  let chipClass = "bb-chip bb-chip-idle"
+  if (s.phase === 'done') {
+    chipText = `Done — optimal tour ${s.bestTour!.join('→')} costs ${s.bestCost!.toFixed(0)} (${s.nodes.length} nodes, ${s.pruned} pruned)`
+    chipClass = "bb-chip bb-chip-done"
+  } else if (chipText.startsWith('New best')) {
+    chipClass = "bb-chip bb-chip-best"
+  } else if (chipText.startsWith('Pruned')) {
+    chipClass = "bb-chip bb-chip-pruned"
+  } else if (chipText.startsWith('Expanded')) {
+    chipClass = "bb-chip bb-chip-open"
+  } else if (chipText.startsWith('Leaf')) {
+    chipClass = "bb-chip bb-chip-leaf"
+  }
+
+  return (
+    <div className="bb-root">
+      <style>{CSS}</style>
+
+      <header className="bb-header">
+        <div className="bb-eyebrow">teeline · algorithms/branch_bound</div>
+        <h2 className="bb-title">Branch &amp; Bound — exact search with pruning</h2>
+        <p className="bb-sub">
+          B&amp;B explores the tree of partial tours. At every node the <strong>lower bound</strong>
+          ({'partial cost + MST(start ∪ remaining)'}) is compared with the <strong>best complete
+          tour</strong> found so far — any branch whose bound cannot beat it is <strong>pruned</strong>.
+          The bound is valid, so the surviving leaf is the exact optimum.
+        </p>
+      </header>
+
+      <div className="bb-viz-row">
+        <div className="bb-side">
+          <div className="bb-section-label">Search tree</div>
+          <SearchTree sim={s} selectedId={selectedId} onSelect={setSelectedId} />
+          <div className="bb-section-label" style={{ marginTop: 6 }}>Tour at selected node</div>
+          <CityMap sim={s} node={infoNode} />
+        </div>
+        <div className="bb-panel">
+          <div className="bb-section-label">Node info</div>
+          <div className="bb-nodeinfo">
+            {infoNode ? (
+              <>
+                <div className="bb-nodeinfo-row"><span>path</span><span className="bb-mono">{infoNode.path.join(' → ')}</span></div>
+                <div className="bb-nodeinfo-row"><span>bound</span><span className="bb-mono">{infoNode.lb.toFixed(1)}</span></div>
+                <div className="bb-nodeinfo-row"><span>status</span><span className="bb-mono">{infoNode.status}</span></div>
+                <div className="bb-nodeinfo-note">
+                  bound = partial {infoNode.cost.toFixed(1)} + MST(start ∪ {infoNode.unvisited.join(',')})
+                </div>
+                {infoNode.status === 'pruned' && selectedId === infoNode.id && (
+                  <div className="bb-nodeinfo-why">Pruned because {infoNode.lb.toFixed(1)} ≥ best {s.bestCost?.toFixed(1) ?? '—'} — no tour below this branch can win.</div>
+                )}
+              </>
+            ) : (
+              <div className="bb-nodeinfo-row">click a tree node to inspect it</div>
+            )}
+          </div>
+
+          <div className="bb-section-label" style={{ marginTop: 10 }}>Best tour</div>
+          <div className="bb-best">
+            <span className="bb-mono">{s.bestCost === null ? '— (none yet)' : s.bestTour!.join(' → ') + ' = ' + s.bestCost.toFixed(1)}</span>
+          </div>
+
+          <div className="bb-section-label" style={{ marginTop: 10 }}>Stats</div>
+          <div className="bb-statgrid">
+            <div><div className="bb-statlabel">nodes</div><div className="bb-mono">{s.nodes.length}</div></div>
+            <div><div className="bb-statlabel">explored</div><div className="bb-mono">{s.explored}</div></div>
+            <div><div className="bb-statlabel">pruned</div><div className="bb-mono">{s.pruned}</div></div>
+            <div><div className="bb-statlabel">leaves</div><div className="bb-mono">{s.leaves}</div></div>
+            <div><div className="bb-statlabel">best</div><div className="bb-mono">{s.bestCost === null ? '—' : s.bestCost.toFixed(0)}</div></div>
+            <div><div className="bb-statlabel">step</div><div className="bb-mono">{s.step}</div></div>
+          </div>
+        </div>
+      </div>
+
+      <div className="bb-legend">
+        <span><span className="bb-swatch bb-swatch-open" /> open</span>
+        <span><span className="bb-swatch bb-swatch-active" /> active path</span>
+        <span><span className="bb-swatch bb-swatch-pruned" /> pruned</span>
+        <span><span className="bb-swatch bb-swatch-leaf" /> leaf</span>
+        <span><span className="bb-swatch bb-swatch-best" /> new best</span>
+      </div>
+
+      <div className={chipClass}>{chipText}</div>
+
+      <div className="bb-config">
+        <div className="bb-config-row">
+          <span className="bb-label">Speed</span>
+          <div className="bb-speed-btns">
+            {SPEED_LABELS.map((l, i) => (
+              <button key={l} className={`bb-speed-btn ${i === speedIdx ? 'bb-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="bb-controls">
+        <button className="bb-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
+        <button className="bb-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
+        <button className="bb-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
+          {running ? "⏸ Pause" : "▶ Run"}
+        </button>
+        <button className="bb-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+      </div>
+
+      <div className="bb-scenarios">
+        <div className="bb-section-label">Scenarios</div>
+        <div className="bb-scenario-row">
+          {Object.entries(SCENARIOS).map(([key, sc]) => (
+            <button key={key} className="bb-scenario-btn" title={sc.desc}
+              onClick={() => reinit(sc)} disabled={running}>
+              {sc.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="bb-footer">
+        <span className="bb-mono">cities: {s.n}</span>
+        <span className="bb-mono">bound = partial + MST(start ∪ remaining) · prune when bound ≥ best</span>
+      </footer>
+    </div>
+  )
+}
+
+const CSS = `
+.bb-root {
+  --accent: #0d9488;
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --line: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 900px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.bb-root * { box-sizing: border-box; }
+.bb-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
+}
+
+.bb-header { margin-bottom: 2px; }
+.bb-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+.bb-title { font-size: 1.25rem; font-weight: 650; margin: 0 0 6px; line-height: 1.3; }
+.bb-sub { margin: 0; color: var(--muted); font-size: 0.88rem; line-height: 1.55; }
+
+.bb-viz-row { display: flex; gap: 12px; align-items: stretch; }
+.bb-side { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.bb-panel { width: 250px; flex-shrink: 0; display: flex; flex-direction: column; }
+
+.bb-section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+
+.bb-tree-scroll {
+  overflow: auto; max-height: 300px;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--panel);
+}
+.bb-tree { display: block; }
+.bb-edge { stroke: #cbd5e1; stroke-width: 1.5; }
+.bb-edge-active { stroke: #0d9488; }
+.bb-node { cursor: pointer; }
+.bb-node rect { fill: #e2e8f0; stroke: #94a3b8; stroke-width: 1; }
+.bb-node-open rect { fill: #ccfbf1; stroke: var(--accent); }
+.bb-node-current rect { stroke: #0d9488; stroke-width: 2.5; }
+.bb-node-pruned rect { fill: #fee2e2; stroke: #ef4444; }
+.bb-node-best rect { fill: #fef3c7; stroke: #f59e0b; stroke-width: 2; }
+.bb-node-leaf rect { fill: #dbeafe; stroke: #60a5fa; }
+.bb-node-selected rect { stroke: #1f2328; stroke-width: 2; }
+.bb-node-city {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; font-weight: 700; fill: var(--text); text-anchor: middle;
+}
+.bb-node-lb { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 8px; fill: var(--muted); }
+.bb-node-x { font-size: 9px; fill: #ef4444; font-weight: 700; }
+.bb-node-pruned .bb-node-city { text-decoration: line-through; }
+
+.bb-map {
+  width: 100%; display: block; border-radius: 8px;
+  border: 1px solid var(--line);
+}
+.bb-bg { fill: var(--panel); }
+.bb-map-edge { stroke: #0d9488; stroke-width: 2.5; stroke-linecap: round; }
+.bb-city { fill: #1f2937; stroke: #fff; stroke-width: 1.5; }
+.bb-city-unvisited { fill: #9ca3af; stroke: #fff; stroke-width: 1.5; }
+.bb-city-gray { fill: #1f2937; stroke: #fff; stroke-width: 1.5; opacity: 0.5; }
+.bb-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; fill: #374151; text-anchor: middle;
+  paint-order: stroke fill; stroke: white; stroke-width: 3;
+  pointer-events: none; user-select: none;
+}
+
+.bb-nodeinfo { display: flex; flex-direction: column; gap: 4px; }
+.bb-nodeinfo-row {
+  display: flex; justify-content: space-between; gap: 8px;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 6px; background: var(--panel);
+}
+.bb-nodeinfo-note { font-size: 0.72rem; color: var(--muted); padding: 0 4px; }
+.bb-nodeinfo-why {
+  font-size: 0.74rem; color: #991b1b; background: #fee2e2;
+  border-radius: 6px; padding: 6px 8px;
+}
+.bb-best { font-size: 0.78rem; padding: 4px 8px; background: #fefce8; border-radius: 6px; }
+
+.bb-statgrid { display: flex; flex-wrap: wrap; gap: 10px 16px; font-size: 0.8rem; }
+.bb-statlabel { color: var(--muted); font-size: 0.7em; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.bb-legend {
+  display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.78rem; color: var(--muted);
+}
+.bb-swatch {
+  display: inline-block; width: 12px; height: 12px; border-radius: 3px;
+  margin-right: 4px; vertical-align: middle; border: 1px solid #94a3b8;
+}
+.bb-swatch-open { background: #ccfbf1; }
+.bb-swatch-active { background: #0d9488; }
+.bb-swatch-pruned { background: #fee2e2; border-color: #ef4444; }
+.bb-swatch-leaf { background: #dbeafe; border-color: #60a5fa; }
+.bb-swatch-best { background: #fef3c7; border-color: #f59e0b; }
+
+.bb-chip {
+  font-size: 0.82rem; padding: 6px 12px; border-radius: 8px;
+  font-weight: 500; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.bb-chip-idle { background: #f1f5f9; color: var(--muted); }
+.bb-chip-open { background: #ccfbf1; color: #115e59; }
+.bb-chip-pruned { background: #fee2e2; color: #991b1b; }
+.bb-chip-best { background: #fef3c7; color: #92400e; }
+.bb-chip-leaf { background: #dbeafe; color: #1e40af; }
+.bb-chip-done { background: #dcfce7; color: #166534; }
+
+.bb-config {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px; background: var(--panel); border-radius: 8px;
+}
+.bb-config-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.bb-label { font-size: 0.82rem; font-weight: 500; color: var(--text); }
+.bb-speed-btns { display: flex; gap: 4px; }
+.bb-speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem; padding: 3px 8px; border-radius: 5px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bb-speed-btn:hover:not(:disabled) { background: #f0fdf4; }
+.bb-speed-btn:disabled { opacity: 0.4; cursor: default; }
+.bb-speed-btn-sel { background: #ccfbf1; border-color: var(--accent); color: #115e59; font-weight: 600; }
+
+.bb-controls { display: flex; gap: 8px; }
+.bb-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem; padding: 6px 14px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bb-btn:hover:not(:disabled) { background: #f0fdf4; }
+.bb-btn:disabled { opacity: 0.4; cursor: default; }
+
+.bb-scenarios { display: flex; flex-direction: column; gap: 6px; }
+.bb-scenario-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.bb-scenario-btn {
+  font-size: 0.8rem; padding: 5px 12px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--text);
+  cursor: pointer;
+}
+.bb-scenario-btn:hover:not(:disabled) { background: #f0fdf4; border-color: var(--accent); }
+.bb-scenario-btn:disabled { opacity: 0.4; cursor: default; }
+
+.bb-footer {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 8px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 0.78rem;
+}
+`

--- a/teeline-web/src/explainers/explainer-cities.ts
+++ b/teeline-web/src/explainers/explainer-cities.ts
@@ -76,6 +76,21 @@ export const tourLength8 = makeTourLength(dist8)
 
 // Defaults (the 10-city layout) — the local-search explainers re-export these
 // names directly; the 12/8-city explainers alias the *_12 / *_8 bindings.
+/** Distance matrix for an arbitrary small city layout (the exact-algorithm
+ * explainers — B&B, BHK — run on custom ≤6-city layouts). */
+export function makeDm(cities: [number, number][]): number[][] {
+  const n = cities.length
+  const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
+      dm[i][j] = d
+      dm[j][i] = d
+    }
+  }
+  return dm
+}
+
 export const CITIES = CITIES_10
 export const N_CITIES = N_CITIES_10
 export const dist = dist10

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -120,6 +120,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of the Branch & Bound exact TSP solver: watch the search tree grow as partial tours branch, with the MST lower bound pruning any branch that cannot beat the best tour found so far.',
     backLabel: 'Branch & Bound',
   },
+  bhk: {
+    title: 'Bellman-Held-Karp — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of the Bellman-Held-Karp dynamic program: watch the subset-cost table fill cell by cell (dp[mask][i] built from one smaller subset plus one edge), then read the optimal route back through the recorded predecessors.',
+    backLabel: 'BHK',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -114,6 +114,12 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
       'Interactive walkthrough of the Christofides ≤1.5× approximation: grow the MST, patch the odd-degree vertices with a matching, walk the Eulerian circuit, and shortcut it into a tour — with the proof made visible.',
     backLabel: 'Christofides',
   },
+  branch_bound: {
+    title: 'Branch & Bound — Interactive Explainer — Teeline',
+    description:
+      'Interactive walkthrough of the Branch & Bound exact TSP solver: watch the search tree grow as partial tours branch, with the MST lower bound pruning any branch that cannot beat the best tour found so far.',
+    backLabel: 'Branch & Bound',
+  },
   '2opt': {
     title: '2-opt — Interactive Explainer — Teeline',
     description:

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -34,6 +34,7 @@ import OrOptExplainer from '../../../../explainers/or-opt'
 import ThreeOptExplainer from '../../../../explainers/three-opt'
 import ChristofidesExplainer from '../../../../explainers/christofides'
 import BranchBoundExplainer from '../../../../explainers/branch-bound'
+import BhkExplainer from '../../../../explainers/bhk'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -86,6 +87,7 @@ const jsonLd = {
       {id === '3opt' && <ThreeOptExplainer client:visible />}
       {id === 'christofides' && <ChristofidesExplainer client:visible />}
       {id === 'branch_bound' && <BranchBoundExplainer client:visible />}
+      {id === 'bhk' && <BhkExplainer client:visible />}
       {id === '2opt' && <TwoOptExplainer client:visible />}
       {id === 'nn' && <NNExplainer client:visible />}
     </main>

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -14,6 +14,7 @@
 // client bundle to ship). Hence the explicit per-id branches below instead
 // of a single `<ExplainerComponent client:visible />`.
 import BaseLayout from '../../../../layouts/BaseLayout.astro'
+import ExplainerSidebar from '../../../../components/ExplainerSidebar.astro'
 import { EXPLAINER_META, EXPLAINER_IDS } from '../../../../explainers/registry'
 import PsoExplainer from '../../../../explainers/pso'
 import GsaExplainer from '../../../../explainers/gsa'
@@ -56,28 +57,35 @@ const jsonLd = {
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>
-  <main class="mx-auto max-w-content px-6 py-8">
-    <p class="mb-4 font-mono text-xs text-text-dim">
-      <a href={`/algorithms/${id}/`} class="text-accent no-underline hover:underline">← Back to {meta.backLabel} docs</a>
-    </p>
-    {id === 'pso' && <PsoExplainer client:visible />}
-    {id === 'gsa' && <GsaExplainer client:visible />}
-    {id === 'tabu' && <TabuExplainer client:visible />}
-    {id === 'ga' && <GaExplainer client:visible />}
-    {id === 'cs' && <CsExplainer client:visible />}
-    {id === 'fpa' && <FpaExplainer client:visible />}
-    {id === 'lk' && <LkExplainer client:visible />}
-    {id === 'sa' && <SaExplainer client:visible />}
-    {id === 'som' && <SomExplainer client:visible />}
-    {id === 'fourier' && <FourierExplainer client:visible />}
-    {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
-    {id === 'savings' && <SavingsExplainer client:visible />}
-    {id === 'aco' && <AcoExplainer client:visible />}
+  <div class="mx-auto grid w-full max-w-content grid-cols-1 md:grid-cols-[220px_1fr]">
+    <aside class="hidden border-r border-border md:block">
+      <nav aria-label="Explainer" class="sticky top-14 max-h-[calc(100vh-56px)] overflow-y-auto py-4">
+        <ExplainerSidebar currentId={id} />
+      </nav>
+    </aside>
+    <main class="docs-main min-w-0 px-6 py-8 md:px-10">
+      <p class="mb-4 font-mono text-xs text-text-dim">
+        <a href={`/algorithms/${id}/`} class="text-accent no-underline hover:underline">← Back to {meta.backLabel} docs</a>
+      </p>
+      {id === 'pso' && <PsoExplainer client:visible />}
+      {id === 'gsa' && <GsaExplainer client:visible />}
+      {id === 'tabu' && <TabuExplainer client:visible />}
+      {id === 'ga' && <GaExplainer client:visible />}
+      {id === 'cs' && <CsExplainer client:visible />}
+      {id === 'fpa' && <FpaExplainer client:visible />}
+      {id === 'lk' && <LkExplainer client:visible />}
+      {id === 'sa' && <SaExplainer client:visible />}
+      {id === 'som' && <SomExplainer client:visible />}
+      {id === 'fourier' && <FourierExplainer client:visible />}
+      {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
+      {id === 'savings' && <SavingsExplainer client:visible />}
+      {id === 'aco' && <AcoExplainer client:visible />}
     {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
     {id === 'or_opt' && <OrOptExplainer client:visible />}
     {id === '3opt' && <ThreeOptExplainer client:visible />}
     {id === 'christofides' && <ChristofidesExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
-  </main>
+    </main>
+  </div>
 </BaseLayout>

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -81,13 +81,13 @@ const jsonLd = {
       {id === 'greedy_edge' && <GreedyEdgeExplainer client:visible />}
       {id === 'savings' && <SavingsExplainer client:visible />}
       {id === 'aco' && <AcoExplainer client:visible />}
-    {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
-    {id === 'or_opt' && <OrOptExplainer client:visible />}
-    {id === '3opt' && <ThreeOptExplainer client:visible />}
-    {id === 'christofides' && <ChristofidesExplainer client:visible />}
-    {id === 'branch_bound' && <BranchBoundExplainer client:visible />}
-    {id === '2opt' && <TwoOptExplainer client:visible />}
-    {id === 'nn' && <NNExplainer client:visible />}
+      {id === 'stochastic_hill' && <StochasticHillExplainer client:visible />}
+      {id === 'or_opt' && <OrOptExplainer client:visible />}
+      {id === '3opt' && <ThreeOptExplainer client:visible />}
+      {id === 'christofides' && <ChristofidesExplainer client:visible />}
+      {id === 'branch_bound' && <BranchBoundExplainer client:visible />}
+      {id === '2opt' && <TwoOptExplainer client:visible />}
+      {id === 'nn' && <NNExplainer client:visible />}
     </main>
   </div>
 </BaseLayout>

--- a/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
+++ b/teeline-web/src/pages/algorithms/[id]/explainer/index.astro
@@ -33,6 +33,7 @@ import StochasticHillExplainer from '../../../../explainers/stochastic-hill'
 import OrOptExplainer from '../../../../explainers/or-opt'
 import ThreeOptExplainer from '../../../../explainers/three-opt'
 import ChristofidesExplainer from '../../../../explainers/christofides'
+import BranchBoundExplainer from '../../../../explainers/branch-bound'
 import TwoOptExplainer from '../../../../explainers/two-opt'
 import NNExplainer from '../../../../explainers/nearest-neighbor'
 
@@ -84,6 +85,7 @@ const jsonLd = {
     {id === 'or_opt' && <OrOptExplainer client:visible />}
     {id === '3opt' && <ThreeOptExplainer client:visible />}
     {id === 'christofides' && <ChristofidesExplainer client:visible />}
+    {id === 'branch_bound' && <BranchBoundExplainer client:visible />}
     {id === '2opt' && <TwoOptExplainer client:visible />}
     {id === 'nn' && <NNExplainer client:visible />}
     </main>

--- a/teeline-web/tests/bhk.spec.ts
+++ b/teeline-web/tests/bhk.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the Bellman-Held-Karp explainer (/algorithms/bhk/explainer/).
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.bhk-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.bhk-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('dp[', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  await page.getByRole('button', { name: 'Reset' }).click()
+}
+
+test.describe('bhk explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/bhk/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the DP table, map, stats and scenarios', async ({ page }) => {
+    await expect(page.locator('.bhk-title')).toContainText('Bellman-Held-Karp')
+    await expect(page.locator('.bhk-table')).toBeVisible()
+    await expect(page.locator('.bhk-map')).toBeVisible()
+
+    const stats = page.locator('.bhk-statgrid')
+    await expect(stats).toContainText('subset size')
+    await expect(stats).toContainText('bits set')
+    await expect(stats).toContainText('phase')
+
+    for (const label of ['6-city grid', 'Circle', 'Two clusters']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step fills one DP cell at a time', async ({ page }) => {
+    const chip = page.locator('.bhk-chip')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('dp[')
+    await expect(chip).toContainText('via city')
+  })
+
+  test('clicking a cell explains its computation', async ({ page }) => {
+    // the first size-2 cell (mask 00011, row 0) exists after one step
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.locator('.bhk-cell', { hasText: /^[0-9]/ }).first().click()
+    await expect(page.locator('.bhk-cellinfo')).toContainText('dp[')
+  })
+
+  test('Run completes the whole DP, then read-back reveals the optimal route', async ({ page }) => {
+    const chip = page.locator('.bhk-chip')
+
+    // Run goes all the way through the table and the read-back to Done
+    await page.getByRole('button', { name: 'Run' }).click()
+    await expect(chip).toContainText('Done — optimal tour', { timeout: 30_000 })
+
+    // jump to the read-back mode and step: the route is revealed city by city
+    await page.getByRole('button', { name: 'Read-back' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('Read-back')
+    await expect(chip).toContainText('revealed')
+  })
+
+  test('Done shows the full optimal tour; Reset restores', async ({ page }) => {
+    const chip = page.locator('.bhk-chip')
+
+    await page.getByRole('button', { name: 'Done' }).click()
+    await expect(chip).toContainText('Done — optimal tour')
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(chip).toContainText('fills subset by subset')
+  })
+
+  test('Back restores the previous step', async ({ page }) => {
+    const step = page.locator('.bhk-statgrid').locator('div', { hasText: /^step/ }).locator('.bhk-mono')
+    const back = page.getByRole('button', { name: '⏴ Back' })
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    const after = await step.textContent()
+
+    await back.click()
+    await expect(step).not.toHaveText(after ?? '')
+  })
+
+  test('scenario buttons restart the run', async ({ page }) => {
+    const step = page.locator('.bhk-statgrid').locator('div', { hasText: /^step/ }).locator('.bhk-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(step).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Circle' }).click()
+    await expect(step).toHaveText('0')
+  })
+})

--- a/teeline-web/tests/branch-bound.spec.ts
+++ b/teeline-web/tests/branch-bound.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test'
+
+// E2E smoke tests for the Branch & Bound explainer (/algorithms/branch_bound/explainer/).
+async function waitHydrated(page: import('@playwright/test').Page) {
+  const root = page.locator('.bb-root')
+  await root.scrollIntoViewIfNeeded()
+  const chip = page.locator('.bb-chip')
+  const step = page.getByRole('button', { name: 'Step' })
+  await expect(async () => {
+    await step.click()
+    await expect(chip).toContainText('Expanded', { timeout: 1500 })
+  }).toPass({ timeout: 15_000 })
+  await page.getByRole('button', { name: 'Reset' }).click()
+}
+
+test.describe('branch & bound explainer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/algorithms/branch_bound/explainer/')
+    await waitHydrated(page)
+  })
+
+  test('renders the search tree, city map, stats and scenarios', async ({ page }) => {
+    await expect(page.locator('.bb-title')).toContainText('Branch & Bound')
+    await expect(page.locator('.bb-tree')).toBeVisible()
+    await expect(page.locator('.bb-map')).toBeVisible()
+
+    const stats = page.locator('.bb-statgrid')
+    await expect(stats).toContainText('nodes')
+    await expect(stats).toContainText('explored')
+    await expect(stats).toContainText('pruned')
+    await expect(stats).toContainText('leaves')
+    await expect(stats).toContainText('best')
+
+    for (const label of ['Small grid', 'Good bound', 'Worst case', 'Early best']) {
+      await expect(page.getByRole('button', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Step expands the search tree one node at a time', async ({ page }) => {
+    const chip = page.locator('.bb-chip')
+    const nodes = page.locator('.bb-statgrid').locator('div', { hasText: /^nodes/ }).locator('.bb-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText('Expanded')
+    await expect(nodes).toHaveText('2')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(chip).toContainText(/Expanded|Leaf|Pruned|Backtracked/)
+  })
+
+  test('Run completes the search with the optimal tour; Reset restores', async ({ page }) => {
+    const chip = page.locator('.bb-chip')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await expect(chip).toContainText('Done — optimal tour', { timeout: 30_000 })
+
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(chip).toContainText('search tree grows')
+  })
+
+  test('Back restores the previous step', async ({ page }) => {
+    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await page.getByRole('button', { name: 'Step' }).click()
+    const after = await step.textContent()
+
+    await page.getByRole('button', { name: 'Back' }).click()
+    await expect(step).not.toHaveText(after ?? '')
+  })
+
+  test('Pause stops the animation mid-run', async ({ page }) => {
+    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+
+    await page.getByRole('button', { name: 'Run' }).click()
+    await page.getByRole('button', { name: 'Pause' }).click()
+    const paused = await step.textContent()
+    await page.waitForTimeout(600)
+    await expect(step).toHaveText(paused ?? '')
+  })
+
+  test('scenario buttons restart the run', async ({ page }) => {
+    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(step).not.toHaveText('0')
+
+    await page.getByRole('button', { name: 'Good bound' }).click()
+    await expect(step).toHaveText('0')
+    await page.getByRole('button', { name: 'Step' }).click()
+    await expect(page.locator('.bb-chip')).toContainText('Expanded')
+  })
+
+  test('clicking a tree node pins it in the info panel', async ({ page }) => {
+    await page.getByRole('button', { name: 'Step' }).click()
+    const node = page.locator('.bb-node').first()
+    await node.click()
+    await expect(page.locator('.bb-nodeinfo')).toContainText('status')
+  })
+})


### PR DESCRIPTION
## What

Interactive explainer for **Bellman-Held-Karp** at `/algorithms/bhk/explainer/` — the exact DP TSP solver, taught through its **subset-cost table**.

**Rust-faithful DP model** (`src/tsp/bellman_karp.rs`) with a cleaner start-city convention: city 0 is the start, and the DP lives on the other n−1 cities. `dp[mask][i]` = min cost of a path from 0 visiting exactly `mask` ending at i; base `dp[{i}][i] = d(0,i)`; answer `min_i dp[full][i] + d(i,0)`. The predecessor choice is recorded per cell so the optimal route can be **read back**. n = 6 per scenario → a 5×32 table, easy to scan. Deterministic, no RNG; state is plain data (cloneable for Back).

## UI

- **Interactive DP table** (rows = end city, columns = subset bitmask): base cells highlighted, the next cell to compute ringed, the optimal route's cells gold during read-back; **clicking any cell explains its computation** (`dp[mask][i] = dp[mask∖{i}][via] + d(via, i)`)
- **City map** highlighting the current subset (or the route being read back)
- Forward / Read-back / Done mode buttons, stats (subset size, bits set), Step/Run/Pause/Back/Reset, speed slider

## Scenarios (6-city layouts, all verified optimal vs brute force)

6-city grid · circle · two clusters

## Files

- `bhk-algo.ts`, `bhk.tsx`, `bhk.test.ts` (9 unit tests), `tests/bhk.spec.ts` (7 Playwright e2e)
- `registry.ts`, `[id]/explainer/index.astro`, `docs/algorithms/bellman-held-karp.md`

## Verification

- `vitest run`: 465 tests pass (33 files) · `astro check` + `tsc`: clean · Playwright e2e: 7/7

Closes #429