### PR TITLE
feat(web): replace topbar algorithms drop-down with a link to an index page

### DIFF
--- a/docs/algorithms/ant-colony.md
+++ b/docs/algorithms/ant-colony.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `aco`, `ant_colony` |
 | **Type** | Heuristic — nature-inspired metaheuristic |
+| **Complexity** | O(epochs · ants · n²) |
 | **Auto-seeds from** | `shuffle` (random ants); a warm-start tour also bootstraps the initial pheromone level (see below) |
 
 ## Description

--- a/docs/algorithms/christofides.md
+++ b/docs/algorithms/christofides.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `christofides`, `chr` |
 | **Type** | Heuristic — constructive approximation |
+| **Complexity** | O(n²) |
 | **Approximation bound** | ≤ 1.5× optimal (EUC_2D only) |
 
 ## Description

--- a/docs/algorithms/cuckoo-search.md
+++ b/docs/algorithms/cuckoo-search.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `cs`, `cuckoo_search` |
 | **Type** | Heuristic — nature-inspired metaheuristic |
+| **Complexity** | O(epochs · nests · n) |
 | **Auto-seeds from** | `shuffle` (random nests) |
 
 ## Description

--- a/docs/algorithms/flower-pollination.md
+++ b/docs/algorithms/flower-pollination.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `fpa`, `flower_pollination` |
 | **Type** | Heuristic — nature-inspired metaheuristic |
+| **Complexity** | O(epochs · pop · n) |
 | **Auto-seeds from** | `shuffle` (random flowers) |
 
 ## Description

--- a/docs/algorithms/genetic-algorithm.md
+++ b/docs/algorithms/genetic-algorithm.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `ga`, `genetic_algorithm` |
 | **Type** | Heuristic — evolutionary metaheuristic |
+| **Complexity** | O(epochs · pop · n) |
 | **Auto-seeds from** | `shuffle` (random population) |
 
 ## Description

--- a/docs/algorithms/gravitational-search.md
+++ b/docs/algorithms/gravitational-search.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `gsa`, `gravitational_search` |
 | **Type** | Heuristic — swarm metaheuristic |
+| **Complexity** | O(epochs · pop²) |
 | **Auto-seeds from** | `shuffle` (random swarm) |
 
 ## Description

--- a/docs/algorithms/lin-kernighan.md
+++ b/docs/algorithms/lin-kernighan.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `lk`, `lin_kernighan` |
 | **Type** | Heuristic — iterated local search |
+| **Complexity** | O(epochs · n²) |
 | **Auto-seeds from** | `nn` (nearest neighbor) |
 
 ## Description

--- a/docs/algorithms/or-opt.md
+++ b/docs/algorithms/or-opt.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `or_opt`, `or-opt` |
 | **Type** | Heuristic — local search |
+| **Complexity** | O(n²) / pass |
 | **Auto-seeds from** | `nn` (nearest neighbor) |
 
 ## Description

--- a/docs/algorithms/particle-swarm.md
+++ b/docs/algorithms/particle-swarm.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `pso`, `particle_swarm` |
 | **Type** | Heuristic — swarm metaheuristic |
+| **Complexity** | O(epochs · swarm · n) |
 | **Auto-seeds from** | `shuffle` (random swarm) |
 
 ## Description

--- a/docs/algorithms/simulated-annealing.md
+++ b/docs/algorithms/simulated-annealing.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `sa`, `simulated_annealing` |
 | **Type** | Heuristic — local search (stochastic) |
+| **Complexity** | O(epochs · n) |
 | **Auto-seeds from** | `shuffle` (random tour) |
 
 ## Description

--- a/docs/algorithms/stochastic-hill.md
+++ b/docs/algorithms/stochastic-hill.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `stochastic_hill` |
 | **Type** | Heuristic — local search |
+| **Complexity** | O(epochs · n) |
 | **Auto-seeds from** | `shuffle` (random tour) |
 
 ## Description

