### PR TITLE
fix(web): stop corrupting static host when building opt.tour URL

### DIFF
--- a/teeline-web/src/upload.test.ts
+++ b/teeline-web/src/upload.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { formatMetadata, exampleUrl, parseOptTour } from './upload'
+import {
+  formatMetadata,
+  exampleUrl,
+  parseOptTour,
+  datasetBaseUrl,
+  datasetTspUrl,
+  datasetOptTourUrl,
+} from './upload'
 import type { ParsedProblem } from 'teeline-wasm'
 
 const cities = (n: number) =>
@@ -67,5 +74,29 @@ describe('exampleUrl', () => {
     expect(exampleUrl('berlin52')).toBe('/examples/berlin52.tsp')
     expect(exampleUrl('burma14')).toBe('/examples/burma14.tsp')
     expect(exampleUrl('ulysses22')).toBe('/examples/ulysses22.tsp')
+  })
+})
+
+describe('dataset URLs', () => {
+  it('uses the dev proxy prefix in dev', () => {
+    expect(datasetBaseUrl(true)).toBe('/tsplib')
+    expect(datasetTspUrl('berlin52', true)).toBe('/tsplib/berlin52.tsp')
+    expect(datasetOptTourUrl('berlin52', true)).toBe('/tsplib/berlin52.opt.tour')
+  })
+
+  it('uses the static host in production', () => {
+    expect(datasetBaseUrl(false)).toBe('https://static.tspsolver.com/tsplib')
+    expect(datasetTspUrl('berlin52', false)).toBe(
+      'https://static.tspsolver.com/tsplib/berlin52.tsp',
+    )
+  })
+
+  // Regression: `.replace('.tsp', '.opt.tour')` matched the ".tsp" inside
+  // "static.tspsolver.com" and produced the non-existent
+  // "static.opt.toursolver.com" host (CORS / ERR_NAME_NOT_RESOLVED).
+  it('never rewrites the static host when building the opt.tour URL', () => {
+    const optUrl = datasetOptTourUrl('berlin52', false)
+    expect(optUrl).toBe('https://static.tspsolver.com/tsplib/berlin52.opt.tour')
+    expect(optUrl).not.toContain('toursolver')
   })
 })

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -10,6 +10,21 @@ export function exampleUrl(name: string): string {
   return `/examples/${name}.tsp`
 }
 
+// Base URL for the hosted TSPLIB dataset files. In dev, Vite proxies /tsplib/
+// → static.tspsolver.com/tsplib/ to avoid CORS; in production we fetch the
+// static host directly.
+export function datasetBaseUrl(dev: boolean): string {
+  return dev ? '/tsplib' : 'https://static.tspsolver.com/tsplib'
+}
+
+export function datasetTspUrl(name: string, dev: boolean): string {
+  return `${datasetBaseUrl(dev)}/${name}.tsp`
+}
+
+export function datasetOptTourUrl(name: string, dev: boolean): string {
+  return `${datasetBaseUrl(dev)}/${name}.opt.tour`
+}
+
 export function parseOptTour(text: string): number[] {
   const lines = text.split('\n')
   let inSection = false
@@ -212,9 +227,8 @@ export function initUpload(
 
   if (datasetParam) {
     // In dev, Vite proxies /tsplib/ → static.tspsolver.com/tsplib/ to avoid CORS
-    const tspUrl = import.meta.env.DEV
-      ? `/tsplib/${datasetParam}.tsp`
-      : `https://static.tspsolver.com/tsplib/${datasetParam}.tsp`
+    const tspUrl = datasetTspUrl(datasetParam, import.meta.env.DEV)
+    const optTourUrl = datasetOptTourUrl(datasetParam, import.meta.env.DEV)
     ;(async () => {
       try {
         const resp = await fetch(tspUrl)
@@ -224,7 +238,7 @@ export function initUpload(
 
         // Also try to load the .opt.tour if available
         try {
-          const optResp = await fetch(tspUrl.replace('.tsp', '.opt.tour')) 
+          const optResp = await fetch(optTourUrl)
           if (optResp.ok) {
             const optText = await optResp.text()
             const route = parseOptTour(optText)


### PR DESCRIPTION
## Summary

Fixes the spurious CORS / `ERR_NAME_NOT_RESOLVED` error seen when clicking **Open in Solver** on a problem page (e.g. `/problems/berlin52/`), which tried to fetch `https://static.opt.toursolver.com/tsplib/berlin52.tsp` — a host that does not exist.

## Root cause

`teeline-web/src/upload.ts` built the optimal-tour URL with:

```js
const optResp = await fetch(tspUrl.replace('.tsp', '.opt.tour'))
```

`String.prototype.replace` with a string pattern replaces the **first** occurrence. In production `tspUrl` is `https://static.tspsolver.com/tsplib/berlin52.tsp`, and the first `.tsp` is inside `static.tsp**solver**`.com`, not the file extension. The result was:

```
https://static.opt.toursolver.com/tsplib/berlin52.tsp
```

The bug was invisible in dev because the proxied base `/tsplib/...` contains no `.tsp` substring, so the naive replace happened to work there.

## Fix

Build both URLs explicitly from a shared, testable base:

- `datasetBaseUrl(dev)` → `/tsplib` in dev, `https://static.tspsolver.com/tsplib` in prod
- `datasetTspUrl(name, dev)`
- `datasetOptTourUrl(name, dev)`

No string replacement is involved anymore.

## Tests

- Added regression tests asserting the production opt.tour URL is `https://static.tspsolver.com/tsplib/<id>.opt.tour` and never contains `toursolver`.
- Verified in a real browser (Playwright): before the fix the live site issued a request to `static.opt.toursolver.com` (failed); after the fix a local production build (`astro preview`) requests `https://static.tspsolver.com/tsplib/berlin52.opt.tour` → **200**, with no `toursolver` request.
- `npx tsc --noEmit` clean, `astro check` 0 errors, full vitest suite **471 passed**.

## Notes

The live site still serves the previous bundle, so `teeline-web` needs to be redeployed for the fix to reach users.