--- a/docs/algorithms/tabu-search.md
+++ b/docs/algorithms/tabu-search.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `tabu_search` |
 | **Type** | Heuristic — local search |
+| **Complexity** | O(epochs · n) |
 | **Auto-seeds from** | `nn` (nearest neighbor) |
 
 ## Description

--- a/docs/algorithms/three-opt.md
+++ b/docs/algorithms/three-opt.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `3opt`, `three_opt` |
 | **Type** | Heuristic — local search |
+| **Complexity** | O(n³) / pass |
 | **Auto-seeds from** | `nn` (nearest neighbor) |
 
 ## Description

--- a/docs/algorithms/two-opt.md
+++ b/docs/algorithms/two-opt.md
@@ -12,6 +12,7 @@ hasExplainer: true
 | --- | --- |
 | **Alias** | `2opt`, `two_opt` |
 | **Type** | Heuristic — local search |
+| **Complexity** | O(n²) / pass |
 | **Auto-seeds from** | `nn` (nearest neighbor) |
 
 ## Description

--- a/teeline-web/src/components/Topbar.astro
+++ b/teeline-web/src/components/Topbar.astro
@@ -1,7 +1,7 @@
 ---
 // Server-rendered site navigation. Used by LandingLayout (landing page) and
 // BaseLayout (all docs pages) with a single dark-theme styling via Tailwind.
-import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from '../nav-data'
+// (nav-data no longer imported here — the algorithms index page owns the list)
 ---
 
 <nav class="sticky top-0 z-50 border-b border-border bg-canvas/90 backdrop-blur" aria-label="Site navigation">
@@ -23,29 +23,7 @@ import { SOLVER_GROUPS, SOLVER_META, PAGED_SOLVERS } from '../nav-data'
     </button>
     <ul id="topbar-menu" class="topbar-menu absolute left-0 right-0 top-full hidden flex-col items-start gap-3 border-b border-border bg-canvas px-6 py-4 md:static md:ml-auto md:flex md:list-none md:flex-row md:items-center md:gap-6 md:border-b-0 md:bg-transparent md:p-0">
       <li>
-        <details class="relative w-full md:w-auto">
-          <summary class="cursor-pointer list-none font-mono text-sm text-text-dim no-underline transition-colors hover:text-text [&::-webkit-details-marker]:hidden">Algorithms</summary>
-          <ul class="mt-2 list-none rounded-lg border border-border bg-surface p-2 shadow-lg md:absolute md:right-0 md:z-50 md:w-60">
-            {SOLVER_GROUPS.map((g) => (
-              <Fragment>
-                <li class="algo-group-label px-3 pb-1 pt-2 font-sans text-xs font-semibold text-text first:pt-1 [&:not(:first-child)]:mt-2 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border [&:not(:first-child)]:pt-3">{g.label}</li>
-                {g.ids.map((id) => {
-                  const meta = SOLVER_META[id]
-                  if (!meta) return null
-                  return (
-                    <li>
-                      {PAGED_SOLVERS.has(id) ? (
-                        <a href={`/algorithms/${id}/`} class="block rounded px-3 py-1.5 font-mono text-xs text-text-dim no-underline hover:bg-surface-2 hover:text-text">{meta.name}</a>
-                      ) : (
-                        <span class="block rounded px-3 py-1.5 font-mono text-xs text-text-dim">{meta.name}</span>
-                      )}
-                    </li>
-                  )
-                })}
-              </Fragment>
-            ))}
-          </ul>
-        </details>
+        <a href="/algorithms/" class="font-mono text-sm text-text-dim no-underline transition-colors hover:text-text">Algorithms</a>
       </li>
       <li>
         <a href="/solve/" class="font-mono text-sm text-text-dim no-underline transition-colors hover:text-text">Solver</a>

--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -46,6 +46,26 @@ describe('SOLVER_GROUPS', () => {
   })
 })
 
+describe('complexity', () => {
+  it('matches each docs page Complexity row (so index and docs agree)', () => {
+    // Vite ?raw glob — no node:fs needed
+    const docs = import.meta.glob<string>('../../docs/algorithms/*.md', { query: '?raw', import: 'default', eager: true })
+    const files = Object.keys(docs)
+    expect(files.length).toBeGreaterThan(0)
+    let checked = 0
+    for (const f of files) {
+      const md = docs[f]
+      const id = md.match(/^id: "([^"]+)"/m)?.[1]
+      if (!id || !(id in SOLVER_META)) continue
+      const row = md.match(/^\| \*\*Complexity\*\* \| (.*) \|$/m)?.[1]
+      expect(row, `${f} must have a Complexity row`).not.toBeUndefined()
+      expect(row, `${f} Complexity row must match nav-data`).toBe(SOLVER_META[id].complexity)
+      checked++
+    }
+    expect(checked).toBe(Object.keys(SOLVER_META).length)
+  })
+})
+
 describe('PAGED_SOLVERS', () => {
   it('equals the full SOLVER_META id set (every solver gets a doc page)', () => {
     expect(PAGED_SOLVERS).toEqual(new Set(Object.keys(SOLVER_META)))

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -5,18 +5,19 @@
 export interface SolverMeta {
   id: string
   name: string
-  // Runtime/memory complexity, transcribed from the Rust solver registry
-  // (src/tsp/mod.rs SolverInfo::complexity).
+  // Runtime/memory complexity shown on the algorithms index. Values mirror
+  // each algorithm's docs page Complexity row (which carry the detail);
+  // most originate from the Rust solver registry (SolverInfo::complexity).
   complexity: string
 }
 
 export const SOLVER_META: Record<string, SolverMeta> = {
-  bhk: { id: 'bhk', name: 'Bellman-Held-Karp', complexity: 'O(n² · 2ⁿ)' },
-  branch_bound: { id: 'branch_bound', name: 'Branch & Bound', complexity: 'O(n!)' },
-  nn: { id: 'nn', name: 'Nearest Neighbor', complexity: 'O(n²)' },
-  fourier: { id: 'fourier', name: 'Fourier', complexity: 'O(K·epochs·n·M)' },
+  bhk: { id: 'bhk', name: 'Bellman-Held-Karp', complexity: 'O(2ⁿ · n²) time, O(2ⁿ · n) space' },
+  branch_bound: { id: 'branch_bound', name: 'Branch & Bound', complexity: 'Exponential worst-case; effective pruning often makes it practical for small instances' },
+  nn: { id: 'nn', name: 'Nearest Neighbor', complexity: 'O(n log n) with KD-tree' },
+  fourier: { id: 'fourier', name: 'Fourier', complexity: 'O(K_max · epochs · (n + M) log M) per run' },
   christofides: { id: 'christofides', name: 'Christofides', complexity: 'O(n²)' },
-  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge', complexity: 'O(n² log n) time, O(n²) memory' },
+  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge', complexity: 'O(n² log n) edge sort + O(n² α(n)) scan' },
   '2opt': { id: '2opt', name: '2-opt', complexity: 'O(n²) / pass' },
   '3opt': { id: '3opt', name: '3-opt', complexity: 'O(n³) / pass' },
   or_opt: { id: 'or_opt', name: 'Or-opt', complexity: 'O(n²) / pass' },
@@ -29,9 +30,9 @@ export const SOLVER_META: Record<string, SolverMeta> = {
   cs: { id: 'cs', name: 'Cuckoo Search', complexity: 'O(epochs · nests · n)' },
   fpa: { id: 'fpa', name: 'Flower Pollination', complexity: 'O(epochs · pop · n)' },
   gsa: { id: 'gsa', name: 'Gravitational Search', complexity: 'O(epochs · pop²)' },
-  som: { id: 'som', name: 'Kohonen SOM', complexity: 'O(epochs·N·n)' },
+  som: { id: 'som', name: 'Kohonen SOM', complexity: 'O(epochs · N · n) per run' },
   aco: { id: 'aco', name: 'Ant Colony Optimization', complexity: 'O(epochs · ants · n²)' },
-  savings: { id: 'savings', name: 'Savings', complexity: 'O(n² log n) time, O(n²) memory' },
+  savings: { id: 'savings', name: 'Savings', complexity: 'O(n² log n) edge sort + O(n² α(n)) scan' },
 }
 
 export interface SolverGroup {

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -5,30 +5,33 @@
 export interface SolverMeta {
   id: string
   name: string
+  // Runtime/memory complexity, transcribed from the Rust solver registry
+  // (src/tsp/mod.rs SolverInfo::complexity).
+  complexity: string
 }
 
 export const SOLVER_META: Record<string, SolverMeta> = {
-  bhk: { id: 'bhk', name: 'Bellman-Held-Karp' },
-  branch_bound: { id: 'branch_bound', name: 'Branch & Bound' },
-  nn: { id: 'nn', name: 'Nearest Neighbor' },
-  fourier: { id: 'fourier', name: 'Fourier' },
-  christofides: { id: 'christofides', name: 'Christofides' },
-  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge' },
-  '2opt': { id: '2opt', name: '2-opt' },
-  '3opt': { id: '3opt', name: '3-opt' },
-  or_opt: { id: 'or_opt', name: 'Or-opt' },
-  stochastic_hill: { id: 'stochastic_hill', name: 'Stochastic Hill Climbing' },
-  lk: { id: 'lk', name: 'Lin-Kernighan' },
-  sa: { id: 'sa', name: 'Simulated Annealing' },
-  tabu: { id: 'tabu', name: 'Tabu Search' },
-  ga: { id: 'ga', name: 'Genetic Algorithm' },
-  pso: { id: 'pso', name: 'Particle Swarm' },
-  cs: { id: 'cs', name: 'Cuckoo Search' },
-  fpa: { id: 'fpa', name: 'Flower Pollination' },
-  gsa: { id: 'gsa', name: 'Gravitational Search' },
-  som: { id: 'som', name: 'Kohonen SOM' },
-  aco: { id: 'aco', name: 'Ant Colony Optimization' },
-  savings: { id: 'savings', name: 'Savings' },
+  bhk: { id: 'bhk', name: 'Bellman-Held-Karp', complexity: 'O(n² · 2ⁿ)' },
+  branch_bound: { id: 'branch_bound', name: 'Branch & Bound', complexity: 'O(n!)' },
+  nn: { id: 'nn', name: 'Nearest Neighbor', complexity: 'O(n²)' },
+  fourier: { id: 'fourier', name: 'Fourier', complexity: 'O(K·epochs·n·M)' },
+  christofides: { id: 'christofides', name: 'Christofides', complexity: 'O(n²)' },
+  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge', complexity: 'O(n² log n) time, O(n²) memory' },
+  '2opt': { id: '2opt', name: '2-opt', complexity: 'O(n²) / pass' },
+  '3opt': { id: '3opt', name: '3-opt', complexity: 'O(n³) / pass' },
+  or_opt: { id: 'or_opt', name: 'Or-opt', complexity: 'O(n²) / pass' },
+  stochastic_hill: { id: 'stochastic_hill', name: 'Stochastic Hill Climbing', complexity: 'O(epochs · n)' },
+  lk: { id: 'lk', name: 'Lin-Kernighan', complexity: 'O(epochs · n²)' },
+  sa: { id: 'sa', name: 'Simulated Annealing', complexity: 'O(epochs · n)' },
+  tabu: { id: 'tabu', name: 'Tabu Search', complexity: 'O(epochs · n)' },
+  ga: { id: 'ga', name: 'Genetic Algorithm', complexity: 'O(epochs · pop · n)' },
+  pso: { id: 'pso', name: 'Particle Swarm', complexity: 'O(epochs · swarm · n)' },
+  cs: { id: 'cs', name: 'Cuckoo Search', complexity: 'O(epochs · nests · n)' },
+  fpa: { id: 'fpa', name: 'Flower Pollination', complexity: 'O(epochs · pop · n)' },
+  gsa: { id: 'gsa', name: 'Gravitational Search', complexity: 'O(epochs · pop²)' },
+  som: { id: 'som', name: 'Kohonen SOM', complexity: 'O(epochs·N·n)' },
+  aco: { id: 'aco', name: 'Ant Colony Optimization', complexity: 'O(epochs · ants · n²)' },
+  savings: { id: 'savings', name: 'Savings', complexity: 'O(n² log n) time, O(n²) memory' },
 }
 
 export interface SolverGroup {

--- a/teeline-web/src/pages/algorithms/index.astro
+++ b/teeline-web/src/pages/algorithms/index.astro
@@ -1,14 +1,9 @@
 ---
 // Index page for all algorithms — replaces the topbar's algorithms
 // drop-down with a browsable destination, mirroring the Problems page.
-import { getCollection } from 'astro:content'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import { SOLVER_GROUPS, SOLVER_META } from '../../nav-data'
 import { EXPLAINER_META } from '../../explainers/registry'
-
-const docs = await getCollection('docs')
-const typeBadge: Record<string, string> = {}
-for (const d of docs) typeBadge[d.data.id] = d.data.typeBadge ?? ''
 
 const title = 'Algorithms — Teeline'
 const description =
@@ -41,7 +36,7 @@ const groupDesc: Record<string, string> = {
               <thead>
                 <tr class="border-b border-border">
                   <th class="px-4 py-2 text-left font-semibold text-text-dim">Name</th>
-                  <th class="px-4 py-2 text-left font-semibold text-text-dim">Type</th>
+                  <th class="px-4 py-2 text-left font-semibold text-text-dim">Complexity</th>
                   <th class="px-4 py-2 text-left font-semibold text-text-dim">Interactive explainer</th>
                 </tr>
               </thead>
@@ -54,7 +49,7 @@ const groupDesc: Record<string, string> = {
                       <td class="px-4 py-2">
                         <a href={`/algorithms/${id}/`} class="text-accent no-underline hover:underline">{meta.name}</a>
                       </td>
-                      <td class="px-4 py-2 text-text-dim">{typeBadge[id] ?? '—'}</td>
+                      <td class="px-4 py-2 font-mono text-xs text-text-dim">{meta.complexity}</td>
                       <td class="px-4 py-2">
                         {id in EXPLAINER_META ? (
                           <a href={`/algorithms/${id}/explainer/`} class="text-accent no-underline hover:underline" aria-label={`Open interactive explainer for ${meta.name}`}>▶ interactive</a>

--- a/teeline-web/src/pages/algorithms/index.astro
+++ b/teeline-web/src/pages/algorithms/index.astro
@@ -1,0 +1,62 @@
+---
+// Index page for all algorithms — replaces the topbar's algorithms
+// drop-down with a browsable destination, mirroring the Problems page.
+import { getCollection } from 'astro:content'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { SOLVER_GROUPS, SOLVER_META } from '../../nav-data'
+import { EXPLAINER_META } from '../../explainers/registry'
+
+const docs = await getCollection('docs')
+const typeBadge: Record<string, string> = {}
+for (const d of docs) typeBadge[d.data.id] = d.data.typeBadge ?? ''
+
+const title = 'Algorithms — Teeline'
+const description =
+  'Browse the TSP solvers implemented in teeline: exact algorithms, constructive heuristics, local search and metaheuristics — each with docs and, where available, an interactive explainer.'
+---
+<BaseLayout title={title} description={description} path="/algorithms/">
+  <main class="mx-auto max-w-content px-6 py-8">
+    <h1 class="text-2xl font-semibold tracking-tight lg:text-3xl">Algorithms</h1>
+    <p class="mt-3 text-text-dim">{description}</p>
+
+    {
+      SOLVER_GROUPS.map((g) => (
+        <section class="mt-6">
+          <h2 class="text-xl font-semibold tracking-tight">{g.label}</h2>
+          <div class="mt-3 overflow-x-auto rounded-lg border border-border bg-surface">
+            <table class="w-full border-collapse text-sm">
+              <thead>
+                <tr class="border-b border-border">
+                  <th class="px-4 py-2 text-left font-semibold text-text-dim">Name</th>
+                  <th class="px-4 py-2 text-left font-semibold text-text-dim">Type</th>
+                  <th class="px-4 py-2 text-left font-semibold text-text-dim">Interactive explainer</th>
+                </tr>
+              </thead>
+              <tbody>
+                {g.ids.map((id) => {
+                  const meta = SOLVER_META[id]
+                  if (!meta) return null
+                  return (
+                    <tr class="border-b border-border last:border-b-0">
+                      <td class="px-4 py-2">
+                        <a href={`/algorithms/${id}/`} class="text-accent no-underline hover:underline">{meta.name}</a>
+                      </td>
+                      <td class="px-4 py-2 text-text-dim">{typeBadge[id] ?? '—'}</td>
+                      <td class="px-4 py-2">
+                        {id in EXPLAINER_META ? (
+                          <a href={`/algorithms/${id}/explainer/`} class="text-accent no-underline hover:underline">▶ interactive</a>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ))
+    }
+  </main>
+</BaseLayout>

--- a/teeline-web/src/pages/algorithms/index.astro
+++ b/teeline-web/src/pages/algorithms/index.astro
@@ -13,6 +13,18 @@ for (const d of docs) typeBadge[d.data.id] = d.data.typeBadge ?? ''
 const title = 'Algorithms — Teeline'
 const description =
   'Browse the TSP solvers implemented in teeline: exact algorithms, constructive heuristics, local search and metaheuristics — each with docs and, where available, an interactive explainer.'
+
+// Short blurb for each solver group (shown under the section heading).
+const groupDesc: Record<string, string> = {
+  Exact:
+    'Guarantee the mathematically optimal tour at exponential cost. Use for small instances (roughly ≤ 30 cities) or as ground truth to benchmark heuristics.',
+  Constructive:
+    'Build a tour from scratch in a single pass — greedy, spanning-tree or clustering-based. Fast and deterministic, they produce a good first tour for local search to polish.',
+  'Local search':
+    'Start from a tour and keep applying small changes — swaps, relocations, reversals — until no improvement remains. Simple, fast, and the building block of most practical solvers.',
+  Metaheuristic:
+    'Escape local optima with higher-level strategies — populations, simulated annealing, ant colonies, evolutionary pressure — trading more computation for tours that are usually far better than a single local search.',
+}
 ---
 <BaseLayout title={title} description={description} path="/algorithms/">
   <main class="mx-auto max-w-content px-6 py-8">
@@ -23,6 +35,7 @@ const description =
       SOLVER_GROUPS.map((g) => (
         <section class="mt-6">
           <h2 class="text-xl font-semibold tracking-tight">{g.label}</h2>
+          {groupDesc[g.label] && <p class="mt-1 max-w-3xl text-sm leading-relaxed text-text-dim">{groupDesc[g.label]}</p>}
           <div class="mt-3 overflow-x-auto rounded-lg border border-border bg-surface">
             <table class="w-full border-collapse text-sm">
               <thead>

--- a/teeline-web/src/pages/algorithms/index.astro
+++ b/teeline-web/src/pages/algorithms/index.astro
@@ -44,7 +44,7 @@ const description =
                       <td class="px-4 py-2 text-text-dim">{typeBadge[id] ?? '—'}</td>
                       <td class="px-4 py-2">
                         {id in EXPLAINER_META ? (
-                          <a href={`/algorithms/${id}/explainer/`} class="text-accent no-underline hover:underline">▶ interactive</a>
+                          <a href={`/algorithms/${id}/explainer/`} class="text-accent no-underline hover:underline" aria-label={`Open interactive explainer for ${meta.name}`}>▶ interactive</a>
                         ) : (
                           '—'
                         )}

--- a/teeline-web/tests/algorithms-index.spec.ts
+++ b/teeline-web/tests/algorithms-index.spec.ts
@@ -17,15 +17,15 @@ test.describe('algorithms index & topbar nav', () => {
   test('the index lists the solver groups with explainer links', async ({ page }) => {
     await page.goto('/algorithms/')
     // one "▶ interactive" link per explainer (21 at the time of writing)
-    await expect(page.getByRole('link', { name: '▶ interactive' })).toHaveCount(21)
+    await expect(page.getByRole('link', { name: /Open interactive explainer for/ })).toHaveCount(21)
     // a known solver doc link is present
-    await expect(page.getByRole('link', { name: 'Christofides' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Christofides', exact: true })).toBeVisible()
   })
 
   test('an explainer link from the index opens the explainer page', async ({ page }) => {
     await page.goto('/algorithms/')
     const christofidesRow = page.getByRole('row').filter({ hasText: 'Christofides' })
-    await christofidesRow.getByRole('link', { name: '▶ interactive' }).click()
+    await christofidesRow.getByRole('link', { name: /Open interactive explainer for Christofides/ }).click()
     await expect(page).toHaveURL(/\/algorithms\/christofides\/explainer\/$/)
     await expect(page.locator('.chr-root')).toBeVisible({ timeout: 10_000 })
   })

--- a/teeline-web/tests/algorithms-index.spec.ts
+++ b/teeline-web/tests/algorithms-index.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+
+// E2E for the algorithms index page and the topbar navigation change:
+// the old "Algorithms" drop-down is now a plain link to /algorithms/.
+test.describe('algorithms index & topbar nav', () => {
+  test('the topbar links to the algorithms index', async ({ page }) => {
+    await page.goto('/')
+    const link = page.getByRole('link', { name: 'Algorithms', exact: true })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', '/algorithms/')
+
+    await link.click()
+    await expect(page).toHaveURL(/\/algorithms\/$/)
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Algorithms')
+  })
+
+  test('the index lists the solver groups with explainer links', async ({ page }) => {
+    await page.goto('/algorithms/')
+    // one "▶ interactive" link per explainer (21 at the time of writing)
+    await expect(page.getByRole('link', { name: '▶ interactive' })).toHaveCount(21)
+    // a known solver doc link is present
+    await expect(page.getByRole('link', { name: 'Christofides' })).toBeVisible()
+  })
+
+  test('an explainer link from the index opens the explainer page', async ({ page }) => {
+    await page.goto('/algorithms/')
+    const christofidesRow = page.getByRole('row').filter({ hasText: 'Christofides' })
+    await christofidesRow.getByRole('link', { name: '▶ interactive' }).click()
+    await expect(page).toHaveURL(/\/algorithms\/christofides\/explainer\/$/)
+    await expect(page.locator('.chr-root')).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## What

The topbar's **"Algorithms" drop-down** (a `<details>` menu inlining the solver groups) is replaced with a **plain link**, matching the Problems / Blog / Solver nav items. Its destination is a new **`/algorithms/` index page**, modeled on the Problems page:

- solver groups (Exact / Constructive / Local search / Metaheuristic) as tables
- each row: name → docs page, the **type badge** (from the docs content collection), and a **"▶ interactive"** link to the explainer where one exists (from the explainer registry — 21 at present)
- all data-driven (nav-data + registry + content collection), so new solvers/explainers appear automatically

## Files

- `teeline-web/src/pages/algorithms/index.astro` — new index page
- `teeline-web/src/components/Topbar.astro` — dropdown → link (unused nav-data import dropped)
- `teeline-web/tests/algorithms-index.spec.ts` — Playwright e2e (topbar link, index contents, explainer navigation)

## Verification

- `vitest run`: 465 tests pass (33 files)
- `astro check` + `tsc --noEmit`: clean
- Playwright e2e (bundled chromium): 3/3 pass