### PR TITLE
chore(web): adopt Prettier for teeline-web

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -77,6 +77,20 @@ if [ -n "$TS_FILES" ]; then
     fi
 fi
 
+# ── Prettier (teeline-web) ────────────────────────────────────────────────────
+PF_FILES=$(echo "$STAGED" | grep -E '^teeline-web/.*\.(ts|tsx|js|mjs|cjs|json|css)$' || true)
+if [ -n "$PF_FILES" ]; then
+    if [ ! -d "teeline-web/node_modules" ]; then
+        skip_notice "teeline-web/node_modules (run: cd teeline-web && npm install)"
+    else
+        echo "[CHECK] prettier (teeline-web)"
+        PF_REL=$(echo "$PF_FILES" | sed 's|^teeline-web/||')
+        if ! (cd teeline-web && npx prettier --check $PF_REL) 2>&1; then
+            fail_notice "prettier: formatting issues in teeline-web" "cd teeline-web && npx prettier --write <files>"
+        fi
+    fi
+fi
+
 # ── TOML ──────────────────────────────────────────────────────────────────────
 TOML_FILES=$(echo "$STAGED" | grep -E '\.toml$' || true)
 if [ -n "$TOML_FILES" ]; then

--- a/.github/workflows/teeline-web.yml
+++ b/.github/workflows/teeline-web.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Format check (prettier)
+        run: npm run format:check
+
       - name: Build gate (Pages Functions bundle)
         # Compiles teeline-web/functions/* (WebAuthn auth) to catch bundler /
         # SimpleWebAuthn edge-runtime issues early, and type-checks them with

--- a/teeline-web/.prettierignore
+++ b/teeline-web/.prettierignore
@@ -1,0 +1,18 @@
+# Dependencies, build output, tooling state
+node_modules/
+dist/
+.astro/
+.wrangler/
+test-results/
+
+# Generated or binary assets — not source
+public/
+package-lock.json
+
+# Astro components require prettier-plugin-astro; formatting them is a follow-up
+*.astro
+
+# Markdown and YAML have dedicated linters (markdownlint / yamllint)
+*.md
+*.yml
+*.yaml

--- a/teeline-web/.prettierrc
+++ b/teeline-web/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/teeline-web/astro.config.mjs
+++ b/teeline-web/astro.config.mjs
@@ -48,10 +48,14 @@ export default defineConfig({
       {
         name: 'force-preview2-shim-browser',
         resolveId(id) {
-          if (!id.startsWith('@bytecodealliance/preview2-shim')) return undefined
+          if (!id.startsWith('@bytecodealliance/preview2-shim'))
+            return undefined
           const sub = id.slice('@bytecodealliance/preview2-shim'.length)
           const name = sub.replace(/^\//, '') || 'index'
-          return resolvePath(configDir, `node_modules/@bytecodealliance/preview2-shim/lib/browser/${name}.js`)
+          return resolvePath(
+            configDir,
+            `node_modules/@bytecodealliance/preview2-shim/lib/browser/${name}.js`,
+          )
         },
       },
       sentryVitePlugin({ org: 'timo-sulg', project: 'javascript' }),

--- a/teeline-web/functions/api/auth/handlers.test.ts
+++ b/teeline-web/functions/api/auth/handlers.test.ts
@@ -5,7 +5,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
 import { makeD1, SCHEMA, type D1Like } from '../../lib/test/sqlite-d1'
-import { addCredential, createUser, getChallenge, getCredentialById, getUser, setUserBanned } from '../../lib/db'
+import {
+  addCredential,
+  createUser,
+  getChallenge,
+  getCredentialById,
+  getUser,
+  setUserBanned,
+} from '../../lib/db'
 import { createSessionToken } from '../../lib/session'
 import Database from 'better-sqlite3'
 
@@ -26,7 +33,10 @@ import { onRequestPost as logout } from './logout'
 import { onRequestGet as listKeys, onRequestPost as createKey } from './keys'
 
 let shim: D1Like
-const env = { SESSION_SECRET: 'test-session-secret', ALLOWED_ORIGINS: 'http://localhost:8788' } as never // DB injected below
+const env = {
+  SESSION_SECRET: 'test-session-secret',
+  ALLOWED_ORIGINS: 'http://localhost:8788',
+} as never // DB injected below
 
 function ctx(request: Request) {
   return { request, env: { ...env, DB: shim } } as never
@@ -35,7 +45,11 @@ function ctx(request: Request) {
 function req(path: string, init: RequestInit = {}): Request {
   return new Request(`http://localhost:8788${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': '1.2.3.4' },
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'http://localhost:8788',
+      'CF-Connecting-IP': '1.2.3.4',
+    },
     ...init,
   })
 }
@@ -48,26 +62,50 @@ beforeEach(() => {
   shim = makeD1(new Database(':memory:'))
   shim.exec(SCHEMA)
   vi.clearAllMocks()
-  mocks.generateRegistrationOptions.mockResolvedValue({ challenge: 'reg-challenge' })
-  mocks.generateAuthenticationOptions.mockResolvedValue({ challenge: 'login-challenge', rpId: 'localhost', allowCredentials: [], userVerification: 'preferred' })
+  mocks.generateRegistrationOptions.mockResolvedValue({
+    challenge: 'reg-challenge',
+  })
+  mocks.generateAuthenticationOptions.mockResolvedValue({
+    challenge: 'login-challenge',
+    rpId: 'localhost',
+    allowCredentials: [],
+    userVerification: 'preferred',
+  })
   mocks.verifyRegistrationResponse.mockResolvedValue({
     verified: true,
     registrationInfo: {
-      credential: { id: 'cred-1', publicKey: new Uint8Array(32).fill(7), counter: 3, transports: ['internal', 'usb'] },
+      credential: {
+        id: 'cred-1',
+        publicKey: new Uint8Array(32).fill(7),
+        counter: 3,
+        transports: ['internal', 'usb'],
+      },
       credentialType: 'public-key',
       fmt: 'none',
       aaguid: '00000000-0000-0000-0000-000000000000',
       attestationObject: new Uint8Array(0),
     },
   })
-  mocks.verifyAuthenticationResponse.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 9 } })
+  mocks.verifyAuthenticationResponse.mockResolvedValue({
+    verified: true,
+    authenticationInfo: { newCounter: 9 },
+  })
 })
 
 describe('register', () => {
   it('begin stores a challenge; complete creates the user + credential atomically and sets the session cookie', async () => {
-    const beginRes = await registerBegin(ctx(req('/api/auth/register/begin', { body: JSON.stringify({ displayName: 'Tim' }) })))
+    const beginRes = await registerBegin(
+      ctx(
+        req('/api/auth/register/begin', {
+          body: JSON.stringify({ displayName: 'Tim' }),
+        }),
+      ),
+    )
     expect(beginRes.status).toBe(201)
-    const { options, nonce } = (await beginRes.json()) as { options: { challenge: string }; nonce: string }
+    const { options, nonce } = (await beginRes.json()) as {
+      options: { challenge: string }
+      nonce: string
+    }
     expect(options.challenge).toBe('reg-challenge')
 
     const stored = await getChallenge(shim, nonce)
@@ -75,7 +113,17 @@ describe('register', () => {
     expect(stored?.user_handle).toBeTruthy()
 
     const completeRes = await registerComplete(
-      ctx(req('/api/auth/register/complete', { body: JSON.stringify({ nonce, credential: { id: 'x', response: { clientDataJSON: 'client', attestationObject: 'att' } } }) })),
+      ctx(
+        req('/api/auth/register/complete', {
+          body: JSON.stringify({
+            nonce,
+            credential: {
+              id: 'x',
+              response: { clientDataJSON: 'client', attestationObject: 'att' },
+            },
+          }),
+        }),
+      ),
     )
     expect(completeRes.status).toBe(201)
     const setCookie = completeRes.headers.get('Set-Cookie')
@@ -85,24 +133,62 @@ describe('register', () => {
 
     // challenge consumed, user + credential persisted
     expect(await getChallenge(shim, nonce)).toBeNull()
-    const users = await shim.prepare('SELECT id FROM users').bind().all<{ id: string }>()
+    const users = await shim
+      .prepare('SELECT id FROM users')
+      .bind()
+      .all<{ id: string }>()
     expect(users.results).toHaveLength(1)
-    const creds = await shim.prepare('SELECT id, counter, transports FROM credentials').bind().all<{ id: string; counter: number; transports: string }>()
+    const creds = await shim
+      .prepare('SELECT id, counter, transports FROM credentials')
+      .bind()
+      .all<{ id: string; counter: number; transports: string }>()
     expect(creds.results).toHaveLength(1)
     expect(creds.results[0]).toMatchObject({ id: 'cred-1', counter: 3 })
     expect(JSON.parse(creds.results[0].transports)).toEqual(['internal', 'usb'])
   })
 
   it('rejects a replayed nonce', async () => {
-    const begin = (await registerBegin(ctx(req('/api/auth/register/begin', { body: '{}' })))).json() as unknown as Promise<{ nonce: string }>
+    const begin = (
+      await registerBegin(ctx(req('/api/auth/register/begin', { body: '{}' })))
+    ).json() as unknown as Promise<{ nonce: string }>
     const { nonce } = await begin
-    const body = JSON.stringify({ nonce, credential: { id: 'x', response: { clientDataJSON: 'client', attestationObject: 'att' } } })
-    expect((await registerComplete(ctx(req('/api/auth/register/complete', { body })))).status).toBe(201)
-    expect((await registerComplete(ctx(req('/api/auth/register/complete', { body })))).status).toBe(400)
+    const body = JSON.stringify({
+      nonce,
+      credential: {
+        id: 'x',
+        response: { clientDataJSON: 'client', attestationObject: 'att' },
+      },
+    })
+    expect(
+      (
+        await registerComplete(
+          ctx(req('/api/auth/register/complete', { body })),
+        )
+      ).status,
+    ).toBe(201)
+    expect(
+      (
+        await registerComplete(
+          ctx(req('/api/auth/register/complete', { body })),
+        )
+      ).status,
+    ).toBe(400)
   })
 
   it('rejects an unknown nonce', async () => {
-    const res = await registerComplete(ctx(req('/api/auth/register/complete', { body: JSON.stringify({ nonce: 'ghost', credential: { id: 'x', response: { clientDataJSON: 'client', attestationObject: 'att' } } }) })))
+    const res = await registerComplete(
+      ctx(
+        req('/api/auth/register/complete', {
+          body: JSON.stringify({
+            nonce: 'ghost',
+            credential: {
+              id: 'x',
+              response: { clientDataJSON: 'client', attestationObject: 'att' },
+            },
+          }),
+        }),
+      ),
+    )
     expect(res.status).toBe(400)
   })
 })
@@ -121,24 +207,58 @@ describe('login', () => {
 
   it('begin + complete authenticates and updates the counter', async () => {
     await seedUser()
-    const beginRes = await loginBegin(ctx(req('/api/auth/login/begin', { body: '{}' })))
+    const beginRes = await loginBegin(
+      ctx(req('/api/auth/login/begin', { body: '{}' })),
+    )
     expect(beginRes.status).toBe(201)
     const { nonce } = (await beginRes.json()) as { nonce: string }
 
     const completeRes = await loginComplete(
-      ctx(req('/api/auth/login/complete', { body: JSON.stringify({ nonce, credential: { id: 'cred-1', response: { clientDataJSON: 'client', authenticatorData: 'auth', signature: 'sig' } } }) })),
+      ctx(
+        req('/api/auth/login/complete', {
+          body: JSON.stringify({
+            nonce,
+            credential: {
+              id: 'cred-1',
+              response: {
+                clientDataJSON: 'client',
+                authenticatorData: 'auth',
+                signature: 'sig',
+              },
+            },
+          }),
+        }),
+      ),
     )
     expect(completeRes.status).toBe(200)
-    expect(completeRes.headers.get('Set-Cookie')).toContain('__Host-teeline-session')
+    expect(completeRes.headers.get('Set-Cookie')).toContain(
+      '__Host-teeline-session',
+    )
     expect((await getCredentialById(shim, 'cred-1'))?.counter).toBe(9) // newCounter from mock
   })
 
   it('rejects an unknown credential', async () => {
     await seedUser()
-    const beginRes = await loginBegin(ctx(req('/api/auth/login/begin', { body: '{}' })))
+    const beginRes = await loginBegin(
+      ctx(req('/api/auth/login/begin', { body: '{}' })),
+    )
     const { nonce } = (await beginRes.json()) as { nonce: string }
     const res = await loginComplete(
-      ctx(req('/api/auth/login/complete', { body: JSON.stringify({ nonce, credential: { id: 'ghost', response: { clientDataJSON: 'client', authenticatorData: 'auth', signature: 'sig' } } }) })),
+      ctx(
+        req('/api/auth/login/complete', {
+          body: JSON.stringify({
+            nonce,
+            credential: {
+              id: 'ghost',
+              response: {
+                clientDataJSON: 'client',
+                authenticatorData: 'auth',
+                signature: 'sig',
+              },
+            },
+          }),
+        }),
+      ),
     )
     expect(res.status).toBe(400)
   })
@@ -146,11 +266,27 @@ describe('login', () => {
   it('denies a banned user (403) but still advances the credential counter', async () => {
     await seedUser()
     await setUserBanned(shim, 'u1', true)
-    const beginRes = await loginBegin(ctx(req('/api/auth/login/begin', { body: '{}' })))
+    const beginRes = await loginBegin(
+      ctx(req('/api/auth/login/begin', { body: '{}' })),
+    )
     const { nonce } = (await beginRes.json()) as { nonce: string }
 
     const res = await loginComplete(
-      ctx(req('/api/auth/login/complete', { body: JSON.stringify({ nonce, credential: { id: 'cred-1', response: { clientDataJSON: 'client', authenticatorData: 'auth', signature: 'sig' } } }) })),
+      ctx(
+        req('/api/auth/login/complete', {
+          body: JSON.stringify({
+            nonce,
+            credential: {
+              id: 'cred-1',
+              response: {
+                clientDataJSON: 'client',
+                authenticatorData: 'auth',
+                signature: 'sig',
+              },
+            },
+          }),
+        }),
+      ),
     )
     expect(res.status).toBe(403)
     expect(res.headers.get('Set-Cookie')).toBeNull() // no session for a banned user
@@ -162,38 +298,98 @@ describe('login', () => {
 describe('session endpoints', () => {
   it('me returns the user for a valid session cookie', async () => {
     await createUser(shim, { id: 'u1', displayName: 'Tim', createdAt: NOW })
-    const token = await createSessionToken(env.SESSION_SECRET as string, 'u1', NOW)
-    const res = await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: `__Host-teeline-session=${token}` } })))
+    const token = await createSessionToken(
+      env.SESSION_SECRET as string,
+      'u1',
+      NOW,
+    )
+    const res = await me(
+      ctx(
+        new Request('http://localhost:8788/api/auth/me', {
+          headers: { Cookie: `__Host-teeline-session=${token}` },
+        }),
+      ),
+    )
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { user: { id: string; displayName: string } }
+    const body = (await res.json()) as {
+      user: { id: string; displayName: string }
+    }
     expect(body.user).toMatchObject({ id: 'u1', displayName: 'Tim' })
   })
 
   it('me rejects a missing or tampered cookie', async () => {
-    expect((await me(ctx(new Request('http://localhost:8788/api/auth/me')))).status).toBe(401)
-    expect((await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: '__Host-teeline-session=tampered' } })))).status).toBe(401)
+    expect(
+      (await me(ctx(new Request('http://localhost:8788/api/auth/me')))).status,
+    ).toBe(401)
+    expect(
+      (
+        await me(
+          ctx(
+            new Request('http://localhost:8788/api/auth/me', {
+              headers: { Cookie: '__Host-teeline-session=tampered' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(401)
   })
 
   it('me rejects a banned user (403) despite a valid cookie', async () => {
     await createUser(shim, { id: 'u1', displayName: 'Tim', createdAt: NOW })
-    const token = await createSessionToken(env.SESSION_SECRET as string, 'u1', NOW)
+    const token = await createSessionToken(
+      env.SESSION_SECRET as string,
+      'u1',
+      NOW,
+    )
     const cookie = `__Host-teeline-session=${token}`
-    expect((await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: cookie } })))).status).toBe(200)
+    expect(
+      (
+        await me(
+          ctx(
+            new Request('http://localhost:8788/api/auth/me', {
+              headers: { Cookie: cookie },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(200)
 
     await setUserBanned(shim, 'u1', true)
-    const res = await me(ctx(new Request('http://localhost:8788/api/auth/me', { headers: { Cookie: cookie } })))
+    const res = await me(
+      ctx(
+        new Request('http://localhost:8788/api/auth/me', {
+          headers: { Cookie: cookie },
+        }),
+      ),
+    )
     expect(res.status).toBe(403)
     expect(res.headers.get('Set-Cookie')).toBeNull() // no session slide for a banned user
   })
 
   it('banned users cannot mint or list API keys (requireSession 403)', async () => {
     await createUser(shim, { id: 'u1', displayName: 'Tim', createdAt: NOW })
-    const token = await createSessionToken(env.SESSION_SECRET as string, 'u1', NOW)
+    const token = await createSessionToken(
+      env.SESSION_SECRET as string,
+      'u1',
+      NOW,
+    )
     const cookie = `__Host-teeline-session=${token}`
     await setUserBanned(shim, 'u1', true)
 
-    expect((await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).status).toBe(403)
-    expect((await listKeys(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).status).toBe(403)
+    expect(
+      (
+        await createKey(
+          ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+        )
+      ).status,
+    ).toBe(403)
+    expect(
+      (
+        await listKeys(
+          ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+        )
+      ).status,
+    ).toBe(403)
   })
 
   it('logout clears the cookie', async () => {
@@ -213,7 +409,9 @@ describe('origin policy', () => {
   })
 
   it('rejects mutating requests with no Origin header (e.g. cross-site POSTs)', async () => {
-    const noOrigin = new Request('http://localhost:8788/api/auth/logout', { method: 'POST' })
+    const noOrigin = new Request('http://localhost:8788/api/auth/logout', {
+      method: 'POST',
+    })
     expect((await logout(ctx(noOrigin))).status).toBe(403)
     // same-origin requests with the Origin header pass
     expect((await logout(ctx(req('/api/auth/logout')))).status).toBe(200)

--- a/teeline-web/functions/api/auth/keys.test.ts
+++ b/teeline-web/functions/api/auth/keys.test.ts
@@ -26,7 +26,12 @@ function req(path: string, init: RequestInit = {}): Request {
   const { headers, ...rest } = init
   return new Request(`http://localhost:8788${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': '1.2.3.4', ...(headers as Record<string, string>) },
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'http://localhost:8788',
+      'CF-Connecting-IP': '1.2.3.4',
+      ...(headers as Record<string, string>),
+    },
     ...rest,
   })
 }
@@ -56,21 +61,37 @@ describe('key creation (show-once)', () => {
   it('mints a well-formed key, stores only the hash, and returns the secret once', async () => {
     await seedUser()
     const cookie = await sessionCookie('u1')
-    const res = await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'my-laptop' }), headers: { Cookie: cookie } })))
+    const res = await createKey(
+      ctx(
+        req('/api/auth/keys', {
+          body: JSON.stringify({ name: 'my-laptop' }),
+          headers: { Cookie: cookie },
+        }),
+      ),
+    )
     expect(res.status).toBe(201)
-    const body = (await res.json()) as { id: string; name: string | null; secret: string }
+    const body = (await res.json()) as {
+      id: string
+      name: string | null
+      secret: string
+    }
     expect(body.id).toMatch(/^key_/)
     expect(body.name).toBe('my-laptop')
     expect(body.secret).toMatch(/^ak_[A-Za-z0-9_-]{43}$/)
 
     // only the hash is stored: looking up by the secret's hash finds it
-    const rows = await shim.prepare('SELECT id, secret_hash FROM api_keys').bind().all<{ id: string; secret_hash: string }>()
+    const rows = await shim
+      .prepare('SELECT id, secret_hash FROM api_keys')
+      .bind()
+      .all<{ id: string; secret_hash: string }>()
     expect(rows.results).toHaveLength(1)
     expect(rows.results[0].secret_hash).not.toBe(body.secret)
     expect(rows.results[0].secret_hash).toMatch(/^[0-9a-f]{64}$/)
 
     // second mint → different secret
-    const res2 = await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))
+    const res2 = await createKey(
+      ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+    )
     const body2 = (await res2.json()) as { secret: string }
     expect(body2.secret).not.toBe(body.secret)
   })
@@ -80,12 +101,35 @@ describe('key listing', () => {
   it('returns metadata only — never the secret or hash', async () => {
     await seedUser()
     const cookie = await sessionCookie('u1')
-    await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'a' }), headers: { Cookie: cookie } })))
-    await createKey(ctx(req('/api/auth/keys', { body: JSON.stringify({ name: 'b' }), headers: { Cookie: cookie } })))
+    await createKey(
+      ctx(
+        req('/api/auth/keys', {
+          body: JSON.stringify({ name: 'a' }),
+          headers: { Cookie: cookie },
+        }),
+      ),
+    )
+    await createKey(
+      ctx(
+        req('/api/auth/keys', {
+          body: JSON.stringify({ name: 'b' }),
+          headers: { Cookie: cookie },
+        }),
+      ),
+    )
 
-    const res = await listKeys(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))
+    const res = await listKeys(
+      ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+    )
     expect(res.status).toBe(200)
-    const { keys } = (await res.json()) as { keys: { id: string; name: string | null; secret?: string; secret_hash?: string }[] }
+    const { keys } = (await res.json()) as {
+      keys: {
+        id: string
+        name: string | null
+        secret?: string
+        secret_hash?: string
+      }[]
+    }
     expect(keys).toHaveLength(2)
     for (const k of keys) {
       expect(k.secret).toBeUndefined()
@@ -104,77 +148,204 @@ describe('key revocation', () => {
     await seedUser()
     await seedUser('u2')
     const cookie = await sessionCookie('u1')
-    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ id: string; secret: string }>
+    const minted = (
+      await createKey(
+        ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+      )
+    ).json() as unknown as Promise<{ id: string; secret: string }>
     const { id, secret } = await minted
 
     // verify works before revocation
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body: JSON.stringify({ secret }),
+              headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(200)
 
     // non-owner cannot revoke
     const nonOwner = await revokeKey(ctx(req('/api/auth/keys'), { id }), { id })
     expect((nonOwner as Response).status).toBe(401) // no session
     const otherCookie = await sessionCookie('u2')
-    const asOther = await revokeKey(ctx(req('/api/auth/keys', { headers: { Cookie: otherCookie } }), { id }), { id })
+    const asOther = await revokeKey(
+      ctx(req('/api/auth/keys', { headers: { Cookie: otherCookie } }), { id }),
+      { id },
+    )
     expect((asOther as Response).status).toBe(400) // 'Key not found' (scoped)
 
     // owner revokes → verify now 404
-    const revoked = await revokeKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } }), { id }), { id })
+    const revoked = await revokeKey(
+      ctx(req('/api/auth/keys', { headers: { Cookie: cookie } }), { id }),
+      { id },
+    )
     expect((revoked as Response).status).toBe(200)
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(404)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body: JSON.stringify({ secret }),
+              headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(404)
   })
 })
 
 describe('internal verify endpoint', () => {
   it('rejects missing or wrong shared secret', async () => {
     const body = JSON.stringify({ secret: 'ak_anything' })
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body })))).status).toBe(401)
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body, headers: { 'X-Auth-Secret': 'wrong' } })))).status).toBe(401)
+    expect(
+      (await verifyKey(ctx(req('/api/auth/keys/verify', { body })))).status,
+    ).toBe(401)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body,
+              headers: { 'X-Auth-Secret': 'wrong' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(401)
   })
 
   it('returns the Clerk-shaped contract for a valid key', async () => {
     await seedUser()
     const cookie = await sessionCookie('u1')
-    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ secret: string }>
+    const minted = (
+      await createKey(
+        ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+      )
+    ).json() as unknown as Promise<{ secret: string }>
     const { secret } = await minted
 
-    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    const res = await verifyKey(
+      ctx(
+        req('/api/auth/keys/verify', {
+          body: JSON.stringify({ secret }),
+          headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+        }),
+      ),
+    )
     expect(res.status).toBe(200)
-    expect(await res.json()).toMatchObject({ subject: 'u1', revoked: false, expired: false })
+    expect(await res.json()).toMatchObject({
+      subject: 'u1',
+      revoked: false,
+      expired: false,
+    })
   })
 
   it('404s for a key owned by a banned user (ban kills existing keys)', async () => {
     await seedUser()
     const cookie = await sessionCookie('u1')
-    const minted = (await createKey(ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })))).json() as unknown as Promise<{ secret: string }>
+    const minted = (
+      await createKey(
+        ctx(req('/api/auth/keys', { headers: { Cookie: cookie } })),
+      )
+    ).json() as unknown as Promise<{ secret: string }>
     const { secret } = await minted
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body: JSON.stringify({ secret }),
+              headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(200)
 
     // operator bans the account → the key stops verifying immediately
     await setUserBanned(shim, 'u1', true)
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(404)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body: JSON.stringify({ secret }),
+              headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(404)
 
     // unban restores it (flag is a toggle, not a deletion)
     await setUserBanned(shim, 'u1', false)
-    expect((await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))).status).toBe(200)
+    expect(
+      (
+        await verifyKey(
+          ctx(
+            req('/api/auth/keys/verify', {
+              body: JSON.stringify({ secret }),
+              headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+            }),
+          ),
+        )
+      ).status,
+    ).toBe(200)
   })
 
   it('404s for an unknown key', async () => {
-    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret: 'ak_doesnotexist123456789012345678901234' }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    const res = await verifyKey(
+      ctx(
+        req('/api/auth/keys/verify', {
+          body: JSON.stringify({
+            secret: 'ak_doesnotexist123456789012345678901234',
+          }),
+          headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+        }),
+      ),
+    )
     expect(res.status).toBe(404)
   })
 
   it('rejects a missing secret field', async () => {
-    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: '{}', headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    const res = await verifyKey(
+      ctx(
+        req('/api/auth/keys/verify', {
+          body: '{}',
+          headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+        }),
+      ),
+    )
     expect(res.status).toBe(400)
   })
 
   it('handles a literal null body without crashing', async () => {
-    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: 'null', headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    const res = await verifyKey(
+      ctx(
+        req('/api/auth/keys/verify', {
+          body: 'null',
+          headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+        }),
+      ),
+    )
     expect(res.status).toBe(400)
   })
 
   it('rejects malformed secrets early (shape check)', async () => {
-    const res = await verifyKey(ctx(req('/api/auth/keys/verify', { body: JSON.stringify({ secret: 'not-a-key' }), headers: { 'X-Auth-Secret': 'verify-shared-secret' } })))
+    const res = await verifyKey(
+      ctx(
+        req('/api/auth/keys/verify', {
+          body: JSON.stringify({ secret: 'not-a-key' }),
+          headers: { 'X-Auth-Secret': 'verify-shared-secret' },
+        }),
+      ),
+    )
     expect(res.status).toBe(404)
   })
 })

--- a/teeline-web/functions/api/auth/keys.ts
+++ b/teeline-web/functions/api/auth/keys.ts
@@ -18,7 +18,12 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   let name: string | undefined
   try {
     const body = (await request.json()) as { name?: unknown } | null
-    if (typeof body === 'object' && body !== null && typeof body.name === 'string' && body.name.trim()) {
+    if (
+      typeof body === 'object' &&
+      body !== null &&
+      typeof body.name === 'string' &&
+      body.name.trim()
+    ) {
       name = Array.from(body.name.trim()).slice(0, 64).join('')
     }
   } catch (err) {
@@ -37,7 +42,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       createdAt: now,
     })
     const clientIp = request.headers.get('CF-Connecting-IP') ?? null
-    console.log('[audit] api_key_created', JSON.stringify({ keyId: id, userId: auth.userId, ip: clientIp, at: now }))
+    console.log(
+      '[audit] api_key_created',
+      JSON.stringify({ keyId: id, userId: auth.userId, ip: clientIp, at: now }),
+    )
     // `secret` is the only time the plaintext exists — the client must save
     // it now (the UI shows it once until the page is refreshed).
     return json({ id, name: name ?? null, secret, createdAt: now }, 201)

--- a/teeline-web/functions/api/auth/keys/[id].ts
+++ b/teeline-web/functions/api/auth/keys/[id].ts
@@ -6,7 +6,11 @@ import { badRequest, json, serverError } from '../../../lib/http'
 import { requireSession } from '../../../lib/auth'
 import { rateLimit } from '../../../lib/ratelimit'
 
-export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {
+export const onRequestDelete: PagesFunction<Env> = async ({
+  request,
+  env,
+  params,
+}) => {
   const auth = await requireSession(request, env)
   if (auth instanceof Response) return auth
   const limited = await rateLimit(request, env, 'keys-revoke', 60)
@@ -19,7 +23,15 @@ export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params
     const revoked = await revokeKey(env.DB, id, auth.userId)
     if (!revoked) return badRequest('Key not found')
     const clientIp = request.headers.get('CF-Connecting-IP') ?? null
-    console.log('[audit] api_key_revoked', JSON.stringify({ keyId: id, userId: auth.userId, ip: clientIp, at: Date.now() }))
+    console.log(
+      '[audit] api_key_revoked',
+      JSON.stringify({
+        keyId: id,
+        userId: auth.userId,
+        ip: clientIp,
+        at: Date.now(),
+      }),
+    )
     return json({ ok: true })
   } catch (err) {
     console.error('Failed to revoke API key:', err)

--- a/teeline-web/functions/api/auth/keys/verify.ts
+++ b/teeline-web/functions/api/auth/keys/verify.ts
@@ -8,14 +8,22 @@
 //     -d '{"secret":"ak_..."}'
 //   → 200 {subject, revoked:false, expired:false} | 404 unknown/revoked | 401 bad secret
 import type { Env } from '../../../lib/env'
-import { findActiveKeyByHash, timingSafeEqual, touchKeyLastUsed } from '../../../lib/db'
+import {
+  findActiveKeyByHash,
+  timingSafeEqual,
+  touchKeyLastUsed,
+} from '../../../lib/db'
 import { badRequest, json, unauthorized } from '../../../lib/http'
 import { hashSecret, isKeySecretShape } from '../../../lib/keys'
 import { rateLimit } from '../../../lib/ratelimit'
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const presented = request.headers.get('X-Auth-Secret')
-  if (!env.AUTH_SERVICE_SECRET || !presented || !timingSafeEqual(presented, env.AUTH_SERVICE_SECRET)) {
+  if (
+    !env.AUTH_SERVICE_SECRET ||
+    !presented ||
+    !timingSafeEqual(presented, env.AUTH_SERVICE_SECRET)
+  ) {
     return unauthorized()
   }
   // Generous: teeline-api verifies on every request (its own limit is 100 RPM).
@@ -28,9 +36,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   } catch {
     return badRequest('Invalid JSON body')
   }
-  if (!body || typeof body.secret !== 'string') return badRequest('secret is required')
+  if (!body || typeof body.secret !== 'string')
+    return badRequest('secret is required')
   // Early reject of malformed secrets before hashing + DB lookup.
-  if (!isKeySecretShape(body.secret)) return json({ error: 'Unknown or revoked key' }, 404)
+  if (!isKeySecretShape(body.secret))
+    return json({ error: 'Unknown or revoked key' }, 404)
 
   try {
     const hash = await hashSecret(body.secret)

--- a/teeline-web/functions/api/auth/login/begin.ts
+++ b/teeline-web/functions/api/auth/login/begin.ts
@@ -4,7 +4,11 @@
 import { generateAuthenticationOptions } from '@simplewebauthn/server'
 import type { Env } from '../../../lib/env'
 import { insertChallenge } from '../../../lib/db'
-import { CHALLENGE_TTL_MS, isClientOriginAllowed, rpIdFor } from '../../../lib/webauthn'
+import {
+  CHALLENGE_TTL_MS,
+  isClientOriginAllowed,
+  rpIdFor,
+} from '../../../lib/webauthn'
 import { rateLimit } from '../../../lib/ratelimit'
 import { forbidden, json, serverError } from '../../../lib/http'
 

--- a/teeline-web/functions/api/auth/login/complete.ts
+++ b/teeline-web/functions/api/auth/login/complete.ts
@@ -5,20 +5,38 @@
 import { verifyAuthenticationResponse } from '@simplewebauthn/server'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
 import type { Env } from '../../../lib/env'
-import { consumeChallenge, getChallenge, getCredentialById, getUser, updateCredentialCounter } from '../../../lib/db'
-import { isClientOriginAllowed, rpIdFor, serverOrigin } from '../../../lib/webauthn'
+import {
+  consumeChallenge,
+  getChallenge,
+  getCredentialById,
+  getUser,
+  updateCredentialCounter,
+} from '../../../lib/db'
+import {
+  isClientOriginAllowed,
+  rpIdFor,
+  serverOrigin,
+} from '../../../lib/webauthn'
 import { badRequest, forbidden, json, serverError } from '../../../lib/http'
 import { rateLimit } from '../../../lib/ratelimit'
 import { createSessionToken, sessionCookieHeader } from '../../../lib/session'
 
-type AuthenticationResponse = Parameters<typeof verifyAuthenticationResponse>[0]['response']
+type AuthenticationResponse = Parameters<
+  typeof verifyAuthenticationResponse
+>[0]['response']
 
 // Minimal runtime shape check before handing the payload to the verifier
 // (defense-in-depth; the library validates the details).
 function isAuthenticationCredential(v: unknown): v is AuthenticationResponse {
   if (typeof v !== 'object' || v === null) return false
   const c = v as { id?: unknown; response?: unknown }
-  const r = c.response as { clientDataJSON?: unknown; authenticatorData?: unknown; signature?: unknown } | undefined
+  const r = c.response as
+    | {
+        clientDataJSON?: unknown
+        authenticatorData?: unknown
+        signature?: unknown
+      }
+    | undefined
   return (
     typeof c.id === 'string' &&
     typeof r?.clientDataJSON === 'string' &&
@@ -39,7 +57,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   } catch {
     return badRequest('Invalid JSON body')
   }
-  if (typeof body.nonce !== 'string' || !isAuthenticationCredential(body.credential)) {
+  if (
+    typeof body.nonce !== 'string' ||
+    !isAuthenticationCredential(body.credential)
+  ) {
     return badRequest('nonce and credential are required')
   }
   const credentialId = (body.credential as { id: string }).id
@@ -60,7 +81,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   const rpID = rpIdFor(new URL(request.url).hostname)
   // transports type derived from the verifier's expectation (avoids a direct
   // dep on @simplewebauthn/typescript-types for one cast)
-  type Transport = NonNullable<Parameters<typeof verifyAuthenticationResponse>[0]['credential']['transports']>[number]
+  type Transport = NonNullable<
+    Parameters<
+      typeof verifyAuthenticationResponse
+    >[0]['credential']['transports']
+  >[number]
   function safeParseTransports(raw: string): Transport[] | undefined {
     try {
       return JSON.parse(raw) as Transport[]
@@ -79,7 +104,9 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
         id: credential.id,
         publicKey: isoBase64URL.toBuffer(credential.public_key),
         counter: credential.counter,
-        transports: credential.transports ? safeParseTransports(credential.transports) : undefined,
+        transports: credential.transports
+          ? safeParseTransports(credential.transports)
+          : undefined,
       },
     })
   } catch (err) {
@@ -97,7 +124,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
 
     // Counter rollback is the clone-detection signal; SimpleWebAuthn already
     // rejected a lower counter, so persisting the new one is safe and atomic.
-    await updateCredentialCounter(env.DB, credential.id, verification.authenticationInfo.newCounter)
+    await updateCredentialCounter(
+      env.DB,
+      credential.id,
+      verification.authenticationInfo.newCounter,
+    )
 
     // Banned account: the ceremony succeeded but access is denied. The counter
     // is updated above so an eventual unban leaves the credential usable.
@@ -105,7 +136,13 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
 
     const token = await createSessionToken(env.SESSION_SECRET, user.id)
     return json(
-      { user: { id: user.id, displayName: user.display_name, createdAt: user.created_at } },
+      {
+        user: {
+          id: user.id,
+          displayName: user.display_name,
+          createdAt: user.created_at,
+        },
+      },
       200,
       { 'Set-Cookie': sessionCookieHeader(token) },
     )

--- a/teeline-web/functions/api/auth/me.ts
+++ b/teeline-web/functions/api/auth/me.ts
@@ -3,7 +3,12 @@
 import type { Env } from '../../lib/env'
 import { getUser } from '../../lib/db'
 import { json, forbidden, serverError, unauthorized } from '../../lib/http'
-import { createSessionToken, getSessionUser, sessionCookieHeader, shouldRefreshSession } from '../../lib/session'
+import {
+  createSessionToken,
+  getSessionUser,
+  sessionCookieHeader,
+  shouldRefreshSession,
+} from '../../lib/session'
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const session = await getSessionUser(env, request.headers)
@@ -22,12 +27,24 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const headers: Record<string, string> = {}
   if (shouldRefreshSession(session) && env.SESSION_SECRET) {
     try {
-      headers['Set-Cookie'] = sessionCookieHeader(await createSessionToken(env.SESSION_SECRET, user.id))
+      headers['Set-Cookie'] = sessionCookieHeader(
+        await createSessionToken(env.SESSION_SECRET, user.id),
+      )
     } catch (err) {
       // Sliding refresh is best-effort: the existing token stays valid until
       // exp, so a mint failure must not break the response.
       console.error('Session refresh failed:', err)
     }
   }
-  return json({ user: { id: user.id, displayName: user.display_name, createdAt: user.created_at } }, 200, headers)
+  return json(
+    {
+      user: {
+        id: user.id,
+        displayName: user.display_name,
+        createdAt: user.created_at,
+      },
+    },
+    200,
+    headers,
+  )
 }

--- a/teeline-web/functions/api/auth/ratelimit-handler.test.ts
+++ b/teeline-web/functions/api/auth/ratelimit-handler.test.ts
@@ -5,7 +5,10 @@ import Database from 'better-sqlite3'
 import { onRequestPost as registerBegin } from './register/begin'
 
 let shim: D1Like
-const env = { SESSION_SECRET: 'test-session-secret', ALLOWED_ORIGINS: 'http://localhost:8788' } as never
+const env = {
+  SESSION_SECRET: 'test-session-secret',
+  ALLOWED_ORIGINS: 'http://localhost:8788',
+} as never
 
 function ctx(request: Request) {
   return { request, env: { ...env, DB: shim } } as never
@@ -23,7 +26,11 @@ describe('register/begin rate limit', () => {
     const makeReq = (ip: string) =>
       new Request('http://localhost:8788/api/auth/register/begin', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:8788', 'CF-Connecting-IP': ip },
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:8788',
+          'CF-Connecting-IP': ip,
+        },
         body: '{}',
       })
 

--- a/teeline-web/functions/api/auth/register/begin.ts
+++ b/teeline-web/functions/api/auth/register/begin.ts
@@ -5,7 +5,12 @@
 import { generateRegistrationOptions } from '@simplewebauthn/server'
 import type { Env } from '../../../lib/env'
 import { insertChallenge } from '../../../lib/db'
-import { CHALLENGE_TTL_MS, RP_NAME, isClientOriginAllowed, rpIdFor } from '../../../lib/webauthn'
+import {
+  CHALLENGE_TTL_MS,
+  RP_NAME,
+  isClientOriginAllowed,
+  rpIdFor,
+} from '../../../lib/webauthn'
 import { rateLimit } from '../../../lib/ratelimit'
 import { forbidden, json, serverError } from '../../../lib/http'
 

--- a/teeline-web/functions/api/auth/register/complete.ts
+++ b/teeline-web/functions/api/auth/register/complete.ts
@@ -4,13 +4,23 @@
 import { verifyRegistrationResponse } from '@simplewebauthn/server'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
 import type { Env } from '../../../lib/env'
-import { consumeChallenge, createUserWithCredential, getChallenge } from '../../../lib/db'
-import { isClientOriginAllowed, rpIdFor, serverOrigin } from '../../../lib/webauthn'
+import {
+  consumeChallenge,
+  createUserWithCredential,
+  getChallenge,
+} from '../../../lib/db'
+import {
+  isClientOriginAllowed,
+  rpIdFor,
+  serverOrigin,
+} from '../../../lib/webauthn'
 import { badRequest, forbidden, json, serverError } from '../../../lib/http'
 import { rateLimit } from '../../../lib/ratelimit'
 import { createSessionToken, sessionCookieHeader } from '../../../lib/session'
 
-type RegistrationResponse = Parameters<typeof verifyRegistrationResponse>[0]['response']
+type RegistrationResponse = Parameters<
+  typeof verifyRegistrationResponse
+>[0]['response']
 
 // D1/SQLite unique-constraint failures surface as an error whose message
 // contains the constraint name — distinguish "already registered" from a
@@ -25,8 +35,12 @@ function isConstraintViolation(err: unknown): boolean {
 function isRegistrationCredential(v: unknown): v is RegistrationResponse {
   if (typeof v !== 'object' || v === null) return false
   const c = v as { response?: unknown }
-  const r = c.response as { clientDataJSON?: unknown; attestationObject?: unknown } | undefined
-  return typeof r?.clientDataJSON === 'string' && typeof r.attestationObject === 'string'
+  const r = c.response as
+    { clientDataJSON?: unknown; attestationObject?: unknown } | undefined
+  return (
+    typeof r?.clientDataJSON === 'string' &&
+    typeof r.attestationObject === 'string'
+  )
 }
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
@@ -41,7 +55,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   } catch {
     return badRequest('Invalid JSON body')
   }
-  if (typeof body.nonce !== 'string' || !isRegistrationCredential(body.credential)) {
+  if (
+    typeof body.nonce !== 'string' ||
+    !isRegistrationCredential(body.credential)
+  ) {
     return badRequest('nonce and credential are required')
   }
 
@@ -106,7 +123,9 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     // bare 500 (e.g. duplicate credential id, transient DB failure).
     console.error('Failed to create user with credential:', err)
     if (isConstraintViolation(err)) {
-      return badRequest('This passkey is already registered — please log in instead')
+      return badRequest(
+        'This passkey is already registered — please log in instead',
+      )
     }
     return serverError('Failed to complete registration — please try again')
   }
@@ -120,7 +139,12 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     // duplicate registration attempt).
     console.error('Failed to create session token after registration:', err)
     return json(
-      { error: 'Registration succeeded but the session could not be established — please log in.', user: { id: userId }, session_established: false },
+      {
+        error:
+          'Registration succeeded but the session could not be established — please log in.',
+        user: { id: userId },
+        session_established: false,
+      },
       201,
     )
   }

--- a/teeline-web/functions/lib/db.test.ts
+++ b/teeline-web/functions/lib/db.test.ts
@@ -46,7 +46,11 @@ const NOW = 1_752_000_000_000
 
 describe('users', () => {
   it('creates and reads a user', async () => {
-    await createUser(db as never, { id: 'u1', displayName: 'Tim', createdAt: NOW })
+    await createUser(db as never, {
+      id: 'u1',
+      displayName: 'Tim',
+      createdAt: NOW,
+    })
     const u = await getUser(db as never, 'u1')
     expect(u).toMatchObject({ id: 'u1', display_name: 'Tim', created_at: NOW })
   })
@@ -57,8 +61,19 @@ describe('users', () => {
 
   it('deleteUser wipes user, credentials and keys atomically', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
-    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk', counter: 0, createdAt: NOW })
-    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: await hashSecret('ak_x'), createdAt: NOW })
+    await addCredential(db as never, {
+      id: 'c1',
+      userId: 'u1',
+      publicKey: 'pk',
+      counter: 0,
+      createdAt: NOW,
+    })
+    await createApiKey(db as never, {
+      id: 'k1',
+      userId: 'u1',
+      secretHash: await hashSecret('ak_x'),
+      createdAt: NOW,
+    })
     await deleteUser(db as never, 'u1')
     expect(await getUser(db as never, 'u1')).toBeNull()
     expect(await getCredentialById(db as never, 'c1')).toBeNull()
@@ -80,8 +95,21 @@ describe('users', () => {
 describe('credentials', () => {
   it('adds, lists and looks up by id (login path)', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
-    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk1', counter: 1, transports: ['internal'], createdAt: NOW })
-    await addCredential(db as never, { id: 'c2', userId: 'u1', publicKey: 'pk2', counter: 2, createdAt: NOW })
+    await addCredential(db as never, {
+      id: 'c1',
+      userId: 'u1',
+      publicKey: 'pk1',
+      counter: 1,
+      transports: ['internal'],
+      createdAt: NOW,
+    })
+    await addCredential(db as never, {
+      id: 'c2',
+      userId: 'u1',
+      publicKey: 'pk2',
+      counter: 2,
+      createdAt: NOW,
+    })
 
     const byUser = await listCredentialsByUser(db as never, 'u1')
     expect(byUser.map((c) => c.id)).toEqual(['c1', 'c2'])
@@ -94,7 +122,13 @@ describe('credentials', () => {
 
   it('updates the counter atomically', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
-    await addCredential(db as never, { id: 'c1', userId: 'u1', publicKey: 'pk', counter: 0, createdAt: NOW })
+    await addCredential(db as never, {
+      id: 'c1',
+      userId: 'u1',
+      publicKey: 'pk',
+      counter: 0,
+      createdAt: NOW,
+    })
     await updateCredentialCounter(db as never, 'c1', 7)
     expect((await getCredentialById(db as never, 'c1'))?.counter).toBe(7)
   })
@@ -104,7 +138,13 @@ describe('api keys', () => {
   it('creates, lists metadata and finds by hash', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
     const secret = 'ak_abc123'
-    await createApiKey(db as never, { id: 'k1', userId: 'u1', name: 'laptop', secretHash: await hashSecret(secret), createdAt: NOW })
+    await createApiKey(db as never, {
+      id: 'k1',
+      userId: 'u1',
+      name: 'laptop',
+      secretHash: await hashSecret(secret),
+      createdAt: NOW,
+    })
 
     const keys = await listApiKeysByUser(db as never, 'u1')
     expect(keys).toHaveLength(1)
@@ -112,39 +152,71 @@ describe('api keys', () => {
     // secret_hash is present (needed for verify) but callers must never expose it
     expect(keys[0].secret_hash).toBe(await hashSecret(secret))
 
-    const found = await findActiveKeyByHash(db as never, await hashSecret(secret))
+    const found = await findActiveKeyByHash(
+      db as never,
+      await hashSecret(secret),
+    )
     expect(found?.user_id).toBe('u1')
-    expect(await findActiveKeyByHash(db as never, await hashSecret('ak_wrong'))).toBeNull()
+    expect(
+      await findActiveKeyByHash(db as never, await hashSecret('ak_wrong')),
+    ).toBeNull()
   })
 
   it('revoke hides the key from verify immediately, scoped to owner', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
     await createUser(db as never, { id: 'u2', createdAt: NOW })
     const secret = 'ak_xyz'
-    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: await hashSecret(secret), createdAt: NOW })
+    await createApiKey(db as never, {
+      id: 'k1',
+      userId: 'u1',
+      secretHash: await hashSecret(secret),
+      createdAt: NOW,
+    })
 
     // non-owner cannot revoke
     expect(await revokeKey(db as never, 'k1', 'u2')).toBe(false)
-    expect(await findActiveKeyByHash(db as never, await hashSecret(secret))).not.toBeNull()
+    expect(
+      await findActiveKeyByHash(db as never, await hashSecret(secret)),
+    ).not.toBeNull()
 
     // owner revokes → verify path immediately returns nothing
     expect(await revokeKey(db as never, 'k1', 'u1')).toBe(true)
-    expect(await findActiveKeyByHash(db as never, await hashSecret(secret))).toBeNull()
+    expect(
+      await findActiveKeyByHash(db as never, await hashSecret(secret)),
+    ).toBeNull()
   })
 
   it('touchKeyLastUsed records usage', async () => {
     await createUser(db as never, { id: 'u1', createdAt: NOW })
-    await createApiKey(db as never, { id: 'k1', userId: 'u1', secretHash: 'h', createdAt: NOW })
+    await createApiKey(db as never, {
+      id: 'k1',
+      userId: 'u1',
+      secretHash: 'h',
+      createdAt: NOW,
+    })
     await touchKeyLastUsed(db as never, 'k1', 123)
-    expect((await listApiKeysByUser(db as never, 'u1'))[0].last_used_at).toBe(123)
+    expect((await listApiKeysByUser(db as never, 'u1'))[0].last_used_at).toBe(
+      123,
+    )
   })
 })
 
 describe('challenges', () => {
   it('insert, read and single-use consume', async () => {
-    await insertChallenge(db as never, { id: 'ch1', type: 'register', challenge: 'abc', userHandle: 'uh', expiresAt: NOW + 300_000 })
+    await insertChallenge(db as never, {
+      id: 'ch1',
+      type: 'register',
+      challenge: 'abc',
+      userHandle: 'uh',
+      expiresAt: NOW + 300_000,
+    })
     const c = await getChallenge(db as never, 'ch1')
-    expect(c).toMatchObject({ id: 'ch1', type: 'register', challenge: 'abc', user_handle: 'uh' })
+    expect(c).toMatchObject({
+      id: 'ch1',
+      type: 'register',
+      challenge: 'abc',
+      user_handle: 'uh',
+    })
 
     expect(await consumeChallenge(db as never, 'ch1')).toBe(true)
     expect(await consumeChallenge(db as never, 'ch1')).toBe(false) // replay fails
@@ -152,7 +224,13 @@ describe('challenges', () => {
   })
 
   it('login challenge stores a user_id', async () => {
-    await insertChallenge(db as never, { id: 'ch2', type: 'login', challenge: 'def', userId: 'u1', expiresAt: NOW + 300_000 })
+    await insertChallenge(db as never, {
+      id: 'ch2',
+      type: 'login',
+      challenge: 'def',
+      userId: 'u1',
+      expiresAt: NOW + 300_000,
+    })
     expect((await getChallenge(db as never, 'ch2'))?.user_id).toBe('u1')
   })
 })
@@ -175,10 +253,20 @@ describe('crypto helpers', () => {
 
 describe('d1 shim', () => {
   it('first(col) returns a single column value like real D1', async () => {
-    await createUser(db as never, { id: 'u1', displayName: 'Tim', createdAt: NOW })
-    const name = await db.prepare('SELECT id, display_name FROM users WHERE id = ?1').bind('u1').first<{ display_name: string }>('display_name')
+    await createUser(db as never, {
+      id: 'u1',
+      displayName: 'Tim',
+      createdAt: NOW,
+    })
+    const name = await db
+      .prepare('SELECT id, display_name FROM users WHERE id = ?1')
+      .bind('u1')
+      .first<{ display_name: string }>('display_name')
     expect(name).toBe('Tim')
-    const missing = await db.prepare('SELECT id, display_name FROM users WHERE id = ?1').bind('nope').first('display_name')
+    const missing = await db
+      .prepare('SELECT id, display_name FROM users WHERE id = ?1')
+      .bind('nope')
+      .first('display_name')
     expect(missing).toBeNull()
   })
 })

--- a/teeline-web/functions/lib/db.ts
+++ b/teeline-web/functions/lib/db.ts
@@ -51,9 +51,11 @@ const USER_COLS = 'id, display_name, created_at'
 // SELECT list includes the ban flag (INSERTs omit it — the column defaults to 0).
 const USER_SELECT_COLS = 'id, display_name, created_at, banned'
 const CRED_COLS = 'id, user_id, public_key, counter, transports, created_at'
-const KEY_COLS = 'id, user_id, name, secret_hash, created_at, last_used_at, revoked'
+const KEY_COLS =
+  'id, user_id, name, secret_hash, created_at, last_used_at, revoked'
 // Same columns, qualified for the api_keys↔users JOIN in findActiveKeyByHash.
-const KEY_COLS_ALIASED = 'k.id, k.user_id, k.name, k.secret_hash, k.created_at, k.last_used_at, k.revoked'
+const KEY_COLS_ALIASED =
+  'k.id, k.user_id, k.name, k.secret_hash, k.created_at, k.last_used_at, k.revoked'
 
 // ---- Users ---------------------------------------------------------------
 
@@ -67,17 +69,29 @@ export async function createUser(
     .run()
 }
 
-export async function getUser(db: D1Database, id: string): Promise<UserRow | null> {
+export async function getUser(
+  db: D1Database,
+  id: string,
+): Promise<UserRow | null> {
   return (
-    (await db.prepare(`SELECT ${USER_SELECT_COLS} FROM users WHERE id = ?1`).bind(id).first<UserRow>()) ??
-    null
+    (await db
+      .prepare(`SELECT ${USER_SELECT_COLS} FROM users WHERE id = ?1`)
+      .bind(id)
+      .first<UserRow>()) ?? null
   )
 }
 
 // Operator hook: set or clear the ban flag. Returns false when the user
 // doesn't exist. Banned users can't log in and their keys stop verifying.
-export async function setUserBanned(db: D1Database, id: string, banned: boolean): Promise<boolean> {
-  const res = await db.prepare('UPDATE users SET banned = ?1 WHERE id = ?2').bind(banned ? 1 : 0, id).run()
+export async function setUserBanned(
+  db: D1Database,
+  id: string,
+  banned: boolean,
+): Promise<boolean> {
+  const res = await db
+    .prepare('UPDATE users SET banned = ?1 WHERE id = ?2')
+    .bind(banned ? 1 : 0, id)
+    .run()
   return res.meta.changes > 0
 }
 
@@ -105,8 +119,17 @@ export async function addCredential(
   },
 ): Promise<void> {
   await db
-    .prepare(`INSERT INTO credentials (${CRED_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`)
-    .bind(c.id, c.userId, c.publicKey, c.counter, c.transports ? JSON.stringify(c.transports) : null, c.createdAt)
+    .prepare(
+      `INSERT INTO credentials (${CRED_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(
+      c.id,
+      c.userId,
+      c.publicKey,
+      c.counter,
+      c.transports ? JSON.stringify(c.transports) : null,
+      c.createdAt,
+    )
     .run()
 }
 
@@ -115,22 +138,42 @@ export async function addCredential(
 export async function createUserWithCredential(
   db: D1Database,
   user: { id: string; displayName?: string; createdAt: number },
-  credential: { id: string; publicKey: string; counter: number; transports?: string[]; createdAt: number },
+  credential: {
+    id: string
+    publicKey: string
+    counter: number
+    transports?: string[]
+    createdAt: number
+  },
 ): Promise<void> {
   await db.batch([
     db
       .prepare(`INSERT INTO users (${USER_COLS}) VALUES (?1, ?2, ?3)`)
       .bind(user.id, user.displayName ?? null, user.createdAt),
     db
-      .prepare(`INSERT INTO credentials (${CRED_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`)
-      .bind(credential.id, user.id, credential.publicKey, credential.counter, credential.transports ? JSON.stringify(credential.transports) : null, credential.createdAt),
+      .prepare(
+        `INSERT INTO credentials (${CRED_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+      )
+      .bind(
+        credential.id,
+        user.id,
+        credential.publicKey,
+        credential.counter,
+        credential.transports ? JSON.stringify(credential.transports) : null,
+        credential.createdAt,
+      ),
   ])
 }
 
-export async function listCredentialsByUser(db: D1Database, userId: string): Promise<CredentialRow[]> {
+export async function listCredentialsByUser(
+  db: D1Database,
+  userId: string,
+): Promise<CredentialRow[]> {
   return (
     await db
-      .prepare(`SELECT ${CRED_COLS} FROM credentials WHERE user_id = ?1 ORDER BY created_at`)
+      .prepare(
+        `SELECT ${CRED_COLS} FROM credentials WHERE user_id = ?1 ORDER BY created_at`,
+      )
       .bind(userId)
       .all<CredentialRow>()
   ).results
@@ -138,36 +181,61 @@ export async function listCredentialsByUser(db: D1Database, userId: string): Pro
 
 // Discoverable-credential login: the client sends only the credential id, so
 // we look the credential up across all users.
-export async function getCredentialById(db: D1Database, id: string): Promise<CredentialRow | null> {
+export async function getCredentialById(
+  db: D1Database,
+  id: string,
+): Promise<CredentialRow | null> {
   return (
-    (await db.prepare(`SELECT ${CRED_COLS} FROM credentials WHERE id = ?1`).bind(id).first<CredentialRow>()) ??
-    null
+    (await db
+      .prepare(`SELECT ${CRED_COLS} FROM credentials WHERE id = ?1`)
+      .bind(id)
+      .first<CredentialRow>()) ?? null
   )
 }
 
 // Single-statement update = atomic; prevents lost counter increments under
 // concurrent assertions (the counter is the anti-clone bookkeeping).
-export async function updateCredentialCounter(db: D1Database, id: string, counter: number): Promise<void> {
-  await db.prepare('UPDATE credentials SET counter = ?1 WHERE id = ?2').bind(counter, id).run()
+export async function updateCredentialCounter(
+  db: D1Database,
+  id: string,
+  counter: number,
+): Promise<void> {
+  await db
+    .prepare('UPDATE credentials SET counter = ?1 WHERE id = ?2')
+    .bind(counter, id)
+    .run()
 }
 
 // ---- API keys ------------------------------------------------------------
 
 export async function createApiKey(
   db: D1Database,
-  k: { id: string; userId: string; name?: string; secretHash: string; createdAt: number },
+  k: {
+    id: string
+    userId: string
+    name?: string
+    secretHash: string
+    createdAt: number
+  },
 ): Promise<void> {
   await db
-    .prepare(`INSERT INTO api_keys (${KEY_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, NULL, 0)`)
+    .prepare(
+      `INSERT INTO api_keys (${KEY_COLS}) VALUES (?1, ?2, ?3, ?4, ?5, NULL, 0)`,
+    )
     .bind(k.id, k.userId, k.name ?? null, k.secretHash, k.createdAt)
     .run()
 }
 
 // Metadata only — the secret itself is never stored, so it can never be listed.
-export async function listApiKeysByUser(db: D1Database, userId: string): Promise<ApiKeyRow[]> {
+export async function listApiKeysByUser(
+  db: D1Database,
+  userId: string,
+): Promise<ApiKeyRow[]> {
   return (
     await db
-      .prepare(`SELECT ${KEY_COLS} FROM api_keys WHERE user_id = ?1 ORDER BY created_at DESC`)
+      .prepare(
+        `SELECT ${KEY_COLS} FROM api_keys WHERE user_id = ?1 ORDER BY created_at DESC`,
+      )
       .bind(userId)
       .all<ApiKeyRow>()
   ).results
@@ -177,7 +245,10 @@ export async function listApiKeysByUser(db: D1Database, userId: string): Promise
 // flag, effective immediately — no cache to invalidate). Also invisible: keys
 // owned by a banned user — banning an account kills its existing keys in the
 // same query, no per-key bookkeeping.
-export async function findActiveKeyByHash(db: D1Database, secretHash: string): Promise<ApiKeyRow | null> {
+export async function findActiveKeyByHash(
+  db: D1Database,
+  secretHash: string,
+): Promise<ApiKeyRow | null> {
   return (
     (await db
       .prepare(
@@ -191,7 +262,11 @@ export async function findActiveKeyByHash(db: D1Database, secretHash: string): P
 }
 
 // Scoped to the key's owner so one user can't revoke another's key.
-export async function revokeKey(db: D1Database, id: string, userId: string): Promise<boolean> {
+export async function revokeKey(
+  db: D1Database,
+  id: string,
+  userId: string,
+): Promise<boolean> {
   const res = await db
     .prepare('UPDATE api_keys SET revoked = 1 WHERE id = ?1 AND user_id = ?2')
     .bind(id, userId)
@@ -199,8 +274,15 @@ export async function revokeKey(db: D1Database, id: string, userId: string): Pro
   return res.meta.changes > 0
 }
 
-export async function touchKeyLastUsed(db: D1Database, id: string, at: number = Date.now()): Promise<void> {
-  await db.prepare('UPDATE api_keys SET last_used_at = ?1 WHERE id = ?2').bind(at, id).run()
+export async function touchKeyLastUsed(
+  db: D1Database,
+  id: string,
+  at: number = Date.now(),
+): Promise<void> {
+  await db
+    .prepare('UPDATE api_keys SET last_used_at = ?1 WHERE id = ?2')
+    .bind(at, id)
+    .run()
 }
 
 // ---- Challenges ----------------------------------------------------------
@@ -217,23 +299,43 @@ export async function insertChallenge(
   },
 ): Promise<void> {
   await db
-    .prepare('INSERT INTO challenges (id, type, challenge, user_id, user_handle, expires_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)')
-    .bind(c.id, c.type, c.challenge, c.userId ?? null, c.userHandle ?? null, c.expiresAt)
+    .prepare(
+      'INSERT INTO challenges (id, type, challenge, user_id, user_handle, expires_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)',
+    )
+    .bind(
+      c.id,
+      c.type,
+      c.challenge,
+      c.userId ?? null,
+      c.userHandle ?? null,
+      c.expiresAt,
+    )
     .run()
 }
 
-export async function getChallenge(db: D1Database, id: string): Promise<ChallengeRow | null> {
+export async function getChallenge(
+  db: D1Database,
+  id: string,
+): Promise<ChallengeRow | null> {
   return (
     (await db
-      .prepare('SELECT id, type, challenge, user_id, user_handle, expires_at FROM challenges WHERE id = ?1')
+      .prepare(
+        'SELECT id, type, challenge, user_id, user_handle, expires_at FROM challenges WHERE id = ?1',
+      )
       .bind(id)
       .first<ChallengeRow>()) ?? null
   )
 }
 
 // Single-use: DELETE is the consume step; returns false on a second attempt.
-export async function consumeChallenge(db: D1Database, id: string): Promise<boolean> {
-  const res = await db.prepare('DELETE FROM challenges WHERE id = ?1').bind(id).run()
+export async function consumeChallenge(
+  db: D1Database,
+  id: string,
+): Promise<boolean> {
+  const res = await db
+    .prepare('DELETE FROM challenges WHERE id = ?1')
+    .bind(id)
+    .run()
   return res.meta.changes > 0
 }
 
@@ -242,8 +344,13 @@ export async function consumeChallenge(db: D1Database, id: string): Promise<bool
 // SHA-256 hex of a secret. API keys are stored hashed; the plaintext exists
 // only in the one HTTPS response that mints it.
 export async function hashSecret(secret: string): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret))
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('')
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(secret),
+  )
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
 }
 
 // Constant-time comparison for equal-length strings (hash comparison — we

--- a/teeline-web/functions/lib/http.ts
+++ b/teeline-web/functions/lib/http.ts
@@ -1,6 +1,10 @@
 // Small HTTP helpers shared by the auth Pages Functions.
 
-export function json(data: unknown, status = 200, headers: Record<string, string> = {}): Response {
+export function json(
+  data: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: {

--- a/teeline-web/functions/lib/keys.ts
+++ b/teeline-web/functions/lib/keys.ts
@@ -14,7 +14,10 @@ export function generateKeySecret(): string {
   crypto.getRandomValues(bytes)
   let bin = ''
   for (const b of bytes) bin += String.fromCharCode(b)
-  const b64 = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  const b64 = btoa(bin)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
   return `ak_${b64}`
 }
 

--- a/teeline-web/functions/lib/ratelimit.test.ts
+++ b/teeline-web/functions/lib/ratelimit.test.ts
@@ -18,32 +18,79 @@ const NOW = 1_752_000_000_000
 describe('checkRateLimit', () => {
   it('allows up to the limit, then denies within the same window', async () => {
     for (let i = 1; i <= 3; i++) {
-      const r = await checkRateLimit(db, '1.2.3.4', 'login-begin', 3, 60_000, NOW)
+      const r = await checkRateLimit(
+        db,
+        '1.2.3.4',
+        'login-begin',
+        3,
+        60_000,
+        NOW,
+      )
       expect(r.allowed).toBe(true)
     }
-    const denied = await checkRateLimit(db, '1.2.3.4', 'login-begin', 3, 60_000, NOW)
+    const denied = await checkRateLimit(
+      db,
+      '1.2.3.4',
+      'login-begin',
+      3,
+      60_000,
+      NOW,
+    )
     expect(denied.allowed).toBe(false)
     expect(denied.retryAfterSeconds).toBeGreaterThan(0)
   })
 
   it('tracks different scopes and IPs independently', async () => {
     await checkRateLimit(db, '1.1.1.1', 'register-begin', 1, 60_000, NOW)
-    expect((await checkRateLimit(db, '1.1.1.1', 'login-begin', 1, 60_000, NOW)).allowed).toBe(true)
-    expect((await checkRateLimit(db, '2.2.2.2', 'register-begin', 1, 60_000, NOW)).allowed).toBe(true)
-    expect((await checkRateLimit(db, '1.1.1.1', 'register-begin', 1, 60_000, NOW)).allowed).toBe(false)
+    expect(
+      (await checkRateLimit(db, '1.1.1.1', 'login-begin', 1, 60_000, NOW))
+        .allowed,
+    ).toBe(true)
+    expect(
+      (await checkRateLimit(db, '2.2.2.2', 'register-begin', 1, 60_000, NOW))
+        .allowed,
+    ).toBe(true)
+    expect(
+      (await checkRateLimit(db, '1.1.1.1', 'register-begin', 1, 60_000, NOW))
+        .allowed,
+    ).toBe(false)
   })
 
   it('resets the counter in a new window', async () => {
     await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW)
-    expect((await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW)).allowed).toBe(false)
-    expect((await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW + 60_000)).allowed).toBe(true)
+    expect(
+      (await checkRateLimit(db, '1.2.3.4', 'keys-verify', 1, 60_000, NOW))
+        .allowed,
+    ).toBe(false)
+    expect(
+      (
+        await checkRateLimit(
+          db,
+          '1.2.3.4',
+          'keys-verify',
+          1,
+          60_000,
+          NOW + 60_000,
+        )
+      ).allowed,
+    ).toBe(true)
   })
 
   it('cleanupRateLimits removes expired windows only', async () => {
-    await checkRateLimit(db, '1.2.3.4', 'scope', 5, 60_000, NOW - 48 * 3600 * 1000) // window older than the 24h cleanup threshold
+    await checkRateLimit(
+      db,
+      '1.2.3.4',
+      'scope',
+      5,
+      60_000,
+      NOW - 48 * 3600 * 1000,
+    ) // window older than the 24h cleanup threshold
     await checkRateLimit(db, '1.2.3.4', 'scope', 5, 60_000, NOW) // current window
     await cleanupRateLimits(db, NOW)
-    const rows = await db.prepare('SELECT count FROM rate_limits').bind().all<{ count: number }>()
+    const rows = await db
+      .prepare('SELECT count FROM rate_limits')
+      .bind()
+      .all<{ count: number }>()
     expect(rows.results).toHaveLength(1)
   })
 })

--- a/teeline-web/functions/lib/ratelimit.ts
+++ b/teeline-web/functions/lib/ratelimit.ts
@@ -38,21 +38,34 @@ export async function checkRateLimit(
     db.prepare('SELECT count FROM rate_limits WHERE key = ?1').bind(key),
   ])
 
-  const row = (results[1] as { results: { count: number }[] }).results[0] ?? undefined
+  const row =
+    (results[1] as { results: { count: number }[] }).results[0] ?? undefined
   if (!row) {
     // INSERT succeeded but the row isn't visible — unexpected; don't mask it.
-    console.warn('[rate-limit] INSERT succeeded but SELECT returned no row for key:', key)
+    console.warn(
+      '[rate-limit] INSERT succeeded but SELECT returned no row for key:',
+      key,
+    )
   }
   const count = row?.count ?? 1
   return {
     allowed: count <= limit,
-    retryAfterSeconds: Math.max(1, Math.ceil((windowStart + windowMs - now) / 1000)),
+    retryAfterSeconds: Math.max(
+      1,
+      Math.ceil((windowStart + windowMs - now) / 1000),
+    ),
   }
 }
 
 /** Opportunistic cleanup of expired windows — call occasionally, never block. */
-export async function cleanupRateLimits(db: D1Database, now: number = Date.now()): Promise<void> {
-  await db.prepare('DELETE FROM rate_limits WHERE window_start < ?1').bind(now - 24 * 3600 * 1000).run()
+export async function cleanupRateLimits(
+  db: D1Database,
+  now: number = Date.now(),
+): Promise<void> {
+  await db
+    .prepare('DELETE FROM rate_limits WHERE window_start < ?1')
+    .bind(now - 24 * 3600 * 1000)
+    .run()
 }
 
 /**
@@ -77,18 +90,28 @@ export async function rateLimit(
 
   // ~1% of requests also sweep stale windows, regardless of allow/deny.
   if (Math.random() < 0.01) {
-    cleanupRateLimits(env.DB).catch((err) => console.error('[rate-limit] cleanup failed:', err))
+    cleanupRateLimits(env.DB).catch((err) =>
+      console.error('[rate-limit] cleanup failed:', err),
+    )
   }
 
   let allowed: boolean
   let retryAfterSeconds: number
   try {
-    ;({ allowed, retryAfterSeconds } = await checkRateLimit(env.DB, ip, scope, limit, windowMs))
+    ;({ allowed, retryAfterSeconds } = await checkRateLimit(
+      env.DB,
+      ip,
+      scope,
+      limit,
+      windowMs,
+    ))
   } catch (err) {
     console.error('[rate-limit] D1 error, failing open:', err)
     return null
   }
 
   if (allowed) return null
-  return json({ error: 'Too many requests' }, 429, { 'Retry-After': String(retryAfterSeconds) })
+  return json({ error: 'Too many requests' }, 429, {
+    'Retry-After': String(retryAfterSeconds),
+  })
 }

--- a/teeline-web/functions/lib/session.test.ts
+++ b/teeline-web/functions/lib/session.test.ts
@@ -17,7 +17,11 @@ describe('session tokens', () => {
   it('round-trips a token', async () => {
     const token = await createSessionToken(SECRET, 'u1', NOW)
     const payload = await readSessionToken(SECRET, token)
-    expect(payload).toMatchObject({ sub: 'u1', iat: NOW, exp: NOW + 30 * 24 * 3600 * 1000 })
+    expect(payload).toMatchObject({
+      sub: 'u1',
+      iat: NOW,
+      exp: NOW + 30 * 24 * 3600 * 1000,
+    })
   })
 
   it('rejects a tampered token', async () => {

--- a/teeline-web/functions/lib/session.ts
+++ b/teeline-web/functions/lib/session.ts
@@ -24,7 +24,9 @@ function b64urlEncode(bytes: Uint8Array): string {
 }
 
 function b64urlDecode(s: string): Uint8Array {
-  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (s.length % 4)) % 4)
+  const b64 =
+    s.replace(/-/g, '+').replace(/_/g, '/') +
+    '='.repeat((4 - (s.length % 4)) % 4)
   const bin = atob(b64)
   const out = new Uint8Array(bin.length)
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
@@ -39,11 +41,21 @@ async function hmacSha256Hex(secret: string, data: string): Promise<string> {
     false,
     ['sign'],
   )
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data))
-  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('')
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(data),
+  )
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
 }
 
-export async function createSessionToken(secret: string, sub: string, now: number = Date.now()): Promise<string> {
+export async function createSessionToken(
+  secret: string,
+  sub: string,
+  now: number = Date.now(),
+): Promise<string> {
   const payload: SessionPayload = { sub, iat: now, exp: now + SESSION_TTL_MS }
   const body = b64urlEncode(new TextEncoder().encode(JSON.stringify(payload)))
   const sig = await hmacSha256Hex(secret, body)
@@ -65,8 +77,15 @@ export async function readSessionToken(
   try {
     const expected = await hmacSha256Hex(secret, body)
     if (!timingSafeEqual(sig, expected)) return null
-    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(body))) as SessionPayload
-    if (typeof payload.sub !== 'string' || typeof payload.iat !== 'number' || typeof payload.exp !== 'number') return null
+    const payload = JSON.parse(
+      new TextDecoder().decode(b64urlDecode(body)),
+    ) as SessionPayload
+    if (
+      typeof payload.sub !== 'string' ||
+      typeof payload.iat !== 'number' ||
+      typeof payload.exp !== 'number'
+    )
+      return null
     if (payload.exp <= now) return null
     return payload
   } catch {
@@ -74,13 +93,19 @@ export async function readSessionToken(
   }
 }
 
-export function shouldRefreshSession(payload: SessionPayload, now: number = Date.now()): boolean {
+export function shouldRefreshSession(
+  payload: SessionPayload,
+  now: number = Date.now(),
+): boolean {
   return payload.exp - now < SLIDING_AFTER_MS
 }
 
 // ---- Cookie helpers ------------------------------------------------------
 
-export function sessionCookieHeader(token: string, maxAgeSeconds: number = SESSION_TTL_MS / 1000): string {
+export function sessionCookieHeader(
+  token: string,
+  maxAgeSeconds: number = SESSION_TTL_MS / 1000,
+): string {
   return `${SESSION_COOKIE}=${token}; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=${maxAgeSeconds}`
 }
 
@@ -88,7 +113,10 @@ export function clearSessionCookieHeader(): string {
   return `${SESSION_COOKIE}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0`
 }
 
-export function readCookie(headerValue: string | null, name: string): string | null {
+export function readCookie(
+  headerValue: string | null,
+  name: string,
+): string | null {
   if (!headerValue) return null
   for (const part of headerValue.split(';')) {
     const eq = part.indexOf('=')
@@ -99,7 +127,13 @@ export function readCookie(headerValue: string | null, name: string): string | n
 }
 
 // Resolves the current session from the request's Cookie header.
-export async function getSessionUser(env: Env, headers: Headers): Promise<SessionPayload | null> {
+export async function getSessionUser(
+  env: Env,
+  headers: Headers,
+): Promise<SessionPayload | null> {
   if (!env.SESSION_SECRET) return null
-  return readSessionToken(env.SESSION_SECRET, readCookie(headers.get('Cookie'), SESSION_COOKIE))
+  return readSessionToken(
+    env.SESSION_SECRET,
+    readCookie(headers.get('Cookie'), SESSION_COOKIE),
+  )
 }

--- a/teeline-web/functions/lib/test/sqlite-d1.ts
+++ b/teeline-web/functions/lib/test/sqlite-d1.ts
@@ -29,7 +29,13 @@ export type D1Like = {
       run(): { meta: { changes: number; last_row_id: number } }
     }
   }
-  batch(stmts: { _isSelect?: boolean; all?<T>(): { results: T[] }; run?(): { meta: { changes: number } } }[]): unknown[]
+  batch(
+    stmts: {
+      _isSelect?: boolean
+      all?<T>(): { results: T[] }
+      run?(): { meta: { changes: number } }
+    }[],
+  ): unknown[]
 }
 
 export function makeD1(db: Database.Database): D1Like {
@@ -55,7 +61,8 @@ export function makeD1(db: Database.Database): D1Like {
           return {
             _isSelect: isSelect,
             first<T>(col?: string): T | null {
-              const row = stmt.get(...params) as Record<string, unknown> | undefined
+              const row = stmt.get(...params) as
+                Record<string, unknown> | undefined
               if (row === undefined) return null
               if (col !== undefined) return (row[col] as T | undefined) ?? null
               return row as T
@@ -65,14 +72,21 @@ export function makeD1(db: Database.Database): D1Like {
             },
             run() {
               const info = stmt.run(...params)
-              return { meta: { changes: info.changes, last_row_id: info.lastInsertRowid as number } }
+              return {
+                meta: {
+                  changes: info.changes,
+                  last_row_id: info.lastInsertRowid as number,
+                },
+              }
             },
           }
         },
       }
     },
     batch(stmts) {
-      return db.transaction(() => stmts.map((s) => (s._isSelect ? s.all() : s.run())))()
+      return db.transaction(() =>
+        stmts.map((s) => (s._isSelect ? s.all() : s.run())),
+      )()
     },
   }
 }

--- a/teeline-web/functions/lib/webauthn.test.ts
+++ b/teeline-web/functions/lib/webauthn.test.ts
@@ -1,6 +1,12 @@
 // WebAuthn origin/rpID policy tests.
 import { describe, expect, it } from 'vitest'
-import { clientOrigin, isAllowedOrigin, isClientOriginAllowed, rpIdFor, serverOrigin } from './webauthn'
+import {
+  clientOrigin,
+  isAllowedOrigin,
+  isClientOriginAllowed,
+  rpIdFor,
+  serverOrigin,
+} from './webauthn'
 import type { Env } from './env'
 
 const baseEnv = { DB: null as never } as Env
@@ -33,21 +39,32 @@ describe('isAllowedOrigin', () => {
 
   it('rejects unknown remote origins', () => {
     expect(isAllowedOrigin('https://evil.com', baseEnv)).toBe(false)
-    expect(isAllowedOrigin('https://tspsolver.com.evil.com', baseEnv)).toBe(false)
+    expect(isAllowedOrigin('https://tspsolver.com.evil.com', baseEnv)).toBe(
+      false,
+    )
     expect(isAllowedOrigin('http://localhost.evil.com', baseEnv)).toBe(false)
   })
 
   it('honours ALLOWED_ORIGINS extras (preview deploys etc.)', () => {
-    const env = { ...baseEnv, ALLOWED_ORIGINS: 'https://preview.teeline-web.pages.dev' }
-    expect(isAllowedOrigin('https://preview.teeline-web.pages.dev', env)).toBe(true)
+    const env = {
+      ...baseEnv,
+      ALLOWED_ORIGINS: 'https://preview.teeline-web.pages.dev',
+    }
+    expect(isAllowedOrigin('https://preview.teeline-web.pages.dev', env)).toBe(
+      true,
+    )
     expect(isAllowedOrigin('https://other.pages.dev', env)).toBe(false)
   })
 })
 
 describe('serverOrigin', () => {
   it('derives the destination origin from the request URL (WebAuthn expectedOrigin)', () => {
-    expect(serverOrigin(new Request('https://tspsolver.com/api/auth/me'))).toBe('https://tspsolver.com')
-    expect(serverOrigin(new Request('http://localhost:8788/api/auth/login/begin'))).toBe('http://localhost:8788')
+    expect(serverOrigin(new Request('https://tspsolver.com/api/auth/me'))).toBe(
+      'https://tspsolver.com',
+    )
+    expect(
+      serverOrigin(new Request('http://localhost:8788/api/auth/login/begin')),
+    ).toBe('http://localhost:8788')
   })
 })
 
@@ -55,7 +72,10 @@ describe('clientOrigin / CSRF helper', () => {
   it('prefers the Origin header', () => {
     const req = new Request('https://tspsolver.com/api/auth/logout', {
       method: 'POST',
-      headers: { Origin: 'https://tspsolver.com', Referer: 'https://evil.com/x' },
+      headers: {
+        Origin: 'https://tspsolver.com',
+        Referer: 'https://evil.com/x',
+      },
     })
     expect(clientOrigin(req)).toBe('https://tspsolver.com')
     expect(isClientOriginAllowed(req, baseEnv)).toBe(true)
@@ -70,7 +90,9 @@ describe('clientOrigin / CSRF helper', () => {
   })
 
   it('returns null with neither header, and the origin check rejects', () => {
-    const req = new Request('https://tspsolver.com/api/auth/logout', { method: 'POST' })
+    const req = new Request('https://tspsolver.com/api/auth/logout', {
+      method: 'POST',
+    })
     expect(clientOrigin(req)).toBeNull()
     expect(isClientOriginAllowed(req, baseEnv)).toBe(false)
   })

--- a/teeline-web/functions/lib/webauthn.ts
+++ b/teeline-web/functions/lib/webauthn.ts
@@ -20,13 +20,17 @@ export const CHALLENGE_TTL_MS = 5 * 60 * 1000
 
 export function rpIdFor(hostname: string): string {
   const h = hostname.toLowerCase()
-  if (h === 'tspsolver.com' || h.endsWith('.tspsolver.com')) return 'tspsolver.com'
+  if (h === 'tspsolver.com' || h.endsWith('.tspsolver.com'))
+    return 'tspsolver.com'
   return h
 }
 
 export function isAllowedOrigin(origin: string, env: Env): boolean {
   if (origin === 'https://tspsolver.com') return true
-  const extra = env.ALLOWED_ORIGINS?.split(',').map((s) => s.trim()).filter(Boolean) ?? []
+  const extra =
+    env.ALLOWED_ORIGINS?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean) ?? []
   // Local dev origins (http://localhost / 127.0.0.1) are allowed only when
   // explicitly listed in ALLOWED_ORIGINS (e.g. via .dev.vars) — no blanket
   // allowance, so a misconfigured shared/staging environment can't inherit it.

--- a/teeline-web/functions/tunnel.js
+++ b/teeline-web/functions/tunnel.js
@@ -13,7 +13,10 @@ export async function onRequest({ request }) {
     const header = JSON.parse(body.split('\n')[0])
     const dsn = new URL(header.dsn)
     const projectId = dsn.pathname.replace('/', '')
-    if (dsn.hostname !== SENTRY_HOST || !ALLOWED_PROJECT_IDS.includes(projectId)) {
+    if (
+      dsn.hostname !== SENTRY_HOST ||
+      !ALLOWED_PROJECT_IDS.includes(projectId)
+    ) {
       return new Response('Forbidden', { status: 403 })
     }
     return fetch(`https://${SENTRY_HOST}/api/${projectId}/envelope/`, {

--- a/teeline-web/package-lock.json
+++ b/teeline-web/package-lock.json
@@ -30,6 +30,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
         "better-sqlite3": "13.0.3",
+        "prettier": "^3.9.6",
         "typescript": "6.0.3",
         "vitest": "5.0.0",
         "wrangler": "4.129.0"
@@ -5096,6 +5097,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -8,6 +8,8 @@
     "build": "astro check && tsc --noEmit && astro build && node scripts/copy-wasm.mjs",
     "build:check": "astro check && tsc --noEmit && astro build",
     "preview": "astro preview",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
@@ -36,6 +38,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
     "better-sqlite3": "13.0.3",
+    "prettier": "^3.9.6",
     "typescript": "6.0.3",
     "vitest": "5.0.0",
     "wrangler": "4.129.0"

--- a/teeline-web/scripts/copy-wasm.mjs
+++ b/teeline-web/scripts/copy-wasm.mjs
@@ -12,15 +12,21 @@ const distAssets = 'dist/assets'
 const pkgDir = 'node_modules/teeline-wasm'
 
 if (!existsSync(pkgDir)) {
-  console.error('[copy-wasm] ERROR: node_modules/teeline-wasm not found — run npm ci after jco transpile')
+  console.error(
+    '[copy-wasm] ERROR: node_modules/teeline-wasm not found — run npm ci after jco transpile',
+  )
   process.exit(1)
 }
 
 const wasmFiles = readdirSync(pkgDir).filter((f) => f.endsWith('.wasm'))
 
 if (wasmFiles.length === 0) {
-  console.error('[copy-wasm] ERROR: no .wasm files in node_modules/teeline-wasm')
-  console.error('[copy-wasm] Ensure deploy-web.yml runs: jco transpile ... --name teeline_wasm -o ../teeline-wasm/js-bindings')
+  console.error(
+    '[copy-wasm] ERROR: no .wasm files in node_modules/teeline-wasm',
+  )
+  console.error(
+    '[copy-wasm] Ensure deploy-web.yml runs: jco transpile ... --name teeline_wasm -o ../teeline-wasm/js-bindings',
+  )
   process.exit(1)
 }
 

--- a/teeline-web/src/auth/api.test.ts
+++ b/teeline-web/src/auth/api.test.ts
@@ -8,13 +8,18 @@ afterEach(() => {
 
 function stubFetch(status: number, body: unknown) {
   const res = new Response(JSON.stringify(body), { status })
-  vi.stubGlobal('fetch', vi.fn(async () => res))
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => res),
+  )
 }
 
 describe('apiFetch', () => {
   it('returns parsed JSON on success', async () => {
     stubFetch(200, { ok: true })
-    await expect(apiFetch<{ ok: boolean }>('/api/auth/me')).resolves.toEqual({ ok: true })
+    await expect(apiFetch<{ ok: boolean }>('/api/auth/me')).resolves.toEqual({
+      ok: true,
+    })
   })
 
   it('sends same-origin credentials and JSON content type', async () => {
@@ -23,7 +28,9 @@ describe('apiFetch', () => {
     const [url, init] = vi.mocked(fetch).mock.calls[0]
     expect(url).toBe('/api/auth/keys')
     expect((init as RequestInit).credentials).toBe('same-origin')
-    expect(((init as RequestInit).headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(
+      ((init as RequestInit).headers as Record<string, string>)['Content-Type'],
+    ).toBe('application/json')
   })
 
   it('throws ApiError with the server error message', async () => {

--- a/teeline-web/src/auth/api.ts
+++ b/teeline-web/src/auth/api.ts
@@ -12,7 +12,10 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+export async function apiFetch<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
   // Destructure `credentials` out so callers cannot override the same-origin
   // policy enforced below (see header comment).
   const { headers, credentials: _enforced, ...rest } = init

--- a/teeline-web/src/auth/webauthn.test.ts
+++ b/teeline-web/src/auth/webauthn.test.ts
@@ -16,41 +16,85 @@ afterEach(() => {
 
 // fetch stub: route begin/complete based on the URL
 function stubAuthFetch() {
-  vi.stubGlobal('fetch', vi.fn(async (input: string) => {
-    const path = String(input)
-    if (path.endsWith('/register/begin')) {
-      return new Response(JSON.stringify({ options: { challenge: 'reg-challenge' }, nonce: 'n1' }), { status: 201 })
-    }
-    if (path.endsWith('/register/complete')) {
-      return new Response(JSON.stringify({ user: { id: 'u1', displayName: null, createdAt: 1 } }), { status: 201 })
-    }
-    if (path.endsWith('/login/begin')) {
-      return new Response(JSON.stringify({ options: { challenge: 'login-challenge' }, nonce: 'n2' }), { status: 201 })
-    }
-    if (path.endsWith('/login/complete')) {
-      return new Response(JSON.stringify({ user: { id: 'u1', displayName: 'Tim', createdAt: 1 } }), { status: 200 })
-    }
-    if (path.endsWith('/me')) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
-    }
-    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 })
-  }))
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string) => {
+      const path = String(input)
+      if (path.endsWith('/register/begin')) {
+        return new Response(
+          JSON.stringify({
+            options: { challenge: 'reg-challenge' },
+            nonce: 'n1',
+          }),
+          { status: 201 },
+        )
+      }
+      if (path.endsWith('/register/complete')) {
+        return new Response(
+          JSON.stringify({
+            user: { id: 'u1', displayName: null, createdAt: 1 },
+          }),
+          { status: 201 },
+        )
+      }
+      if (path.endsWith('/login/begin')) {
+        return new Response(
+          JSON.stringify({
+            options: { challenge: 'login-challenge' },
+            nonce: 'n2',
+          }),
+          { status: 201 },
+        )
+      }
+      if (path.endsWith('/login/complete')) {
+        return new Response(
+          JSON.stringify({
+            user: { id: 'u1', displayName: 'Tim', createdAt: 1 },
+          }),
+          { status: 200 },
+        )
+      }
+      if (path.endsWith('/me')) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+        })
+      }
+      return new Response(JSON.stringify({ error: 'not found' }), {
+        status: 404,
+      })
+    }),
+  )
 }
 
 describe('registerPasskey', () => {
   it('runs begin → startRegistration → complete and returns the user', async () => {
     stubAuthFetch()
-    mocks.startRegistration.mockResolvedValue({ id: 'cred-1', rawId: 'raw', type: 'public-key', response: { clientDataJSON: 'c', attestationObject: 'a' }, clientExtensionResults: {} })
+    mocks.startRegistration.mockResolvedValue({
+      id: 'cred-1',
+      rawId: 'raw',
+      type: 'public-key',
+      response: { clientDataJSON: 'c', attestationObject: 'a' },
+      clientExtensionResults: {},
+    })
     const user = await registerPasskey('Tim')
     expect(user).toMatchObject({ id: 'u1' })
     expect(mocks.startRegistration).toHaveBeenCalledTimes(1)
-    expect(mocks.startRegistration.mock.calls[0][0].optionsJSON.challenge).toBe('reg-challenge')
+    expect(mocks.startRegistration.mock.calls[0][0].optionsJSON.challenge).toBe(
+      'reg-challenge',
+    )
   })
 
   it('maps user cancellation to a friendly error', async () => {
     stubAuthFetch()
-    mocks.startRegistration.mockRejectedValue(new DOMException('The operation either timed out or was not allowed.', 'NotAllowedError'))
-    await expect(registerPasskey()).rejects.toThrow('Passkey creation was cancelled')
+    mocks.startRegistration.mockRejectedValue(
+      new DOMException(
+        'The operation either timed out or was not allowed.',
+        'NotAllowedError',
+      ),
+    )
+    await expect(registerPasskey()).rejects.toThrow(
+      'Passkey creation was cancelled',
+    )
   })
 
   it('maps unexpected failures to a generic error', async () => {
@@ -63,17 +107,29 @@ describe('registerPasskey', () => {
 describe('loginWithPasskey', () => {
   it('runs begin → startAuthentication → complete and returns the user', async () => {
     stubAuthFetch()
-    mocks.startAuthentication.mockResolvedValue({ id: 'cred-1', rawId: 'raw', type: 'public-key', response: { clientDataJSON: 'c', authenticatorData: 'a', signature: 's' }, clientExtensionResults: {} })
+    mocks.startAuthentication.mockResolvedValue({
+      id: 'cred-1',
+      rawId: 'raw',
+      type: 'public-key',
+      response: { clientDataJSON: 'c', authenticatorData: 'a', signature: 's' },
+      clientExtensionResults: {},
+    })
     const user = await loginWithPasskey()
     expect(user).toMatchObject({ id: 'u1', displayName: 'Tim' })
     expect(mocks.startAuthentication).toHaveBeenCalledTimes(1)
-    expect(mocks.startAuthentication.mock.calls[0][0].optionsJSON.challenge).toBe('login-challenge')
+    expect(
+      mocks.startAuthentication.mock.calls[0][0].optionsJSON.challenge,
+    ).toBe('login-challenge')
   })
 
   it('maps user cancellation to a friendly error', async () => {
     stubAuthFetch()
-    mocks.startAuthentication.mockRejectedValue(new DOMException('aborted', 'AbortError'))
-    await expect(loginWithPasskey()).rejects.toThrow('Passkey sign-in was cancelled')
+    mocks.startAuthentication.mockRejectedValue(
+      new DOMException('aborted', 'AbortError'),
+    )
+    await expect(loginWithPasskey()).rejects.toThrow(
+      'Passkey sign-in was cancelled',
+    )
   })
 })
 

--- a/teeline-web/src/auth/webauthn.ts
+++ b/teeline-web/src/auth/webauthn.ts
@@ -16,12 +16,18 @@ export interface User {
 }
 
 /** Map common WebAuthn failures to user-friendly messages. */
-async function withCancellation<T>(fn: () => Promise<T>, cancelledMessage: string): Promise<T> {
+async function withCancellation<T>(
+  fn: () => Promise<T>,
+  cancelledMessage: string,
+): Promise<T> {
   try {
     return await fn()
   } catch (err) {
     // User dismissed the prompt or timed out — treat as a graceful cancel.
-    if (err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'AbortError')) {
+    if (
+      err instanceof DOMException &&
+      (err.name === 'NotAllowedError' || err.name === 'AbortError')
+    ) {
       throw new Error(cancelledMessage)
     }
     throw new Error('Passkey operation failed — please try again')
@@ -43,10 +49,13 @@ export async function registerPasskey(displayName?: string): Promise<User> {
     'Passkey creation was cancelled',
   )
 
-  const { user } = await apiFetch<{ user: User }>('/api/auth/register/complete', {
-    method: 'POST',
-    body: JSON.stringify({ nonce, credential: response }),
-  })
+  const { user } = await apiFetch<{ user: User }>(
+    '/api/auth/register/complete',
+    {
+      method: 'POST',
+      body: JSON.stringify({ nonce, credential: response }),
+    },
+  )
   return user
 }
 

--- a/teeline-web/src/canvas.ts
+++ b/teeline-web/src/canvas.ts
@@ -16,8 +16,10 @@ export function scaleCoords(
 
   const xs = cities.map((c) => c.x)
   const ys = cities.map((c) => c.y)
-  const minX = Math.min(...xs), maxX = Math.max(...xs)
-  const minY = Math.min(...ys), maxY = Math.max(...ys)
+  const minX = Math.min(...xs),
+    maxX = Math.max(...xs)
+  const minY = Math.min(...ys),
+    maxY = Math.max(...ys)
   const rangeX = maxX - minX || 1
   const rangeY = maxY - minY || 1
 
@@ -53,7 +55,9 @@ const W = 600
 const H = 400
 const PAD = 20
 
-function el<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+function el<K extends keyof SVGElementTagNameMap>(
+  tag: K,
+): SVGElementTagNameMap[K] {
   return document.createElementNS(SVG_NS, tag)
 }
 

--- a/teeline-web/src/components/ApiKeyManager.tsx
+++ b/teeline-web/src/components/ApiKeyManager.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'preact/hooks'
 import { ApiError, apiFetch } from '../auth/api'
-import { loginWithPasskey, logout, me, registerPasskey, type User } from '../auth/webauthn'
+import {
+  loginWithPasskey,
+  logout,
+  me,
+  registerPasskey,
+  type User,
+} from '../auth/webauthn'
 
 interface ApiKeyMeta {
   id: string
@@ -104,7 +110,10 @@ export default function ApiKeyManager() {
 
   const onGenerate = () =>
     run(async () => {
-      const key = await apiFetch<FreshSecret>('/api/auth/keys', { method: 'POST', body: '{}' })
+      const key = await apiFetch<FreshSecret>('/api/auth/keys', {
+        method: 'POST',
+        body: '{}',
+      })
       setFresh(key)
       setCopied(false)
       try {
@@ -135,7 +144,9 @@ export default function ApiKeyManager() {
       await navigator.clipboard.writeText(fresh?.secret ?? '')
       setCopied(true)
     } catch {
-      setError('Could not copy automatically — select and copy the key manually.')
+      setError(
+        'Could not copy automatically — select and copy the key manually.',
+      )
     }
   }
 
@@ -143,25 +154,36 @@ export default function ApiKeyManager() {
     return <p class="text-text-dim">Loading…</p>
   }
 
-  const btnBase = 'inline-flex items-center justify-center rounded-md px-5 py-2 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50'
+  const btnBase =
+    'inline-flex items-center justify-center rounded-md px-5 py-2 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50'
 
   return (
     <section class="my-6 max-w-2xl">
       {error && (
-        <p class="mb-4 rounded-md border border-negative/40 bg-negative/10 px-4 py-2 text-sm text-negative" role="alert">
+        <p
+          class="mb-4 rounded-md border border-negative/40 bg-negative/10 px-4 py-2 text-sm text-negative"
+          role="alert"
+        >
           {error}
         </p>
       )}
 
       {view === 'anonymous' && (
         <div class="rounded-lg border border-border bg-surface p-6">
-          <h2 class="mb-1 text-xl font-semibold text-text">Sign in with a passkey</h2>
+          <h2 class="mb-1 text-xl font-semibold text-text">
+            Sign in with a passkey
+          </h2>
           <p class="mb-4 text-sm text-text-dim">
-            No account or password needed. First time here? <strong class="text-text">Create a passkey</strong> —
-            your browser or password manager stores it. Later visits are a single tap.
+            No account or password needed. First time here?{' '}
+            <strong class="text-text">Create a passkey</strong> — your browser
+            or password manager stores it. Later visits are a single tap.
           </p>
           <div class="flex flex-wrap gap-3">
-            <button class={`${btnBase} bg-accent text-white hover:bg-accent/90`} onClick={onRegister} disabled={busy}>
+            <button
+              class={`${btnBase} bg-accent text-white hover:bg-accent/90`}
+              onClick={onRegister}
+              disabled={busy}
+            >
               {busy ? 'Working…' : 'Create a passkey'}
             </button>
             <button
@@ -181,58 +203,104 @@ export default function ApiKeyManager() {
             <div>
               <h2 class="text-xl font-semibold text-text">API keys</h2>
               <p class="text-sm text-text-dim">
-                Signed in as <span class="font-mono text-accent">{user.displayName ?? user.id.slice(0, 8)}</span>
+                Signed in as{' '}
+                <span class="font-mono text-accent">
+                  {user.displayName ?? user.id.slice(0, 8)}
+                </span>
               </p>
             </div>
-            <button class={`${btnBase} border border-border px-3 py-1 text-sm text-text-dim hover:text-text`} onClick={onLogout} disabled={busy}>
+            <button
+              class={`${btnBase} border border-border px-3 py-1 text-sm text-text-dim hover:text-text`}
+              onClick={onLogout}
+              disabled={busy}
+            >
               Sign out
             </button>
           </div>
 
           {fresh && (
-            <div class="mb-5 rounded-md border border-positive/50 bg-positive/10 p-4" role="status">
-              <p class="mb-2 text-sm font-semibold text-positive">Your new API key — shown once</p>
-              <code class="block break-all rounded bg-surface-2 px-3 py-2 font-mono text-sm text-text" data-testid="fresh-secret">
+            <div
+              class="mb-5 rounded-md border border-positive/50 bg-positive/10 p-4"
+              role="status"
+            >
+              <p class="mb-2 text-sm font-semibold text-positive">
+                Your new API key — shown once
+              </p>
+              <code
+                class="block break-all rounded bg-surface-2 px-3 py-2 font-mono text-sm text-text"
+                data-testid="fresh-secret"
+              >
                 {fresh.secret}
               </code>
               <p class="mt-2 text-sm text-text">
-                <strong>Copy it into your password manager now.</strong> It won't be shown again — after you
-                refresh or leave this page it's gone for good.
+                <strong>Copy it into your password manager now.</strong> It
+                won't be shown again — after you refresh or leave this page it's
+                gone for good.
               </p>
               <div class="mt-3 flex flex-wrap gap-2">
-                <button class={`${btnBase} bg-accent px-4 py-1 text-sm text-white hover:bg-accent/90`} onClick={onCopySecret}>
+                <button
+                  class={`${btnBase} bg-accent px-4 py-1 text-sm text-white hover:bg-accent/90`}
+                  onClick={onCopySecret}
+                >
                   {copied ? 'Copied!' : 'Copy to clipboard'}
                 </button>
-                {copied && <span class="sr-only" role="status">API key copied to clipboard</span>}
-                <button class={`${btnBase} border border-border px-4 py-1 text-sm text-text hover:border-accent hover:text-accent`} onClick={() => setFresh(null)}>
+                {copied && (
+                  <span class="sr-only" role="status">
+                    API key copied to clipboard
+                  </span>
+                )}
+                <button
+                  class={`${btnBase} border border-border px-4 py-1 text-sm text-text hover:border-accent hover:text-accent`}
+                  onClick={() => setFresh(null)}
+                >
                   I've saved it
                 </button>
               </div>
             </div>
           )}
 
-          <button class={`${btnBase} mb-5 bg-accent text-white hover:bg-accent/90`} onClick={onGenerate} disabled={busy}>
+          <button
+            class={`${btnBase} mb-5 bg-accent text-white hover:bg-accent/90`}
+            onClick={onGenerate}
+            disabled={busy}
+          >
             {busy ? 'Working…' : 'Generate API key'}
           </button>
 
           {keys.length === 0 ? (
-            <p class="text-sm text-text-dim">No keys yet — generate one above.</p>
+            <p class="text-sm text-text-dim">
+              No keys yet — generate one above.
+            </p>
           ) : (
             <table class="w-full border-collapse text-sm">
               <thead>
                 <tr class="text-left text-text-dim">
-                  <th class="border-b border-border py-2 pr-3 font-semibold">Name</th>
-                  <th class="border-b border-border py-2 pr-3 font-semibold">Created</th>
-                  <th class="border-b border-border py-2 pr-3 font-semibold">Last used</th>
-                  <th class="border-b border-border py-2 text-right font-semibold">Revoke</th>
+                  <th class="border-b border-border py-2 pr-3 font-semibold">
+                    Name
+                  </th>
+                  <th class="border-b border-border py-2 pr-3 font-semibold">
+                    Created
+                  </th>
+                  <th class="border-b border-border py-2 pr-3 font-semibold">
+                    Last used
+                  </th>
+                  <th class="border-b border-border py-2 text-right font-semibold">
+                    Revoke
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {keys.map((k) => (
                   <tr key={k.id} class={k.revoked ? 'opacity-50' : ''}>
-                    <td class="border-b border-border py-2 pr-3 font-mono text-text">{k.name ?? k.id.slice(0, 10)}</td>
-                    <td class="border-b border-border py-2 pr-3 text-text-dim">{formatDate(k.createdAt)}</td>
-                    <td class="border-b border-border py-2 pr-3 text-text-dim">{formatDate(k.lastUsedAt)}</td>
+                    <td class="border-b border-border py-2 pr-3 font-mono text-text">
+                      {k.name ?? k.id.slice(0, 10)}
+                    </td>
+                    <td class="border-b border-border py-2 pr-3 text-text-dim">
+                      {formatDate(k.createdAt)}
+                    </td>
+                    <td class="border-b border-border py-2 pr-3 text-text-dim">
+                      {formatDate(k.lastUsedAt)}
+                    </td>
                     <td class="border-b border-border py-2 text-right">
                       {k.revoked ? (
                         <span class="text-xs text-text-dim">revoked</span>

--- a/teeline-web/src/download.test.ts
+++ b/teeline-web/src/download.test.ts
@@ -66,7 +66,12 @@ describe('buildCsvText', () => {
 })
 
 describe('buildJsonText', () => {
-  const record: RunRecord = { solver: 'nn', total: 42.5, runtime: 123, route: [1, 2, 3] }
+  const record: RunRecord = {
+    solver: 'nn',
+    total: 42.5,
+    runtime: 123,
+    route: [1, 2, 3],
+  }
 
   it('parses back to a valid object', () => {
     const text = buildJsonText('berlin52', record, cities, 9999)

--- a/teeline-web/src/download.ts
+++ b/teeline-web/src/download.ts
@@ -37,8 +37,13 @@ export function serializeSvg(svgEl: SVGSVGElement): Blob {
   return new Blob([svg], { type: 'image/svg+xml' })
 }
 
-export function triggerDownload(content: string | Blob, filename: string, mime: string): void {
-  const blob = typeof content === 'string' ? new Blob([content], { type: mime }) : content
+export function triggerDownload(
+  content: string | Blob,
+  filename: string,
+  mime: string,
+): void {
+  const blob =
+    typeof content === 'string' ? new Blob([content], { type: mime }) : content
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url

--- a/teeline-web/src/explainers/aco-algo.ts
+++ b/teeline-web/src/explainers/aco-algo.ts
@@ -4,7 +4,12 @@
 // and advances the epoch. Mirrors the Rust `ant_colony.rs` Ant System loop
 // (construct -> best-update -> evaporate -> deposit).
 
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, dist12 as dist, tourLength12 as tourLength } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  dist12 as dist,
+  tourLength12 as tourLength,
+} from './explainer-cities'
 export { CITIES, N_CITIES, dist, tourLength }
 
 export type Phase = 'building' | 'depositing'
@@ -12,10 +17,10 @@ export type EventMode = 'ant-built' | 'improved' | 'evaporated' | 'deposited'
 
 export type SimState = {
   phase: Phase
-  antIdx: number            // 0..numAnts — which ant is building now (building phase only)
+  antIdx: number // 0..numAnts — which ant is building now (building phase only)
   epoch: number
-  pheromone: number[][]     // symmetric NxN; pheromone[i][j] = pheromone[j][i]
-  eta: number[][]           // precomputed (1/dist)^beta; symmetric
+  pheromone: number[][] // symmetric NxN; pheromone[i][j] = pheromone[j][i]
+  eta: number[][] // precomputed (1/dist)^beta; symmetric
   alpha: number
   beta: number
   evaporationRate: number
@@ -24,23 +29,29 @@ export type SimState = {
   tauMin: number
   bestTour: number[]
   bestCost: number
-  lastTours: number[][]     // tours built this epoch (cleared after deposit)
+  lastTours: number[][] // tours built this epoch (cleared after deposit)
   lastEvent: EventMode | null
   lastTour: number[] | null // most recently built tour (for canvas highlight)
-  costHistory: number[]     // epoch-best costs
+  costHistory: number[] // epoch-best costs
   step: number
 }
 
 export function averageDistance(): number {
-  let sum = 0, count = 0
+  let sum = 0,
+    count = 0
   for (let i = 0; i < N_CITIES; i++)
-    for (let j = i + 1; j < N_CITIES; j++)
-      { sum += dist(i, j); count++ }
+    for (let j = i + 1; j < N_CITIES; j++) {
+      sum += dist(i, j)
+      count++
+    }
   return sum / count
 }
 
 function computeEta(beta: number): number[][] {
-  const eta: number[][] = Array.from({ length: N_CITIES }, () => new Array(N_CITIES))
+  const eta: number[][] = Array.from(
+    { length: N_CITIES },
+    () => new Array(N_CITIES),
+  )
   for (let i = 0; i < N_CITIES; i++) {
     eta[i][i] = 0
     for (let j = i + 1; j < N_CITIES; j++) {
@@ -56,7 +67,12 @@ function computeEta(beta: number): number[][] {
 // chosen probabilistically weighted by pheromone^alpha * eta^beta among unvisited
 // cities. Falls back to first-unvisited if all weights are zero (matching the
 // Rust solver's graceful underflow guard).
-function buildTour(pheromone: number[][], eta: number[][], alpha: number, _beta: number): number[] {
+function buildTour(
+  pheromone: number[][],
+  eta: number[][],
+  alpha: number,
+  _beta: number,
+): number[] {
   const unvisited = new Set(Array.from({ length: N_CITIES }, (_, i) => i))
   const start = Math.floor(Math.random() * N_CITIES)
   unvisited.delete(start)
@@ -65,10 +81,10 @@ function buildTour(pheromone: number[][], eta: number[][], alpha: number, _beta:
   while (unvisited.size > 0) {
     const current = tour[tour.length - 1]
     const candidates = Array.from(unvisited)
-    const weights = candidates.map(j => {
+    const weights = candidates.map((j) => {
       const p = Math.max(pheromone[current][j], 1e-30)
       const e = eta[current][j]
-      return (p ** alpha) * e
+      return p ** alpha * e
     })
     const total = weights.reduce((s, w) => s + w, 0)
 
@@ -79,7 +95,10 @@ function buildTour(pheromone: number[][], eta: number[][], alpha: number, _beta:
       let r = Math.random() * total
       for (let k = 0; k < candidates.length; k++) {
         r -= weights[k]
-        if (r <= 0) { next = candidates[k]; break }
+        if (r <= 0) {
+          next = candidates[k]
+          break
+        }
       }
     }
     tour.push(next)
@@ -97,11 +116,16 @@ export function maxPheromone(s: SimState): number {
 }
 
 export function makeInitState(
-  alpha: number, beta: number, evaporationRate: number, numAnts: number,
+  alpha: number,
+  beta: number,
+  evaporationRate: number,
+  numAnts: number,
 ): SimState {
   const avgDist = averageDistance()
   const tau0 = numAnts / avgDist
-  const pheromone: number[][] = Array.from({ length: N_CITIES }, () => new Array(N_CITIES).fill(tau0))
+  const pheromone: number[][] = Array.from({ length: N_CITIES }, () =>
+    new Array(N_CITIES).fill(tau0),
+  )
   for (let i = 0; i < N_CITIES; i++) pheromone[i][i] = 0
   const eta = computeEta(beta)
 
@@ -170,16 +194,19 @@ export function stepOnce(s: SimState): SimState {
 
   // Phase === 'depositing': evaporate + deposit, then advance epoch
   const rate = s.evaporationRate
-  const newPheromone = s.pheromone.map(row => row.map(p => {
-    const evap = p * (1 - rate)
-    return Math.max(evap, s.tauMin)
-  }))
+  const newPheromone = s.pheromone.map((row) =>
+    row.map((p) => {
+      const evap = p * (1 - rate)
+      return Math.max(evap, s.tauMin)
+    }),
+  )
 
   // Deposit from each ant's tour
   for (const tour of s.lastTours) {
     const deposit = 1 / tourLength(tour)
     for (let k = 0; k < tour.length; k++) {
-      const u = tour[k], v = tour[(k + 1) % tour.length]
+      const u = tour[k],
+        v = tour[(k + 1) % tour.length]
       newPheromone[u][v] += deposit
       newPheromone[v][u] += deposit
     }

--- a/teeline-web/src/explainers/aco.test.ts
+++ b/teeline-web/src/explainers/aco.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, tourLength,
-  makeInitState, stepOnce, maxPheromone,
+  N_CITIES,
+  tourLength,
+  makeInitState,
+  stepOnce,
+  maxPheromone,
 } from './aco-algo'
 
 describe('makeInitState', () => {
@@ -50,9 +53,9 @@ describe('stepOnce', () => {
   it('after depositing, advances epoch and returns to building', () => {
     const numAnts = 3
     let s = makeInitState(1, 2, 0.5, numAnts)
-    for (let i = 0; i < numAnts; i++) s = stepOnce(s)  // build all ants
+    for (let i = 0; i < numAnts; i++) s = stepOnce(s) // build all ants
     expect(s.phase).toBe('depositing')
-    s = stepOnce(s)  // deposit
+    s = stepOnce(s) // deposit
     expect(s.phase).toBe('building')
     expect(s.epoch).toBe(1)
     expect(s.antIdx).toBe(0)
@@ -69,7 +72,9 @@ describe('stepOnce', () => {
   })
 
   it('built tours are valid permutations', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     let s = makeInitState(1, 2, 0.5, 8)
     for (let i = 0; i < 8; i++) s = stepOnce(s)
     for (const tour of s.lastTours) {
@@ -80,8 +85,8 @@ describe('stepOnce', () => {
   it('pheromone floor (tauMin) is respected after evaporation', () => {
     const evap = 0.9
     let s = makeInitState(1, 2, evap, 3)
-    for (let i = 0; i < 3; i++) s = stepOnce(s)  // build
-    s = stepOnce(s)  // deposit (evaporate happens here)
+    for (let i = 0; i < 3; i++) s = stepOnce(s) // build
+    s = stepOnce(s) // deposit (evaporate happens here)
     for (let i = 0; i < N_CITIES; i++) {
       for (let j = i + 1; j < N_CITIES; j++) {
         expect(s.pheromone[i][j]).toBeGreaterThanOrEqual(s.tauMin - 1e-12)

--- a/teeline-web/src/explainers/aco.tsx
+++ b/teeline-web/src/explainers/aco.tsx
@@ -1,20 +1,29 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES,
-  tourLength, maxPheromone, makeInitState, stepOnce,
-} from "./aco-algo"
-import type { EventMode } from "./aco-algo"
+  CITIES,
+  N_CITIES,
+  tourLength,
+  maxPheromone,
+  makeInitState,
+  stepOnce,
+} from './aco-algo'
+import type { EventMode } from './aco-algo'
 
 const AXIS_COLORS = [
-  "#0d9488", "#2563eb", "#7c3aed", "#db2777", "#ea580c",
-  "#16a34a", "#0891b2",
+  '#0d9488',
+  '#2563eb',
+  '#7c3aed',
+  '#db2777',
+  '#ea580c',
+  '#16a34a',
+  '#0891b2',
 ]
 
 const DEFAULTS = { alpha: 1.0, beta: 2.0, evaporationRate: 0.5, numAnts: 10 }
 
 function cityColor(i: number, onBest: boolean, onLast: boolean): string {
-  if (onBest) return "#16a34a"
-  if (onLast) return "#ea580c"
+  if (onBest) return '#16a34a'
+  if (onLast) return '#ea580c'
   return AXIS_COLORS[i % AXIS_COLORS.length]
 }
 
@@ -29,15 +38,29 @@ interface CanvasProps {
   lastTour: number[] | null
   phase: string
 }
-function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: CanvasProps) {
+function PheromoneCanvas({
+  pheromone,
+  maxP,
+  tau0,
+  bestTour,
+  lastTour,
+  phase,
+}: CanvasProps) {
   const bestSet = useMemo(() => new Set(bestTour), [bestTour])
-  const lastSet = useMemo(() => lastTour ? new Set(lastTour) : new Set<number>(), [lastTour])
+  const lastSet = useMemo(
+    () => (lastTour ? new Set(lastTour) : new Set<number>()),
+    [lastTour],
+  )
 
-  const bestPts = bestTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
-  const bestPtsClosed = bestPts + ` ${CITIES[bestTour[0]][0]},${CITIES[bestTour[0]][1]}`
+  const bestPts = bestTour
+    .map((i) => `${CITIES[i][0]},${CITIES[i][1]}`)
+    .join(' ')
+  const bestPtsClosed =
+    bestPts + ` ${CITIES[bestTour[0]][0]},${CITIES[bestTour[0]][1]}`
   const lastPts = lastTour
-    ? lastTour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[lastTour[0]][0]},${CITIES[lastTour[0]][1]}`
-    : ""
+    ? lastTour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ') +
+      ` ${CITIES[lastTour[0]][0]},${CITIES[lastTour[0]][1]}`
+    : ''
 
   const edges: Array<[number, number, number]> = []
   for (let i = 0; i < N_CITIES; i++) {
@@ -47,25 +70,33 @@ function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: C
   }
 
   return (
-    <svg viewBox="0 0 300 300" className="aco-canvas" role="img" aria-label="ACO pheromone map">
+    <svg
+      viewBox="0 0 300 300"
+      className="aco-canvas"
+      role="img"
+      aria-label="ACO pheromone map"
+    >
       <rect x={0} y={0} width={300} height={300} className="aco-bg" />
 
       {/* pheromone edges — only edges above baseline tau0 are visible;
           untouched edges stay invisible so the colony's emergent trails are
           the only thing on the canvas (no full-graph noise at the start) */}
       {edges.map(([i, j, p], k) => {
-        if (p <= tau0 * 1.0001) return null  // untouched, invisible
+        if (p <= tau0 * 1.0001) return null // untouched, invisible
         const ratio = maxP > 0 ? p / maxP : 0
         const amp = Math.pow(ratio, 0.35)
         return (
-          <line key={"p" + k}
-            x1={CITIES[i][0]} y1={CITIES[i][1]}
-            x2={CITIES[j][0]} y2={CITIES[j][1]}
+          <line
+            key={'p' + k}
+            x1={CITIES[i][0]}
+            y1={CITIES[i][1]}
+            x2={CITIES[j][0]}
+            y2={CITIES[j][1]}
             stroke="#0d9488"
             strokeWidth={0.3 + amp * 5.0}
             opacity={0.05 + amp * 0.75}
             strokeLinecap="round"
-            strokeDasharray={amp > 0.35 ? "5 3" : "3 5"}
+            strokeDasharray={amp > 0.35 ? '5 3' : '3 5'}
           />
         )
       })}
@@ -87,11 +118,16 @@ function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: C
         const onLast = lastSet.has(i)
         return (
           <g key={i}>
-            <circle cx={x} cy={y} r={onBest ? 7 : onLast ? 6.5 : 5}
+            <circle
+              cx={x}
+              cy={y}
+              r={onBest ? 7 : onLast ? 6.5 : 5}
               fill={cityColor(i, onBest, onLast)}
               className="aco-city"
             />
-            <text x={x + 8} y={y - 5} className="aco-city-label">{i}</text>
+            <text x={x + 8} y={y - 5} className="aco-city-label">
+              {i}
+            </text>
           </g>
         )
       })}
@@ -102,49 +138,88 @@ function PheromoneCanvas({ pheromone, maxP, tau0, bestTour, lastTour, phase }: C
 // ---------------------------------------------------------------
 // Side panel — epoch, ant progress, pheromone heatmap grid
 // ---------------------------------------------------------------
-function PheromoneHeatmap({ pheromone, maxP }: { pheromone: number[][]; maxP: number }) {
+function PheromoneHeatmap({
+  pheromone,
+  maxP,
+}: {
+  pheromone: number[][]
+  maxP: number
+}) {
   const n = pheromone.length
-  const w = 112, pad = 2, cell = Math.floor((w - pad * 2) / n)
+  const w = 112,
+    pad = 2,
+    cell = Math.floor((w - pad * 2) / n)
   const totalW = cell * n + pad * 2
 
   return (
     <svg viewBox={`0 0 ${totalW} ${totalW}`} className="aco-heatmap">
-      <rect x={0} y={0} width={totalW} height={totalW} className="aco-heatmap-bg" rx={3} />
+      <rect
+        x={0}
+        y={0}
+        width={totalW}
+        height={totalW}
+        className="aco-heatmap-bg"
+        rx={3}
+      />
       {/* separators every 4 cities — visually chunk the 12×12 matrix */}
-      {[4, 8].map(x => (
-        <line key={"v" + x} x1={pad + x * cell} y1={pad} x2={pad + x * cell} y2={pad + n * cell}
-          stroke="var(--line)" strokeWidth={1} />
+      {[4, 8].map((x) => (
+        <line
+          key={'v' + x}
+          x1={pad + x * cell}
+          y1={pad}
+          x2={pad + x * cell}
+          y2={pad + n * cell}
+          stroke="var(--line)"
+          strokeWidth={1}
+        />
       ))}
-      {[4, 8].map(y => (
-        <line key={"h" + y} x1={pad} y1={pad + y * cell} x2={pad + n * cell} y2={pad + y * cell}
-          stroke="var(--line)" strokeWidth={1} />
+      {[4, 8].map((y) => (
+        <line
+          key={'h' + y}
+          x1={pad}
+          y1={pad + y * cell}
+          x2={pad + n * cell}
+          y2={pad + y * cell}
+          stroke="var(--line)"
+          strokeWidth={1}
+        />
       ))}
       {Array.from({ length: n }, (_, i) =>
         Array.from({ length: n }, (_, j) => {
-          if (i >= j) return null  // lower triangle + diagonal
+          if (i >= j) return null // lower triangle + diagonal
           const ratio = maxP > 0 ? pheromone[i][j] / maxP : 0
           const r = Math.round(240 - ratio * 200)
           const g = Math.round(253 - ratio * 200)
           const b = Math.round(244 - ratio * 220)
           return (
-            <rect key={`${i}-${j}`}
-              x={pad + j * cell} y={pad + i * cell}
-              width={cell - 1.5} height={cell - 1.5}
+            <rect
+              key={`${i}-${j}`}
+              x={pad + j * cell}
+              y={pad + i * cell}
+              width={cell - 1.5}
+              height={cell - 1.5}
               fill={`rgb(${r},${g},${b})`}
               rx={1.5}
             >
-              <title>{i}–{j}  {(ratio * 100).toFixed(0)}%</title>
+              <title>
+                {i}–{j} {(ratio * 100).toFixed(0)}%
+              </title>
             </rect>
           )
-        })
+        }),
       )}
     </svg>
   )
 }
 
 function SidePanel(props: {
-  epoch: number; phase: string; antIdx: number; numAnts: number;
-  pheromone: number[][]; bestCost: number; maxP: number;
+  epoch: number
+  phase: string
+  antIdx: number
+  numAnts: number
+  pheromone: number[][]
+  bestCost: number
+  maxP: number
 }) {
   const { epoch, phase, antIdx, numAnts, pheromone, bestCost, maxP } = props
 
@@ -156,7 +231,11 @@ function SidePanel(props: {
       </div>
       <div className="aco-side-section">
         <div className="aco-side-label">phase</div>
-        <div className="aco-mono">{phase === 'building' ? `🐜 ant ${antIdx + 1}/${numAnts}` : '💨 deposit'}</div>
+        <div className="aco-mono">
+          {phase === 'building'
+            ? `🐜 ant ${antIdx + 1}/${numAnts}`
+            : '💨 deposit'}
+        </div>
       </div>
       <div className="aco-side-section">
         <div className="aco-side-label">best cost</div>
@@ -175,7 +254,10 @@ function SidePanel(props: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 54, minC = Math.min(...values), maxC = Math.max(...values)
+  const W = 300,
+    H = 54,
+    minC = Math.min(...values),
+    maxC = Math.max(...values)
   const range = maxC - minC || 1
   const pts = values.map((v, i) => {
     const x = (i / (values.length - 1)) * W
@@ -185,7 +267,13 @@ function Sparkline({ values }: { values: number[] }) {
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="aco-spark">
       <rect x={0} y={0} width={W} height={H} className="aco-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488" strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -203,9 +291,13 @@ export default function AcoExplainer() {
   const simRef = useRef(makeInitState(alpha, beta, evapRate, numAnts))
   const [pheromone, setPheromone] = useState(() => simRef.current.pheromone)
   const [epoch, setEpoch] = useState(0)
-  const [phase, setPhase] = useState<"building" | "depositing">(() => simRef.current.phase)
+  const [phase, setPhase] = useState<'building' | 'depositing'>(
+    () => simRef.current.phase,
+  )
   const [antIdx, setAntIdx] = useState(0)
-  const [bestTour, setBestTour] = useState<number[]>(() => simRef.current.bestTour.slice())
+  const [bestTour, setBestTour] = useState<number[]>(() =>
+    simRef.current.bestTour.slice(),
+  )
   const [bestCost, setBestCost] = useState(() => simRef.current.bestCost)
   const [lastTour, setLastTour] = useState<number[] | null>(null)
   const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
@@ -216,22 +308,33 @@ export default function AcoExplainer() {
 
   const reinit = useCallback((a: number, b: number, e: number, n: number) => {
     simRef.current = makeInitState(a, b, e, n)
-    setPheromone(simRef.current.pheromone); setEpoch(0)
-    setPhase('building'); setAntIdx(0)
-    setBestTour(simRef.current.bestTour.slice()); setBestCost(simRef.current.bestCost)
-    setLastTour(null); setLastEvent(null); setCostHistory([])
+    setPheromone(simRef.current.pheromone)
+    setEpoch(0)
+    setPhase('building')
+    setAntIdx(0)
+    setBestTour(simRef.current.bestTour.slice())
+    setBestCost(simRef.current.bestCost)
+    setLastTour(null)
+    setLastEvent(null)
+    setCostHistory([])
     setTau0(simRef.current.tau0)
-    setStep(0); setRunning(false)
+    setStep(0)
+    setRunning(false)
   }, [])
 
   const step_fn = useCallback(() => {
     const next = stepOnce(simRef.current)
     simRef.current = next
-    setPheromone(next.pheromone.map(r => r.slice()))
-    setEpoch(next.epoch); setPhase(next.phase); setAntIdx(next.antIdx)
-    setBestTour(next.bestTour.slice()); setBestCost(next.bestCost)
-    setLastTour(next.lastTour); setLastEvent(next.lastEvent)
-    setCostHistory(next.costHistory.slice()); setStep(next.step)
+    setPheromone(next.pheromone.map((r) => r.slice()))
+    setEpoch(next.epoch)
+    setPhase(next.phase)
+    setAntIdx(next.antIdx)
+    setBestTour(next.bestTour.slice())
+    setBestCost(next.bestCost)
+    setLastTour(next.lastTour)
+    setLastEvent(next.lastEvent)
+    setCostHistory(next.costHistory.slice())
+    setStep(next.step)
   }, [])
 
   useEffect(() => {
@@ -243,17 +346,17 @@ export default function AcoExplainer() {
 
   const maxP = useMemo(() => maxPheromone(simRef.current), [pheromone])
 
-  let chipText = "Press Step or Run to watch the colony evolve"
-  let chipClass = "aco-chip aco-chip-idle"
+  let chipText = 'Press Step or Run to watch the colony evolve'
+  let chipClass = 'aco-chip aco-chip-idle'
   if (lastEvent === 'ant-built') {
-    chipText = `🐜 ant built a tour — cost ${simRef.current.lastTours.length > 0 ? tourLength(simRef.current.lastTours[simRef.current.lastTours.length - 1]).toFixed(0) : "?"}`
-    chipClass = "aco-chip aco-chip-build"
+    chipText = `🐜 ant built a tour — cost ${simRef.current.lastTours.length > 0 ? tourLength(simRef.current.lastTours[simRef.current.lastTours.length - 1]).toFixed(0) : '?'}`
+    chipClass = 'aco-chip aco-chip-build'
   } else if (lastEvent === 'improved') {
     chipText = `⭐ new best! epoch ${epoch - 1}, cost ${bestCost.toFixed(0)}`
-    chipClass = "aco-chip aco-chip-improve"
+    chipClass = 'aco-chip aco-chip-improve'
   } else if (lastEvent === 'deposited') {
     chipText = `💨 evaporated + 📥 deposited ${numAnts} tours — advancing to epoch ${epoch}`
-    chipClass = "aco-chip aco-chip-deposit"
+    chipClass = 'aco-chip aco-chip-deposit'
   }
 
   return (
@@ -265,30 +368,46 @@ export default function AcoExplainer() {
         <h2 className="aco-title">Ant Colony Optimization</h2>
         <p className="aco-sub">
           A colony of ants independently constructs tours, each next city chosen
-          probabilistically by a <strong>pheromone trail</strong> (reinforced on short edges
-          and decaying over time) weighted by <strong>heuristic desirability</strong>
-          (1/distance). Watch the pheromone edges strengthen on good edges and fade on
-          bad ones as epochs advance.
+          probabilistically by a <strong>pheromone trail</strong> (reinforced on
+          short edges and decaying over time) weighted by{' '}
+          <strong>heuristic desirability</strong>
+          (1/distance). Watch the pheromone edges strengthen on good edges and
+          fade on bad ones as epochs advance.
         </p>
       </header>
 
       <div className="aco-viz-row">
         <div className="aco-canvas-wrap">
           <PheromoneCanvas
-            pheromone={pheromone} maxP={maxP} tau0={tau0} bestTour={bestTour}
-            lastTour={lastTour} phase={phase}
+            pheromone={pheromone}
+            maxP={maxP}
+            tau0={tau0}
+            bestTour={bestTour}
+            lastTour={lastTour}
+            phase={phase}
           />
         </div>
         <SidePanel
-          epoch={epoch} phase={phase} antIdx={antIdx} numAnts={numAnts}
-          pheromone={pheromone} bestCost={bestCost} maxP={maxP}
+          epoch={epoch}
+          phase={phase}
+          antIdx={antIdx}
+          numAnts={numAnts}
+          pheromone={pheromone}
+          bestCost={bestCost}
+          maxP={maxP}
         />
       </div>
 
       <div className="aco-legend">
-        <span><span className="aco-swatch aco-swatch-best" /> best tour</span>
-        <span><span className="aco-swatch aco-swatch-last" /> ant's last tour</span>
-        <span><span className="aco-swatch aco-swatch-phero" /> pheromone edge</span>
+        <span>
+          <span className="aco-swatch aco-swatch-best" /> best tour
+        </span>
+        <span>
+          <span className="aco-swatch aco-swatch-last" /> ant's last tour
+        </span>
+        <span>
+          <span className="aco-swatch aco-swatch-phero" /> pheromone edge
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -317,72 +436,181 @@ export default function AcoExplainer() {
 
       <div className="aco-config">
         <div className="aco-config-row">
-          <label className="aco-config-label">α (pheromone influence) = <strong>{alpha.toFixed(1)}</strong></label>
-          <input type="range" min={0} max={10} step={0.1} value={alpha}
+          <label className="aco-config-label">
+            α (pheromone influence) = <strong>{alpha.toFixed(1)}</strong>
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={10}
+            step={0.1}
+            value={alpha}
             className="aco-slider"
-            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setAlpha(v); reinit(v, beta, evapRate, numAnts) }}
+            onInput={(e) => {
+              const v = Number((e.target as HTMLInputElement).value)
+              setAlpha(v)
+              reinit(v, beta, evapRate, numAnts)
+            }}
           />
         </div>
         <div className="aco-config-row">
-          <label className="aco-config-label">β (heuristic influence) = <strong>{beta.toFixed(1)}</strong></label>
-          <input type="range" min={0} max={6} step={0.1} value={beta}
+          <label className="aco-config-label">
+            β (heuristic influence) = <strong>{beta.toFixed(1)}</strong>
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={6}
+            step={0.1}
+            value={beta}
             className="aco-slider"
-            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setBeta(v); reinit(alpha, v, evapRate, numAnts) }}
+            onInput={(e) => {
+              const v = Number((e.target as HTMLInputElement).value)
+              setBeta(v)
+              reinit(alpha, v, evapRate, numAnts)
+            }}
           />
         </div>
         <div className="aco-config-row">
-          <label className="aco-config-label">ρ (evaporation rate) = <strong>{evapRate.toFixed(2)}</strong></label>
-          <input type="range" min={0.01} max={0.99} step={0.01} value={evapRate}
+          <label className="aco-config-label">
+            ρ (evaporation rate) = <strong>{evapRate.toFixed(2)}</strong>
+          </label>
+          <input
+            type="range"
+            min={0.01}
+            max={0.99}
+            step={0.01}
+            value={evapRate}
             className="aco-slider"
-            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setEvapRate(v); reinit(alpha, beta, v, numAnts) }}
+            onInput={(e) => {
+              const v = Number((e.target as HTMLInputElement).value)
+              setEvapRate(v)
+              reinit(alpha, beta, v, numAnts)
+            }}
           />
         </div>
         <div className="aco-config-row">
-          <label className="aco-config-label">Colony size = <strong>{numAnts}</strong></label>
-          <input type="range" min={2} max={30} step={1} value={numAnts}
+          <label className="aco-config-label">
+            Colony size = <strong>{numAnts}</strong>
+          </label>
+          <input
+            type="range"
+            min={2}
+            max={30}
+            step={1}
+            value={numAnts}
             className="aco-slider"
-            onInput={e => { const v = Number((e.target as HTMLInputElement).value); setNumAnts(v); reinit(alpha, beta, evapRate, v) }}
+            onInput={(e) => {
+              const v = Number((e.target as HTMLInputElement).value)
+              setNumAnts(v)
+              reinit(alpha, beta, evapRate, v)
+            }}
           />
         </div>
         <div className="aco-config-row">
           <label className="aco-config-label">Speed</label>
-          <input type="range" min={1} max={10} step={1} value={speed}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="aco-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
 
-       <div className="aco-controls">
-         <button className="aco-btn" onClick={step_fn} disabled={running}>◀ Step</button>
-         <button className={`aco-btn ${!running ? "aco-btn-primary" : ""}`}
-           onClick={() => setRunning(r => !r)}>
-           {running ? "⏸ Pause" : "▶ Run"}
-         </button>
-         <button className="aco-btn" onClick={() => reinit(alpha, beta, evapRate, numAnts)}>↺ Reset</button>
-       </div>
+      <div className="aco-controls">
+        <button className="aco-btn" onClick={step_fn} disabled={running}>
+          ◀ Step
+        </button>
+        <button
+          className={`aco-btn ${!running ? 'aco-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button
+          className="aco-btn"
+          onClick={() => reinit(alpha, beta, evapRate, numAnts)}
+        >
+          ↺ Reset
+        </button>
+      </div>
 
-       <div className="aco-scenarios">
-         <div className="aco-section-label">Scenarios</div>
-         <div className="aco-scenario-row">
-           {([
-             { label: 'Default', desc: 'balanced α=1.0 β=2.0 ρ=0.50 ants=10', a: 1.0, b: 2.0, e: 0.50, n: 10 },
-             { label: 'Pheromone-heavy', desc: 'high α=3.0 β=1.0 — ants follow existing trails', a: 3.0, b: 1.0, e: 0.30, n: 10 },
-             { label: 'Distance-driven', desc: 'high β=5.0 — ants prioritise short edges', a: 0.5, b: 5.0, e: 0.50, n: 10 },
-             { label: 'Fast evaporation', desc: 'ρ=0.85 — trails fade quickly, more exploration', a: 1.0, b: 2.0, e: 0.85, n: 10 },
-             { label: 'Large colony', desc: 'ants=25 — more deposits per epoch', a: 1.0, b: 2.0, e: 0.50, n: 25 },
-           ] as const).map(s => (
-             <button key={s.label} className="aco-scenario-btn" title={s.desc}
-               onClick={() => { setAlpha(s.a); setBeta(s.b); setEvapRate(s.e); setNumAnts(s.n); reinit(s.a, s.b, s.e, s.n) }}>
-               {s.label}
-             </button>
-           ))}
-         </div>
-       </div>
+      <div className="aco-scenarios">
+        <div className="aco-section-label">Scenarios</div>
+        <div className="aco-scenario-row">
+          {(
+            [
+              {
+                label: 'Default',
+                desc: 'balanced α=1.0 β=2.0 ρ=0.50 ants=10',
+                a: 1.0,
+                b: 2.0,
+                e: 0.5,
+                n: 10,
+              },
+              {
+                label: 'Pheromone-heavy',
+                desc: 'high α=3.0 β=1.0 — ants follow existing trails',
+                a: 3.0,
+                b: 1.0,
+                e: 0.3,
+                n: 10,
+              },
+              {
+                label: 'Distance-driven',
+                desc: 'high β=5.0 — ants prioritise short edges',
+                a: 0.5,
+                b: 5.0,
+                e: 0.5,
+                n: 10,
+              },
+              {
+                label: 'Fast evaporation',
+                desc: 'ρ=0.85 — trails fade quickly, more exploration',
+                a: 1.0,
+                b: 2.0,
+                e: 0.85,
+                n: 10,
+              },
+              {
+                label: 'Large colony',
+                desc: 'ants=25 — more deposits per epoch',
+                a: 1.0,
+                b: 2.0,
+                e: 0.5,
+                n: 25,
+              },
+            ] as const
+          ).map((s) => (
+            <button
+              key={s.label}
+              className="aco-scenario-btn"
+              title={s.desc}
+              onClick={() => {
+                setAlpha(s.a)
+                setBeta(s.b)
+                setEvapRate(s.e)
+                setNumAnts(s.n)
+                reinit(s.a, s.b, s.e, s.n)
+              }}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       <footer className="aco-footer">
         <span className="aco-mono">cities: {N_CITIES}</span>
-        <span className="aco-mono">α={alpha.toFixed(1)} β={beta.toFixed(1)}</span>
+        <span className="aco-mono">
+          α={alpha.toFixed(1)} β={beta.toFixed(1)}
+        </span>
         <span className="aco-mono">ρ={evapRate.toFixed(2)}</span>
         <span className="aco-mono">ants: {numAnts}</span>
         <span className="aco-mono">classic AS</span>

--- a/teeline-web/src/explainers/bhk-algo.ts
+++ b/teeline-web/src/explainers/bhk-algo.ts
@@ -27,19 +27,19 @@ export interface Scenario {
 export interface SimState {
   phase: Phase
   cities: [number, number][]
-  n: number            // total cities (city 0 = start)
-  m: number            // n-1 (DP cities 1..n-1)
-  dm: number[][]       // distance matrix (plain numbers)
+  n: number // total cities (city 0 = start)
+  m: number // n-1 (DP cities 1..n-1)
+  dm: number[][] // distance matrix (plain numbers)
   // DP table: rows = end city index (0..m-1 ↔ city i+1), cols = mask
-  table: number[][]    // ∞ until computed
-  pred: number[][]     // predecessor city (index into rows) per computed cell, -1 if none
+  table: number[][] // ∞ until computed
+  pred: number[][] // predecessor city (index into rows) per computed cell, -1 if none
   // fill order (deterministic): masks by popcount ascending, then value
   fillOrder: { mask: number; row: number }[]
   fillPtr: number
   // optimal route (computed when forward completes)
   optCost: number | null
-  route: number[] | null       // city ids, [0, c1, ..., cn-1]
-  readback: number[]           // city ids revealed so far (from the end backwards)
+  route: number[] | null // city ids, [0, c1, ..., cn-1]
+  readback: number[] // city ids revealed so far (from the end backwards)
   readbackPtr: number
   lastEvent: string | null
   step: number
@@ -49,17 +49,38 @@ export const SCENARIOS: Record<string, Scenario> = {
   grid_6: {
     label: '6-city grid',
     desc: 'The familiar compact grid — a clean DP table to scan',
-    cities: [[60, 60], [240, 60], [240, 240], [60, 240], [150, 60], [150, 240]],
+    cities: [
+      [60, 60],
+      [240, 60],
+      [240, 240],
+      [60, 240],
+      [150, 60],
+      [150, 240],
+    ],
   },
   circle_6: {
     label: 'Circle',
     desc: 'Six cities on a circle — the optimal route is the perimeter',
-    cities: [[270, 150], [210, 254], [90, 254], [30, 150], [90, 46], [210, 46]],
+    cities: [
+      [270, 150],
+      [210, 254],
+      [90, 254],
+      [30, 150],
+      [90, 46],
+      [210, 46],
+    ],
   },
   clusters_6: {
     label: 'Two clusters',
     desc: 'Two tight triples far apart — the DP must bridge them twice',
-    cities: [[60, 60], [90, 60], [60, 90], [240, 240], [210, 240], [240, 210]],
+    cities: [
+      [60, 60],
+      [90, 60],
+      [60, 90],
+      [240, 240],
+      [210, 240],
+      [240, 210],
+    ],
   },
 }
 
@@ -96,8 +117,12 @@ export function makeInitState(scenario: Scenario): SimState {
   const m = n - 1
   const dm = makeDm(cities)
   const size = 1 << m
-  const table: number[][] = Array.from({ length: m }, () => new Array(size).fill(INF))
-  const pred: number[][] = Array.from({ length: m }, () => new Array(size).fill(-1))
+  const table: number[][] = Array.from({ length: m }, () =>
+    new Array(size).fill(INF),
+  )
+  const pred: number[][] = Array.from({ length: m }, () =>
+    new Array(size).fill(-1),
+  )
 
   // base cells: dp[{i}][i] = d(0, city i+1)
   for (let row = 0; row < m; row++) {
@@ -124,7 +149,11 @@ export function makeInitState(scenario: Scenario): SimState {
 }
 
 // Compute one DP cell (mask, row) from its predecessors; record the argmin.
-function fillCell(state: SimState, mask: number, row: number): { value: number; via: number } {
+function fillCell(
+  state: SimState,
+  mask: number,
+  row: number,
+): { value: number; via: number } {
   const rest = mask & ~(1 << row)
   const city = row + 1
   let best = INF
@@ -142,7 +171,10 @@ function fillCell(state: SimState, mask: number, row: number): { value: number; 
 
 // The optimal route: end city e = argmin_i table[i][full] + d(i+1, 0),
 // then read predecessors back to the start.
-export function computeRoute(state: SimState): { cost: number; route: number[] } {
+export function computeRoute(state: SimState): {
+  cost: number
+  route: number[]
+} {
   const full = (1 << state.m) - 1
   let best = INF
   let end = -1
@@ -174,7 +206,12 @@ export function stepOnce(state: SimState): SimState {
   // ----- readback: reveal one city of the optimal route per step -----
   if (state.phase === 'readback') {
     if (state.readbackPtr >= (state.route?.length ?? 0) - 1) {
-      return { ...state, phase: 'done', lastEvent: `Done — optimal tour ${state.route!.join('→')} = ${state.optCost!.toFixed(1)}`, step: state.step + 1 }
+      return {
+        ...state,
+        phase: 'done',
+        lastEvent: `Done — optimal tour ${state.route!.join('→')} = ${state.optCost!.toFixed(1)}`,
+        step: state.step + 1,
+      }
     }
     // the end city is seeded; each step reveals the next city back toward the start
     const city = state.route![state.route!.length - 1 - state.readbackPtr]
@@ -212,9 +249,10 @@ export function stepOnce(state: SimState): SimState {
   pred[row][mask] = via
 
   const sizeLabel = mask.toString(2).padStart(state.m, '0')
-  const event = value === INF
-    ? `Cell (${sizeLabel}, end ${row + 1}) — unreachable`
-    : `dp[${sizeLabel}][${row + 1}] = ${value.toFixed(1)} via city ${via + 1}`
+  const event =
+    value === INF
+      ? `Cell (${sizeLabel}, end ${row + 1}) — unreachable`
+      : `dp[${sizeLabel}][${row + 1}] = ${value.toFixed(1)} via city ${via + 1}`
 
   return {
     ...state,

--- a/teeline-web/src/explainers/bhk.test.ts
+++ b/teeline-web/src/explainers/bhk.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
-  SCENARIOS, makeInitState, stepOnce, makeDm, popcount, computeFillOrder,
+  SCENARIOS,
+  makeInitState,
+  stepOnce,
+  makeDm,
+  popcount,
+  computeFillOrder,
 } from './bhk-algo'
 import type { SimState } from './bhk-algo'
 
@@ -113,10 +118,14 @@ describe('correctness', () => {
   it('every scenario finds the exact optimum and a valid route', () => {
     for (const [key, sc] of Object.entries(SCENARIOS)) {
       const s = runToDone(sc)
-      expect(s.optCost, `${key} must match brute force`).toBeCloseTo(bruteForce(sc.cities), 6)
-      expect([...s.route!].sort((a, b) => a - b), `${key} route must be a permutation`).toEqual(
-        Array.from({ length: sc.cities.length }, (_, i) => i),
+      expect(s.optCost, `${key} must match brute force`).toBeCloseTo(
+        bruteForce(sc.cities),
+        6,
       )
+      expect(
+        [...s.route!].sort((a, b) => a - b),
+        `${key} route must be a permutation`,
+      ).toEqual(Array.from({ length: sc.cities.length }, (_, i) => i))
     }
   })
 
@@ -125,7 +134,8 @@ describe('correctness', () => {
     const dm = s.dm
     const route = s.route!
     let d = 0
-    for (let k = 0; k < route.length; k++) d += dm[route[k]][route[(k + 1) % route.length]]
+    for (let k = 0; k < route.length; k++)
+      d += dm[route[k]][route[(k + 1) % route.length]]
     expect(d).toBeCloseTo(s.optCost!, 6)
   })
 })

--- a/teeline-web/src/explainers/bhk.tsx
+++ b/teeline-web/src/explainers/bhk.tsx
@@ -1,12 +1,10 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
-import {
-  SCENARIOS, makeInitState, stepOnce, popcount,
-} from "./bhk-algo"
-import type { Phase, Scenario, SimState } from "./bhk-algo"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
+import { SCENARIOS, makeInitState, stepOnce, popcount } from './bhk-algo'
+import type { Phase, Scenario, SimState } from './bhk-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.grid_6
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 const INF = Infinity
 
@@ -15,7 +13,11 @@ const INF = Infinity
 // pre-filled; the next cell to compute is ringed; click a cell to
 // inspect its computation. Read-back cells turn gold.
 // ---------------------------------------------------------------
-function DpTable({ sim, selected, onSelect }: {
+function DpTable({
+  sim,
+  selected,
+  onSelect,
+}: {
   sim: SimState
   selected: { mask: number; row: number } | null
   onSelect: (mask: number, row: number) => void
@@ -38,7 +40,8 @@ function DpTable({ sim, selected, onSelect }: {
     return cells
   }, [sim.route, full])
 
-  const nextCell = sim.fillPtr < sim.fillOrder.length ? sim.fillOrder[sim.fillPtr] : null
+  const nextCell =
+    sim.fillPtr < sim.fillOrder.length ? sim.fillOrder[sim.fillPtr] : null
 
   return (
     <div className="bhk-table-scroll">
@@ -47,7 +50,9 @@ function DpTable({ sim, selected, onSelect }: {
           <tr>
             <th className="bhk-th bhk-th-row">end \ subset</th>
             {masks.map((mask) => (
-              <th key={mask} className="bhk-th">{mask.toString(2).padStart(m, '0')}</th>
+              <th key={mask} className="bhk-th">
+                {mask.toString(2).padStart(m, '0')}
+              </th>
             ))}
           </tr>
         </thead>
@@ -68,9 +73,15 @@ function DpTable({ sim, selected, onSelect }: {
                   isRoute ? 'bhk-cell-route' : '',
                   isNext ? 'bhk-cell-next' : '',
                   isSel ? 'bhk-cell-sel' : '',
-                ].join(' ').trim()
+                ]
+                  .join(' ')
+                  .trim()
                 return (
-                  <td key={mask} className={cls} onClick={() => onSelect(mask, row)}>
+                  <td
+                    key={mask}
+                    className={cls}
+                    onClick={() => onSelect(mask, row)}
+                  >
                     {val === INF ? '·' : val.toFixed(0)}
                   </td>
                 )
@@ -103,17 +114,28 @@ function CityMap({ sim }: { sim: SimState }) {
   const routeEdges: Array<[number, number]> = []
   if (inReadback && sim.readback.length >= 2) {
     const pts = [0, ...sim.readback]
-    for (let k = 0; k < pts.length - 1; k++) routeEdges.push([pts[k], pts[k + 1]])
+    for (let k = 0; k < pts.length - 1; k++)
+      routeEdges.push([pts[k], pts[k + 1]])
     if (sim.phase === 'done') routeEdges.push([pts[pts.length - 1], 0])
   }
 
   return (
-    <svg viewBox="0 0 300 300" className="bhk-map" role="img" aria-label="Current subset on the map">
+    <svg
+      viewBox="0 0 300 300"
+      className="bhk-map"
+      role="img"
+      aria-label="Current subset on the map"
+    >
       <rect x={0} y={0} width={300} height={300} className="bhk-bg" />
       {routeEdges.map(([a, b]) => (
-        <line key={`${a}-${b}`} className="bhk-map-edge"
-          x1={sim.cities[a][0]} y1={sim.cities[a][1]}
-          x2={sim.cities[b][0]} y2={sim.cities[b][1]} />
+        <line
+          key={`${a}-${b}`}
+          className="bhk-map-edge"
+          x1={sim.cities[a][0]}
+          y1={sim.cities[a][1]}
+          x2={sim.cities[b][0]}
+          y2={sim.cities[b][1]}
+        />
       ))}
       {Array.from({ length: n }, (_, i) => i).map((i) => {
         const inSub = subset.has(i)
@@ -122,8 +144,19 @@ function CityMap({ sim }: { sim: SimState }) {
         else if (inSub) cls = 'bhk-city'
         return (
           <g key={i}>
-            <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
-            <text className="bhk-label" x={sim.cities[i][0]} y={sim.cities[i][1] + 16}>{i}</text>
+            <circle
+              className={cls}
+              cx={sim.cities[i][0]}
+              cy={sim.cities[i][1]}
+              r={7}
+            />
+            <text
+              className="bhk-label"
+              x={sim.cities[i][0]}
+              y={sim.cities[i][1] + 16}
+            >
+              {i}
+            </text>
           </g>
         )
       })}
@@ -135,10 +168,15 @@ function CityMap({ sim }: { sim: SimState }) {
 // Root component
 // ---------------------------------------------------------------
 export default function BhkExplainer() {
-  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [sim, setSim] = useState<SimState>(() =>
+    makeInitState(DEFAULT_SCENARIO),
+  )
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(2)
-  const [selected, setSelected] = useState<{ mask: number; row: number } | null>(null)
+  const [selected, setSelected] = useState<{
+    mask: number
+    row: number
+  } | null>(null)
 
   const simRef = useRef(sim)
   const historyRef = useRef<SimState[]>([])
@@ -149,13 +187,16 @@ export default function BhkExplainer() {
     setSim(next)
   }, [])
 
-  const reinit = useCallback((scenario: Scenario) => {
-    scenarioRef.current = scenario
-    historyRef.current = []
-    setSelected(null)
-    commit(makeInitState(scenario))
-    setRunning(false)
-  }, [commit])
+  const reinit = useCallback(
+    (scenario: Scenario) => {
+      scenarioRef.current = scenario
+      historyRef.current = []
+      setSelected(null)
+      commit(makeInitState(scenario))
+      setRunning(false)
+    },
+    [commit],
+  )
 
   const stepForward = useCallback(() => {
     const cur = simRef.current
@@ -180,22 +221,36 @@ export default function BhkExplainer() {
   }, [running, speedIdx, stepForward])
 
   // jump to a phase (forward start / read-back start / done)
-  const jumpTo = useCallback((target: Phase) => {
-    let s = makeInitState(scenarioRef.current)
-    let guard = 600
-    while (s.phase !== target && s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
-    if (s.phase !== target && target !== 'done') s = stepOnce(s)
-    historyRef.current = []
-    commit(s)
-    setRunning(false)
-  }, [commit])
+  const jumpTo = useCallback(
+    (target: Phase) => {
+      let s = makeInitState(scenarioRef.current)
+      let guard = 600
+      while (s.phase !== target && s.phase !== 'done' && guard-- > 0)
+        s = stepOnce(s)
+      if (s.phase !== target && target !== 'done') s = stepOnce(s)
+      historyRef.current = []
+      commit(s)
+      setRunning(false)
+    },
+    [commit],
+  )
 
   const s = sim
   const full = (1 << s.m) - 1
-  const currentMask = s.fillPtr < s.fillOrder.length ? s.fillOrder[s.fillPtr].mask : full
-  const selectedCell = selected && selected.mask >= 1 && selected.mask <= full && selected.row >= 0 && selected.row < s.m
-    ? { value: s.table[selected.row][selected.mask], mask: selected.mask, row: selected.row }
-    : null
+  const currentMask =
+    s.fillPtr < s.fillOrder.length ? s.fillOrder[s.fillPtr].mask : full
+  const selectedCell =
+    selected &&
+    selected.mask >= 1 &&
+    selected.mask <= full &&
+    selected.row >= 0 &&
+    selected.row < s.m
+      ? {
+          value: s.table[selected.row][selected.mask],
+          mask: selected.mask,
+          row: selected.row,
+        }
+      : null
 
   // cell info text
   let cellInfo = 'click a cell to see how its value was computed'
@@ -212,11 +267,12 @@ export default function BhkExplainer() {
     }
   }
 
-  let chipText = s.lastEvent ?? 'Bellman-Held-Karp — the DP table fills subset by subset'
-  let chipClass = "bhk-chip bhk-chip-idle"
-  if (s.phase === 'done') chipClass = "bhk-chip bhk-chip-done"
-  else if (s.phase === 'readback') chipClass = "bhk-chip bhk-chip-readback"
-  else if (chipText.includes('dp[')) chipClass = "bhk-chip bhk-chip-cell"
+  let chipText =
+    s.lastEvent ?? 'Bellman-Held-Karp — the DP table fills subset by subset'
+  let chipClass = 'bhk-chip bhk-chip-idle'
+  if (s.phase === 'done') chipClass = 'bhk-chip bhk-chip-done'
+  else if (s.phase === 'readback') chipClass = 'bhk-chip bhk-chip-readback'
+  else if (chipText.includes('dp[')) chipClass = 'bhk-chip bhk-chip-cell'
 
   return (
     <div className="bhk-root">
@@ -224,53 +280,115 @@ export default function BhkExplainer() {
 
       <header className="bhk-header">
         <div className="bhk-eyebrow">teeline · algorithms/bhk</div>
-        <h2 className="bhk-title">Bellman-Held-Karp — exact dynamic programming</h2>
+        <h2 className="bhk-title">
+          Bellman-Held-Karp — exact dynamic programming
+        </h2>
         <p className="bhk-sub">
-          BHK fills a table of <strong>subset costs</strong>: <code>dp[mask][i]</code> is the cheapest
-          path from city 0 that visits exactly the cities in <code>mask</code> and ends at city{' '}
-          <code>i</code>. Every cell is built from one smaller subset plus one edge — then the optimal
-          route is <strong>read back</strong> through the recorded predecessors.
+          BHK fills a table of <strong>subset costs</strong>:{' '}
+          <code>dp[mask][i]</code> is the cheapest path from city 0 that visits
+          exactly the cities in <code>mask</code> and ends at city{' '}
+          <code>i</code>. Every cell is built from one smaller subset plus one
+          edge — then the optimal route is <strong>read back</strong> through
+          the recorded predecessors.
         </p>
       </header>
 
       <div className="bhk-viz-row">
         <div className="bhk-side">
-          <div className="bhk-section-label">DP table — rows end city, columns subset</div>
-          <DpTable sim={s} selected={selected} onSelect={(mask, row) => setSelected({ mask, row })} />
-          <div className="bhk-section-label" style={{ marginTop: 6 }}>Subset on the map</div>
+          <div className="bhk-section-label">
+            DP table — rows end city, columns subset
+          </div>
+          <DpTable
+            sim={s}
+            selected={selected}
+            onSelect={(mask, row) => setSelected({ mask, row })}
+          />
+          <div className="bhk-section-label" style={{ marginTop: 6 }}>
+            Subset on the map
+          </div>
           <CityMap sim={s} />
         </div>
         <div className="bhk-panel">
           <div className="bhk-section-label">Cell info</div>
           <div className="bhk-cellinfo">{cellInfo}</div>
 
-          <div className="bhk-section-label" style={{ marginTop: 10 }}>Optimal</div>
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>
+            Optimal
+          </div>
           <div className="bhk-best">
-            <span className="bhk-mono">{s.optCost === null ? '— (after the table fills)' : s.route!.join(' → ') + ' = ' + s.optCost.toFixed(1)}</span>
+            <span className="bhk-mono">
+              {s.optCost === null
+                ? '— (after the table fills)'
+                : s.route!.join(' → ') + ' = ' + s.optCost.toFixed(1)}
+            </span>
           </div>
 
-          <div className="bhk-section-label" style={{ marginTop: 10 }}>Stats</div>
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>
+            Stats
+          </div>
           <div className="bhk-statgrid">
-            <div><div className="bhk-statlabel">subset size</div><div className="bhk-mono">{popcount(currentMask)}</div></div>
-            <div><div className="bhk-statlabel">bits set</div><div className="bhk-mono">{currentMask.toString(2).padStart(s.m, '0')}</div></div>
-            <div><div className="bhk-statlabel">phase</div><div className="bhk-mono">{s.phase}</div></div>
-            <div><div className="bhk-statlabel">step</div><div className="bhk-mono">{s.step}</div></div>
+            <div>
+              <div className="bhk-statlabel">subset size</div>
+              <div className="bhk-mono">{popcount(currentMask)}</div>
+            </div>
+            <div>
+              <div className="bhk-statlabel">bits set</div>
+              <div className="bhk-mono">
+                {currentMask.toString(2).padStart(s.m, '0')}
+              </div>
+            </div>
+            <div>
+              <div className="bhk-statlabel">phase</div>
+              <div className="bhk-mono">{s.phase}</div>
+            </div>
+            <div>
+              <div className="bhk-statlabel">step</div>
+              <div className="bhk-mono">{s.step}</div>
+            </div>
           </div>
 
-          <div className="bhk-section-label" style={{ marginTop: 10 }}>Mode</div>
+          <div className="bhk-section-label" style={{ marginTop: 10 }}>
+            Mode
+          </div>
           <div className="bhk-mode-row">
-            <button className={`bhk-mode-btn ${s.phase === 'forward' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('forward')} disabled={running}>Forward</button>
-            <button className={`bhk-mode-btn ${s.phase === 'readback' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('readback')} disabled={running}>Read-back</button>
-            <button className={`bhk-mode-btn ${s.phase === 'done' ? 'bhk-mode-cur' : ''}`} onClick={() => jumpTo('done')} disabled={running}>Done</button>
+            <button
+              className={`bhk-mode-btn ${s.phase === 'forward' ? 'bhk-mode-cur' : ''}`}
+              onClick={() => jumpTo('forward')}
+              disabled={running}
+            >
+              Forward
+            </button>
+            <button
+              className={`bhk-mode-btn ${s.phase === 'readback' ? 'bhk-mode-cur' : ''}`}
+              onClick={() => jumpTo('readback')}
+              disabled={running}
+            >
+              Read-back
+            </button>
+            <button
+              className={`bhk-mode-btn ${s.phase === 'done' ? 'bhk-mode-cur' : ''}`}
+              onClick={() => jumpTo('done')}
+              disabled={running}
+            >
+              Done
+            </button>
           </div>
         </div>
       </div>
 
       <div className="bhk-legend">
-        <span><span className="bhk-swatch bhk-swatch-base" /> base cell</span>
-        <span><span className="bhk-swatch bhk-swatch-filled" /> filled</span>
-        <span><span className="bhk-swatch bhk-swatch-next" /> next cell</span>
-        <span><span className="bhk-swatch bhk-swatch-route" /> optimal route</span>
+        <span>
+          <span className="bhk-swatch bhk-swatch-base" /> base cell
+        </span>
+        <span>
+          <span className="bhk-swatch bhk-swatch-filled" /> filled
+        </span>
+        <span>
+          <span className="bhk-swatch bhk-swatch-next" /> next cell
+        </span>
+        <span>
+          <span className="bhk-swatch bhk-swatch-route" /> optimal route
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -280,28 +398,61 @@ export default function BhkExplainer() {
           <span className="bhk-label">Speed</span>
           <div className="bhk-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l} className={`bhk-speed-btn ${i === speedIdx ? 'bhk-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+              <button
+                key={l}
+                className={`bhk-speed-btn ${i === speedIdx ? 'bhk-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
+                {l}
+              </button>
             ))}
           </div>
         </div>
       </div>
 
       <div className="bhk-controls">
-        <button className="bhk-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
-        <button className="bhk-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
-        <button className="bhk-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="bhk-btn"
+          onClick={stepBack}
+          disabled={running || s.step === 0}
+        >
+          ⏴ Back
         </button>
-        <button className="bhk-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="bhk-btn"
+          onClick={stepForward}
+          disabled={running || s.phase === 'done'}
+        >
+          ⏵ Step
+        </button>
+        <button
+          className="bhk-btn"
+          onClick={() => setRunning(!running)}
+          disabled={s.phase === 'done'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button
+          className="bhk-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="bhk-scenarios">
         <div className="bhk-section-label">Scenarios</div>
         <div className="bhk-scenario-row">
           {Object.entries(SCENARIOS).map(([key, sc]) => (
-            <button key={key} className="bhk-scenario-btn" title={sc.desc}
-              onClick={() => reinit(sc)} disabled={running}>
+            <button
+              key={key}
+              className="bhk-scenario-btn"
+              title={sc.desc}
+              onClick={() => reinit(sc)}
+              disabled={running}
+            >
               {sc.label}
             </button>
           ))}
@@ -310,7 +461,9 @@ export default function BhkExplainer() {
 
       <footer className="bhk-footer">
         <span className="bhk-mono">cities: {s.n}</span>
-        <span className="bhk-mono">{'dp[mask][i] = min_j dp[mask∖{i}][j] + d(j, i)'}</span>
+        <span className="bhk-mono">
+          {'dp[mask][i] = min_j dp[mask∖{i}][j] + d(j, i)'}
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/branch-bound-algo.ts
+++ b/teeline-web/src/explainers/branch-bound-algo.ts
@@ -21,11 +21,11 @@ export type NodeStatus = 'open' | 'explored' | 'pruned' | 'leaf' | 'best'
 export interface BnBNode {
   id: number
   parent: number | null
-  depth: number          // path length (k)
-  path: number[]         // partial tour (visited city ids in order)
-  cost: number           // running cost of the partial tour
+  depth: number // path length (k)
+  path: number[] // partial tour (visited city ids in order)
+  cost: number // running cost of the partial tour
   unvisited: number[]
-  lb: number             // cost + MST({start} ∪ unvisited)
+  lb: number // cost + MST({start} ∪ unvisited)
   status: NodeStatus
 }
 
@@ -36,15 +36,15 @@ export interface SimState {
   cities: [number, number][]
   n: number
   startCity: number
-  dm: number[][]          // distance matrix (plain numbers — cloneable)
+  dm: number[][] // distance matrix (plain numbers — cloneable)
   nodes: BnBNode[]
-  stack: number[]         // DFS stack (node ids)
-  current: number | null  // node being expanded (top of stack)
+  stack: number[] // DFS stack (node ids)
+  current: number | null // node being expanded (top of stack)
   bestCost: number | null
   bestTour: number[] | null
-  explored: number        // nodes pushed onto the stack
-  pruned: number          // children filtered by LB ≥ best
-  leaves: number          // complete tours evaluated
+  explored: number // nodes pushed onto the stack
+  pruned: number // children filtered by LB ≥ best
+  leaves: number // complete tours evaluated
   lastEvent: string | null
   step: number
 }
@@ -94,22 +94,50 @@ export const SCENARIOS: Record<string, Scenario> = {
   small_grid: {
     label: 'Small grid',
     desc: 'A compact 6-city instance — the tree completes quickly and shows the full search',
-    cities: [[60, 60], [240, 60], [240, 240], [60, 240], [150, 60], [150, 240]],
+    cities: [
+      [60, 60],
+      [240, 60],
+      [240, 240],
+      [60, 240],
+      [150, 60],
+      [150, 240],
+    ],
   },
   good_bound: {
     label: 'Good bound',
     desc: 'A layout where the MST bound is tight — pruning cuts the tree to a couple of dozen nodes',
-    cities: [[36, 189], [238, 108], [166, 57], [235, 123], [159, 67], [172, 178]],
+    cities: [
+      [36, 189],
+      [238, 108],
+      [166, 57],
+      [235, 123],
+      [159, 67],
+      [172, 178],
+    ],
   },
   worst_case: {
     label: 'Worst case',
     desc: 'A scattered layout with a weak bound — the search nearly enumerates the whole tree',
-    cities: [[221, 167], [83, 178], [184, 162], [197, 243], [263, 44], [188, 171]],
+    cities: [
+      [221, 167],
+      [83, 178],
+      [184, 162],
+      [197, 243],
+      [263, 44],
+      [188, 171],
+    ],
   },
   early_best: {
     label: 'Early best',
     desc: 'Cities on a circle — the first complete tour is already optimal, so almost everything prunes away',
-    cities: [[270, 150], [210, 254], [90, 254], [30, 150], [90, 46], [210, 46]],
+    cities: [
+      [270, 150],
+      [210, 254],
+      [90, 254],
+      [30, 150],
+      [90, 46],
+      [210, 46],
+    ],
   },
 }
 
@@ -121,7 +149,9 @@ export function makeInitState(scenario: Scenario): SimState {
   const n = cities.length
   const dm = makeDm(cities)
   const startCity = 0
-  const unvisited = Array.from({ length: n }, (_, i) => i).filter((i) => i !== startCity)
+  const unvisited = Array.from({ length: n }, (_, i) => i).filter(
+    (i) => i !== startCity,
+  )
   const root: BnBNode = {
     id: 0,
     parent: null,
@@ -157,7 +187,13 @@ export function stepOnce(state: SimState): SimState {
   if (state.phase === 'done') return { ...state, step: state.step + 1 }
 
   if (state.stack.length === 0) {
-    return { ...state, phase: 'done', current: null, lastEvent: 'Search complete — optimal tour found', step: state.step + 1 }
+    return {
+      ...state,
+      phase: 'done',
+      current: null,
+      lastEvent: 'Search complete — optimal tour found',
+      step: state.step + 1,
+    }
   }
 
   const topId = state.stack[state.stack.length - 1]
@@ -166,7 +202,9 @@ export function stepOnce(state: SimState): SimState {
 
   // Candidates not yet branched: unvisited sorted by distance from prev
   const childCount = state.nodes.filter((nd) => nd.parent === topId).length
-  const candidates = [...top.unvisited].sort((a, b) => state.dm[prev][a] - state.dm[prev][b])
+  const candidates = [...top.unvisited].sort(
+    (a, b) => state.dm[prev][a] - state.dm[prev][b],
+  )
 
   if (childCount < candidates.length) {
     const c = candidates[childCount]
@@ -182,7 +220,12 @@ export function stepOnce(state: SimState): SimState {
       const isBest = state.bestCost === null || tourCost < state.bestCost
       const closed = [...path, state.startCity].join('→')
       const node: BnBNode = {
-        id, parent: topId, depth: path.length, path, cost, unvisited,
+        id,
+        parent: topId,
+        depth: path.length,
+        path,
+        cost,
+        unvisited,
         lb: tourCost,
         status: isBest ? 'best' : 'leaf',
       }
@@ -204,7 +247,14 @@ export function stepOnce(state: SimState): SimState {
     if (state.bestCost !== null && lb >= state.bestCost) {
       // Pruned immediately — cannot beat the best tour
       const node: BnBNode = {
-        id, parent: topId, depth: path.length, path, cost, unvisited, lb, status: 'pruned',
+        id,
+        parent: topId,
+        depth: path.length,
+        path,
+        cost,
+        unvisited,
+        lb,
+        status: 'pruned',
       }
       return {
         ...state,
@@ -216,7 +266,14 @@ export function stepOnce(state: SimState): SimState {
     }
 
     const node: BnBNode = {
-      id, parent: topId, depth: path.length, path, cost, unvisited, lb, status: 'open',
+      id,
+      parent: topId,
+      depth: path.length,
+      path,
+      cost,
+      unvisited,
+      lb,
+      status: 'open',
     }
     return {
       ...state,
@@ -237,7 +294,9 @@ export function stepOnce(state: SimState): SimState {
     stack: rest,
     current: parent,
     // mark this node explored (it stays in the tree, but no longer frontier)
-    nodes: state.nodes.map((nd) => (nd.id === topId ? { ...nd, status: 'explored' as NodeStatus } : nd)),
+    nodes: state.nodes.map((nd) =>
+      nd.id === topId ? { ...nd, status: 'explored' as NodeStatus } : nd,
+    ),
     lastEvent: `Backtracked — no better branch under ${top.path.join('→')}`,
     step: state.step + 1,
   }

--- a/teeline-web/src/explainers/branch-bound.test.ts
+++ b/teeline-web/src/explainers/branch-bound.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
-  SCENARIOS, makeInitState, stepOnce,
-  mstCost, makeDm,
+  SCENARIOS,
+  makeInitState,
+  stepOnce,
+  mstCost,
+  makeDm,
 } from './branch-bound-algo'
 import type { SimState } from './branch-bound-algo'
 
@@ -44,11 +47,25 @@ function runToDone(scenario: (typeof SCENARIOS)[string]): SimState {
 // ---------------------------------------------------------------
 describe('mstCost', () => {
   it('is zero for a single node', () => {
-    expect(mstCost([0], makeDm([[0, 0], [1, 0]]))).toBe(0)
+    expect(
+      mstCost(
+        [0],
+        makeDm([
+          [0, 0],
+          [1, 0],
+        ]),
+      ),
+    ).toBe(0)
   })
 
   it('finds the minimal chain MST', () => {
-    const dm = makeDm([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+    const dm = makeDm([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ])
     expect(mstCost([0, 1, 2, 3, 4], dm)).toBeCloseTo(4, 6)
   })
 })
@@ -120,13 +137,20 @@ describe('correctness & scenario pins', () => {
   it('every scenario finds the exact optimum (verified against brute force)', () => {
     for (const [key, sc] of Object.entries(SCENARIOS)) {
       const s = runToDone(sc)
-      expect(s.bestCost, `${key} must find the optimum`).toBeCloseTo(bruteForce(sc.cities), 6)
+      expect(s.bestCost, `${key} must find the optimum`).toBeCloseTo(
+        bruteForce(sc.cities),
+        6,
+      )
       // bestTour is the closed cycle: starts and ends at city 0, middle is a permutation
       expect(s.bestTour![0], `${key} cycle must start at city 0`).toBe(0)
-      expect(s.bestTour![s.bestTour!.length - 1], `${key} cycle must end at city 0`).toBe(0)
-      expect([...s.bestTour!.slice(1, -1)].sort((a, b) => a - b), `${key} middle must be a permutation`).toEqual(
-        Array.from({ length: sc.cities.length - 1 }, (_, i) => i + 1),
-      )
+      expect(
+        s.bestTour![s.bestTour!.length - 1],
+        `${key} cycle must end at city 0`,
+      ).toBe(0)
+      expect(
+        [...s.bestTour!.slice(1, -1)].sort((a, b) => a - b),
+        `${key} middle must be a permutation`,
+      ).toEqual(Array.from({ length: sc.cities.length - 1 }, (_, i) => i + 1))
     }
   })
 
@@ -139,10 +163,16 @@ describe('correctness & scenario pins', () => {
     for (let t = 0; t < 20; t++) {
       const cities: [number, number][] = []
       for (let i = 0; i < 6; i++) {
-        cities.push([Math.round(20 + rnd() * 260), Math.round(20 + rnd() * 260)] as [number, number])
+        cities.push([
+          Math.round(20 + rnd() * 260),
+          Math.round(20 + rnd() * 260),
+        ] as [number, number])
       }
       const s = runToDone({ label: '', desc: '', cities })
-      expect(s.bestCost, `random instance ${t} must match brute force`).toBeCloseTo(bruteForce(cities), 6)
+      expect(
+        s.bestCost,
+        `random instance ${t} must match brute force`,
+      ).toBeCloseTo(bruteForce(cities), 6)
     }
   })
 

--- a/teeline-web/src/explainers/branch-bound.tsx
+++ b/teeline-web/src/explainers/branch-bound.tsx
@@ -1,19 +1,21 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
-import {
-  SCENARIOS, makeInitState, stepOnce,
-} from "./branch-bound-algo"
-import type { Scenario, SimState, BnBNode } from "./branch-bound-algo"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
+import { SCENARIOS, makeInitState, stepOnce } from './branch-bound-algo'
+import type { Scenario, SimState, BnBNode } from './branch-bound-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.small_grid
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 // ---------------------------------------------------------------
 // SearchTree — horizontal tree: root on the left, children to the
 // right. Pruned nodes red with a strike, best leaf gold, the active
 // path green; clicking a node pins it in the info panel.
 // ---------------------------------------------------------------
-function SearchTree({ sim, selectedId, onSelect }: {
+function SearchTree({
+  sim,
+  selectedId,
+  onSelect,
+}: {
   sim: SimState
   selectedId: number | null
   onSelect: (id: number) => void
@@ -23,13 +25,21 @@ function SearchTree({ sim, selectedId, onSelect }: {
 
   const { nodes, stack } = sim
   const onStack = useMemo(() => new Set(stack), [stack])
-  const maxDepth = useMemo(() => nodes.reduce((m, nd) => Math.max(m, nd.depth), 1), [nodes])
+  const maxDepth = useMemo(
+    () => nodes.reduce((m, nd) => Math.max(m, nd.depth), 1),
+    [nodes],
+  )
   const width = maxDepth * X + 70
   const height = Math.max(40, nodes.length * Y + 24)
 
   return (
     <div className="bb-tree-scroll">
-      <svg viewBox={`0 0 ${width} ${height}`} className="bb-tree" role="img" aria-label="Branch and bound search tree">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="bb-tree"
+        role="img"
+        aria-label="Branch and bound search tree"
+      >
         {/* edges */}
         {nodes.map((nd) => {
           if (nd.parent === null) return null
@@ -39,7 +49,16 @@ function SearchTree({ sim, selectedId, onSelect }: {
           const x2 = nd.depth * X - 6
           const y2 = nd.id * Y + Y / 2
           const cls = `bb-edge ${onStack.has(nd.id) ? 'bb-edge-active' : ''}`
-          return <line key={`e${nd.id}`} className={cls} x1={x1} y1={y1} x2={x2} y2={y2} />
+          return (
+            <line
+              key={`e${nd.id}`}
+              className={cls}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+            />
+          )
         })}
         {/* nodes */}
         {nodes.map((nd) => {
@@ -53,14 +72,24 @@ function SearchTree({ sim, selectedId, onSelect }: {
             onStack.has(nd.id) && nd.status === 'open' ? 'bb-node-open' : '',
             nd.id === sim.current ? 'bb-node-current' : '',
             selectedId === nd.id ? 'bb-node-selected' : '',
-          ].join(' ').trim()
+          ]
+            .join(' ')
+            .trim()
           const label = nd.path[nd.path.length - 1]
           return (
             <g key={nd.id} className={cls} onClick={() => onSelect(nd.id)}>
               <rect x={x - 24} y={y} width={48} height={Y - 3} rx={3} />
-              <text x={x} y={y + 11} className="bb-node-city">{label}</text>
-              <text x={x + 6} y={y + 11} className="bb-node-lb">{nd.lb.toFixed(0)}</text>
-              {nd.status === 'pruned' && <text x={x + 22} y={y + 8} className="bb-node-x">✕</text>}
+              <text x={x} y={y + 11} className="bb-node-city">
+                {label}
+              </text>
+              <text x={x + 6} y={y + 11} className="bb-node-lb">
+                {nd.lb.toFixed(0)}
+              </text>
+              {nd.status === 'pruned' && (
+                <text x={x + 22} y={y + 8} className="bb-node-x">
+                  ✕
+                </text>
+              )}
               <title>{`path ${nd.path.join('→')} · bound ${nd.lb.toFixed(0)} · ${nd.status}`}</title>
             </g>
           )
@@ -74,19 +103,29 @@ function SearchTree({ sim, selectedId, onSelect }: {
 // CityMap — partial tour of the pinned/active node, unvisited gray
 // ---------------------------------------------------------------
 function CityMap({ sim, node }: { sim: SimState; node: BnBNode | null }) {
-  const path = node ? node.path : sim.bestTour ?? []
+  const path = node ? node.path : (sim.bestTour ?? [])
   const unvisited = node ? new Set(node.unvisited) : new Set<number>()
   const n = sim.n
   const edges: Array<[number, number]> = []
   for (let k = 0; k < path.length - 1; k++) edges.push([path[k], path[k + 1]])
 
   return (
-    <svg viewBox="0 0 300 300" className="bb-map" role="img" aria-label="Partial tour at the selected node">
+    <svg
+      viewBox="0 0 300 300"
+      className="bb-map"
+      role="img"
+      aria-label="Partial tour at the selected node"
+    >
       <rect x={0} y={0} width={300} height={300} className="bb-bg" />
       {edges.map(([a, b]) => (
-        <line key={`${a}-${b}`} className="bb-map-edge"
-          x1={sim.cities[a][0]} y1={sim.cities[a][1]}
-          x2={sim.cities[b][0]} y2={sim.cities[b][1]} />
+        <line
+          key={`${a}-${b}`}
+          className="bb-map-edge"
+          x1={sim.cities[a][0]}
+          y1={sim.cities[a][1]}
+          x2={sim.cities[b][0]}
+          y2={sim.cities[b][1]}
+        />
       ))}
       {Array.from({ length: n }, (_, i) => i).map((i) => {
         const inPath = path.includes(i)
@@ -95,8 +134,19 @@ function CityMap({ sim, node }: { sim: SimState; node: BnBNode | null }) {
         else if (unvisited.has(i)) cls = 'bb-city-unvisited'
         return (
           <g key={i}>
-            <circle className={cls} cx={sim.cities[i][0]} cy={sim.cities[i][1]} r={7} />
-            <text className="bb-label" x={sim.cities[i][0]} y={sim.cities[i][1] + 16}>{i}</text>
+            <circle
+              className={cls}
+              cx={sim.cities[i][0]}
+              cy={sim.cities[i][1]}
+              r={7}
+            />
+            <text
+              className="bb-label"
+              x={sim.cities[i][0]}
+              y={sim.cities[i][1] + 16}
+            >
+              {i}
+            </text>
           </g>
         )
       })}
@@ -108,7 +158,9 @@ function CityMap({ sim, node }: { sim: SimState; node: BnBNode | null }) {
 // Root component
 // ---------------------------------------------------------------
 export default function BranchBoundExplainer() {
-  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [sim, setSim] = useState<SimState>(() =>
+    makeInitState(DEFAULT_SCENARIO),
+  )
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(2)
   const [selectedId, setSelectedId] = useState<number | null>(null)
@@ -122,13 +174,16 @@ export default function BranchBoundExplainer() {
     setSim(next)
   }, [])
 
-  const reinit = useCallback((scenario: Scenario) => {
-    scenarioRef.current = scenario
-    historyRef.current = []
-    setSelectedId(null)
-    commit(makeInitState(scenario))
-    setRunning(false)
-  }, [commit])
+  const reinit = useCallback(
+    (scenario: Scenario) => {
+      scenarioRef.current = scenario
+      historyRef.current = []
+      setSelectedId(null)
+      commit(makeInitState(scenario))
+      setRunning(false)
+    },
+    [commit],
+  )
 
   const stepForward = useCallback(() => {
     const cur = simRef.current
@@ -152,24 +207,28 @@ export default function BranchBoundExplainer() {
   }, [running, speedIdx, stepForward])
 
   const s = sim
-  const selectedNode = selectedId !== null ? s.nodes.find((nd) => nd.id === selectedId) ?? null : null
+  const selectedNode =
+    selectedId !== null
+      ? (s.nodes.find((nd) => nd.id === selectedId) ?? null)
+      : null
   const activeNode = s.current !== null ? s.nodes[s.current] : null
   const infoNode = selectedNode ?? activeNode
 
   // Status chip
-  let chipText = s.lastEvent ?? 'Branch & Bound — the search tree grows as we step'
-  let chipClass = "bb-chip bb-chip-idle"
+  let chipText =
+    s.lastEvent ?? 'Branch & Bound — the search tree grows as we step'
+  let chipClass = 'bb-chip bb-chip-idle'
   if (s.phase === 'done') {
     chipText = `Done — optimal tour ${s.bestTour?.join('→') ?? '—'} costs ${s.bestCost?.toFixed(0) ?? '—'} (${s.nodes.length} nodes, ${s.pruned} pruned)`
-    chipClass = "bb-chip bb-chip-done"
+    chipClass = 'bb-chip bb-chip-done'
   } else if (chipText.startsWith('New best')) {
-    chipClass = "bb-chip bb-chip-best"
+    chipClass = 'bb-chip bb-chip-best'
   } else if (chipText.startsWith('Pruned')) {
-    chipClass = "bb-chip bb-chip-pruned"
+    chipClass = 'bb-chip bb-chip-pruned'
   } else if (chipText.startsWith('Expanded')) {
-    chipClass = "bb-chip bb-chip-open"
+    chipClass = 'bb-chip bb-chip-open'
   } else if (chipText.startsWith('Leaf')) {
-    chipClass = "bb-chip bb-chip-leaf"
+    chipClass = 'bb-chip bb-chip-leaf'
   }
 
   return (
@@ -178,19 +237,26 @@ export default function BranchBoundExplainer() {
 
       <header className="bb-header">
         <div className="bb-eyebrow">teeline · algorithms/branch_bound</div>
-        <h2 className="bb-title">Branch &amp; Bound — exact search with pruning</h2>
+        <h2 className="bb-title">
+          Branch &amp; Bound — exact search with pruning
+        </h2>
         <p className="bb-sub">
-          B&amp;B explores the tree of partial tours. At every node the <strong>lower bound</strong>
-          ({'partial cost + MST(start ∪ remaining)'}) is compared with the <strong>best complete
-          tour</strong> found so far — any branch whose bound cannot beat it is <strong>pruned</strong>.
-          The bound is valid, so the surviving leaf is the exact optimum.
+          B&amp;B explores the tree of partial tours. At every node the{' '}
+          <strong>lower bound</strong>({'partial cost + MST(start ∪ remaining)'}
+          ) is compared with the <strong>best complete tour</strong> found so
+          far — any branch whose bound cannot beat it is <strong>pruned</strong>
+          . The bound is valid, so the surviving leaf is the exact optimum.
         </p>
       </header>
 
       <div className="bb-viz-row">
         <div className="bb-side">
           <div className="bb-section-label">Search tree</div>
-          <SearchTree sim={s} selectedId={selectedId} onSelect={setSelectedId} />
+          <SearchTree
+            sim={s}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
         </div>
         <div className="bb-panel">
           <div className="bb-section-label">Tour at selected node</div>
@@ -201,44 +267,98 @@ export default function BranchBoundExplainer() {
           <div className="bb-nodeinfo">
             {infoNode ? (
               <>
-                <div className="bb-nodeinfo-row"><span>path</span><span className="bb-mono">{infoNode.path.join(' → ')}</span></div>
-                <div className="bb-nodeinfo-row"><span>bound</span><span className="bb-mono">{infoNode.lb.toFixed(1)}</span></div>
-                <div className="bb-nodeinfo-row"><span>status</span><span className="bb-mono">{infoNode.status}</span></div>
+                <div className="bb-nodeinfo-row">
+                  <span>path</span>
+                  <span className="bb-mono">{infoNode.path.join(' → ')}</span>
+                </div>
+                <div className="bb-nodeinfo-row">
+                  <span>bound</span>
+                  <span className="bb-mono">{infoNode.lb.toFixed(1)}</span>
+                </div>
+                <div className="bb-nodeinfo-row">
+                  <span>status</span>
+                  <span className="bb-mono">{infoNode.status}</span>
+                </div>
                 <div className="bb-nodeinfo-note">
-                  bound = partial {infoNode.cost.toFixed(1)} + MST(start ∪ {infoNode.unvisited.join(',')})
+                  bound = partial {infoNode.cost.toFixed(1)} + MST(start ∪{' '}
+                  {infoNode.unvisited.join(',')})
                 </div>
                 {infoNode.status === 'pruned' && selectedId === infoNode.id && (
-                  <div className="bb-nodeinfo-why">Pruned because {infoNode.lb.toFixed(1)} ≥ best {s.bestCost?.toFixed(1) ?? '—'} — no tour below this branch can win.</div>
+                  <div className="bb-nodeinfo-why">
+                    Pruned because {infoNode.lb.toFixed(1)} ≥ best{' '}
+                    {s.bestCost?.toFixed(1) ?? '—'} — no tour below this branch
+                    can win.
+                  </div>
                 )}
               </>
             ) : (
-              <div className="bb-nodeinfo-row">click a tree node to inspect it</div>
+              <div className="bb-nodeinfo-row">
+                click a tree node to inspect it
+              </div>
             )}
           </div>
 
-          <div className="bb-section-label" style={{ marginTop: 10 }}>Best tour</div>
+          <div className="bb-section-label" style={{ marginTop: 10 }}>
+            Best tour
+          </div>
           <div className="bb-best">
-            <span className="bb-mono">{s.bestCost === null ? '— (none yet)' : s.bestTour!.join(' → ') + ' = ' + s.bestCost.toFixed(1)}</span>
+            <span className="bb-mono">
+              {s.bestCost === null
+                ? '— (none yet)'
+                : s.bestTour!.join(' → ') + ' = ' + s.bestCost.toFixed(1)}
+            </span>
           </div>
 
-          <div className="bb-section-label" style={{ marginTop: 10 }}>Stats</div>
+          <div className="bb-section-label" style={{ marginTop: 10 }}>
+            Stats
+          </div>
           <div className="bb-statgrid">
-            <div><div className="bb-statlabel">nodes</div><div className="bb-mono">{s.nodes.length}</div></div>
-            <div><div className="bb-statlabel">explored</div><div className="bb-mono">{s.explored}</div></div>
-            <div><div className="bb-statlabel">pruned</div><div className="bb-mono">{s.pruned}</div></div>
-            <div><div className="bb-statlabel">leaves</div><div className="bb-mono">{s.leaves}</div></div>
-            <div><div className="bb-statlabel">best</div><div className="bb-mono">{s.bestCost === null ? '—' : s.bestCost.toFixed(0)}</div></div>
-            <div><div className="bb-statlabel">step</div><div className="bb-mono">{s.step}</div></div>
+            <div>
+              <div className="bb-statlabel">nodes</div>
+              <div className="bb-mono">{s.nodes.length}</div>
+            </div>
+            <div>
+              <div className="bb-statlabel">explored</div>
+              <div className="bb-mono">{s.explored}</div>
+            </div>
+            <div>
+              <div className="bb-statlabel">pruned</div>
+              <div className="bb-mono">{s.pruned}</div>
+            </div>
+            <div>
+              <div className="bb-statlabel">leaves</div>
+              <div className="bb-mono">{s.leaves}</div>
+            </div>
+            <div>
+              <div className="bb-statlabel">best</div>
+              <div className="bb-mono">
+                {s.bestCost === null ? '—' : s.bestCost.toFixed(0)}
+              </div>
+            </div>
+            <div>
+              <div className="bb-statlabel">step</div>
+              <div className="bb-mono">{s.step}</div>
+            </div>
           </div>
         </div>
       </div>
 
       <div className="bb-legend">
-        <span><span className="bb-swatch bb-swatch-open" /> open</span>
-        <span><span className="bb-swatch bb-swatch-active" /> active path</span>
-        <span><span className="bb-swatch bb-swatch-pruned" /> pruned</span>
-        <span><span className="bb-swatch bb-swatch-leaf" /> leaf</span>
-        <span><span className="bb-swatch bb-swatch-best" /> new best</span>
+        <span>
+          <span className="bb-swatch bb-swatch-open" /> open
+        </span>
+        <span>
+          <span className="bb-swatch bb-swatch-active" /> active path
+        </span>
+        <span>
+          <span className="bb-swatch bb-swatch-pruned" /> pruned
+        </span>
+        <span>
+          <span className="bb-swatch bb-swatch-leaf" /> leaf
+        </span>
+        <span>
+          <span className="bb-swatch bb-swatch-best" /> new best
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -248,28 +368,61 @@ export default function BranchBoundExplainer() {
           <span className="bb-label">Speed</span>
           <div className="bb-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l} className={`bb-speed-btn ${i === speedIdx ? 'bb-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+              <button
+                key={l}
+                className={`bb-speed-btn ${i === speedIdx ? 'bb-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
+                {l}
+              </button>
             ))}
           </div>
         </div>
       </div>
 
       <div className="bb-controls">
-        <button className="bb-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
-        <button className="bb-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
-        <button className="bb-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="bb-btn"
+          onClick={stepBack}
+          disabled={running || s.step === 0}
+        >
+          ⏴ Back
         </button>
-        <button className="bb-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="bb-btn"
+          onClick={stepForward}
+          disabled={running || s.phase === 'done'}
+        >
+          ⏵ Step
+        </button>
+        <button
+          className="bb-btn"
+          onClick={() => setRunning(!running)}
+          disabled={s.phase === 'done'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button
+          className="bb-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="bb-scenarios">
         <div className="bb-section-label">Scenarios</div>
         <div className="bb-scenario-row">
           {Object.entries(SCENARIOS).map(([key, sc]) => (
-            <button key={key} className="bb-scenario-btn" title={sc.desc}
-              onClick={() => reinit(sc)} disabled={running}>
+            <button
+              key={key}
+              className="bb-scenario-btn"
+              title={sc.desc}
+              onClick={() => reinit(sc)}
+              disabled={running}
+            >
               {sc.label}
             </button>
           ))}
@@ -278,7 +431,9 @@ export default function BranchBoundExplainer() {
 
       <footer className="bb-footer">
         <span className="bb-mono">cities: {s.n}</span>
-        <span className="bb-mono">bound = partial + MST(start ∪ remaining) · prune when bound ≥ best</span>
+        <span className="bb-mono">
+          bound = partial + MST(start ∪ remaining) · prune when bound ≥ best
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/christofides-algo.ts
+++ b/teeline-web/src/explainers/christofides-algo.ts
@@ -31,7 +31,14 @@ export interface Instance {
 
 export type Phase = 'mst' | 'odd' | 'matching' | 'euler' | 'shortcut' | 'done'
 
-export const PHASES: Phase[] = ['mst', 'odd', 'matching', 'euler', 'shortcut', 'done']
+export const PHASES: Phase[] = [
+  'mst',
+  'odd',
+  'matching',
+  'euler',
+  'shortcut',
+  'done',
+]
 
 export interface SimState {
   phase: Phase
@@ -50,22 +57,25 @@ export interface SimState {
   tourCost: number
   opt: number
   ratio: number
-  nnCost: number       // greedy nearest-neighbor tour (comparison)
-  approx2Cost: number  // doubled-MST tour (comparison)
+  nnCost: number // greedy nearest-neighbor tour (comparison)
+  approx2Cost: number // doubled-MST tour (comparison)
   // progressive state
-  mstRevealed: number      // MST edges revealed so far
+  mstRevealed: number // MST edges revealed so far
   matchingRevealed: number // matching pairs revealed so far
-  walkerPos: number        // index into eulerCircuit (euler phase)
-  shortcutStep: number     // index into eulerCircuit (shortcut phase)
-  kept: number[]           // shortcut: fresh cities so far (in walk order)
-  skipped: number[]        // shortcut: circuit positions that were repeats
+  walkerPos: number // index into eulerCircuit (euler phase)
+  shortcutStep: number // index into eulerCircuit (shortcut phase)
+  kept: number[] // shortcut: fresh cities so far (in walk order)
+  skipped: number[] // shortcut: circuit positions that were repeats
   step: number
 }
 
 // ---------------------------------------------------------------
 // Step 1 — Prim's MST (port of prim_mst)
 // ---------------------------------------------------------------
-export function primMst(n: number, dist: (i: number, j: number) => number): [number, number][] {
+export function primMst(
+  n: number,
+  dist: (i: number, j: number) => number,
+): [number, number][] {
   const inMst = new Array<boolean>(n).fill(false)
   const key = new Array<number>(n).fill(Infinity)
   const parent = new Array<number>(n).fill(-1)
@@ -101,7 +111,10 @@ export function primMst(n: number, dist: (i: number, j: number) => number): [num
 // ---------------------------------------------------------------
 // Step 2 — odd-degree vertices (port of odd_degree_nodes)
 // ---------------------------------------------------------------
-export function oddDegreeNodes(mstEdges: [number, number][], n: number): number[] {
+export function oddDegreeNodes(
+  mstEdges: [number, number][],
+  n: number,
+): number[] {
   const degree = new Array<number>(n).fill(0)
   for (const [u, v] of mstEdges) {
     degree[u]++
@@ -223,7 +236,10 @@ export function christofidesPipeline(
 // ---------------------------------------------------------------
 // Comparisons — the 2× cousin (doubled MST) and greedy NN
 // ---------------------------------------------------------------
-export function doubledMstTourCost(n: number, dist: (i: number, j: number) => number): number {
+export function doubledMstTourCost(
+  n: number,
+  dist: (i: number, j: number) => number,
+): number {
   const mstEdges = primMst(n, dist)
   // double every MST edge → all degrees even → Eulerian
   const adj: number[][] = Array.from({ length: n }, () => [])
@@ -236,7 +252,10 @@ export function doubledMstTourCost(n: number, dist: (i: number, j: number) => nu
   return closedTourCost(tour, dist)
 }
 
-export function nearestNeighborTourCost(n: number, dist: (i: number, j: number) => number): number {
+export function nearestNeighborTourCost(
+  n: number,
+  dist: (i: number, j: number) => number,
+): number {
   const visited = new Array<boolean>(n).fill(false)
   const tour: number[] = []
   let cur = 0
@@ -261,7 +280,10 @@ export function nearestNeighborTourCost(n: number, dist: (i: number, j: number) 
   return closedTourCost(tour, dist)
 }
 
-export function closedTourCost(tour: number[], dist: (i: number, j: number) => number): number {
+export function closedTourCost(
+  tour: number[],
+  dist: (i: number, j: number) => number,
+): number {
   let d = 0
   for (let k = 0; k < tour.length; k++) {
     d += dist(tour[k], tour[(k + 1) % tour.length])
@@ -272,7 +294,10 @@ export function closedTourCost(tour: number[], dist: (i: number, j: number) => n
 // ---------------------------------------------------------------
 // Exact optimum (brute force over (n-1)! permutations, start fixed at 0)
 // ---------------------------------------------------------------
-export function bruteForceOpt(n: number, dist: (i: number, j: number) => number): number {
+export function bruteForceOpt(
+  n: number,
+  dist: (i: number, j: number) => number,
+): number {
   let best = Infinity
   const rest = Array.from({ length: n - 1 }, (_, i) => i + 1)
   const used = new Array<boolean>(rest.length).fill(false)
@@ -309,33 +334,64 @@ export const SCENARIOS: Record<string, Instance> = {
     label: 'Near-optimal',
     desc: 'Cities on a circle — Christofides finds the exact optimum (1.00×)',
     cities: [
-      [280, 150], [255, 226], [190, 274], [110, 274], [45, 226],
-      [20, 150], [45, 74], [110, 26], [190, 26], [255, 74],
+      [280, 150],
+      [255, 226],
+      [190, 274],
+      [110, 274],
+      [45, 226],
+      [20, 150],
+      [45, 74],
+      [110, 26],
+      [190, 26],
+      [255, 74],
     ],
   },
   matching_heavy: {
     label: 'Matching-heavy',
     desc: 'Two tight clusters joined by a bridge — the odd-vertex matching is half the tour cost',
     cities: [
-      [57, 69], [77, 80], [65, 93], [93, 71], [79, 80],
-      [247, 244], [230, 240], [238, 244], [224, 215], [246, 211],
+      [57, 69],
+      [77, 80],
+      [65, 93],
+      [93, 71],
+      [79, 80],
+      [247, 244],
+      [230, 240],
+      [238, 244],
+      [224, 215],
+      [246, 211],
     ],
   },
   clustered: {
     label: 'Clustered',
     desc: 'Three clusters — the matching edges bridge between them (the doubled-MST cousin loses here)',
     cities: [
-      [69, 65], [90, 62], [84, 60],
-      [202, 79], [216, 79], [196, 101],
-      [149, 215], [152, 239], [159, 220], [139, 215],
+      [69, 65],
+      [90, 62],
+      [84, 60],
+      [202, 79],
+      [216, 79],
+      [196, 101],
+      [149, 215],
+      [152, 239],
+      [159, 220],
+      [139, 215],
     ],
   },
   worst_case: {
     label: 'Worst case',
     desc: 'A layout where the ratio stretches to 1.39× — the 1.5× bound is real, not hand-wavy',
     cities: [
-      [155, 192], [60, 131], [170, 148], [187, 60], [148, 139],
-      [105, 224], [108, 20], [52, 220], [148, 262], [165, 174],
+      [155, 192],
+      [60, 131],
+      [170, 148],
+      [187, 60],
+      [148, 139],
+      [105, 224],
+      [108, 20],
+      [52, 220],
+      [148, 262],
+      [165, 174],
     ],
   },
 }
@@ -344,7 +400,8 @@ export function makeInitState(instance: Instance): SimState {
   const cities = instance.cities
   const n = cities.length
   const dist = makeDist(cities)
-  const { mstEdges, odd, matchingEdges, eulerCircuit, shortcutTour } = christofidesPipeline(n, dist)
+  const { mstEdges, odd, matchingEdges, eulerCircuit, shortcutTour } =
+    christofidesPipeline(n, dist)
 
   const mstCost = mstEdges.reduce((s, [u, v]) => s + dist(u, v), 0)
   const matchingCost = matchingEdges.reduce((s, [u, v]) => s + dist(u, v), 0)
@@ -388,7 +445,11 @@ export function stepOnce(state: SimState): SimState {
   // --- MST phase: reveal one Prim edge per step ---
   if (state.phase === 'mst') {
     if (state.mstRevealed < state.mstEdges.length) {
-      return { ...state, mstRevealed: state.mstRevealed + 1, step: state.step + 1 }
+      return {
+        ...state,
+        mstRevealed: state.mstRevealed + 1,
+        step: state.step + 1,
+      }
     }
     return { ...state, phase: 'odd', step: state.step + 1 }
   }
@@ -401,7 +462,11 @@ export function stepOnce(state: SimState): SimState {
   // --- Matching phase: reveal one pair per step ---
   if (state.phase === 'matching') {
     if (state.matchingRevealed < state.matchingEdges.length) {
-      return { ...state, matchingRevealed: state.matchingRevealed + 1, step: state.step + 1 }
+      return {
+        ...state,
+        matchingRevealed: state.matchingRevealed + 1,
+        step: state.step + 1,
+      }
     }
     return { ...state, phase: 'euler', step: state.step + 1 }
   }

--- a/teeline-web/src/explainers/christofides.test.ts
+++ b/teeline-web/src/explainers/christofides.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import {
   SCENARIOS,
-  primMst, oddDegreeNodes, greedyMatching, buildMultigraph, hierholzer, shortcut,
-  christofidesPipeline, closedTourCost, makeInitState, stepOnce,
+  primMst,
+  oddDegreeNodes,
+  greedyMatching,
+  buildMultigraph,
+  hierholzer,
+  shortcut,
+  christofidesPipeline,
+  closedTourCost,
+  makeInitState,
+  stepOnce,
 } from './christofides-algo'
 import { makeDist } from './explainer-cities'
 
@@ -11,7 +19,12 @@ import { makeDist } from './explainer-cities'
 // ---------------------------------------------------------------
 describe('primMst', () => {
   it('has exactly n-1 edges and spans all nodes', () => {
-    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1]])
+    const dist = makeDist([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [1, 1],
+    ])
     const edges = primMst(4, dist)
     expect(edges).toHaveLength(3)
     const seen = new Set<number>([0])
@@ -23,7 +36,13 @@ describe('primMst', () => {
   })
 
   it('finds the minimal chain MST (weight 4.0)', () => {
-    const dist = makeDist([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]])
+    const dist = makeDist([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ])
     const edges = primMst(5, dist)
     const weight = edges.reduce((s, [u, v]) => s + dist(u, v), 0)
     expect(weight).toBeCloseTo(4.0, 3)
@@ -35,13 +54,21 @@ describe('primMst', () => {
 // ---------------------------------------------------------------
 describe('oddDegreeNodes', () => {
   it('counts an even number of odd-degree vertices (handshaking lemma)', () => {
-    const mst: [number, number][] = [[0, 1], [1, 2], [1, 3]]
+    const mst: [number, number][] = [
+      [0, 1],
+      [1, 2],
+      [1, 3],
+    ]
     const odd = oddDegreeNodes(mst, 4)
     expect(odd.length % 2).toBe(0)
   })
 
   it('finds the endpoints of a path', () => {
-    const mst: [number, number][] = [[0, 1], [1, 2], [2, 3]]
+    const mst: [number, number][] = [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+    ]
     expect(oddDegreeNodes(mst, 4).sort()).toEqual([0, 3])
   })
 })
@@ -51,7 +78,13 @@ describe('oddDegreeNodes', () => {
 // ---------------------------------------------------------------
 describe('greedyMatching', () => {
   it('covers every odd-degree node exactly once', () => {
-    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1], [3, 0]])
+    const dist = makeDist([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [1, 1],
+      [3, 0],
+    ])
     const mst = primMst(5, dist)
     const odd = oddDegreeNodes(mst, 5)
     const matching = greedyMatching(odd, dist, 5)
@@ -71,8 +104,17 @@ describe('greedyMatching', () => {
 // ---------------------------------------------------------------
 describe('hierholzer', () => {
   it('circuit length equals edges + 1 and consumes every edge', () => {
-    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1], [3, 0]])
-    const { mstEdges, matchingEdges, eulerCircuit } = christofidesPipeline(5, dist)
+    const dist = makeDist([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [1, 1],
+      [3, 0],
+    ])
+    const { mstEdges, matchingEdges, eulerCircuit } = christofidesPipeline(
+      5,
+      dist,
+    )
     const totalEdges = mstEdges.length + matchingEdges.length
     expect(eulerCircuit).toHaveLength(totalEdges + 1)
     // every consecutive pair in the circuit is an edge of the multigraph
@@ -84,8 +126,13 @@ describe('hierholzer', () => {
       }
     }
     for (let t = 0; t < eulerCircuit.length - 1; t++) {
-      const [a, b] = [eulerCircuit[t], eulerCircuit[t + 1]].sort((x, y) => x - y)
-      expect(edgeSet.has(`${a}-${b}`), `circuit step ${t} must use a real edge`).toBe(true)
+      const [a, b] = [eulerCircuit[t], eulerCircuit[t + 1]].sort(
+        (x, y) => x - y,
+      )
+      expect(
+        edgeSet.has(`${a}-${b}`),
+        `circuit step ${t} must use a real edge`,
+      ).toBe(true)
     }
   })
 })
@@ -115,9 +162,15 @@ describe('christofidesPipeline', () => {
         Array.from({ length: s.n }, (_, i) => i),
       )
       // tour cost matches a recomputation
-      expect(closedTourCost(s.shortcutTour, makeDist(inst.cities))).toBeCloseTo(s.tourCost, 6)
+      expect(closedTourCost(s.shortcutTour, makeDist(inst.cities))).toBeCloseTo(
+        s.tourCost,
+        6,
+      )
       // ratio ≤ 1.5 on every scenario
-      expect(s.ratio, `${key} ratio must stay within the 1.5× bound`).toBeLessThanOrEqual(1.5)
+      expect(
+        s.ratio,
+        `${key} ratio must stay within the 1.5× bound`,
+      ).toBeLessThanOrEqual(1.5)
     }
   })
 
@@ -130,7 +183,10 @@ describe('christofidesPipeline', () => {
     for (let t = 0; t < 12; t++) {
       const cities: [number, number][] = []
       for (let i = 0; i < 10; i++) {
-        cities.push([Math.round(20 + rnd() * 260), Math.round(20 + rnd() * 260)] as [number, number])
+        cities.push([
+          Math.round(20 + rnd() * 260),
+          Math.round(20 + rnd() * 260),
+        ] as [number, number])
       }
       const s = makeInitState({ label: '', desc: '', cities })
       expect(s.ratio).toBeLessThanOrEqual(1.5)
@@ -203,7 +259,8 @@ describe('stepOnce phase machine', () => {
   it('odd → matching → euler → shortcut → done in order', () => {
     let s = s0
     // walk the whole machine to completion
-    let guard = mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
+    let guard =
+      mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
     while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
     expect(s.phase).toBe('done')
     expect(s.kept).toEqual(s.shortcutTour)
@@ -223,7 +280,8 @@ describe('stepOnce phase machine', () => {
 
   it('done is a no-op apart from the step counter', () => {
     let s = s0
-    let guard = mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
+    let guard =
+      mstSteps + 5 + matchingSteps + 1 + eulerSteps + 1 + shortcutSteps + 2
     while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
     const again = stepOnce(s)
     expect(again.phase).toBe('done')
@@ -257,7 +315,12 @@ describe('purity & determinism', () => {
   })
 
   it('primitives are pure — hierholzer does not mutate its input adjacency', () => {
-    const dist = makeDist([[0, 0], [1, 0], [2, 0], [1, 1]])
+    const dist = makeDist([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [1, 1],
+    ])
     const mst = primMst(4, dist)
     const odd = oddDegreeNodes(mst, 4)
     const matching = greedyMatching(odd, dist, 4)

--- a/teeline-web/src/explainers/christofides.tsx
+++ b/teeline-web/src/explainers/christofides.tsx
@@ -1,13 +1,10 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
-import {
-  PHASES, SCENARIOS,
-  makeInitState, stepOnce,
-} from "./christofides-algo"
-import type { Phase, Instance, SimState } from "./christofides-algo"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
+import { PHASES, SCENARIOS, makeInitState, stepOnce } from './christofides-algo'
+import type { Phase, Instance, SimState } from './christofides-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.balanced
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 const PHASE_LABELS: Record<Phase, string> = {
   mst: 'MST',
@@ -27,7 +24,12 @@ function edgeKey(a: number, b: number): string {
 // green MST edges, purple dashed matching, the multigraph with a
 // walking dot (euler), and the final tour being carved out (shortcut).
 // ---------------------------------------------------------------
-function TourCanvas({ sim, showMst, showMatch, showTour }: {
+function TourCanvas({
+  sim,
+  showMst,
+  showMatch,
+  showTour,
+}: {
   sim: SimState
   showMst: boolean
   showMatch: boolean
@@ -37,9 +39,16 @@ function TourCanvas({ sim, showMst, showMatch, showTour }: {
   const pos = (i: number) => cities[i]
 
   const multigraphEdges = useMemo(() => {
-    const list: Array<{ id: number; a: number; b: number; kind: 'mst' | 'match' }> = []
-    for (const [a, b] of sim.mstEdges) list.push({ id: list.length, a, b, kind: 'mst' })
-    for (const [a, b] of sim.matchingEdges) list.push({ id: list.length, a, b, kind: 'match' })
+    const list: Array<{
+      id: number
+      a: number
+      b: number
+      kind: 'mst' | 'match'
+    }> = []
+    for (const [a, b] of sim.mstEdges)
+      list.push({ id: list.length, a, b, kind: 'mst' })
+    for (const [a, b] of sim.matchingEdges)
+      list.push({ id: list.length, a, b, kind: 'match' })
     return list
   }, [sim.mstEdges, sim.matchingEdges])
 
@@ -80,20 +89,25 @@ function TourCanvas({ sim, showMst, showMatch, showTour }: {
   // final tour edges (built during shortcut; complete at done)
   const tourEdges: Array<[number, number]> = []
   const kept = phase === 'done' ? sim.shortcutTour : sim.kept
-  for (let t = 0; t < kept.length - 1; t++) tourEdges.push([kept[t], kept[t + 1]])
-  if (phase === 'done' && kept.length > 1) tourEdges.push([kept[kept.length - 1], kept[0]])
+  for (let t = 0; t < kept.length - 1; t++)
+    tourEdges.push([kept[t], kept[t + 1]])
+  if (phase === 'done' && kept.length > 1)
+    tourEdges.push([kept[kept.length - 1], kept[0]])
 
   const skippedSet = new Set(sim.skipped)
 
   // walker position: euler phase follows walkerPos; shortcut follows shortcutStep
   let walkerCity: number | null = null
   if (phase === 'euler') {
-    walkerCity = sim.eulerCircuit[Math.min(sim.walkerPos, sim.eulerCircuit.length - 1)]
+    walkerCity =
+      sim.eulerCircuit[Math.min(sim.walkerPos, sim.eulerCircuit.length - 1)]
   } else if (phase === 'shortcut') {
-    walkerCity = sim.eulerCircuit[Math.min(sim.shortcutStep, sim.eulerCircuit.length - 1)]
+    walkerCity =
+      sim.eulerCircuit[Math.min(sim.shortcutStep, sim.eulerCircuit.length - 1)]
   }
 
-  const constructing = phase === 'mst' || phase === 'odd' || phase === 'matching'
+  const constructing =
+    phase === 'mst' || phase === 'odd' || phase === 'matching'
   let mstShown: [number, number][] = []
   if (showMst && constructing) {
     const limit = phase === 'mst' ? sim.mstRevealed : sim.mstEdges.length
@@ -102,62 +116,113 @@ function TourCanvas({ sim, showMst, showMatch, showTour }: {
   let matchShown: [number, number][] = []
   if (showMatch && phase === 'matching') {
     matchShown = sim.matchingEdges.slice(0, sim.matchingRevealed)
-  } else if (showMatch && (phase === 'euler' || phase === 'shortcut' || phase === 'done')) {
+  } else if (
+    showMatch &&
+    (phase === 'euler' || phase === 'shortcut' || phase === 'done')
+  ) {
     matchShown = sim.matchingEdges
   }
   const showMultigraph = phase === 'euler' || phase === 'shortcut'
   const showTourLayer = showTour && (phase === 'shortcut' || phase === 'done')
 
   return (
-    <svg viewBox="0 0 300 300" className="chr-canvas" role="img" aria-label="Christofides construction">
+    <svg
+      viewBox="0 0 300 300"
+      className="chr-canvas"
+      role="img"
+      aria-label="Christofides construction"
+    >
       <rect x={0} y={0} width={300} height={300} className="chr-bg" />
 
       {/* Plain construction layers */}
       {mstShown.map(([a, b]) => (
-        <line key={`m${edgeKey(a, b)}`} className="chr-mst-edge"
-          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
+        <line
+          key={`m${edgeKey(a, b)}`}
+          className="chr-mst-edge"
+          x1={pos(a)[0]}
+          y1={pos(a)[1]}
+          x2={pos(b)[0]}
+          y2={pos(b)[1]}
+        />
       ))}
       {matchShown.map(([a, b]) => (
-        <line key={`p${edgeKey(a, b)}`} className="chr-match-edge"
-          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
+        <line
+          key={`p${edgeKey(a, b)}`}
+          className="chr-match-edge"
+          x1={pos(a)[0]}
+          y1={pos(a)[1]}
+          x2={pos(b)[0]}
+          y2={pos(b)[1]}
+        />
       ))}
 
       {/* Multigraph (euler/shortcut): used edges fade */}
-      {showMultigraph && multigraphEdges.map((e) => {
-        const used = isEdgeUsed(e.a, e.b)
-        const cls = `chr-multi-edge ${e.kind === 'mst' ? 'chr-multi-mst' : 'chr-multi-match'} ${used ? 'chr-multi-used' : ''}`
-        return <line key={e.id} className={cls}
-          x1={pos(e.a)[0]} y1={pos(e.a)[1]} x2={pos(e.b)[0]} y2={pos(e.b)[1]} />
-      })}
+      {showMultigraph &&
+        multigraphEdges.map((e) => {
+          const used = isEdgeUsed(e.a, e.b)
+          const cls = `chr-multi-edge ${e.kind === 'mst' ? 'chr-multi-mst' : 'chr-multi-match'} ${used ? 'chr-multi-used' : ''}`
+          return (
+            <line
+              key={e.id}
+              className={cls}
+              x1={pos(e.a)[0]}
+              y1={pos(e.a)[1]}
+              x2={pos(e.b)[0]}
+              y2={pos(e.b)[1]}
+            />
+          )
+        })}
 
       {/* Final tour (shortcut phase + done) */}
-      {showTourLayer && tourEdges.map(([a, b]) => (
-        <line key={`t${edgeKey(a, b)}`} className="chr-tour-edge"
-          x1={pos(a)[0]} y1={pos(a)[1]} x2={pos(b)[0]} y2={pos(b)[1]} />
-      ))}
+      {showTourLayer &&
+        tourEdges.map(([a, b]) => (
+          <line
+            key={`t${edgeKey(a, b)}`}
+            className="chr-tour-edge"
+            x1={pos(a)[0]}
+            y1={pos(a)[1]}
+            x2={pos(b)[0]}
+            y2={pos(b)[1]}
+          />
+        ))}
 
       {/* Cities */}
       {cities.map(([x, y], id) => {
         const oddHighlight = phase === 'odd' || phase === 'matching'
         return (
           <g key={id}>
-            <circle className={`chr-city ${sim.odd.includes(id) && oddHighlight ? 'chr-city-odd' : ''}`}
-              cx={x} cy={y} r={7} />
-            <text className="chr-label" x={x} y={y + 16}>{id}</text>
+            <circle
+              className={`chr-city ${sim.odd.includes(id) && oddHighlight ? 'chr-city-odd' : ''}`}
+              cx={x}
+              cy={y}
+              r={7}
+            />
+            <text className="chr-label" x={x} y={y + 16}>
+              {id}
+            </text>
           </g>
         )
       })}
 
       {/* Walker dot */}
       {walkerCity !== null && (
-        <circle className="chr-walker" cx={pos(walkerCity)[0]} cy={pos(walkerCity)[1]} r={5} />
+        <circle
+          className="chr-walker"
+          cx={pos(walkerCity)[0]}
+          cy={pos(walkerCity)[1]}
+          r={5}
+        />
       )}
 
       {/* Skipped repeat markers (shortcut) */}
       {[...skippedSet].map((idx) => {
         const city = sim.eulerCircuit[idx]
         const [x, y] = pos(city)
-        return <text key={`sk${idx}`} className="chr-skip" x={x} y={y - 8}>✕</text>
+        return (
+          <text key={`sk${idx}`} className="chr-skip" x={x} y={y - 8}>
+            ✕
+          </text>
+        )
       })}
     </svg>
   )
@@ -172,10 +237,16 @@ function RatioMeter({ ratio }: { ratio: number }) {
   return (
     <div className="chr-meter">
       <div className="chr-meter-track">
-        <div className="chr-meter-fill" style={{ width: `${Math.min(100, pct)}%` }} />
+        <div
+          className="chr-meter-fill"
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
         <div className="chr-meter-mark chr-meter-mark-opt" />
         <div className="chr-meter-mark chr-meter-mark-bound" />
-        <div className="chr-meter-dot" style={{ left: `${Math.min(100, pct)}%` }} />
+        <div
+          className="chr-meter-dot"
+          style={{ left: `${Math.min(100, pct)}%` }}
+        />
       </div>
       <div className="chr-meter-labels">
         <span>1.0× OPT</span>
@@ -189,14 +260,27 @@ function RatioMeter({ ratio }: { ratio: number }) {
 // ---------------------------------------------------------------
 // Comparison rows — NN / doubled-MST / Christofides
 // ---------------------------------------------------------------
-function CompareRow({ label, cost, opt, best }: { label: string; cost: number; opt: number; best: boolean }) {
+function CompareRow({
+  label,
+  cost,
+  opt,
+  best,
+}: {
+  label: string
+  cost: number
+  opt: number
+  best: boolean
+}) {
   const ratio = cost / opt
   const pct = Math.min(100, ((ratio - 1) / 0.6) * 100)
   return (
     <div className={`chr-compare-row ${best ? 'chr-compare-best' : ''}`}>
       <span className="chr-compare-label">{label}</span>
       <div className="chr-compare-track">
-        <div className="chr-compare-fill" style={{ width: `${Math.max(0, pct)}%` }} />
+        <div
+          className="chr-compare-fill"
+          style={{ width: `${Math.max(0, pct)}%` }}
+        />
       </div>
       <span className="chr-compare-value">{ratio.toFixed(2)}×</span>
     </div>
@@ -207,7 +291,9 @@ function CompareRow({ label, cost, opt, best }: { label: string; cost: number; o
 // Root component
 // ---------------------------------------------------------------
 export default function ChristofidesExplainer() {
-  const [sim, setSim] = useState<SimState>(() => makeInitState(DEFAULT_SCENARIO))
+  const [sim, setSim] = useState<SimState>(() =>
+    makeInitState(DEFAULT_SCENARIO),
+  )
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(2) // 3x default
   const [showMstLayer, setShowMstLayer] = useState(true)
@@ -223,12 +309,15 @@ export default function ChristofidesExplainer() {
     setSim(next)
   }, [])
 
-  const reinit = useCallback((instance: Instance) => {
-    scenarioRef.current = instance
-    historyRef.current = []
-    commit(makeInitState(instance))
-    setRunning(false)
-  }, [commit])
+  const reinit = useCallback(
+    (instance: Instance) => {
+      scenarioRef.current = instance
+      historyRef.current = []
+      commit(makeInitState(instance))
+      setRunning(false)
+    },
+    [commit],
+  )
 
   const stepForward = useCallback(() => {
     const cur = simRef.current
@@ -253,14 +342,18 @@ export default function ChristofidesExplainer() {
   }, [running, speedIdx, stepForward])
 
   // Phase selector — jump straight to a phase's start (replays deterministically)
-  const jumpTo = useCallback((target: Phase) => {
-    let s = makeInitState(scenarioRef.current)
-    let guard = 600
-    while (s.phase !== target && s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
-    historyRef.current = []
-    commit(s)
-    setRunning(false)
-  }, [commit])
+  const jumpTo = useCallback(
+    (target: Phase) => {
+      let s = makeInitState(scenarioRef.current)
+      let guard = 600
+      while (s.phase !== target && s.phase !== 'done' && guard-- > 0)
+        s = stepOnce(s)
+      historyRef.current = []
+      commit(s)
+      setRunning(false)
+    },
+    [commit],
+  )
 
   const s = sim
   const phaseIdx = PHASES.indexOf(s.phase)
@@ -268,7 +361,7 @@ export default function ChristofidesExplainer() {
 
   // Status chip
   let chipText = "Step 1 — growing the Minimum Spanning Tree (Prim's)"
-  let chipClass = "chr-chip chr-chip-idle"
+  let chipClass = 'chr-chip chr-chip-idle'
   if (s.phase === 'mst') {
     if (s.mstRevealed === 0) {
       chipText = `MST — click Step to grow the tree (Prim's, cost ${s.mstCost.toFixed(0)})`
@@ -279,25 +372,27 @@ export default function ChristofidesExplainer() {
     }
   } else if (s.phase === 'odd') {
     chipText = `Odd-degree vertices: ${s.odd.join(', ')} — always an even count (handshaking lemma)`
-    chipClass = "chr-chip chr-chip-odd"
+    chipClass = 'chr-chip chr-chip-odd'
   } else if (s.phase === 'matching') {
-    chipText = s.matchingRevealed < s.matchingEdges.length
-      ? `Matching — paired ${s.matchingEdges[s.matchingRevealed - 1][0]}–${s.matchingEdges[s.matchingRevealed - 1][1]} (${s.matchingRevealed}/${s.matchingEdges.length} pairs)`
-      : `Matching complete — cost ${s.matchingCost.toFixed(0)}`
-    chipClass = "chr-chip chr-chip-match"
+    chipText =
+      s.matchingRevealed < s.matchingEdges.length
+        ? `Matching — paired ${s.matchingEdges[s.matchingRevealed - 1][0]}–${s.matchingEdges[s.matchingRevealed - 1][1]} (${s.matchingRevealed}/${s.matchingEdges.length} pairs)`
+        : `Matching complete — cost ${s.matchingCost.toFixed(0)}`
+    chipClass = 'chr-chip chr-chip-match'
   } else if (s.phase === 'euler') {
     chipText = `Eulerian circuit — walking ${s.eulerCircuit[s.walkerPos - 1] ?? '—'}→${s.eulerCircuit[s.walkerPos]} (${s.walkerPos}/${s.eulerCircuit.length - 1})`
-    chipClass = "chr-chip chr-chip-euler"
+    chipClass = 'chr-chip chr-chip-euler'
   } else if (s.phase === 'shortcut') {
-    const city = s.eulerCircuit[Math.min(s.shortcutStep, s.eulerCircuit.length - 1)]
+    const city =
+      s.eulerCircuit[Math.min(s.shortcutStep, s.eulerCircuit.length - 1)]
     const fresh = s.kept.includes(city)
     chipText = fresh
       ? `Shortcut — ${city} added to the tour`
       : `Shortcut — ${city} already visited, skipped (✕)`
-    chipClass = "chr-chip chr-chip-shortcut"
+    chipClass = 'chr-chip chr-chip-shortcut'
   } else if (s.phase === 'done') {
     chipText = `Done — tour cost ${s.tourCost.toFixed(0)} = ${s.ratio.toFixed(2)}× OPT (bound 1.5×)`
-    chipClass = "chr-chip chr-chip-done"
+    chipClass = 'chr-chip chr-chip-done'
   }
 
   return (
@@ -308,16 +403,25 @@ export default function ChristofidesExplainer() {
         <div className="chr-eyebrow">teeline · algorithms/christofides</div>
         <h2 className="chr-title">Christofides — a ≤1.5× Approximation</h2>
         <p className="chr-sub">
-          The only simple TSP heuristic with a <strong>provable worst-case bound</strong>: the tour is
-          always within 1.5× of optimal. Three ingredients — <strong>MST</strong> (skeleton, ≤ OPT),
-          <strong>matching</strong> on the odd-degree vertices (patch, ≤ OPT/2), and an
-          <strong>Eulerian walk + shortcut</strong> (≤ MST + matching) — add up to the guarantee.
+          The only simple TSP heuristic with a{' '}
+          <strong>provable worst-case bound</strong>: the tour is always within
+          1.5× of optimal. Three ingredients — <strong>MST</strong> (skeleton, ≤
+          OPT),
+          <strong>matching</strong> on the odd-degree vertices (patch, ≤ OPT/2),
+          and an
+          <strong>Eulerian walk + shortcut</strong> (≤ MST + matching) — add up
+          to the guarantee.
         </p>
       </header>
 
       <div className="chr-viz-row">
         <div className="chr-canvas-wrap">
-          <TourCanvas sim={s} showMst={showMstLayer} showMatch={showMatchLayer} showTour={showTourLayer} />
+          <TourCanvas
+            sim={s}
+            showMst={showMstLayer}
+            showMatch={showMatchLayer}
+            showTour={showTourLayer}
+          />
         </div>
         <div className="chr-side">
           <div className="chr-section-label">Pipeline</div>
@@ -325,8 +429,12 @@ export default function ChristofidesExplainer() {
             {PHASES.map((p, i) => {
               const done = i < phaseIdx || s.phase === 'done'
               return (
-                <button key={p} className={`chr-phase-btn ${i === phaseIdx ? 'chr-phase-cur' : ''} ${done ? 'chr-phase-done' : ''}`}
-                  onClick={() => jumpTo(p)} disabled={running}>
+                <button
+                  key={p}
+                  className={`chr-phase-btn ${i === phaseIdx ? 'chr-phase-cur' : ''} ${done ? 'chr-phase-done' : ''}`}
+                  onClick={() => jumpTo(p)}
+                  disabled={running}
+                >
                   <span className="chr-phase-num">{done ? '✓' : i + 1}</span>
                   {PHASE_LABELS[p]}
                 </button>
@@ -339,81 +447,202 @@ export default function ChristofidesExplainer() {
 
           <div className="chr-section-label">Why ≤ 1.5×?</div>
           <div className="chr-proof">
-            <div className={`chr-proof-line ${phaseIdx >= 1 ? 'chr-proof-on' : ''}`}>
-              <span className="chr-proof-tag">MST</span> {s.mstCost.toFixed(0)} ≤ OPT {s.opt.toFixed(0)}
+            <div
+              className={`chr-proof-line ${phaseIdx >= 1 ? 'chr-proof-on' : ''}`}
+            >
+              <span className="chr-proof-tag">MST</span> {s.mstCost.toFixed(0)}{' '}
+              ≤ OPT {s.opt.toFixed(0)}
             </div>
-            <div className={`chr-proof-line ${phaseIdx >= 3 ? 'chr-proof-on' : ''}`}>
-              <span className="chr-proof-tag">Match</span> {s.matchingCost.toFixed(0)} {s.matchingCost > s.opt / 2 ? '>' : '≤'} OPT/2 {(s.opt / 2).toFixed(0)}
+            <div
+              className={`chr-proof-line ${phaseIdx >= 3 ? 'chr-proof-on' : ''}`}
+            >
+              <span className="chr-proof-tag">Match</span>{' '}
+              {s.matchingCost.toFixed(0)}{' '}
+              {s.matchingCost > s.opt / 2 ? '>' : '≤'} OPT/2{' '}
+              {(s.opt / 2).toFixed(0)}
               {s.matchingCost > s.opt / 2 && (
-                <span className="chr-proof-note"> greedy &gt; theory — the 1.5× bound assumes the true minimum matching</span>
+                <span className="chr-proof-note">
+                  {' '}
+                  greedy &gt; theory — the 1.5× bound assumes the true minimum
+                  matching
+                </span>
               )}
             </div>
-            <div className={`chr-proof-line ${s.phase === 'done' ? 'chr-proof-on' : ''}`}>
-              <span className="chr-proof-tag">Tour</span> {s.tourCost.toFixed(0)} ≤ MST+matching {s.eulerCost.toFixed(0)} ≤ 1.5·OPT {(1.5 * s.opt).toFixed(0)}
+            <div
+              className={`chr-proof-line ${s.phase === 'done' ? 'chr-proof-on' : ''}`}
+            >
+              <span className="chr-proof-tag">Tour</span>{' '}
+              {s.tourCost.toFixed(0)} ≤ MST+matching {s.eulerCost.toFixed(0)} ≤
+              1.5·OPT {(1.5 * s.opt).toFixed(0)}
             </div>
           </div>
 
           <div className="chr-section-label">Compare on this instance</div>
           <div className="chr-compare">
-            <CompareRow label="Nearest neighbour" cost={s.nnCost} opt={s.opt} best={s.nnCost <= s.approx2Cost && s.nnCost <= s.tourCost} />
-            <CompareRow label="Doubled MST (2×)" cost={s.approx2Cost} opt={s.opt} best={s.approx2Cost < s.nnCost && s.approx2Cost <= s.tourCost} />
-            <CompareRow label="Christofides" cost={s.tourCost} opt={s.opt} best={s.tourCost < s.nnCost && s.tourCost < s.approx2Cost} />
+            <CompareRow
+              label="Nearest neighbour"
+              cost={s.nnCost}
+              opt={s.opt}
+              best={s.nnCost <= s.approx2Cost && s.nnCost <= s.tourCost}
+            />
+            <CompareRow
+              label="Doubled MST (2×)"
+              cost={s.approx2Cost}
+              opt={s.opt}
+              best={s.approx2Cost < s.nnCost && s.approx2Cost <= s.tourCost}
+            />
+            <CompareRow
+              label="Christofides"
+              cost={s.tourCost}
+              opt={s.opt}
+              best={s.tourCost < s.nnCost && s.tourCost < s.approx2Cost}
+            />
           </div>
         </div>
       </div>
 
       <div className="chr-legend">
-        <span><span className="chr-swatch chr-swatch-mst" /> MST edge</span>
-        <span><span className="chr-swatch chr-swatch-match" /> matching edge</span>
-        <span><span className="chr-swatch chr-swatch-tour" /> final tour</span>
-        <span><span className="chr-swatch chr-swatch-odd" /> odd-degree vertex</span>
-        <span><span className="chr-swatch chr-swatch-walker" /> walker</span>
+        <span>
+          <span className="chr-swatch chr-swatch-mst" /> MST edge
+        </span>
+        <span>
+          <span className="chr-swatch chr-swatch-match" /> matching edge
+        </span>
+        <span>
+          <span className="chr-swatch chr-swatch-tour" /> final tour
+        </span>
+        <span>
+          <span className="chr-swatch chr-swatch-odd" /> odd-degree vertex
+        </span>
+        <span>
+          <span className="chr-swatch chr-swatch-walker" /> walker
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
 
       <div className="chr-statgrid">
-        <div><div className="chr-statlabel">phase</div><div className="chr-mono">{PHASE_LABELS[s.phase]}</div></div>
-        <div><div className="chr-statlabel">MST cost</div><div className="chr-mono">{s.mstCost.toFixed(0)}</div></div>
-        <div><div className="chr-statlabel">matching cost</div><div className="chr-mono">{s.matchingCost.toFixed(0)} ({Math.round(matchShare * 100)}%)</div></div>
-        <div><div className="chr-statlabel">tour cost</div><div className="chr-mono">{s.tourCost.toFixed(0)}</div></div>
-        <div><div className="chr-statlabel">ratio</div><div className="chr-mono">{s.ratio.toFixed(2)}×</div></div>
-        <div><div className="chr-statlabel">step</div><div className="chr-mono">{s.step}</div></div>
+        <div>
+          <div className="chr-statlabel">phase</div>
+          <div className="chr-mono">{PHASE_LABELS[s.phase]}</div>
+        </div>
+        <div>
+          <div className="chr-statlabel">MST cost</div>
+          <div className="chr-mono">{s.mstCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="chr-statlabel">matching cost</div>
+          <div className="chr-mono">
+            {s.matchingCost.toFixed(0)} ({Math.round(matchShare * 100)}%)
+          </div>
+        </div>
+        <div>
+          <div className="chr-statlabel">tour cost</div>
+          <div className="chr-mono">{s.tourCost.toFixed(0)}</div>
+        </div>
+        <div>
+          <div className="chr-statlabel">ratio</div>
+          <div className="chr-mono">{s.ratio.toFixed(2)}×</div>
+        </div>
+        <div>
+          <div className="chr-statlabel">step</div>
+          <div className="chr-mono">{s.step}</div>
+        </div>
       </div>
 
       <div className="chr-config">
         <div className="chr-config-row">
           <span className="chr-label">Show</span>
-          <label className="chr-toggle"><input type="checkbox" checked={showMstLayer} onChange={(e) => setShowMstLayer((e.target as HTMLInputElement).checked)} /> MST</label>
-          <label className="chr-toggle"><input type="checkbox" checked={showMatchLayer} onChange={(e) => setShowMatchLayer((e.target as HTMLInputElement).checked)} /> Matching</label>
-          <label className="chr-toggle"><input type="checkbox" checked={showTourLayer} onChange={(e) => setShowTourLayer((e.target as HTMLInputElement).checked)} /> Tour</label>
+          <label className="chr-toggle">
+            <input
+              type="checkbox"
+              checked={showMstLayer}
+              onChange={(e) =>
+                setShowMstLayer((e.target as HTMLInputElement).checked)
+              }
+            />{' '}
+            MST
+          </label>
+          <label className="chr-toggle">
+            <input
+              type="checkbox"
+              checked={showMatchLayer}
+              onChange={(e) =>
+                setShowMatchLayer((e.target as HTMLInputElement).checked)
+              }
+            />{' '}
+            Matching
+          </label>
+          <label className="chr-toggle">
+            <input
+              type="checkbox"
+              checked={showTourLayer}
+              onChange={(e) =>
+                setShowTourLayer((e.target as HTMLInputElement).checked)
+              }
+            />{' '}
+            Tour
+          </label>
         </div>
         <div className="chr-config-row">
           <span className="chr-label">Speed</span>
           <div className="chr-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l} className={`chr-speed-btn ${i === speedIdx ? 'chr-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>{l}</button>
+              <button
+                key={l}
+                className={`chr-speed-btn ${i === speedIdx ? 'chr-speed-btn-sel' : ''}`}
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
+                {l}
+              </button>
             ))}
           </div>
         </div>
       </div>
 
       <div className="chr-controls">
-        <button className="chr-btn" onClick={stepBack} disabled={running || s.step === 0}>⏴ Back</button>
-        <button className="chr-btn" onClick={stepForward} disabled={running || s.phase === 'done'}>⏵ Step</button>
-        <button className="chr-btn" onClick={() => setRunning(!running)} disabled={s.phase === 'done'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="chr-btn"
+          onClick={stepBack}
+          disabled={running || s.step === 0}
+        >
+          ⏴ Back
         </button>
-        <button className="chr-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="chr-btn"
+          onClick={stepForward}
+          disabled={running || s.phase === 'done'}
+        >
+          ⏵ Step
+        </button>
+        <button
+          className="chr-btn"
+          onClick={() => setRunning(!running)}
+          disabled={s.phase === 'done'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button
+          className="chr-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="chr-scenarios">
         <div className="chr-section-label">Scenarios</div>
         <div className="chr-scenario-row">
           {Object.entries(SCENARIOS).map(([key, inst]) => (
-            <button key={key} className="chr-scenario-btn" title={inst.desc}
-              onClick={() => reinit(inst)} disabled={running}>
+            <button
+              key={key}
+              className="chr-scenario-btn"
+              title={inst.desc}
+              onClick={() => reinit(inst)}
+              disabled={running}
+            >
               {inst.label}
             </button>
           ))}
@@ -422,7 +651,9 @@ export default function ChristofidesExplainer() {
 
       <footer className="chr-footer">
         <span className="chr-mono">cities: {s.n}</span>
-        <span className="chr-mono">MST + matching + Euler + shortcut · ≤ 1.5× optimal</span>
+        <span className="chr-mono">
+          MST + matching + Euler + shortcut · ≤ 1.5× optimal
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/cs.tsx
+++ b/teeline-web/src/explainers/cs.tsx
@@ -1,12 +1,21 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
 
 // ---------------------------------------------------------------
 // Fixed demo instance: same 18 cities as fpa.tsx (300×300 canvas)
 // ---------------------------------------------------------------
 const CITIES: [number, number][] = [
-  [45, 45], [155, 18], [265, 45], [285, 150],
-  [255, 265], [150, 285], [40, 260], [18, 150],
-  [110, 115], [200, 95], [220, 210], [95, 215],
+  [45, 45],
+  [155, 18],
+  [265, 45],
+  [285, 150],
+  [255, 265],
+  [150, 285],
+  [40, 260],
+  [18, 150],
+  [110, 115],
+  [200, 95],
+  [220, 210],
+  [95, 215],
 ]
 const N_CITIES = CITIES.length
 
@@ -71,9 +80,9 @@ function tourEdgeSet(tour: number[]): EdgeSet {
 }
 
 type EdgeDiff = {
-  removed: [number, number][]   // orange dashed
-  added: [number, number][]     // green
-  changedCities: Set<number>    // larger circles
+  removed: [number, number][] // orange dashed
+  added: [number, number][] // green
+  changedCities: Set<number> // larger circles
 }
 
 function computeEdgeDiff(before: number[], after: number[]): EdgeDiff {
@@ -84,7 +93,8 @@ function computeEdgeDiff(before: number[], after: number[]): EdgeDiff {
   const changedCities = new Set<number>()
 
   for (let i = 0; i < before.length; i++) {
-    const a = before[i], b = before[(i + 1) % before.length]
+    const a = before[i],
+      b = before[(i + 1) % before.length]
     const key = edgeKey(a, b)
     if (!aSet.has(key)) {
       removed.push([a, b])
@@ -93,7 +103,8 @@ function computeEdgeDiff(before: number[], after: number[]): EdgeDiff {
     }
   }
   for (let i = 0; i < after.length; i++) {
-    const a = after[i], b = after[(i + 1) % after.length]
+    const a = after[i],
+      b = after[(i + 1) % after.length]
     const key = edgeKey(a, b)
     if (!bSet.has(key)) {
       added.push([a, b])
@@ -112,7 +123,7 @@ type SimState = {
   costs: number[]
   best: number[]
   bestCost: number
-  nestIdx: number       // which nest within the current epoch
+  nestIdx: number // which nest within the current epoch
   epoch: number
   step: number
   replacements: number
@@ -124,11 +135,15 @@ function makeInitState(nNests: number): SimState {
   const costs = nests.map(tourLength)
   const bestIdx = costs.indexOf(Math.min(...costs))
   return {
-    nests, costs,
+    nests,
+    costs,
     best: nests[bestIdx].slice(),
     bestCost: costs[bestIdx],
-    nestIdx: 0, epoch: 0, step: 0,
-    replacements: 0, abandonments: 0,
+    nestIdx: 0,
+    epoch: 0,
+    step: 0,
+    replacements: 0,
+    abandonments: 0,
   }
 }
 
@@ -142,7 +157,12 @@ interface NestHeatmapProps {
   abandonedIdxs: number[]
 }
 
-function NestHeatmap({ costs, activeIdx, targetIdx, abandonedIdxs }: NestHeatmapProps) {
+function NestHeatmap({
+  costs,
+  activeIdx,
+  targetIdx,
+  abandonedIdxs,
+}: NestHeatmapProps) {
   if (!costs.length) return null
   const minC = Math.min(...costs)
   const maxC = Math.max(...costs)
@@ -152,23 +172,28 @@ function NestHeatmap({ costs, activeIdx, targetIdx, abandonedIdxs }: NestHeatmap
     <div className="cs-heatmap" aria-label="Nest quality heatmap">
       <div className="cs-heatmap-title">Nests</div>
       {costs.map((c, i) => {
-        const norm = (maxC - c) / range          // 1 = best, 0 = worst
-        const hue = Math.round(norm * 120)       // 120=green, 0=red
+        const norm = (maxC - c) / range // 1 = best, 0 = worst
+        const hue = Math.round(norm * 120) // 120=green, 0=red
         const isAbandoned = abandonedIdxs.includes(i)
-        const bg = isAbandoned ? "#cbd5e1" : `hsl(${hue},55%,42%)`
+        const bg = isAbandoned ? '#cbd5e1' : `hsl(${hue},55%,42%)`
         const border =
-          i === activeIdx ? "2px solid #3b82f6" :
-          i === targetIdx ? "2px solid #d97706" : "2px solid transparent"
-        const status =
-          isAbandoned ? "abandoned" :
-          i === activeIdx ? "active cuckoo" :
-          i === targetIdx ? "target host" :
-          `quality ${Math.round(norm * 100)}%`
+          i === activeIdx
+            ? '2px solid #3b82f6'
+            : i === targetIdx
+              ? '2px solid #d97706'
+              : '2px solid transparent'
+        const status = isAbandoned
+          ? 'abandoned'
+          : i === activeIdx
+            ? 'active cuckoo'
+            : i === targetIdx
+              ? 'target host'
+              : `quality ${Math.round(norm * 100)}%`
         return (
           <div
             key={i}
             className="cs-heatmap-cell"
-            style={{ background: bg, outline: border, outlineOffset: "1px" }}
+            style={{ background: bg, outline: border, outlineOffset: '1px' }}
           >
             <span className="cs-heatmap-idx">{i}</span>
             <span className="cs-heatmap-cost">{c.toFixed(0)}</span>
@@ -190,13 +215,20 @@ interface TourSVGProps {
 }
 
 function polylinePoints(tour: number[], close = true): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
-  return close && tour.length ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}` : pts
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
+  return close && tour.length
+    ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : pts
 }
 
 function TourSVG({ tour, best, diff }: TourSVGProps) {
   return (
-    <svg viewBox="0 0 300 300" className="cs-canvas" role="img" aria-label="Cuckoo search tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="cs-canvas"
+      role="img"
+      aria-label="Cuckoo search tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="cs-bg" />
 
       {/* Best-tour underlay (faint green dashed) */}
@@ -208,8 +240,10 @@ function TourSVG({ tour, best, diff }: TourSVGProps) {
       {diff?.removed.map(([a, b], i) => (
         <line
           key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
+          x1={CITIES[a][0]}
+          y1={CITIES[a][1]}
+          x2={CITIES[b][0]}
+          y2={CITIES[b][1]}
           className="cs-removed"
         />
       ))}
@@ -221,8 +255,10 @@ function TourSVG({ tour, best, diff }: TourSVGProps) {
       {diff?.added.map(([a, b], i) => (
         <line
           key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
+          x1={CITIES[a][0]}
+          y1={CITIES[a][1]}
+          x2={CITIES[b][0]}
+          y2={CITIES[b][1]}
           className="cs-added"
         />
       ))}
@@ -242,7 +278,9 @@ function TourSVG({ tour, best, diff }: TourSVGProps) {
 
       {/* City labels — rendered last so they sit above edges */}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="cs-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="cs-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -251,13 +289,15 @@ function TourSVG({ tour, best, diff }: TourSVGProps) {
 // ---------------------------------------------------------------
 // Lévy sparkline — colored by step outcome (mirrors FPA pattern)
 // ---------------------------------------------------------------
-type SparkEntry = { value: number; mode: "levy-hit" | "levy-miss" | "abandon" }
+type SparkEntry = { value: number; mode: 'levy-hit' | 'levy-miss' | 'abandon' }
 
 function LevySparkline({ history }: { history: SparkEntry[] }) {
-  const W = 180, H = 54
+  const W = 180,
+    H = 54
   const visible = history.slice(-30)
-  if (!visible.length) return <svg viewBox={`0 0 ${W} ${H}`} className="cs-spark" />
-  const maxVal = Math.min(Math.max(...visible.map(h => h.value), 0.5), 4)
+  if (!visible.length)
+    return <svg viewBox={`0 0 ${W} ${H}`} className="cs-spark" />
+  const maxVal = Math.min(Math.max(...visible.map((h) => h.value), 0.5), 4)
   const slotW = W / 30
   const barW = Math.max(1, slotW - 1)
   return (
@@ -265,8 +305,11 @@ function LevySparkline({ history }: { history: SparkEntry[] }) {
       {visible.map((h, i) => {
         const bh = Math.max(2, (Math.min(h.value, maxVal) / maxVal) * (H - 4))
         const fill =
-          h.mode === "levy-hit" ? "#3b82f6" :
-          h.mode === "abandon" ? "#d97706" : "#94a3b8"
+          h.mode === 'levy-hit'
+            ? '#3b82f6'
+            : h.mode === 'abandon'
+              ? '#d97706'
+              : '#94a3b8'
         return (
           <rect
             key={i}
@@ -286,7 +329,7 @@ function LevySparkline({ history }: { history: SparkEntry[] }) {
 // ---------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------
-type Mode = "levy-hit" | "levy-miss" | "abandon" | null
+type Mode = 'levy-hit' | 'levy-miss' | 'abandon' | null
 
 export default function CSExplainer() {
   // Config
@@ -350,10 +393,10 @@ export default function CSExplainer() {
     // --- Cuckoo event for sim.nestIdx ---
     const ci = sim.nestIdx
     const levy = levyStep()
-    const k = Math.max(1, Math.min(
-      Math.ceil(levy * N_CITIES * 0.1),
-      Math.floor(N_CITIES / 2)
-    ))
+    const k = Math.max(
+      1,
+      Math.min(Math.ceil(levy * N_CITIES * 0.1), Math.floor(N_CITIES / 2)),
+    )
 
     const beforeTour = sim.nests[ci].slice()
     const newTour = applyKRandom2Opt(beforeTour, k)
@@ -361,7 +404,9 @@ export default function CSExplainer() {
 
     // Pick random target ≠ ci
     let ti: number
-    do { ti = Math.floor(Math.random() * n) } while (ti === ci && n > 1)
+    do {
+      ti = Math.floor(Math.random() * n)
+    } while (ti === ci && n > 1)
 
     const hit = newCost < sim.costs[ti]
     const newNests = sim.nests.slice()
@@ -433,17 +478,17 @@ export default function CSExplainer() {
     setAbandonedIdxs(abandonedList)
     setLastLevy(levy)
     setLastK(k)
-    const stepMode: "levy-hit" | "levy-miss" | "abandon" =
-      abandonedList.length > 0 ? "abandon" : hit ? "levy-hit" : "levy-miss"
-    setLevyHistory(h => [...h.slice(-99), { value: levy, mode: stepMode }])
+    const stepMode: 'levy-hit' | 'levy-miss' | 'abandon' =
+      abandonedList.length > 0 ? 'abandon' : hit ? 'levy-hit' : 'levy-miss'
+    setLevyHistory((h) => [...h.slice(-99), { value: levy, mode: stepMode }])
     setDiff(computeEdgeDiff(beforeTour, newTour))
 
     if (abandonedList.length > 0) {
-      setMode("abandon")
+      setMode('abandon')
     } else if (hit) {
-      setMode("levy-hit")
+      setMode('levy-hit')
     } else {
-      setMode("levy-miss")
+      setMode('levy-miss')
     }
   }, [])
 
@@ -456,19 +501,24 @@ export default function CSExplainer() {
 
   // Mode chip content
   const modeLabel = (() => {
-    if (!mode) return "Press Step or Run to begin"
-    if (mode === "abandon") {
+    if (!mode) return 'Press Step or Run to begin'
+    if (mode === 'abandon') {
       const n = abandonedIdxs.length
-      return `💨 Epoch ${epoch}: ${n} nest${n !== 1 ? "s" : ""} abandoned and re-seeded`
+      return `💨 Epoch ${epoch}: ${n} nest${n !== 1 ? 's' : ''} abandoned and re-seeded`
     }
-    if (mode === "levy-hit") return `🐦 k=${lastK} reversal${lastK !== 1 ? "s" : ""} → beat host #${targetIdx}`
-    return `❌ k=${lastK} reversal${lastK !== 1 ? "s" : ""} → host #${targetIdx} not beaten`
+    if (mode === 'levy-hit')
+      return `🐦 k=${lastK} reversal${lastK !== 1 ? 's' : ''} → beat host #${targetIdx}`
+    return `❌ k=${lastK} reversal${lastK !== 1 ? 's' : ''} → host #${targetIdx} not beaten`
   })()
 
   const modeClass =
-    mode === "levy-hit" ? "cs-mode-hit" :
-    mode === "levy-miss" ? "cs-mode-miss" :
-    mode === "abandon" ? "cs-mode-abandon" : "cs-mode-idle"
+    mode === 'levy-hit'
+      ? 'cs-mode-hit'
+      : mode === 'levy-miss'
+        ? 'cs-mode-miss'
+        : mode === 'abandon'
+          ? 'cs-mode-abandon'
+          : 'cs-mode-idle'
 
   return (
     <div className="cs-root">
@@ -478,11 +528,13 @@ export default function CSExplainer() {
         <div className="cs-eyebrow">teeline · algorithms/cs</div>
         <h2 className="cs-title">Cuckoo Search</h2>
         <p className="cs-sub">
-          Each step a cuckoo applies <strong>k random 2-opt reversals</strong> (k drawn from a
-          Lévy distribution) and competes with a random host nest — winner keeps the slot.
-          At epoch end, each nest is independently{" "}
-          <strong>abandoned with probability <code>pa</code></strong> and re-seeded to
-          maintain diversity.
+          Each step a cuckoo applies <strong>k random 2-opt reversals</strong>{' '}
+          (k drawn from a Lévy distribution) and competes with a random host
+          nest — winner keeps the slot. At epoch end, each nest is independently{' '}
+          <strong>
+            abandoned with probability <code>pa</code>
+          </strong>{' '}
+          and re-seeded to maintain diversity.
         </p>
       </header>
 
@@ -499,13 +551,29 @@ export default function CSExplainer() {
 
       {/* Canvas legend — directly under the visualization */}
       <div className="cs-canvas-legend">
-        <span><span className="cs-swatch cs-swatch-tour">—</span> current tour</span>
-        <span><span className="cs-swatch cs-swatch-best">- -</span> best tour</span>
-        <span><span className="cs-swatch cs-swatch-added">—</span> added edges</span>
-        <span><span className="cs-swatch cs-swatch-removed">- -</span> removed edges</span>
-        <span><span className="cs-ring-demo">◎</span> reversal endpoint</span>
-        <span><span style={{ color: "#3b82f6", fontWeight: 700 }}>▌</span> active cuckoo</span>
-        <span><span style={{ color: "#d97706", fontWeight: 700 }}>▌</span> target host</span>
+        <span>
+          <span className="cs-swatch cs-swatch-tour">—</span> current tour
+        </span>
+        <span>
+          <span className="cs-swatch cs-swatch-best">- -</span> best tour
+        </span>
+        <span>
+          <span className="cs-swatch cs-swatch-added">—</span> added edges
+        </span>
+        <span>
+          <span className="cs-swatch cs-swatch-removed">- -</span> removed edges
+        </span>
+        <span>
+          <span className="cs-ring-demo">◎</span> reversal endpoint
+        </span>
+        <span>
+          <span style={{ color: '#3b82f6', fontWeight: 700 }}>▌</span> active
+          cuckoo
+        </span>
+        <span>
+          <span style={{ color: '#d97706', fontWeight: 700 }}>▌</span> target
+          host
+        </span>
       </div>
 
       {/* Event chip */}
@@ -517,16 +585,20 @@ export default function CSExplainer() {
           <LevySparkline history={levyHistory} />
           <div className="cs-spark-caption">
             Lévy step (last 30) &nbsp;
-            <span style={{ color: "#3b82f6" }}>■</span> hit &nbsp;
-            <span style={{ color: "#94a3b8" }}>■</span> miss &nbsp;
-            <span style={{ color: "#d97706" }}>■</span> abandon
+            <span style={{ color: '#3b82f6' }}>■</span> hit &nbsp;
+            <span style={{ color: '#94a3b8' }}>■</span> miss &nbsp;
+            <span style={{ color: '#d97706' }}>■</span> abandon
           </div>
         </div>
         <div className="cs-stepval-wrap">
           <div className="cs-statlabel">levy draw</div>
-          <div className="cs-mono cs-stepval">{lastLevy !== null ? lastLevy.toFixed(3) : "—"}</div>
-          <div className="cs-statlabel" style={{ marginTop: "6px" }}>k reversals</div>
-          <div className="cs-mono cs-kval">{lastK !== null ? lastK : "—"}</div>
+          <div className="cs-mono cs-stepval">
+            {lastLevy !== null ? lastLevy.toFixed(3) : '—'}
+          </div>
+          <div className="cs-statlabel" style={{ marginTop: '6px' }}>
+            k reversals
+          </div>
+          <div className="cs-mono cs-kval">{lastK !== null ? lastK : '—'}</div>
         </div>
       </div>
 
@@ -561,8 +633,12 @@ export default function CSExplainer() {
             Abandon prob <code>pa</code> = <strong>{pa.toFixed(2)}</strong>
           </label>
           <input
-            type="range" min={0} max={0.5} step={0.05}
-            value={pa} className="cs-slider"
+            type="range"
+            min={0}
+            max={0.5}
+            step={0.05}
+            value={pa}
+            className="cs-slider"
             onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
               setPa(v)
@@ -571,9 +647,9 @@ export default function CSExplainer() {
           />
           <div className="cs-hint">
             {pa === 0
-              ? "No abandonment — population never diversifies"
+              ? 'No abandonment — population never diversifies'
               : pa >= 0.4
-                ? "High abandonment — lots of re-seeding, slower convergence"
+                ? 'High abandonment — lots of re-seeding, slower convergence'
                 : `~${Math.round(pa * 100)}% of nests replaced each epoch`}
           </div>
         </div>
@@ -582,8 +658,12 @@ export default function CSExplainer() {
             Nests (population) = <strong>{nNests}</strong>
           </label>
           <input
-            type="range" min={3} max={15} step={1}
-            value={nNests} className="cs-slider"
+            type="range"
+            min={3}
+            max={15}
+            step={1}
+            value={nNests}
+            className="cs-slider"
             onInput={(e) => {
               const n = Number((e.target as HTMLInputElement).value)
               setNNests(n)
@@ -594,23 +674,33 @@ export default function CSExplainer() {
         <div className="cs-config-row">
           <label className="cs-config-label">Speed</label>
           <input
-            type="range" min={1} max={10} step={1}
-            value={speed} className="cs-slider"
-            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
+            className="cs-slider"
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
 
       {/* Controls */}
       <div className="cs-controls">
-        <button className="cs-btn" onClick={stepOnce} disabled={running}>◀ Step</button>
-        <button
-          className={`cs-btn ${!running ? "cs-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}
-        >
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button className="cs-btn" onClick={stepOnce} disabled={running}>
+          ◀ Step
         </button>
-        <button className="cs-btn" onClick={() => reinit(nNests)}>↺ Reset</button>
+        <button
+          className={`cs-btn ${!running ? 'cs-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button className="cs-btn" onClick={() => reinit(nNests)}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="cs-footer">

--- a/teeline-web/src/explainers/explainer-cities.ts
+++ b/teeline-web/src/explainers/explainer-cities.ts
@@ -13,36 +13,47 @@
 //   - som-algo.ts — generates its 12 cities programmatically on a circle
 
 export const CITIES_10: [number, number][] = [
-  [150, 20],   // 0 — top
-  [270, 70],   // 1 — top-right
-  [260, 180],  // 2 — right
-  [180, 280],  // 3 — bottom-right
-  [120, 290],  // 4 — bottom
-  [35, 220],   // 5 — bottom-left
-  [25, 80],    // 6 — left
-  [80, 25],    // 7 — top-left
-  [155, 155],  // 8 — centre
-  [90, 140],   // 9 — inner-left
+  [150, 20], // 0 — top
+  [270, 70], // 1 — top-right
+  [260, 180], // 2 — right
+  [180, 280], // 3 — bottom-right
+  [120, 290], // 4 — bottom
+  [35, 220], // 5 — bottom-left
+  [25, 80], // 6 — left
+  [80, 25], // 7 — top-left
+  [155, 155], // 8 — centre
+  [90, 140], // 9 — inner-left
 ]
 
 export const CITIES_12: [number, number][] = [
-  [45, 45], [155, 18], [265, 45], [285, 150],
-  [255, 265], [150, 285], [40, 260], [18, 150],
-  [110, 115], [200, 95], [220, 210], [95, 215],
+  [45, 45],
+  [155, 18],
+  [265, 45],
+  [285, 150],
+  [255, 265],
+  [150, 285],
+  [40, 260],
+  [18, 150],
+  [110, 115],
+  [200, 95],
+  [220, 210],
+  [95, 215],
 ]
 
 export const CITIES_8: [number, number][] = [
-  [150, 20],   // 0 — top
-  [270, 70],   // 1 — top-right
-  [260, 180],  // 2 — right
-  [180, 280],  // 3 — bottom-right
-  [120, 290],  // 4 — bottom
-  [35, 220],   // 5 — bottom-left
-  [25, 80],    // 6 — left
-  [80, 25],    // 7 — top-left
+  [150, 20], // 0 — top
+  [270, 70], // 1 — top-right
+  [260, 180], // 2 — right
+  [180, 280], // 3 — bottom-right
+  [120, 290], // 4 — bottom
+  [35, 220], // 5 — bottom-left
+  [25, 80], // 6 — left
+  [80, 25], // 7 — top-left
 ]
 
-export function makeDist(cities: [number, number][]): (i: number, j: number) => number {
+export function makeDist(
+  cities: [number, number][],
+): (i: number, j: number) => number {
   return (i, j) => {
     const [x1, y1] = cities[i]
     const [x2, y2] = cities[j]
@@ -52,7 +63,9 @@ export function makeDist(cities: [number, number][]): (i: number, j: number) => 
 
 // Closed-cycle tour length (the wrap-around edge is included). Returns 0 for
 // tours of length ≤ 1, matching the guard the population-based explainers use.
-export function makeTourLength(dist: (i: number, j: number) => number): (tour: number[]) => number {
+export function makeTourLength(
+  dist: (i: number, j: number) => number,
+): (tour: number[]) => number {
   return (tour) => {
     if (tour.length <= 1) return 0
     let d = 0
@@ -83,7 +96,10 @@ export function makeDm(cities: [number, number][]): number[][] {
   const dm: number[][] = Array.from({ length: n }, () => new Array(n).fill(0))
   for (let i = 0; i < n; i++) {
     for (let j = i + 1; j < n; j++) {
-      const d = Math.hypot(cities[i][0] - cities[j][0], cities[i][1] - cities[j][1])
+      const d = Math.hypot(
+        cities[i][0] - cities[j][0],
+        cities[i][1] - cities[j][1],
+      )
       dm[i][j] = d
       dm[j][i] = d
     }

--- a/teeline-web/src/explainers/fourier.tsx
+++ b/teeline-web/src/explainers/fourier.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from "preact/hooks";
-import type { ComponentChildren, CSSProperties } from "preact";
+import { useState, useRef, useEffect, useMemo, useCallback } from 'preact/hooks'
+import type { ComponentChildren, CSSProperties } from 'preact'
 
 /**
  * FourierExplainer
@@ -18,194 +18,281 @@ import type { ComponentChildren, CSSProperties } from "preact";
 // Small enough to animate smoothly in-browser.
 // ---------------------------------------------------------------
 const CITIES: [number, number][] = [
-  [40, 60], [80, 30], [140, 20], [200, 40], [250, 70], [270, 130],
-  [250, 200], [200, 250], [140, 270], [80, 250], [40, 200], [20, 130],
-  [150, 150], [100, 100], [200, 100],
-];
-const K_MAX = 4;
-const N_COEFFS = 2 * K_MAX + 1; // index ki -> k = ki - K_MAX
-const M = 72; // curve sampling resolution
-const SCALE = 300; // canvas size; coeffs are computed in [0,1] space, then scaled
+  [40, 60],
+  [80, 30],
+  [140, 20],
+  [200, 40],
+  [250, 70],
+  [270, 130],
+  [250, 200],
+  [200, 250],
+  [140, 270],
+  [80, 250],
+  [40, 200],
+  [20, 130],
+  [150, 150],
+  [100, 100],
+  [200, 100],
+]
+const K_MAX = 4
+const N_COEFFS = 2 * K_MAX + 1 // index ki -> k = ki - K_MAX
+const M = 72 // curve sampling resolution
+const SCALE = 300 // canvas size; coeffs are computed in [0,1] space, then scaled
 
 // ---------------------------------------------------------------
 // Core math: γ(s) = Σ_{k=-K}^{K} c_k · e^{2πiks}, with c_k = a_k + i·b_k
 // ---------------------------------------------------------------
-function curvePoints(a: number[], b: number[], kActiveMax = K_MAX, m = M): [number, number][] {
-  const pts: [number, number][] = new Array(m);
+function curvePoints(
+  a: number[],
+  b: number[],
+  kActiveMax = K_MAX,
+  m = M,
+): [number, number][] {
+  const pts: [number, number][] = new Array(m)
   for (let j = 0; j < m; j++) {
-    const s = j / m;
-    let x = 0, y = 0;
+    const s = j / m
+    let x = 0,
+      y = 0
     for (let ki = 0; ki < N_COEFFS; ki++) {
-      const k = ki - K_MAX;
-      if (Math.abs(k) > kActiveMax) continue;
-      const theta = 2 * Math.PI * k * s;
-      const c = Math.cos(theta), si = Math.sin(theta);
-      x += a[ki] * c - b[ki] * si;
-      y += a[ki] * si + b[ki] * c;
+      const k = ki - K_MAX
+      if (Math.abs(k) > kActiveMax) continue
+      const theta = 2 * Math.PI * k * s
+      const c = Math.cos(theta),
+        si = Math.sin(theta)
+      x += a[ki] * c - b[ki] * si
+      y += a[ki] * si + b[ki] * c
     }
-    pts[j] = [x * SCALE, y * SCALE];
+    pts[j] = [x * SCALE, y * SCALE]
   }
-  return pts;
+  return pts
 }
 
 // init in [0,1] city-coordinate space
 function initCoeffsNormalized(): { a: number[]; b: number[] } {
-  const a = new Array(N_COEFFS).fill(0) as number[];
-  const b = new Array(N_COEFFS).fill(0) as number[];
-  const cities01 = CITIES.map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
-  let cx = 0, cy = 0;
-  cities01.forEach(([x, y]) => { cx += x; cy += y; });
-  cx /= cities01.length; cy /= cities01.length;
-  let r = 0;
-  cities01.forEach(([x, y]) => { r += Math.hypot(x - cx, y - cy); });
-  r /= cities01.length;
-  a[K_MAX] = cx; b[K_MAX] = cy;     // c_0 = centroid
-  a[K_MAX + 1] = r / 2;             // c_1 = radius / 2
-  return { a, b };
+  const a = new Array(N_COEFFS).fill(0) as number[]
+  const b = new Array(N_COEFFS).fill(0) as number[]
+  const cities01 = CITIES.map(
+    ([x, y]) => [x / SCALE, y / SCALE] as [number, number],
+  )
+  let cx = 0,
+    cy = 0
+  cities01.forEach(([x, y]) => {
+    cx += x
+    cy += y
+  })
+  cx /= cities01.length
+  cy /= cities01.length
+  let r = 0
+  cities01.forEach(([x, y]) => {
+    r += Math.hypot(x - cx, y - cy)
+  })
+  r /= cities01.length
+  a[K_MAX] = cx
+  b[K_MAX] = cy // c_0 = centroid
+  a[K_MAX + 1] = r / 2 // c_1 = radius / 2
+  return { a, b }
 }
 
-function energy(a: number[], b: number[], lambda: number, kActiveMax: number, cities01: [number, number][]): { eAttr: number; eTen: number; total: number } {
-  const pts = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
-  let eAttr = 0;
+function energy(
+  a: number[],
+  b: number[],
+  lambda: number,
+  kActiveMax: number,
+  cities01: [number, number][],
+): { eAttr: number; eTen: number; total: number } {
+  const pts = curvePoints(a, b, kActiveMax).map(
+    ([x, y]) => [x / SCALE, y / SCALE] as [number, number],
+  )
+  let eAttr = 0
   for (const [cx, cy] of cities01) {
-    let best = Infinity;
+    let best = Infinity
     for (const [px, py] of pts) {
-      const d = (cx - px) ** 2 + (cy - py) ** 2;
-      if (d < best) best = d;
+      const d = (cx - px) ** 2 + (cy - py) ** 2
+      if (d < best) best = d
     }
-    eAttr += best;
+    eAttr += best
   }
-  let eTen = 0;
+  let eTen = 0
   for (let ki = 0; ki < N_COEFFS; ki++) {
-    const k = ki - K_MAX;
-    eTen += (2 * Math.PI * k) ** 2 * (a[ki] ** 2 + b[ki] ** 2);
+    const k = ki - K_MAX
+    eTen += (2 * Math.PI * k) ** 2 * (a[ki] ** 2 + b[ki] ** 2)
   }
-  return { eAttr, eTen: lambda * eTen, total: eAttr + lambda * eTen };
+  return { eAttr, eTen: lambda * eTen, total: eAttr + lambda * eTen }
 }
 
-function gradStep(a: number[], b: number[], kActiveMax: number, lambda: number, lr: number, cities01: [number, number][]): { a: number[]; b: number[] } {
-  const pts01 = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
-  const gradA = new Array(N_COEFFS).fill(0) as number[];
-  const gradB = new Array(N_COEFFS).fill(0) as number[];
+function gradStep(
+  a: number[],
+  b: number[],
+  kActiveMax: number,
+  lambda: number,
+  lr: number,
+  cities01: [number, number][],
+): { a: number[]; b: number[] } {
+  const pts01 = curvePoints(a, b, kActiveMax).map(
+    ([x, y]) => [x / SCALE, y / SCALE] as [number, number],
+  )
+  const gradA = new Array(N_COEFFS).fill(0) as number[]
+  const gradB = new Array(N_COEFFS).fill(0) as number[]
   // attraction: each city pulls its nearest curve sample
   for (const [cx, cy] of cities01) {
-    let best = Infinity, bestJ = 0;
+    let best = Infinity,
+      bestJ = 0
     for (let j = 0; j < pts01.length; j++) {
-      const [px, py] = pts01[j];
-      const d = (cx - px) ** 2 + (cy - py) ** 2;
-      if (d < best) { best = d; bestJ = j; }
+      const [px, py] = pts01[j]
+      const d = (cx - px) ** 2 + (cy - py) ** 2
+      if (d < best) {
+        best = d
+        bestJ = j
+      }
     }
-    const s = bestJ / pts01.length;
-    const [px, py] = pts01[bestJ];
-    const dx = cx - px, dy = cy - py;
+    const s = bestJ / pts01.length
+    const [px, py] = pts01[bestJ]
+    const dx = cx - px,
+      dy = cy - py
     for (let ki = 0; ki < N_COEFFS; ki++) {
-      const k = ki - K_MAX;
-      if (Math.abs(k) > kActiveMax) continue;
-      const theta = 2 * Math.PI * k * s;
-      const cth = Math.cos(theta), sth = Math.sin(theta);
-      gradA[ki] += -2 * dx * cth - 2 * dy * sth;
-      gradB[ki] += 2 * dx * sth - 2 * dy * cth;
+      const k = ki - K_MAX
+      if (Math.abs(k) > kActiveMax) continue
+      const theta = 2 * Math.PI * k * s
+      const cth = Math.cos(theta),
+        sth = Math.sin(theta)
+      gradA[ki] += -2 * dx * cth - 2 * dy * sth
+      gradB[ki] += 2 * dx * sth - 2 * dy * cth
     }
   }
   // tension: penalise high-frequency modes
   for (let ki = 0; ki < N_COEFFS; ki++) {
-    const k = ki - K_MAX;
-    if (Math.abs(k) > kActiveMax) continue;
-    const w = 2 * lambda * (2 * Math.PI * k) ** 2;
-    gradA[ki] += w * a[ki];
-    gradB[ki] += w * b[ki];
+    const k = ki - K_MAX
+    if (Math.abs(k) > kActiveMax) continue
+    const w = 2 * lambda * (2 * Math.PI * k) ** 2
+    gradA[ki] += w * a[ki]
+    gradB[ki] += w * b[ki]
   }
-  const n = cities01.length;
-  const nextA = a.slice(), nextB = b.slice();
+  const n = cities01.length
+  const nextA = a.slice(),
+    nextB = b.slice()
   for (let ki = 0; ki < N_COEFFS; ki++) {
-    const k = ki - K_MAX;
-    if (Math.abs(k) > kActiveMax) continue;
-    nextA[ki] -= (lr / n) * gradA[ki];
-    nextB[ki] -= (lr / n) * gradB[ki];
+    const k = ki - K_MAX
+    if (Math.abs(k) > kActiveMax) continue
+    nextA[ki] -= (lr / n) * gradA[ki]
+    nextB[ki] -= (lr / n) * gradB[ki]
   }
-  return { a: nextA, b: nextB };
+  return { a: nextA, b: nextB }
 }
 
-function decodeTour(a: number[], b: number[], kActiveMax: number, cities01: [number, number][]): { order: number[]; sVals: number[] } {
-  const pts01 = curvePoints(a, b, kActiveMax).map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+function decodeTour(
+  a: number[],
+  b: number[],
+  kActiveMax: number,
+  cities01: [number, number][],
+): { order: number[]; sVals: number[] } {
+  const pts01 = curvePoints(a, b, kActiveMax).map(
+    ([x, y]) => [x / SCALE, y / SCALE] as [number, number],
+  )
   const sVals = cities01.map(([cx, cy]) => {
-    let best = Infinity, bestJ = 0;
+    let best = Infinity,
+      bestJ = 0
     for (let j = 0; j < pts01.length; j++) {
-      const [px, py] = pts01[j];
-      const d = (cx - px) ** 2 + (cy - py) ** 2;
-      if (d < best) { best = d; bestJ = j; }
+      const [px, py] = pts01[j]
+      const d = (cx - px) ** 2 + (cy - py) ** 2
+      if (d < best) {
+        best = d
+        bestJ = j
+      }
     }
-    return bestJ / pts01.length;
-  });
-  const order = cities01.map((_: [number, number], i: number) => i).sort((i: number, j: number) => sVals[i] - sVals[j]);
-  return { order, sVals };
+    return bestJ / pts01.length
+  })
+  const order = cities01
+    .map((_: [number, number], i: number) => i)
+    .sort((i: number, j: number) => sVals[i] - sVals[j])
+  return { order, sVals }
 }
 
 // ---------------------------------------------------------------
 // Shared hyperparameters (mirroring docs/algorithms/fourier.md defaults,
 // scaled for normalized [0,1] city coordinates)
 // ---------------------------------------------------------------
-const LAMBDA0 = 0.05;
-const LAMBDA_DECAY = 0.5;
-const LR = 0.05;
-const EPOCHS_PER_STAGE = 90;
-const STEPS_PER_TICK = 2;
+const LAMBDA0 = 0.05
+const LAMBDA_DECAY = 0.5
+const LR = 0.05
+const EPOCHS_PER_STAGE = 90
+const STEPS_PER_TICK = 2
 
-const CITIES01 = CITIES.map(([x, y]) => [x / SCALE, y / SCALE] as [number, number]);
+const CITIES01 = CITIES.map(
+  ([x, y]) => [x / SCALE, y / SCALE] as [number, number],
+)
 
 // ---------------------------------------------------------------
 // SVG sub-components
 // ---------------------------------------------------------------
 interface CurveSVGProps {
-  curve: [number, number][];
-  showCities?: boolean;
-  tour?: [number, number][] | null;
-  highlightSample?: ComponentChildren;
-  children?: ComponentChildren;
+  curve: [number, number][]
+  showCities?: boolean
+  tour?: [number, number][] | null
+  highlightSample?: ComponentChildren
+  children?: ComponentChildren
 }
 
-function CurveSVG({ curve, showCities = true, tour = null, highlightSample = null, children }: CurveSVGProps) {
+function CurveSVG({
+  curve,
+  showCities = true,
+  tour = null,
+  highlightSample = null,
+  children,
+}: CurveSVGProps) {
   const path = curve.length
-    ? "M " + curve.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" L ") + " Z"
-    : "";
+    ? 'M ' +
+      curve.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' L ') +
+      ' Z'
+    : ''
   return (
-    <svg viewBox="0 0 300 300" className="fx-canvas" role="img" aria-label="Fourier curve and cities">
+    <svg
+      viewBox="0 0 300 300"
+      className="fx-canvas"
+      role="img"
+      aria-label="Fourier curve and cities"
+    >
       <rect x="0" y="0" width="300" height="300" className="fx-bg" />
       {tour && tour.length > 1 && (
         <polyline
           className="fx-tour"
-          points={tour.map(([x, y]) => `${x},${y}`).join(" ")}
+          points={tour.map(([x, y]) => `${x},${y}`).join(' ')}
         />
       )}
       {path && <path d={path} className="fx-curve" />}
-      {showCities && CITIES.map(([x, y], i) => (
-        <circle key={i} cx={x} cy={y} r="4.5" className="fx-city" />
-      ))}
+      {showCities &&
+        CITIES.map(([x, y], i) => (
+          <circle key={i} cx={x} cy={y} r="4.5" className="fx-city" />
+        ))}
       {highlightSample}
       {children}
     </svg>
-  );
+  )
 }
 
 interface SparklineProps {
-  values: number[];
-  max?: number;
+  values: number[]
+  max?: number
 }
 
 function Sparkline({ values, max }: SparklineProps) {
-  if (!values.length) return null;
-  const w = 300, h = 60;
-  const m = max ?? Math.max(...values, 1e-9);
+  if (!values.length) return null
+  const w = 300,
+    h = 60
+  const m = max ?? Math.max(...values, 1e-9)
   const pts = values.map((v, i) => {
-    const x = (i / Math.max(values.length - 1, 1)) * w;
-    const y = h - (v / m) * (h - 4) - 2;
-    return `${x.toFixed(1)},${y.toFixed(1)}`;
-  });
+    const x = (i / Math.max(values.length - 1, 1)) * w
+    const y = h - (v / m) * (h - 4) - 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
   return (
-    <svg viewBox={`0 0 ${w} ${h}`} className="fx-spark" preserveAspectRatio="none">
-      <polyline points={pts.join(" ")} className="fx-spark-line" />
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      className="fx-spark"
+      preserveAspectRatio="none"
+    >
+      <polyline points={pts.join(' ')} className="fx-spark-line" />
     </svg>
-  );
+  )
 }
 
 // ---------------------------------------------------------------
@@ -213,11 +300,11 @@ function Sparkline({ values, max }: SparklineProps) {
 // ---------------------------------------------------------------
 function IdeaTab() {
   // a nicely-converged coefficient set, precomputed for illustration
-  const a = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04];
-  const b = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02];
-  const curve = useMemo(() => curvePoints(a, b), []);
-  const { order } = useMemo(() => decodeTour(a, b, K_MAX, CITIES01), []);
-  const tour = order.map(i => CITIES[i]).concat([CITIES[order[0]]]);
+  const a = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04]
+  const b = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02]
+  const curve = useMemo(() => curvePoints(a, b), [])
+  const { order } = useMemo(() => decodeTour(a, b, K_MAX, CITIES01), [])
+  const tour = order.map((i) => CITIES[i]).concat([CITIES[order[0]]])
 
   return (
     <div className="fx-tab">
@@ -225,58 +312,66 @@ function IdeaTab() {
       <div className="fx-prose">
         <p>
           Every tour is drawn as a single closed curve in the plane,
-          <code> γ(s) = Σ c_k · e^{"{2πiks}"}</code>, sampled at <code>M</code> points.
-          A small set of complex coefficients <code>c_k</code> (here <code>2K+1 = 9</code> of them)
-          is the <em>entire</em> search space &mdash; gradient descent only ever moves these
-          9 numbers.
+          <code> γ(s) = Σ c_k · e^{'{2πiks}'}</code>, sampled at <code>M</code>{' '}
+          points. A small set of complex coefficients <code>c_k</code> (here{' '}
+          <code>2K+1 = 9</code> of them) is the <em>entire</em> search space
+          &mdash; gradient descent only ever moves these 9 numbers.
         </p>
         <p>
-          To turn the curve into a tour, every city snaps to its nearest sample point on
-          the loop (<strong>argsort decode</strong>, dashed line above). Because a sort can
-          never produce duplicates or skip a city, the result is <em>always</em> a valid
-          Hamiltonian tour &mdash; even before training finishes.
+          To turn the curve into a tour, every city snaps to its nearest sample
+          point on the loop (<strong>argsort decode</strong>, dashed line
+          above). Because a sort can never produce duplicates or skip a city,
+          the result is <em>always</em> a valid Hamiltonian tour &mdash; even
+          before training finishes.
         </p>
         <p className="fx-note">
-          Try the other two tabs: <strong>Modes</strong> shows what each frequency
-          contributes to the loop shape, and <strong>Train</strong> runs the actual
-          coarse-to-fine gradient descent live in your browser.
+          Try the other two tabs: <strong>Modes</strong> shows what each
+          frequency contributes to the loop shape, and <strong>Train</strong>{' '}
+          runs the actual coarse-to-fine gradient descent live in your browser.
         </p>
       </div>
     </div>
-  );
+  )
 }
 
 // ---------------------------------------------------------------
 // Tab 2: Modes — coarse-to-fine intuition via partial sums
 // ---------------------------------------------------------------
 function ModesTab() {
-  const targetA = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04];
-  const targetB = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02];
-  const [kActive, setKActive] = useState(0);
+  const targetA = [-0.02, -0.01, -0.0, -0.01, 0.44, 0.35, -0.03, -0.05, -0.04]
+  const targetB = [-0.03, -0.03, -0.01, -0.01, 0.46, -0.01, -0.0, 0.03, 0.02]
+  const [kActive, setKActive] = useState(0)
 
-  const curve = useMemo(() => curvePoints(targetA, targetB, kActive), [kActive]);
+  const curve = useMemo(() => curvePoints(targetA, targetB, kActive), [kActive])
 
   const descriptions = [
     "k = 0 only: a single point at the centroid c₀. The curve hasn't opened up yet.",
-    "± k = 1 added: the curve becomes a single loop (an ellipse-ish ring) enclosing the cities.",
-    "± k = 2 added: the loop can now bend into a rounder, asymmetric shape.",
-    "± k = 3 added: finer wiggles let the loop hug clusters of cities more closely.",
-    "± k = 4 added (k_max): the full default resolution — enough detail for berlin52-scale instances.",
-  ];
+    '± k = 1 added: the curve becomes a single loop (an ellipse-ish ring) enclosing the cities.',
+    '± k = 2 added: the loop can now bend into a rounder, asymmetric shape.',
+    '± k = 3 added: finer wiggles let the loop hug clusters of cities more closely.',
+    '± k = 4 added (k_max): the full default resolution — enough detail for berlin52-scale instances.',
+  ]
 
   return (
     <div className="fx-tab">
       <CurveSVG curve={curve} />
       <div className="fx-prose">
         <p>
-          The coarse-to-fine loop in <code>fourier.md</code> unlocks one frequency pair
-          (<code>±k</code>) at a time. Slide through the stages below to see how each
-          added mode refines the loop — exactly the order the optimiser itself follows.
+          The coarse-to-fine loop in <code>fourier.md</code> unlocks one
+          frequency pair (<code>±k</code>) at a time. Slide through the stages
+          below to see how each added mode refines the loop — exactly the order
+          the optimiser itself follows.
         </p>
         <div className="fx-row">
           <input
-            type="range" min={0} max={K_MAX} step={1} value={kActive}
-            onChange={(e) => setKActive(Number((e.target as HTMLInputElement).value))}
+            type="range"
+            min={0}
+            max={K_MAX}
+            step={1}
+            value={kActive}
+            onChange={(e) =>
+              setKActive(Number((e.target as HTMLInputElement).value))
+            }
             className="fx-slider"
             aria-label="active modes"
           />
@@ -284,100 +379,133 @@ function ModesTab() {
         </div>
         <p className="fx-caption">{descriptions[kActive]}</p>
         <p className="fx-note">
-          Why this order? Low modes set the overall loop shape; unlocking high modes too
-          early creates competing gradients and saddle points. Coarse-to-fine avoids that
-          by giving each frequency band its own optimisation stage.
+          Why this order? Low modes set the overall loop shape; unlocking high
+          modes too early creates competing gradients and saddle points.
+          Coarse-to-fine avoids that by giving each frequency band its own
+          optimisation stage.
         </p>
       </div>
     </div>
-  );
+  )
 }
 
 // ---------------------------------------------------------------
 // Tab 3: Train & Decode — live coarse-to-fine gradient descent
 // ---------------------------------------------------------------
 function TrainTab() {
-  const stateRef = useRef(initCoeffsNormalized());
-  const [coeffs, setCoeffs] = useState(stateRef.current);
-  const [kActive, setKActive] = useState(1);
-  const [lambda, setLambda] = useState(LAMBDA0);
-  const [epoch, setEpoch] = useState(0);
-  const [history, setHistory] = useState<number[]>([]);
-  const [playing, setPlaying] = useState(false);
-  const [done, setDone] = useState(false);
+  const stateRef = useRef(initCoeffsNormalized())
+  const [coeffs, setCoeffs] = useState(stateRef.current)
+  const [kActive, setKActive] = useState(1)
+  const [lambda, setLambda] = useState(LAMBDA0)
+  const [epoch, setEpoch] = useState(0)
+  const [history, setHistory] = useState<number[]>([])
+  const [playing, setPlaying] = useState(false)
+  const [done, setDone] = useState(false)
 
   const reset = useCallback(() => {
-    stateRef.current = initCoeffsNormalized();
-    setCoeffs(stateRef.current);
-    setKActive(1);
-    setLambda(LAMBDA0);
-    setEpoch(0);
-    setHistory([]);
-    setDone(false);
-    setPlaying(false);
-  }, []);
+    stateRef.current = initCoeffsNormalized()
+    setCoeffs(stateRef.current)
+    setKActive(1)
+    setLambda(LAMBDA0)
+    setEpoch(0)
+    setHistory([])
+    setDone(false)
+    setPlaying(false)
+  }, [])
 
   const stepOnce = useCallback(() => {
-    let { a, b } = stateRef.current;
-    let curKActive = kActive, curLambda = lambda, curEpoch = epoch, curDone = done;
-    if (curDone) return;
+    let { a, b } = stateRef.current
+    let curKActive = kActive,
+      curLambda = lambda,
+      curEpoch = epoch,
+      curDone = done
+    if (curDone) return
     for (let s = 0; s < STEPS_PER_TICK; s++) {
-      ({ a, b } = gradStep(a, b, curKActive, curLambda, LR, CITIES01));
-      curEpoch += 1;
+      ;({ a, b } = gradStep(a, b, curKActive, curLambda, LR, CITIES01))
+      curEpoch += 1
       if (curEpoch >= EPOCHS_PER_STAGE) {
-        curEpoch = 0;
+        curEpoch = 0
         if (curKActive < K_MAX) {
-          curKActive += 1;
-          curLambda *= LAMBDA_DECAY;
+          curKActive += 1
+          curLambda *= LAMBDA_DECAY
         } else {
-          curDone = true;
-          break;
+          curDone = true
+          break
         }
       }
     }
-    stateRef.current = { a, b };
-    setCoeffs({ a, b });
-    setKActive(curKActive);
-    setLambda(curLambda);
-    setEpoch(curEpoch);
-    const e = energy(a, b, curLambda, curKActive, CITIES01);
-    setHistory(h => [...h.slice(-149), e.total]);
-    if (curDone) { setDone(true); setPlaying(false); }
-  }, [kActive, lambda, epoch, done]);
+    stateRef.current = { a, b }
+    setCoeffs({ a, b })
+    setKActive(curKActive)
+    setLambda(curLambda)
+    setEpoch(curEpoch)
+    const e = energy(a, b, curLambda, curKActive, CITIES01)
+    setHistory((h) => [...h.slice(-149), e.total])
+    if (curDone) {
+      setDone(true)
+      setPlaying(false)
+    }
+  }, [kActive, lambda, epoch, done])
 
   useEffect(() => {
-    if (!playing) return;
-    const id = setInterval(stepOnce, 60);
-    return () => clearInterval(id);
-  }, [playing, stepOnce]);
+    if (!playing) return
+    const id = setInterval(stepOnce, 60)
+    return () => clearInterval(id)
+  }, [playing, stepOnce])
 
-  const curve = useMemo(() => curvePoints(coeffs.a, coeffs.b, kActive), [coeffs, kActive]);
+  const curve = useMemo(
+    () => curvePoints(coeffs.a, coeffs.b, kActive),
+    [coeffs, kActive],
+  )
   const { order } = useMemo(
     () => decodeTour(coeffs.a, coeffs.b, kActive, CITIES01),
-    [coeffs, kActive]
-  );
-  const tour = order.map(i => CITIES[i]).concat([CITIES[order[0]]]);
-  const stageProgress = Math.round((epoch / EPOCHS_PER_STAGE) * 100);
-  const totalEnergy = history.length ? history[history.length - 1] : null;
+    [coeffs, kActive],
+  )
+  const tour = order.map((i) => CITIES[i]).concat([CITIES[order[0]]])
+  const stageProgress = Math.round((epoch / EPOCHS_PER_STAGE) * 100)
+  const totalEnergy = history.length ? history[history.length - 1] : null
 
   return (
     <div className="fx-tab">
       <CurveSVG curve={curve} tour={tour} />
       <div className="fx-prose">
         <div className="fx-controls">
-          <button className="fx-btn fx-btn-primary" onClick={() => setPlaying(p => !p)} disabled={done}>
-            {playing ? "Pause" : done ? "Converged" : "Play"}
+          <button
+            className="fx-btn fx-btn-primary"
+            onClick={() => setPlaying((p) => !p)}
+            disabled={done}
+          >
+            {playing ? 'Pause' : done ? 'Converged' : 'Play'}
           </button>
-          <button className="fx-btn" onClick={stepOnce} disabled={playing || done}>Step</button>
-          <button className="fx-btn" onClick={reset}>Reset</button>
+          <button
+            className="fx-btn"
+            onClick={stepOnce}
+            disabled={playing || done}
+          >
+            Step
+          </button>
+          <button className="fx-btn" onClick={reset}>
+            Reset
+          </button>
         </div>
 
         <div className="fx-stagebar" aria-hidden="true">
-          {Array.from({ length: K_MAX }, (_, i) => i + 1).map(stage => (
+          {Array.from({ length: K_MAX }, (_, i) => i + 1).map((stage) => (
             <div
               key={stage}
-              className={"fx-stage" + (stage < kActive || done ? " fx-stage-done" : stage === kActive ? " fx-stage-active" : "")}
-              style={stage === kActive && !done ? { "--p": `${stageProgress}%` } as CSSProperties : undefined}
+              className={
+                'fx-stage' +
+                (stage < kActive || done
+                  ? ' fx-stage-done'
+                  : stage === kActive
+                    ? ' fx-stage-active'
+                    : '')
+              }
+              style={
+                stage === kActive && !done
+                  ? ({ '--p': `${stageProgress}%` } as CSSProperties)
+                  : undefined
+              }
             >
               <span>k≤{stage}</span>
             </div>
@@ -387,7 +515,10 @@ function TrainTab() {
         <div className="fx-statgrid">
           <div>
             <div className="fx-statlabel">stage</div>
-            <div className="fx-mono">k_active = {kActive}{done ? " (done)" : ` / ${K_MAX}`}</div>
+            <div className="fx-mono">
+              k_active = {kActive}
+              {done ? ' (done)' : ` / ${K_MAX}`}
+            </div>
           </div>
           <div>
             <div className="fx-statlabel">λ (tension weight)</div>
@@ -395,47 +526,49 @@ function TrainTab() {
           </div>
           <div>
             <div className="fx-statlabel">energy E(c)</div>
-            <div className="fx-mono">{totalEnergy !== null ? totalEnergy.toFixed(4) : "—"}</div>
+            <div className="fx-mono">
+              {totalEnergy !== null ? totalEnergy.toFixed(4) : '—'}
+            </div>
           </div>
         </div>
 
         <Sparkline values={history} />
         <p className="fx-caption">
-          Energy decreases within each stage; small jumps at stage boundaries are expected
-          &mdash; new modes (and a smaller λ) are unlocked, briefly changing the loss
-          landscape before the optimiser re-settles.
+          Energy decreases within each stage; small jumps at stage boundaries
+          are expected &mdash; new modes (and a smaller λ) are unlocked, briefly
+          changing the loss landscape before the optimiser re-settles.
         </p>
         <p className="fx-note">
-          The dashed line is the <strong>decode</strong> step re-run on the current curve:
-          each city snaps to its nearest sample, then cities are sorted by that sample's
-          position <code>s ∈ [0,1)</code> to get the tour. It's always a valid tour, even
-          mid-training.
+          The dashed line is the <strong>decode</strong> step re-run on the
+          current curve: each city snaps to its nearest sample, then cities are
+          sorted by that sample's position <code>s ∈ [0,1)</code> to get the
+          tour. It's always a valid tour, even mid-training.
         </p>
       </div>
     </div>
-  );
+  )
 }
 
 // ---------------------------------------------------------------
 // Root component
 // ---------------------------------------------------------------
-type TabId = "idea" | "modes" | "train";
+type TabId = 'idea' | 'modes' | 'train'
 
 interface TabDef {
-  id: TabId;
-  label: string;
-  Component: () => preact.JSX.Element;
+  id: TabId
+  label: string
+  Component: () => preact.JSX.Element
 }
 
 const TABS: TabDef[] = [
-  { id: "idea", label: "Idea", Component: IdeaTab },
-  { id: "modes", label: "Modes", Component: ModesTab },
-  { id: "train", label: "Train & decode", Component: TrainTab },
-];
+  { id: 'idea', label: 'Idea', Component: IdeaTab },
+  { id: 'modes', label: 'Modes', Component: ModesTab },
+  { id: 'train', label: 'Train & decode', Component: TrainTab },
+]
 
 export default function FourierExplainer() {
-  const [tab, setTab] = useState<TabId>("idea");
-  const Active = TABS.find(t => t.id === tab)!.Component;
+  const [tab, setTab] = useState<TabId>('idea')
+  const Active = TABS.find((t) => t.id === tab)!.Component
 
   return (
     <div className="fx-root">
@@ -444,18 +577,18 @@ export default function FourierExplainer() {
         <div className="fx-eyebrow">teeline · algorithms/fourier.md</div>
         <h2 className="fx-title">Fourier-basis constructive solver</h2>
         <p className="fx-sub">
-          A tour is a closed curve γ(s) = Σ c_k·e^{"{2πiks}"}; gradient descent shapes the
-          curve, an argsort decodes it into a valid tour.
+          A tour is a closed curve γ(s) = Σ c_k·e^{'{2πiks}'}; gradient descent
+          shapes the curve, an argsort decodes it into a valid tour.
         </p>
       </header>
 
       <nav className="fx-tabs" role="tablist">
-        {TABS.map(t => (
+        {TABS.map((t) => (
           <button
             key={t.id}
             role="tab"
             aria-selected={tab === t.id}
-            className={"fx-tabbtn" + (tab === t.id ? " fx-tabbtn-active" : "")}
+            className={'fx-tabbtn' + (tab === t.id ? ' fx-tabbtn-active' : '')}
             onClick={() => setTab(t.id)}
           >
             {t.label}
@@ -473,7 +606,7 @@ export default function FourierExplainer() {
         <span className="fx-mono">λ₀: {LAMBDA0}</span>
       </footer>
     </div>
-  );
+  )
 }
 
 // ---------------------------------------------------------------
@@ -576,4 +709,4 @@ const CSS = `
 .fx-spark-line { fill: none; stroke: var(--tour); stroke-width: 1.5; }
 
 .fx-footer { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--line); color: var(--muted); }
-`;
+`

--- a/teeline-web/src/explainers/fpa.tsx
+++ b/teeline-web/src/explainers/fpa.tsx
@@ -1,12 +1,21 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
 
 // ---------------------------------------------------------------
 // Fixed demo instance: 18 cities on a 300×300 canvas.
 // ---------------------------------------------------------------
 const CITIES: [number, number][] = [
-  [45, 45], [155, 18], [265, 45], [285, 150],
-  [255, 265], [150, 285], [40, 260], [18, 150],
-  [110, 115], [200, 95], [220, 210], [95, 215],
+  [45, 45],
+  [155, 18],
+  [265, 45],
+  [285, 150],
+  [255, 265],
+  [150, 285],
+  [40, 260],
+  [18, 150],
+  [110, 115],
+  [200, 95],
+  [220, 210],
+  [95, 215],
 ]
 const N_CITIES = CITIES.length
 
@@ -54,7 +63,11 @@ function swapSequence(a: number[], b: number[]): [number, number][] {
   return swaps
 }
 
-function applySwaps(tour: number[], swaps: [number, number][], n: number): number[] {
+function applySwaps(
+  tour: number[],
+  swaps: [number, number][],
+  n: number,
+): number[] {
   const t = tour.slice()
   const lim = Math.min(n, swaps.length)
   for (let i = 0; i < lim; i++) {
@@ -74,7 +87,8 @@ function shuffle(n: number): number[] {
 }
 
 function centroid(tour: number[]): [number, number] {
-  let x = 0, y = 0
+  let x = 0,
+    y = 0
   for (const idx of tour) {
     x += CITIES[idx][0]
     y += CITIES[idx][1]
@@ -114,8 +128,10 @@ function makeInitState(nFlowers: number): SimState {
 // SVG helper
 // ---------------------------------------------------------------
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
-  return tour.length > 0 ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}` : pts
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
+  return tour.length > 0
+    ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : pts
 }
 
 // ---------------------------------------------------------------
@@ -141,18 +157,24 @@ function FlowerHeatmap({ costs, activeIdx, gbestIdx }: FlowerHeatmapProps) {
         const hue = Math.round(norm * 120)
         const bg = `hsl(${hue},55%,42%)`
         const border =
-          i === activeIdx ? "2px solid #3b82f6" :
-          i === gbestIdx  ? "2px solid #16a34a" : "2px solid transparent"
+          i === activeIdx
+            ? '2px solid #3b82f6'
+            : i === gbestIdx
+              ? '2px solid #16a34a'
+              : '2px solid transparent'
         const status =
-          i === activeIdx && i === gbestIdx ? "active · best" :
-          i === activeIdx ? "active flower" :
-          i === gbestIdx  ? "global best" :
-          `quality ${Math.round(norm * 100)}%`
+          i === activeIdx && i === gbestIdx
+            ? 'active · best'
+            : i === activeIdx
+              ? 'active flower'
+              : i === gbestIdx
+                ? 'global best'
+                : `quality ${Math.round(norm * 100)}%`
         return (
           <div
             key={i}
             className="fp-heatmap-cell"
-            style={{ background: bg, outline: border, outlineOffset: "1px" }}
+            style={{ background: bg, outline: border, outlineOffset: '1px' }}
           >
             <span className="fp-heatmap-idx">{i}</span>
             <span className="fp-heatmap-cost">{c.toFixed(0)}</span>
@@ -177,18 +199,27 @@ function TourSVG({ flowers, gbest, activeIdx }: TourSVGProps) {
   const ghosts = flowers.filter((_, i) => i !== activeIdx).slice(0, 5)
   const active = flowers[activeIdx]
   return (
-    <svg viewBox="0 0 300 300" className="fp-canvas" role="img" aria-label="FPA tour population">
+    <svg
+      viewBox="0 0 300 300"
+      className="fp-canvas"
+      role="img"
+      aria-label="FPA tour population"
+    >
       <rect x={0} y={0} width={300} height={300} className="fp-bg" />
       {ghosts.map((tour, i) => (
         <polyline key={i} className="fp-ghost" points={polyPts(tour)} />
       ))}
       {active && <polyline className="fp-active" points={polyPts(active)} />}
-      {gbest.length > 0 && <polyline className="fp-gbest" points={polyPts(gbest)} />}
+      {gbest.length > 0 && (
+        <polyline className="fp-gbest" points={polyPts(gbest)} />
+      )}
       {CITIES.map(([x, y], i) => (
         <circle key={i} cx={x} cy={y} r={4} className="fp-city" />
       ))}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="fp-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="fp-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -197,15 +228,16 @@ function TourSVG({ flowers, gbest, activeIdx }: TourSVGProps) {
 // ---------------------------------------------------------------
 // Lévy sparkline: bar chart of last 30 step sizes
 // ---------------------------------------------------------------
-type SparkEntry = { value: number; mode: "global" | "local" }
+type SparkEntry = { value: number; mode: 'global' | 'local' }
 
 function LevySparkline({ history }: { history: SparkEntry[] }) {
-  const W = 180, H = 54
+  const W = 180,
+    H = 54
   const visible = history.slice(-30)
   if (!visible.length) {
     return <svg viewBox={`0 0 ${W} ${H}`} className="fp-spark" />
   }
-  const maxVal = Math.min(Math.max(...visible.map(h => h.value), 0.5), 4)
+  const maxVal = Math.min(Math.max(...visible.map((h) => h.value), 0.5), 4)
   const slotW = W / 30
   const barW = Math.max(1, slotW - 1)
   return (
@@ -219,7 +251,7 @@ function LevySparkline({ history }: { history: SparkEntry[] }) {
             y={H - bh - 2}
             width={barW}
             height={bh}
-            fill={h.mode === "global" ? "#3b82f6" : "#d97706"}
+            fill={h.mode === 'global' ? '#3b82f6' : '#d97706'}
             opacity={0.85}
           />
         )
@@ -242,7 +274,9 @@ export default function FPAExplainer() {
   const simRef = useRef<SimState>(makeInitState(8))
 
   // Display state — mirrors simRef for rendering
-  const [flowers, setFlowers] = useState<number[][]>(() => simRef.current.flowers)
+  const [flowers, setFlowers] = useState<number[][]>(
+    () => simRef.current.flowers,
+  )
   const [costs, setCosts] = useState<number[]>(() => simRef.current.costs)
   const [gbest, setGbest] = useState<number[]>(() => simRef.current.gbest)
   const [gbestCost, setGbestCost] = useState(() => simRef.current.gbestCost)
@@ -251,11 +285,15 @@ export default function FPAExplainer() {
   const [localCount, setLocalCount] = useState(0)
 
   // Per-step annotation state
-  const [mode, setMode] = useState<"global" | "local" | null>(null)
+  const [mode, setMode] = useState<'global' | 'local' | null>(null)
   const [activeIdx, setActiveIdx] = useState(0)
   const [levyHistory, setLevyHistory] = useState<SparkEntry[]>([])
   const [lastLevy, setLastLevy] = useState<number | null>(null)
-  const [iconPos, setIconPos] = useState<{ icon: string; x: number; y: number } | null>(null)
+  const [iconPos, setIconPos] = useState<{
+    icon: string
+    x: number
+    y: number
+  } | null>(null)
 
   const [running, setRunning] = useState(false)
 
@@ -287,14 +325,14 @@ export default function FPAExplainer() {
 
     const i = Math.floor(Math.random() * n)
     let newTour: number[]
-    let stepMode: "global" | "local"
+    let stepMode: 'global' | 'local'
     let stepLevy: number
     let localJ = -1
     let localK = -1
 
     if (Math.random() < sp) {
       // Global pollination: Lévy-flight toward gbest
-      stepMode = "global"
+      stepMode = 'global'
       const lv = levyStep()
       stepLevy = lv
       const seq = swapSequence(sim.flowers[i], sim.gbest)
@@ -302,25 +340,35 @@ export default function FPAExplainer() {
         newTour = sim.flowers[i].slice()
       } else {
         // * 0.5 matches the Rust implementation: never jump more than halfway to gbest
-        const nSwaps = Math.min(seq.length, Math.max(1, Math.ceil(lv * seq.length * 0.5)))
+        const nSwaps = Math.min(
+          seq.length,
+          Math.max(1, Math.ceil(lv * seq.length * 0.5)),
+        )
         newTour = applySwaps(sim.flowers[i], seq, nSwaps)
       }
     } else {
       // Local pollination: ε-scaled cross-pollination between two random flowers
-      stepMode = "local"
+      stepMode = 'local'
       if (n < 3) {
         newTour = sim.flowers[i].slice()
         stepLevy = 0
       } else {
-        do { localJ = Math.floor(Math.random() * n) } while (localJ === i)
-        do { localK = Math.floor(Math.random() * n) } while (localK === i || localK === localJ)
+        do {
+          localJ = Math.floor(Math.random() * n)
+        } while (localJ === i)
+        do {
+          localK = Math.floor(Math.random() * n)
+        } while (localK === i || localK === localJ)
         const epsilon = Math.random()
         stepLevy = epsilon
         const seq = swapSequence(sim.flowers[localJ], sim.flowers[localK])
         if (seq.length === 0) {
           newTour = sim.flowers[i].slice()
         } else {
-          const nSwaps = Math.min(seq.length, Math.max(1, Math.ceil(epsilon * seq.length)))
+          const nSwaps = Math.min(
+            seq.length,
+            Math.max(1, Math.ceil(epsilon * seq.length)),
+          )
           newTour = applySwaps(sim.flowers[i], seq, nSwaps)
         }
       }
@@ -343,8 +391,8 @@ export default function FPAExplainer() {
       newGbestCost = newCost
     }
 
-    const newGlobalCount = sim.globalCount + (stepMode === "global" ? 1 : 0)
-    const newLocalCount = sim.localCount + (stepMode === "local" ? 1 : 0)
+    const newGlobalCount = sim.globalCount + (stepMode === 'global' ? 1 : 0)
+    const newLocalCount = sim.localCount + (stepMode === 'local' ? 1 : 0)
     const newIter = sim.iter + 1
 
     simRef.current = {
@@ -367,17 +415,28 @@ export default function FPAExplainer() {
     setMode(stepMode)
     setActiveIdx(i)
     setLastLevy(stepLevy)
-    setLevyHistory(h => [...h.slice(-99), { value: stepLevy, mode: stepMode }])
+    setLevyHistory((h) => [
+      ...h.slice(-99),
+      { value: stepLevy, mode: stepMode },
+    ])
 
     // Position the icon at the midpoint of the relevant move
-    if (stepMode === "global") {
+    if (stepMode === 'global') {
       const [ax, ay] = centroid(sim.flowers[i])
       const [gx, gy] = centroid(sim.gbest)
-      setIconPos({ icon: "🐝", x: ((ax + gx) / 2 / 300) * 100, y: ((ay + gy) / 2 / 300) * 100 })
+      setIconPos({
+        icon: '🐝',
+        x: ((ax + gx) / 2 / 300) * 100,
+        y: ((ay + gy) / 2 / 300) * 100,
+      })
     } else if (localJ !== -1 && localK !== -1) {
       const [jx, jy] = centroid(sim.flowers[localJ])
       const [kx, ky] = centroid(sim.flowers[localK])
-      setIconPos({ icon: "🌬️", x: ((jx + kx) / 2 / 300) * 100, y: ((jy + ky) / 2 / 300) * 100 })
+      setIconPos({
+        icon: '🌬️',
+        x: ((jx + kx) / 2 / 300) * 100,
+        y: ((jy + ky) / 2 / 300) * 100,
+      })
     }
   }, [])
 
@@ -390,11 +449,11 @@ export default function FPAExplainer() {
   }, [running, stepOnce, delay])
 
   const modeLabel =
-    mode === "global"
-      ? "🌍 Global pollination — Lévy flight toward gbest"
-      : mode === "local"
-        ? "🌸 Local pollination — ε cross-pollination"
-        : "Press Step or Run to begin"
+    mode === 'global'
+      ? '🌍 Global pollination — Lévy flight toward gbest'
+      : mode === 'local'
+        ? '🌸 Local pollination — ε cross-pollination'
+        : 'Press Step or Run to begin'
 
   return (
     <div className="fp-root">
@@ -404,10 +463,12 @@ export default function FPAExplainer() {
         <div className="fp-eyebrow">teeline · algorithms/fpa</div>
         <h2 className="fp-title">Flower Pollination Algorithm</h2>
         <p className="fp-sub">
-          A population of candidate tours (flowers) evolves each step: with probability{" "}
-          <code>p</code> a flower makes a long-range <strong>Lévy flight</strong> toward the
-          global best; otherwise it <strong>cross-pollinates</strong> with two random flowers
-          nearby. Drag the sliders to see how <code>p</code> and population size shape search.
+          A population of candidate tours (flowers) evolves each step: with
+          probability <code>p</code> a flower makes a long-range{' '}
+          <strong>Lévy flight</strong> toward the global best; otherwise it{' '}
+          <strong>cross-pollinates</strong> with two random flowers nearby. Drag
+          the sliders to see how <code>p</code> and population size shape
+          search.
         </p>
       </header>
 
@@ -416,7 +477,10 @@ export default function FPAExplainer() {
         <div className="fp-canvas-wrap">
           <TourSVG flowers={flowers} gbest={gbest} activeIdx={activeIdx} />
           {iconPos && (
-            <span className="fp-icon" style={{ left: `${iconPos.x}%`, top: `${iconPos.y}%` }}>
+            <span
+              className="fp-icon"
+              style={{ left: `${iconPos.x}%`, top: `${iconPos.y}%` }}
+            >
               {iconPos.icon}
             </span>
           )}
@@ -430,37 +494,52 @@ export default function FPAExplainer() {
 
       {/* Canvas legend */}
       <div className="fp-legend">
-        <span><span className="fp-dot fp-dot-gbest">●</span> gbest tour</span>
-        <span><span className="fp-dot fp-dot-active">●</span> active flower</span>
-        <span><span className="fp-dot fp-dot-ghost">●</span> population</span>
-        <span><span className="fp-dot fp-dot-city">●</span> city</span>
-        <span><span style={{ color: "#3b82f6", fontWeight: 700 }}>▌</span> active flower</span>
-        <span><span style={{ color: "#16a34a", fontWeight: 700 }}>▌</span> global best</span>
+        <span>
+          <span className="fp-dot fp-dot-gbest">●</span> gbest tour
+        </span>
+        <span>
+          <span className="fp-dot fp-dot-active">●</span> active flower
+        </span>
+        <span>
+          <span className="fp-dot fp-dot-ghost">●</span> population
+        </span>
+        <span>
+          <span className="fp-dot fp-dot-city">●</span> city
+        </span>
+        <span>
+          <span style={{ color: '#3b82f6', fontWeight: 700 }}>▌</span> active
+          flower
+        </span>
+        <span>
+          <span style={{ color: '#16a34a', fontWeight: 700 }}>▌</span> global
+          best
+        </span>
       </div>
 
       {/* Mode chip */}
-      <div className={`fp-mode fp-mode-${mode ?? "idle"}`}>{modeLabel}</div>
+      <div className={`fp-mode fp-mode-${mode ?? 'idle'}`}>{modeLabel}</div>
 
       {/* Lévy sparkline + step size */}
       <div className="fp-spark-row">
         <div className="fp-spark-wrap">
           <LevySparkline history={levyHistory} />
           <div className="fp-spark-caption">
-            <span className="fp-swatch fp-swatch-global">■</span> global Lévy step &nbsp;
+            <span className="fp-swatch fp-swatch-global">■</span> global Lévy
+            step &nbsp;
             <span className="fp-swatch fp-swatch-local">■</span> local ε step
           </div>
         </div>
         <div className="fp-stepval-wrap">
           <div className="fp-statlabel">step size</div>
           <div className="fp-mono fp-stepval">
-            {lastLevy !== null ? lastLevy.toFixed(3) : "—"}
+            {lastLevy !== null ? lastLevy.toFixed(3) : '—'}
           </div>
-          <div className="fp-statlabel" style={{ marginTop: "4px" }}>
-            {mode === "global"
-              ? "Lévy draw"
-              : mode === "local"
-                ? "ε (uniform)"
-                : ""}
+          <div className="fp-statlabel" style={{ marginTop: '4px' }}>
+            {mode === 'global'
+              ? 'Lévy draw'
+              : mode === 'local'
+                ? 'ε (uniform)'
+                : ''}
           </div>
         </div>
       </div>
@@ -489,10 +568,14 @@ export default function FPAExplainer() {
       <div className="fp-config">
         <div className="fp-config-row">
           <label className="fp-config-label">
-            Switch prob <code>p</code> = <strong>{switchProb.toFixed(2)}</strong>
+            Switch prob <code>p</code> ={' '}
+            <strong>{switchProb.toFixed(2)}</strong>
           </label>
           <input
-            type="range" min={0} max={1} step={0.05}
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
             value={switchProb}
             className="fp-slider"
             onInput={(e) => {
@@ -503,9 +586,9 @@ export default function FPAExplainer() {
           />
           <div className="fp-hint">
             {switchProb >= 0.9
-              ? "Mostly global — fast but risks premature convergence"
+              ? 'Mostly global — fast but risks premature convergence'
               : switchProb <= 0.1
-                ? "Mostly local — slow diffuse search, global rarely fires"
+                ? 'Mostly local — slow diffuse search, global rarely fires'
                 : `~${Math.round(switchProb * 100)}% global / ${Math.round((1 - switchProb) * 100)}% local`}
           </div>
         </div>
@@ -515,7 +598,10 @@ export default function FPAExplainer() {
             Flowers (population) = <strong>{nFlowers}</strong>
           </label>
           <input
-            type="range" min={3} max={15} step={1}
+            type="range"
+            min={3}
+            max={15}
+            step={1}
             value={nFlowers}
             className="fp-slider"
             onInput={(e) => {
@@ -526,20 +612,25 @@ export default function FPAExplainer() {
           />
           <div className="fp-hint">
             {nFlowers <= 4
-              ? "Small swarm: fast per-step but low diversity"
+              ? 'Small swarm: fast per-step but low diversity'
               : nFlowers >= 12
-                ? "Large swarm: more diversity, slower per step"
-                : "Balanced population size"}
+                ? 'Large swarm: more diversity, slower per step'
+                : 'Balanced population size'}
           </div>
         </div>
 
         <div className="fp-config-row">
           <label className="fp-config-label">Speed</label>
           <input
-            type="range" min={1} max={10} step={1}
+            type="range"
+            min={1}
+            max={10}
+            step={1}
             value={speed}
             className="fp-slider"
-            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
@@ -550,10 +641,10 @@ export default function FPAExplainer() {
           ◀ Step
         </button>
         <button
-          className={`fp-btn ${!running ? "fp-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}
+          className={`fp-btn ${!running ? 'fp-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
         >
-          {running ? "⏸ Pause" : "▶ Run"}
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
         <button className="fp-btn" onClick={() => reinit(nFlowers)}>
           ↺ Reset

--- a/teeline-web/src/explainers/ga.tsx
+++ b/teeline-web/src/explainers/ga.tsx
@@ -1,12 +1,21 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
 
 // ---------------------------------------------------------------
 // Fixed 12-city demo (same layout as SA / CS / FPA explainers)
 // ---------------------------------------------------------------
 const CITIES: [number, number][] = [
-  [45, 45], [155, 18], [265, 45], [285, 150],
-  [255, 265], [150, 285], [40, 260], [18, 150],
-  [110, 115], [200, 95], [220, 210], [95, 215],
+  [45, 45],
+  [155, 18],
+  [265, 45],
+  [285, 150],
+  [255, 265],
+  [150, 285],
+  [40, 260],
+  [18, 150],
+  [110, 115],
+  [200, 95],
+  [220, 210],
+  [95, 215],
 ]
 const N_CITIES = CITIES.length
 
@@ -49,7 +58,12 @@ function randomPair(n: number): [number, number] {
 
 // Ordered crossover — mirrors ordered_crossover_genes in Rust exactly
 // Segment [from..to] is copied from p2; remaining cities filled from p1 in order
-function orderedCrossover(p1: number[], p2: number[], from: number, to: number): number[] {
+function orderedCrossover(
+  p1: number[],
+  p2: number[],
+  from: number,
+  to: number,
+): number[] {
   const n = p1.length
   const child = new Array(n).fill(-1)
   const inSegment = new Set<number>()
@@ -74,8 +88,13 @@ function orderedCrossover(p1: number[], p2: number[], from: number, to: number):
 function mutate(tour: number[]): number[] {
   const [from, to] = randomPair(tour.length)
   const next = tour.slice()
-  let lo = from, hi = to
-  while (lo < hi) { [next[lo], next[hi]] = [next[hi], next[lo]]; lo++; hi-- }
+  let lo = from,
+    hi = to
+  while (lo < hi) {
+    ;[next[lo], next[hi]] = [next[hi], next[lo]]
+    lo++
+    hi--
+  }
   return next
 }
 
@@ -95,7 +114,7 @@ function rouletteSelect(fitnesses: number[]): number {
 // Simulation state (all mutable data lives here to avoid stale closures)
 // ---------------------------------------------------------------
 type SimState = {
-  population: number[][]   // sorted best→worst
+  population: number[][] // sorted best→worst
   fitnesses: number[]
   best: number[]
   bestCost: number
@@ -104,23 +123,38 @@ type SimState = {
   pendingChildren: number[][]
   totalCrossovers: number
   totalMutations: number
-  genHistory: number[]     // bestCost at each completed generation
+  genHistory: number[] // bestCost at each completed generation
 }
 
-function initSorted(population: number[][]): { population: number[][]; fitnesses: number[] } {
+function initSorted(population: number[][]): {
+  population: number[][]
+  fitnesses: number[]
+} {
   const fitnesses = population.map(fitness)
-  const order = fitnesses.map((f, i) => ({ f, i })).sort((a, b) => b.f - a.f).map(x => x.i)
-  return { population: order.map(i => population[i]), fitnesses: order.map(i => fitnesses[i]) }
+  const order = fitnesses
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => b.f - a.f)
+    .map((x) => x.i)
+  return {
+    population: order.map((i) => population[i]),
+    fitnesses: order.map((i) => fitnesses[i]),
+  }
 }
 
 function makeInitState(popSize: number): SimState {
   const raw = Array.from({ length: popSize }, () => shuffle(N_CITIES))
   const { population, fitnesses } = initSorted(raw)
   return {
-    population, fitnesses,
-    best: population[0].slice(), bestCost: tourLength(population[0]),
-    generation: 0, stepInGen: 0, pendingChildren: [],
-    totalCrossovers: 0, totalMutations: 0, genHistory: [],
+    population,
+    fitnesses,
+    best: population[0].slice(),
+    bestCost: tourLength(population[0]),
+    generation: 0,
+    stepInGen: 0,
+    pendingChildren: [],
+    totalCrossovers: 0,
+    totalMutations: 0,
+    genHistory: [],
   }
 }
 
@@ -128,7 +162,7 @@ function makeInitState(popSize: number): SimState {
 // SVG helpers
 // ---------------------------------------------------------------
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
   return pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
 }
 
@@ -137,14 +171,21 @@ function polyPts(tour: number[]): string {
 // ---------------------------------------------------------------
 function BestTourSVG({ tour }: { tour: number[] }) {
   return (
-    <svg viewBox="0 0 300 300" className="ga-canvas" role="img" aria-label="GA best tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="ga-canvas"
+      role="img"
+      aria-label="GA best tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="ga-bg" />
       <polyline points={polyPts(tour)} className="ga-best-tour" />
       {CITIES.map(([x, y], i) => (
         <circle key={i} cx={x} cy={y} r={4} className="ga-city" />
       ))}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="ga-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="ga-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -159,7 +200,12 @@ interface PopulationHeatmapProps {
   parentBIdx: number
   eliteCount: number
 }
-function PopulationHeatmap({ fitnesses, parentAIdx, parentBIdx, eliteCount }: PopulationHeatmapProps) {
+function PopulationHeatmap({
+  fitnesses,
+  parentAIdx,
+  parentBIdx,
+  eliteCount,
+}: PopulationHeatmapProps) {
   if (!fitnesses.length) return null
   const minF = Math.min(...fitnesses)
   const maxF = Math.max(...fitnesses)
@@ -174,14 +220,29 @@ function PopulationHeatmap({ fitnesses, parentAIdx, parentBIdx, eliteCount }: Po
         const isElite = i < eliteCount
         const isA = i === parentAIdx
         const isB = i === parentBIdx
-        const border = isA ? '2.5px solid #3b82f6'
-          : isB ? '2.5px solid #d97706'
-          : isElite ? '2.5px solid #f59e0b'
-          : '2px solid transparent'
-        const statusText = isA && isB ? 'A + B' : isA ? 'parent A' : isB ? 'parent B'
-          : isElite ? 'elite' : `fitness ${(norm * 100).toFixed(0)}%`
+        const border = isA
+          ? '2.5px solid #3b82f6'
+          : isB
+            ? '2.5px solid #d97706'
+            : isElite
+              ? '2.5px solid #f59e0b'
+              : '2px solid transparent'
+        const statusText =
+          isA && isB
+            ? 'A + B'
+            : isA
+              ? 'parent A'
+              : isB
+                ? 'parent B'
+                : isElite
+                  ? 'elite'
+                  : `fitness ${(norm * 100).toFixed(0)}%`
         return (
-          <div key={i} className="ga-heatmap-cell" style={{ background: bg, border }}>
+          <div
+            key={i}
+            className="ga-heatmap-cell"
+            style={{ background: bg, border }}
+          >
             <span className="ga-heatmap-idx">{i}</span>
             <div className="ga-heatmap-overlay">{statusText}</div>
           </div>
@@ -201,25 +262,43 @@ interface MiniTourSVGProps {
   label: string
   mutated?: boolean
 }
-function MiniTourSVG({ tour, segmentCityIds, edgeColor, label, mutated }: MiniTourSVGProps) {
+function MiniTourSVG({
+  tour,
+  segmentCityIds,
+  edgeColor,
+  label,
+  mutated,
+}: MiniTourSVGProps) {
   return (
     <div className="ga-mini-wrap">
       <svg viewBox="0 0 300 300" className="ga-mini-svg">
         <rect x={0} y={0} width={300} height={300} className="ga-bg" />
-        <polyline points={polyPts(tour)} fill="none" stroke={edgeColor} strokeWidth={2} strokeLinejoin="round" />
+        <polyline
+          points={polyPts(tour)}
+          fill="none"
+          stroke={edgeColor}
+          strokeWidth={2}
+          strokeLinejoin="round"
+        />
         {CITIES.map(([x, y], i) => {
           const inSeg = segmentCityIds.has(i)
           return (
-            <circle key={i} cx={x} cy={y}
+            <circle
+              key={i}
+              cx={x}
+              cy={y}
               r={inSeg ? 7 : 4}
-              fill={inSeg ? "#f97316" : "#f2a154"}
-              stroke={inSeg ? "#fff" : "none"}
+              fill={inSeg ? '#f97316' : '#f2a154'}
+              stroke={inSeg ? '#fff' : 'none'}
               strokeWidth={1.5}
             />
           )
         })}
       </svg>
-      <div className="ga-mini-label">{label}{mutated ? " (mutated)" : ""}</div>
+      <div className="ga-mini-label">
+        {label}
+        {mutated ? ' (mutated)' : ''}
+      </div>
     </div>
   )
 }
@@ -234,7 +313,13 @@ interface CrossoverPanelProps {
   segment: [number, number]
   childMutated: boolean
 }
-function CrossoverPanel({ parentA, parentB, child, segment, childMutated }: CrossoverPanelProps) {
+function CrossoverPanel({
+  parentA,
+  parentB,
+  child,
+  segment,
+  childMutated,
+}: CrossoverPanelProps) {
   const [from, to] = segment
   // Cities occupying the OX segment positions in parent B
   const segmentCityIds = new Set<number>()
@@ -245,11 +330,27 @@ function CrossoverPanel({ parentA, parentB, child, segment, childMutated }: Cros
         Ordered Crossover — positions [{from}..{to}] inherited from B
       </div>
       <div className="ga-crossover-row">
-        <MiniTourSVG tour={parentA} segmentCityIds={segmentCityIds} edgeColor="#3b82f6" label="Parent A" />
+        <MiniTourSVG
+          tour={parentA}
+          segmentCityIds={segmentCityIds}
+          edgeColor="#3b82f6"
+          label="Parent A"
+        />
         <div className="ga-crossover-arrow">→</div>
-        <MiniTourSVG tour={parentB} segmentCityIds={segmentCityIds} edgeColor="#d97706" label="Parent B" />
+        <MiniTourSVG
+          tour={parentB}
+          segmentCityIds={segmentCityIds}
+          edgeColor="#d97706"
+          label="Parent B"
+        />
         <div className="ga-crossover-arrow">→</div>
-        <MiniTourSVG tour={child} segmentCityIds={segmentCityIds} edgeColor="#16a34a" label="Child" mutated={childMutated} />
+        <MiniTourSVG
+          tour={child}
+          segmentCityIds={segmentCityIds}
+          edgeColor="#16a34a"
+          label="Child"
+          mutated={childMutated}
+        />
       </div>
     </div>
   )
@@ -259,21 +360,31 @@ function CrossoverPanel({ parentA, parentB, child, segment, childMutated }: Cros
 // FitnessSparkline — best distance per completed generation
 // ---------------------------------------------------------------
 function FitnessSparkline({ history }: { history: number[] }) {
-  const W = 300, H = 54
+  const W = 300,
+    H = 54
   const visible = history.slice(-20)
-  if (!visible.length) return <svg viewBox={`0 0 ${W} ${H}`} className="ga-spark" />
-  const minV = Math.min(...visible), maxV = Math.max(...visible)
+  if (!visible.length)
+    return <svg viewBox={`0 0 ${W} ${H}`} className="ga-spark" />
+  const minV = Math.min(...visible),
+    maxV = Math.max(...visible)
   const range = maxV - minV || 1
   const slotW = W / 20
   const barW = Math.max(1, slotW - 1)
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="ga-spark">
       {visible.map((v, i) => {
-        const norm = 1 - (v - minV) / range  // taller bar = lower distance = better
+        const norm = 1 - (v - minV) / range // taller bar = lower distance = better
         const bh = Math.max(2, norm * (H - 4))
         return (
-          <rect key={i} x={i * slotW} y={H - bh - 2} width={barW} height={bh}
-            fill="#16a34a" opacity={0.8} />
+          <rect
+            key={i}
+            x={i * slotW}
+            y={H - bh - 2}
+            width={barW}
+            height={bh}
+            fill="#16a34a"
+            opacity={0.8}
+          />
         )
       })}
     </svg>
@@ -286,19 +397,21 @@ function FitnessSparkline({ history }: { history: number[] }) {
 export default function GAExplainer() {
   const [popSize, setPopSize] = useState(8)
   const [nElite, setNElite] = useState(2)
-  const [mutationProb, setMutationProb] = useState(0.20)
+  const [mutationProb, setMutationProb] = useState(0.2)
   const [speed, setSpeed] = useState(5)
 
   // Refs for stable access inside stepOnce (avoids stale closures)
   const popSizeRef = useRef(8)
   const nEliteRef = useRef(2)
-  const mutProbRef = useRef(0.20)
+  const mutProbRef = useRef(0.2)
   const simRef = useRef<SimState>(makeInitState(8))
 
   // Display state (synced from simRef after each step)
   const [best, setBest] = useState<number[]>(() => simRef.current.best)
   const [bestCost, setBestCost] = useState(() => simRef.current.bestCost)
-  const [fitnesses, setFitnesses] = useState<number[]>(() => simRef.current.fitnesses)
+  const [fitnesses, setFitnesses] = useState<number[]>(
+    () => simRef.current.fitnesses,
+  )
   const [generation, setGeneration] = useState(0)
   const [stepInGen, setStepInGen] = useState(0)
   const [totalCrossovers, setTotalCrossovers] = useState(0)
@@ -313,8 +426,8 @@ export default function GAExplainer() {
   const [lastChild, setLastChild] = useState<number[]>([])
   const [lastSegment, setLastSegment] = useState<[number, number]>([0, 3])
   const [lastChildMutated, setLastChildMutated] = useState(false)
-  const [chipText, setChipText] = useState("")
-  const [chipMode, setChipMode] = useState<"cross" | "gen" | "">("")
+  const [chipText, setChipText] = useState('')
+  const [chipMode, setChipMode] = useState<'cross' | 'gen' | ''>('')
   const [running, setRunning] = useState(false)
 
   const reinit = useCallback((size: number) => {
@@ -323,13 +436,20 @@ export default function GAExplainer() {
     setBest(s.best.slice())
     setBestCost(s.bestCost)
     setFitnesses(s.fitnesses.slice())
-    setGeneration(0); setStepInGen(0)
-    setTotalCrossovers(0); setTotalMutations(0)
+    setGeneration(0)
+    setStepInGen(0)
+    setTotalCrossovers(0)
+    setTotalMutations(0)
     setGenHistory([])
-    setParentAIdx(-1); setParentBIdx(-1)
-    setLastParentA([]); setLastParentB([]); setLastChild([])
-    setLastSegment([0, 3]); setLastChildMutated(false)
-    setChipText(""); setChipMode("")
+    setParentAIdx(-1)
+    setParentBIdx(-1)
+    setLastParentA([])
+    setLastParentB([])
+    setLastChild([])
+    setLastSegment([0, 3])
+    setLastChildMutated(false)
+    setChipText('')
+    setChipMode('')
     setRunning(false)
   }, [])
 
@@ -368,8 +488,14 @@ export default function GAExplainer() {
     const parentACost = tourLength(parentA)
     let newBest = s.best
     let newBestCost = s.bestCost
-    if (child1Cost < s.bestCost) { newBest = final1.slice(); newBestCost = child1Cost }
-    if (child2Cost < newBestCost) { newBest = final2.slice(); newBestCost = child2Cost }
+    if (child1Cost < s.bestCost) {
+      newBest = final1.slice()
+      newBestCost = child1Cost
+    }
+    if (child2Cost < newBestCost) {
+      newBest = final2.slice()
+      newBestCost = child2Cost
+    }
 
     let newPopulation = s.population
     let newFitnesses = s.fitnesses
@@ -380,8 +506,10 @@ export default function GAExplainer() {
 
     if (newStepInGen >= stepsPerGen) {
       // Commit generation: keep elite, fill rest with pending children
-      const sorted = s.fitnesses.map((f, i) => ({ f, i })).sort((a, b) => b.f - a.f)
-      const elites = sorted.slice(0, ne).map(x => s.population[x.i])
+      const sorted = s.fitnesses
+        .map((f, i) => ({ f, i }))
+        .sort((a, b) => b.f - a.f)
+      const elites = sorted.slice(0, ne).map((x) => s.population[x.i])
       const slots = s.population.length - ne
       const combined = [...elites, ...newPending.slice(0, slots)]
       const { population: nextPop, fitnesses: nextFit } = initSorted(combined)
@@ -395,12 +523,15 @@ export default function GAExplainer() {
 
     simRef.current = {
       ...s,
-      population: newPopulation, fitnesses: newFitnesses,
-      best: newBest, bestCost: newBestCost,
+      population: newPopulation,
+      fitnesses: newFitnesses,
+      best: newBest,
+      bestCost: newBestCost,
       generation: newGeneration,
       stepInGen: genJustCompleted ? 0 : newStepInGen,
       pendingChildren: newPendingFinal,
-      totalCrossovers: newCrossovers, totalMutations: newMutations,
+      totalCrossovers: newCrossovers,
+      totalMutations: newMutations,
       genHistory: newGenHistory,
     }
 
@@ -424,16 +555,18 @@ export default function GAExplainer() {
     setLastChildMutated(mut1)
 
     if (genJustCompleted) {
-      setChipText(`⭐ Generation ${newGeneration} complete — best ${newBestCost.toFixed(0)}`)
-      setChipMode("gen")
+      setChipText(
+        `⭐ Generation ${newGeneration} complete — best ${newBestCost.toFixed(0)}`,
+      )
+      setChipMode('gen')
     } else {
       const delta = child1Cost - parentACost
-      const sign = delta < 0 ? "✅" : "➡️"
-      const mutStr = mut1 ? " · 🔬 mutated" : ""
+      const sign = delta < 0 ? '✅' : '➡️'
+      const mutStr = mut1 ? ' · 🔬 mutated' : ''
       setChipText(
-        `🧬 [${from}..${to}] from B → child  ${sign} ${delta < 0 ? `−${Math.abs(delta).toFixed(0)}` : `+${delta.toFixed(0)}`}${mutStr}`
+        `🧬 [${from}..${to}] from B → child  ${sign} ${delta < 0 ? `−${Math.abs(delta).toFixed(0)}` : `+${delta.toFixed(0)}`}${mutStr}`,
       )
-      setChipMode("cross")
+      setChipMode('cross')
     }
   }, []) // no deps — all mutable state read from simRef / nEliteRef / mutProbRef
 
@@ -456,10 +589,11 @@ export default function GAExplainer() {
         <div className="ga-eyebrow">teeline · algorithms/ga</div>
         <h2 className="ga-title">Genetic Algorithm</h2>
         <p className="ga-sub">
-          A population of tours evolves step by step. Two parents are chosen by{" "}
-          <strong>roulette selection</strong> (fitter = more likely), combined via{" "}
-          <strong>ordered crossover (OX)</strong>, and optionally <strong>mutated</strong>.
-          The top <code>{nElite}</code> elite individuals survive unchanged each generation.
+          A population of tours evolves step by step. Two parents are chosen by{' '}
+          <strong>roulette selection</strong> (fitter = more likely), combined
+          via <strong>ordered crossover (OX)</strong>, and optionally{' '}
+          <strong>mutated</strong>. The top <code>{nElite}</code> elite
+          individuals survive unchanged each generation.
         </p>
       </div>
 
@@ -474,11 +608,16 @@ export default function GAExplainer() {
       </div>
 
       <div className="ga-legend">
-        <span className="ga-swatch ga-swatch-best" />best tour
-        <span className="ga-swatch ga-swatch-parentA" />parent A
-        <span className="ga-swatch ga-swatch-parentB" />parent B
-        <span className="ga-swatch ga-swatch-elite" />elite
-        <span className="ga-swatch ga-swatch-segment" />OX segment
+        <span className="ga-swatch ga-swatch-best" />
+        best tour
+        <span className="ga-swatch ga-swatch-parentA" />
+        parent A
+        <span className="ga-swatch ga-swatch-parentB" />
+        parent B
+        <span className="ga-swatch ga-swatch-elite" />
+        elite
+        <span className="ga-swatch ga-swatch-segment" />
+        OX segment
       </div>
 
       {hasCrossover && (
@@ -492,7 +631,9 @@ export default function GAExplainer() {
       )}
 
       {chipText && (
-        <div className={`ga-chip ${chipMode === "gen" ? "ga-chip-gen" : "ga-chip-cross"}`}>
+        <div
+          className={`ga-chip ${chipMode === 'gen' ? 'ga-chip-gen' : 'ga-chip-cross'}`}
+        >
           {chipText}
         </div>
       )}
@@ -508,7 +649,9 @@ export default function GAExplainer() {
           <span className="ga-stat-label">gen</span>
         </div>
         <div className="ga-stat">
-          <span className="ga-stat-val">{stepInGen}/{stepsPerGen}</span>
+          <span className="ga-stat-val">
+            {stepInGen}/{stepsPerGen}
+          </span>
           <span className="ga-stat-label">step</span>
         </div>
         <div className="ga-stat">
@@ -528,49 +671,88 @@ export default function GAExplainer() {
       <div className="ga-config">
         <label className="ga-label">
           population = {popSize}
-          <input type="range" min={4} max={16} step={2} value={popSize} className="ga-slider"
-            onInput={e => {
+          <input
+            type="range"
+            min={4}
+            max={16}
+            step={2}
+            value={popSize}
+            className="ga-slider"
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
-              setPopSize(v); popSizeRef.current = v; reinit(v)
+              setPopSize(v)
+              popSizeRef.current = v
+              reinit(v)
             }}
           />
         </label>
         <label className="ga-label">
           elite = {nElite}
-          <input type="range" min={1} max={4} step={1} value={nElite} className="ga-slider"
-            onInput={e => {
+          <input
+            type="range"
+            min={1}
+            max={4}
+            step={1}
+            value={nElite}
+            className="ga-slider"
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
-              setNElite(v); nEliteRef.current = v; reinit(popSizeRef.current)
+              setNElite(v)
+              nEliteRef.current = v
+              reinit(popSizeRef.current)
             }}
           />
         </label>
         <label className="ga-label">
           mutation = {(mutationProb * 100).toFixed(0)}%
-          <input type="range" min={0} max={0.5} step={0.05} value={mutationProb} className="ga-slider"
-            onInput={e => {
+          <input
+            type="range"
+            min={0}
+            max={0.5}
+            step={0.05}
+            value={mutationProb}
+            className="ga-slider"
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
-              setMutationProb(v); mutProbRef.current = v
+              setMutationProb(v)
+              mutProbRef.current = v
             }}
           />
         </label>
         <label className="ga-label">
           speed = {speed}
-          <input type="range" min={1} max={10} step={1} value={speed} className="ga-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
+            className="ga-slider"
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </label>
       </div>
 
       <div className="ga-controls">
-        <button className="ga-btn" onClick={stepOnce} disabled={running}>Step</button>
-        <button className="ga-btn ga-btn-primary" onClick={() => setRunning(r => !r)}>
-          {running ? "Pause" : "Run"}
+        <button className="ga-btn" onClick={stepOnce} disabled={running}>
+          Step
         </button>
-        <button className="ga-btn" onClick={() => reinit(popSizeRef.current)}>Reset</button>
+        <button
+          className="ga-btn ga-btn-primary"
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? 'Pause' : 'Run'}
+        </button>
+        <button className="ga-btn" onClick={() => reinit(popSizeRef.current)}>
+          Reset
+        </button>
       </div>
 
       <div className="ga-footer">
-        {N_CITIES} cities · population {popSize} · elite {nElite} · OX crossover · reversal mutation
+        {N_CITIES} cities · population {popSize} · elite {nElite} · OX crossover
+        · reversal mutation
       </div>
     </div>
   )

--- a/teeline-web/src/explainers/greedy-edge-algo.ts
+++ b/teeline-web/src/explainers/greedy-edge-algo.ts
@@ -3,26 +3,31 @@
 // invariants (degree <= 2, no premature sub-cycle via union-find), same
 // guarantee of terminating with exactly n accepted edges on a complete graph.
 
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, dist12 as dist } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  dist12 as dist,
+} from './explainer-cities'
 export { CITIES, N_CITIES, dist }
 
 export type Edge = { u: number; v: number; dist: number }
 
 export type RejectReason = 'degree' | 'cycle'
-export type EventMode = 'accepted' | 'closing' | 'rejected-degree' | 'rejected-cycle' | 'done'
+export type EventMode =
+  'accepted' | 'closing' | 'rejected-degree' | 'rejected-cycle' | 'done'
 
 export type SimState = {
-  sortedEdges: Edge[]        // all n(n-1)/2 pairs, ascending by distance
-  scanIndex: number          // next edge to evaluate
-  parent: number[]           // union-find: parent[i]
-  degree: number[]           // degree[i]
-  accepted: Edge[]           // accepted edges, in scan order
+  sortedEdges: Edge[] // all n(n-1)/2 pairs, ascending by distance
+  scanIndex: number // next edge to evaluate
+  parent: number[] // union-find: parent[i]
+  degree: number[] // degree[i]
+  accepted: Edge[] // accepted edges, in scan order
   rejected: Array<{ edge: Edge; reason: RejectReason }>
   step: number
-  lastEdge: Edge | null      // edge evaluated on the most recent step
+  lastEdge: Edge | null // edge evaluated on the most recent step
   lastEvent: EventMode | null
   done: boolean
-  tour: number[] | null      // ordered path once the cycle closes (null until done)
+  tour: number[] | null // ordered path once the cycle closes (null until done)
 }
 
 // All n(n-1)/2 pairwise edges, ascending by distance. Stable tiebreak on
@@ -72,7 +77,7 @@ export function components(parent: number[]): number[][] {
     const r = find(parent, i)
     ;(groups[r] ??= []).push(i)
   }
-  return Object.values(groups).map(g => g.sort((a, b) => a - b))
+  return Object.values(groups).map((g) => g.sort((a, b) => a - b))
 }
 
 export function makeInitState(): SimState {
@@ -108,7 +113,7 @@ function walkCycle(accepted: Edge[]): number[] {
   for (let i = 0; i < n; i++) {
     path.push(cur)
     seen[cur] = true
-    const next = adj[cur].find(x => x !== prev && !seen[x]) ?? adj[cur][0]
+    const next = adj[cur].find((x) => x !== prev && !seen[x]) ?? adj[cur][0]
     prev = cur
     cur = next
   }

--- a/teeline-web/src/explainers/greedy-edge.test.ts
+++ b/teeline-web/src/explainers/greedy-edge.test.ts
@@ -43,7 +43,7 @@ describe('makeInitState', () => {
   it('starts with zero accepted edges and zero degree everywhere', () => {
     const s = makeInitState()
     expect(s.accepted).toHaveLength(0)
-    expect(s.degree.every(d => d === 0)).toBe(true)
+    expect(s.degree.every((d) => d === 0)).toBe(true)
     expect(s.done).toBe(false)
     expect(s.step).toBe(0)
   })

--- a/teeline-web/src/explainers/greedy-edge.tsx
+++ b/teeline-web/src/explainers/greedy-edge.tsx
@@ -1,15 +1,28 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, components, makeInitState, stepOnce,
-} from "./greedy-edge-algo"
-import type { Edge, EventMode, RejectReason } from "./greedy-edge-algo"
+  CITIES,
+  N_CITIES,
+  components,
+  makeInitState,
+  stepOnce,
+} from './greedy-edge-algo'
+import type { Edge, EventMode, RejectReason } from './greedy-edge-algo'
 
 // One stable colour per component root, so merges are visible as two groups
 // collapsing into one colour. Sized for N_CITIES components (the start state).
 const COMP_PALETTE = [
-  "#0d9488", "#2563eb", "#7c3aed", "#db2777", "#ea580c",
-  "#16a34a", "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
-  "#0f766e", "#9333ea",
+  '#0d9488',
+  '#2563eb',
+  '#7c3aed',
+  '#db2777',
+  '#ea580c',
+  '#16a34a',
+  '#0891b2',
+  '#ca8a04',
+  '#dc2626',
+  '#4f46e5',
+  '#0f766e',
+  '#9333ea',
 ]
 function compColor(rootIndex: number): string {
   return COMP_PALETTE[rootIndex % COMP_PALETTE.length]
@@ -32,12 +45,20 @@ interface ScanCanvasProps {
   parent: number[]
   tour: number[] | null
 }
-function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, parent, tour }: ScanCanvasProps) {
+function ScanCanvas({
+  accepted,
+  lastEdge,
+  lastEvent,
+  rejectedTrail,
+  degree,
+  parent,
+  tour,
+}: ScanCanvasProps) {
   const comps = useMemo(() => components(parent), [parent])
   // root lookup: city -> index into comps (its component slot)
   const rootOf = useMemo(() => {
     const m = new Map<number, number>()
-    comps.forEach((group, gi) => group.forEach(c => m.set(c, gi)))
+    comps.forEach((group, gi) => group.forEach((c) => m.set(c, gi)))
     return m
   }, [comps])
 
@@ -45,11 +66,17 @@ function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, pare
 
   // tour as a closed polyline (only once done)
   const tourPts = tour
-    ? tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
-    : ""
+    ? tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ') +
+      ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : ''
 
   return (
-    <svg viewBox="0 0 300 300" className="gec-canvas" role="img" aria-label="Greedy edge scan">
+    <svg
+      viewBox="0 0 300 300"
+      className="gec-canvas"
+      role="img"
+      aria-label="Greedy edge scan"
+    >
       <rect x={0} y={0} width={300} height={300} className="gec-bg" />
 
       {/* final closed tour underlay once complete */}
@@ -57,32 +84,47 @@ function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, pare
 
       {/* accepted edges */}
       {accepted.map((e, i) => (
-        <line key={"a" + i}
-          x1={CITIES[e.u][0]} y1={CITIES[e.u][1]}
-          x2={CITIES[e.v][0]} y2={CITIES[e.v][1]}
+        <line
+          key={'a' + i}
+          x1={CITIES[e.u][0]}
+          y1={CITIES[e.u][1]}
+          x2={CITIES[e.v][0]}
+          y2={CITIES[e.v][1]}
           className="gec-accepted"
         />
       ))}
 
       {/* faint trail of recent rejects (last few), so the scan is legible */}
       {rejectedTrail.map((r, i) => (
-        <line key={"r" + i}
-          x1={CITIES[r.edge.u][0]} y1={CITIES[r.edge.u][1]}
-          x2={CITIES[r.edge.v][0]} y2={CITIES[r.edge.v][1]}
-          className={r.reason === "degree" ? "gec-rejected gec-rejected-degree" : "gec-rejected gec-rejected-cycle"}
+        <line
+          key={'r' + i}
+          x1={CITIES[r.edge.u][0]}
+          y1={CITIES[r.edge.u][1]}
+          x2={CITIES[r.edge.v][0]}
+          y2={CITIES[r.edge.v][1]}
+          className={
+            r.reason === 'degree'
+              ? 'gec-rejected gec-rejected-degree'
+              : 'gec-rejected gec-rejected-cycle'
+          }
         />
       ))}
 
       {/* the candidate edge currently under evaluation (bold) */}
       {lastEdge && !acceptedSet.has(edgeKey(lastEdge)) && !tour && (
         <line
-          x1={CITIES[lastEdge.u][0]} y1={CITIES[lastEdge.u][1]}
-          x2={CITIES[lastEdge.v][0]} y2={CITIES[lastEdge.v][1]}
+          x1={CITIES[lastEdge.u][0]}
+          y1={CITIES[lastEdge.u][1]}
+          x2={CITIES[lastEdge.v][0]}
+          y2={CITIES[lastEdge.v][1]}
           className={
-            lastEvent === "rejected-degree" ? "gec-cand gec-cand-degree"
-            : lastEvent === "rejected-cycle" ? "gec-cand gec-cand-cycle"
-            : lastEvent === "closing" ? "gec-cand gec-cand-closing"
-            : "gec-cand gec-cand-accept"
+            lastEvent === 'rejected-degree'
+              ? 'gec-cand gec-cand-degree'
+              : lastEvent === 'rejected-cycle'
+                ? 'gec-cand gec-cand-cycle'
+                : lastEvent === 'closing'
+                  ? 'gec-cand gec-cand-closing'
+                  : 'gec-cand gec-cand-accept'
           }
         />
       )}
@@ -93,13 +135,24 @@ function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, pare
         const full = degree[i] >= 2
         return (
           <g key={i}>
-            <circle cx={x} cy={y} r={5.5}
+            <circle
+              cx={x}
+              cy={y}
+              r={5.5}
               fill={compColor(gi)}
-              className={full ? "gec-city gec-city-full" : "gec-city"}
+              className={full ? 'gec-city gec-city-full' : 'gec-city'}
             />
-            <text x={x + 7} y={y - 6} className="gec-city-label">{i}</text>
-            <text x={x} y={y + 18} className="gec-degree-badge"
-              style={{ opacity: degree[i] > 0 ? 1 : 0.25 }}>{degree[i]}</text>
+            <text x={x + 7} y={y - 6} className="gec-city-label">
+              {i}
+            </text>
+            <text
+              x={x}
+              y={y + 18}
+              className="gec-degree-badge"
+              style={{ opacity: degree[i] > 0 ? 1 : 0.25 }}
+            >
+              {degree[i]}
+            </text>
           </g>
         )
       })}
@@ -115,10 +168,16 @@ function ComponentPanel({ parent }: { parent: number[] }) {
   return (
     <div className="gec-list-panel">
       <div className="gec-list-title">Union-Find</div>
-      <div className="gec-list-subtitle">{comps.length} component{comps.length === 1 ? "" : "s"}</div>
+      <div className="gec-list-subtitle">
+        {comps.length} component{comps.length === 1 ? '' : 's'}
+      </div>
       {comps.map((g, i) => (
-        <div key={i} className="gec-comp-badge" style={{ borderLeftColor: compColor(i) }}>
-          {"{" + g.join(",") + "}"}
+        <div
+          key={i}
+          className="gec-comp-badge"
+          style={{ borderLeftColor: compColor(i) }}
+        >
+          {'{' + g.join(',') + '}'}
         </div>
       ))}
     </div>
@@ -133,9 +192,15 @@ export default function GreedyEdgeExplainer() {
 
   const simRef = useRef(makeInitState())
   const [accepted, setAccepted] = useState<Edge[]>(() => [])
-  const [rejected, setRejected] = useState<Array<{ edge: Edge; reason: RejectReason }>>(() => [])
-  const [degree, setDegree] = useState<number[]>(() => new Array(N_CITIES).fill(0))
-  const [parent, setParent] = useState<number[]>(() => simRef.current.parent.slice())
+  const [rejected, setRejected] = useState<
+    Array<{ edge: Edge; reason: RejectReason }>
+  >(() => [])
+  const [degree, setDegree] = useState<number[]>(() =>
+    new Array(N_CITIES).fill(0),
+  )
+  const [parent, setParent] = useState<number[]>(() =>
+    simRef.current.parent.slice(),
+  )
   const [lastEdge, setLastEdge] = useState<Edge | null>(null)
   const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
   const [step, setStep] = useState(0)
@@ -145,9 +210,16 @@ export default function GreedyEdgeExplainer() {
 
   const reinit = useCallback(() => {
     simRef.current = makeInitState()
-    setAccepted([]); setRejected([]); setDegree(new Array(N_CITIES).fill(0))
-    setParent(simRef.current.parent.slice()); setLastEdge(null); setLastEvent(null)
-    setStep(0); setDone(false); setTour(null); setRunning(false)
+    setAccepted([])
+    setRejected([])
+    setDegree(new Array(N_CITIES).fill(0))
+    setParent(simRef.current.parent.slice())
+    setLastEdge(null)
+    setLastEvent(null)
+    setStep(0)
+    setDone(false)
+    setTour(null)
+    setRunning(false)
   }, [])
 
   const step_fn = useCallback(() => {
@@ -158,8 +230,11 @@ export default function GreedyEdgeExplainer() {
     setRejected(next.rejected.slice(-6))
     setDegree(next.degree.slice())
     setParent(next.parent.slice())
-    setLastEdge(next.lastEdge); setLastEvent(next.lastEvent)
-    setStep(next.step); setDone(next.done); setTour(next.tour)
+    setLastEdge(next.lastEdge)
+    setLastEvent(next.lastEvent)
+    setStep(next.step)
+    setDone(next.done)
+    setTour(next.tour)
     if (next.done) setRunning(false)
   }, [])
 
@@ -175,20 +250,20 @@ export default function GreedyEdgeExplainer() {
     [accepted],
   )
 
-  let chipText = "Press Step or Run to scan the shortest edges first"
-  let chipClass = "gec-chip gec-chip-idle"
-  if (lastEvent === "accepted" && lastEdge) {
+  let chipText = 'Press Step or Run to scan the shortest edges first'
+  let chipClass = 'gec-chip gec-chip-idle'
+  if (lastEvent === 'accepted' && lastEdge) {
     chipText = `✅ accepted  (${lastEdge.u}, ${lastEdge.v})  — degree/union updated`
-    chipClass = "gec-chip gec-chip-accept"
-  } else if (lastEvent === "rejected-degree" && lastEdge) {
+    chipClass = 'gec-chip gec-chip-accept'
+  } else if (lastEvent === 'rejected-degree' && lastEdge) {
     chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — would give a city degree 3`
-    chipClass = "gec-chip gec-chip-degree"
-  } else if (lastEvent === "rejected-cycle" && lastEdge) {
+    chipClass = 'gec-chip gec-chip-degree'
+  } else if (lastEvent === 'rejected-cycle' && lastEdge) {
     chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — premature sub-cycle`
-    chipClass = "gec-chip gec-chip-cycle"
-  } else if (lastEvent === "closing" && lastEdge) {
+    chipClass = 'gec-chip gec-chip-cycle'
+  } else if (lastEvent === 'closing' && lastEdge) {
     chipText = `🔒 closing edge  (${lastEdge.u}, ${lastEdge.v})  — the path becomes a cycle`
-    chipClass = "gec-chip gec-chip-closing"
+    chipClass = 'gec-chip gec-chip-closing'
   }
 
   const totalEdges = (N_CITIES * (N_CITIES - 1)) / 2
@@ -202,28 +277,47 @@ export default function GreedyEdgeExplainer() {
         <div className="gec-eyebrow">teeline · algorithms/greedy-edge</div>
         <h2 className="gec-title">Greedy Edge Construction</h2>
         <p className="gec-sub">
-          Every pairwise edge is scanned shortest-first and accepted unless it would give a city
-          <strong> degree 3+</strong> or close a <strong>premature sub-cycle</strong> (tracked by a
-          union-find). Watch the components merge until one Hamiltonian cycle remains.
+          Every pairwise edge is scanned shortest-first and accepted unless it
+          would give a city
+          <strong> degree 3+</strong> or close a{' '}
+          <strong>premature sub-cycle</strong> (tracked by a union-find). Watch
+          the components merge until one Hamiltonian cycle remains.
         </p>
       </header>
 
       <div className="gec-viz-row">
         <div className="gec-canvas-wrap">
           <ScanCanvas
-            accepted={accepted} lastEdge={lastEdge} lastEvent={lastEvent}
-            rejectedTrail={rejected} degree={degree} parent={parent} tour={tour}
+            accepted={accepted}
+            lastEdge={lastEdge}
+            lastEvent={lastEvent}
+            rejectedTrail={rejected}
+            degree={degree}
+            parent={parent}
+            tour={tour}
           />
         </div>
         <ComponentPanel parent={parent} />
       </div>
 
       <div className="gec-legend">
-        <span><span className="gec-swatch gec-swatch-accepted" /> accepted edge</span>
-        <span><span className="gec-swatch gec-swatch-degree" /> rejected — degree</span>
-        <span><span className="gec-swatch gec-swatch-cycle" /> rejected — cycle</span>
-        <span><span className="gec-swatch gec-swatch-closing" /> closing edge</span>
-        {done && <span><span className="gec-swatch gec-swatch-tour" /> final tour</span>}
+        <span>
+          <span className="gec-swatch gec-swatch-accepted" /> accepted edge
+        </span>
+        <span>
+          <span className="gec-swatch gec-swatch-degree" /> rejected — degree
+        </span>
+        <span>
+          <span className="gec-swatch gec-swatch-cycle" /> rejected — cycle
+        </span>
+        <span>
+          <span className="gec-swatch gec-swatch-closing" /> closing edge
+        </span>
+        {done && (
+          <span>
+            <span className="gec-swatch gec-swatch-tour" /> final tour
+          </span>
+        )}
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -231,15 +325,21 @@ export default function GreedyEdgeExplainer() {
       <div className="gec-statgrid">
         <div>
           <div className="gec-statlabel">edges scanned</div>
-          <div className="gec-mono">{accepted.length + rejected.length}/{totalEdges}</div>
+          <div className="gec-mono">
+            {accepted.length + rejected.length}/{totalEdges}
+          </div>
         </div>
         <div>
           <div className="gec-statlabel">accepted</div>
-          <div className="gec-mono">{accepted.length}/{N_CITIES}</div>
+          <div className="gec-mono">
+            {accepted.length}/{N_CITIES}
+          </div>
         </div>
         <div>
           <div className="gec-statlabel">rejected</div>
-          <div className="gec-mono">{step > 0 ? simRef.current.rejected.length : 0}</div>
+          <div className="gec-mono">
+            {step > 0 ? simRef.current.rejected.length : 0}
+          </div>
         </div>
         <div>
           <div className="gec-statlabel">components</div>
@@ -258,21 +358,41 @@ export default function GreedyEdgeExplainer() {
       <div className="gec-config">
         <div className="gec-config-row">
           <label className="gec-config-label">Speed</label>
-          <input type="range" min={1} max={10} step={1} value={speed}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="gec-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
-          <div className="gec-hint">Edges are parameter-free — no other knobs to tune.</div>
+          <div className="gec-hint">
+            Edges are parameter-free — no other knobs to tune.
+          </div>
         </div>
       </div>
 
       <div className="gec-controls">
-        <button className="gec-btn" onClick={step_fn} disabled={running || done}>◀ Step</button>
-        <button className={`gec-btn ${!running ? "gec-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)} disabled={done}>
-          {running ? "⏸ Pause" : done ? "✓ Done" : "▶ Run"}
+        <button
+          className="gec-btn"
+          onClick={step_fn}
+          disabled={running || done}
+        >
+          ◀ Step
         </button>
-        <button className="gec-btn" onClick={reinit}>↺ Reset</button>
+        <button
+          className={`gec-btn ${!running ? 'gec-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+          disabled={done}
+        >
+          {running ? '⏸ Pause' : done ? '✓ Done' : '▶ Run'}
+        </button>
+        <button className="gec-btn" onClick={reinit}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="gec-footer">

--- a/teeline-web/src/explainers/gsa-algo.ts
+++ b/teeline-web/src/explainers/gsa-algo.ts
@@ -1,4 +1,8 @@
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, tourLength12 as tourLength } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  tourLength12 as tourLength,
+} from './explainer-cities'
 export { CITIES, N_CITIES, tourLength }
 
 const G0 = 20.0
@@ -71,16 +75,23 @@ export function shuffle(n: number): number[] {
   return t
 }
 
-function computeMassesAndKbest(agents: Agent[]): { masses: number[]; kbest: number[] } {
-  const worstCost = Math.max(...agents.map(a => a.cost))
-  const rawFitness = agents.map(a => worstCost - a.cost)
+function computeMassesAndKbest(agents: Agent[]): {
+  masses: number[]
+  kbest: number[]
+} {
+  const worstCost = Math.max(...agents.map((a) => a.cost))
+  const rawFitness = agents.map((a) => worstCost - a.cost)
   const sumFitness = rawFitness.reduce((s, f) => s + f, 0)
   // Uniform mass fallback when all agents share the same cost (avoids NaN)
-  const masses = sumFitness < 1e-10
-    ? agents.map(() => 1 / agents.length)
-    : rawFitness.map(f => f / sumFitness)
+  const masses =
+    sumFitness < 1e-10
+      ? agents.map(() => 1 / agents.length)
+      : rawFitness.map((f) => f / sumFitness)
   const kSize = Math.ceil(agents.length / 2)
-  const kbest = agents.map((_, i) => i).sort((a, b) => masses[b] - masses[a]).slice(0, kSize)
+  const kbest = agents
+    .map((_, i) => i)
+    .sort((a, b) => masses[b] - masses[a])
+    .slice(0, kSize)
   return { masses, kbest }
 }
 
@@ -90,8 +101,13 @@ export function makeInitState(nAgents: number): SimState {
     return { position, velocity: [], cost: tourLength(position), mass: 0 }
   })
   const { masses, kbest } = computeMassesAndKbest(agents)
-  agents.forEach((a, i) => { a.mass = masses[i] })
-  const bestIdx = agents.reduce((b, a, i) => a.cost < agents[b].cost ? i : b, 0)
+  agents.forEach((a, i) => {
+    a.mass = masses[i]
+  })
+  const bestIdx = agents.reduce(
+    (b, a, i) => (a.cost < agents[b].cost ? i : b),
+    0,
+  )
   return {
     agents,
     gbest: agents[bestIdx].position.slice(),
@@ -112,13 +128,14 @@ export function stepAgent(s: SimState): SimState {
   const v_max = Math.max(1, Math.ceil(N_CITIES * V_MAX_FACTOR))
 
   // Recompute masses, kbest, and G at the start of each epoch (agentIdx === 0)
-  const { masses, kbest, G } = s.agentIdx === 0
-    ? (() => {
-        const { masses, kbest } = computeMassesAndKbest(s.agents)
-        const G = G0 * Math.exp(-ALPHA * s.epoch / TOTAL_EPOCHS)
-        return { masses, kbest, G }
-      })()
-    : { masses: s.masses, kbest: s.kbest, G: s.G }
+  const { masses, kbest, G } =
+    s.agentIdx === 0
+      ? (() => {
+          const { masses, kbest } = computeMassesAndKbest(s.agents)
+          const G = G0 * Math.exp((-ALPHA * s.epoch) / TOTAL_EPOCHS)
+          return { masses, kbest, G }
+        })()
+      : { masses: s.masses, kbest: s.kbest, G: s.G }
 
   const i = s.agentIdx
   const agent = s.agents[i]
@@ -153,7 +170,12 @@ export function stepAgent(s: SimState): SimState {
   const updatedAgents = s.agents.map((a, idx) =>
     idx !== i
       ? { ...a, mass: masses[idx] }
-      : { position: new_pos, velocity: new_vel, cost: new_cost, mass: masses[i] }
+      : {
+          position: new_pos,
+          velocity: new_vel,
+          cost: new_cost,
+          mass: masses[i],
+        },
   )
 
   const nextAgentIdx = i + 1

--- a/teeline-web/src/explainers/gsa.test.ts
+++ b/teeline-web/src/explainers/gsa.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, tourLength, swapSequence, applySwaps,
-  makeInitState, stepAgent,
+  N_CITIES,
+  tourLength,
+  swapSequence,
+  applySwaps,
+  makeInitState,
+  stepAgent,
 } from './gsa-algo'
 
 describe('tourLength', () => {
   it('is positive for a multi-city tour', () => {
-    expect(tourLength(Array.from({ length: N_CITIES }, (_, i) => i))).toBeGreaterThan(0)
+    expect(
+      tourLength(Array.from({ length: N_CITIES }, (_, i) => i)),
+    ).toBeGreaterThan(0)
   })
   it('returns 0 for a single-city tour', () => {
     expect(tourLength([0])).toBe(0)
@@ -18,14 +24,18 @@ describe('swapSequence', () => {
     expect(swapSequence([0, 1, 2, 3], [0, 1, 2, 3])).toEqual([])
   })
   it('applying result of swapSequence(a, b) to a yields b', () => {
-    const a = [0, 3, 1, 2]; const b = [0, 1, 2, 3]
-    expect(applySwaps(a, swapSequence(a, b), swapSequence(a, b).length)).toEqual(b)
+    const a = [0, 3, 1, 2]
+    const b = [0, 1, 2, 3]
+    expect(
+      applySwaps(a, swapSequence(a, b), swapSequence(a, b).length),
+    ).toEqual(b)
   })
 })
 
 describe('applySwaps', () => {
   it('does not mutate input', () => {
-    const t = [0, 1, 2, 3]; applySwaps(t, [[0, 1]], 1)
+    const t = [0, 1, 2, 3]
+    applySwaps(t, [[0, 1]], 1)
     expect(t).toEqual([0, 1, 2, 3])
   })
   it('clamps to swaps.length', () => {
@@ -38,7 +48,9 @@ describe('makeInitState', () => {
     expect(makeInitState(5).agents).toHaveLength(5)
   })
   it('each agent position is a valid permutation', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     for (const ag of makeInitState(4).agents)
       expect(ag.position.slice().sort((a, b) => a - b)).toEqual(expected)
   })
@@ -49,7 +61,10 @@ describe('makeInitState', () => {
   })
   it('gbest_cost equals minimum agent cost', () => {
     const s = makeInitState(6)
-    expect(s.gbest_cost).toBeCloseTo(Math.min(...s.agents.map(a => a.cost)), 1)
+    expect(s.gbest_cost).toBeCloseTo(
+      Math.min(...s.agents.map((a) => a.cost)),
+      1,
+    )
   })
   it('masses sum to ~1', () => {
     const s = makeInitState(4)
@@ -76,7 +91,9 @@ describe('stepAgent', () => {
     }
   })
   it('each agent position remains a valid permutation', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     let s = makeInitState(4)
     s = stepAgent(s)
     for (const ag of s.agents)

--- a/teeline-web/src/explainers/gsa.tsx
+++ b/teeline-web/src/explainers/gsa.tsx
@@ -1,11 +1,11 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
-import type { Agent, ForceBreakdown, SimState } from "./gsa-algo"
-import { CITIES, N_CITIES, makeInitState, stepAgent } from "./gsa-algo"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
+import type { Agent, ForceBreakdown, SimState } from './gsa-algo'
+import { CITIES, N_CITIES, makeInitState, stepAgent } from './gsa-algo'
 
 const G0 = 20.0
 
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
   return pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
 }
 
@@ -18,9 +18,14 @@ interface AgentHeatmapProps {
   activeIdx: number
   kbest: number[]
 }
-function AgentHeatmap({ agents, gbest_cost, activeIdx, kbest }: AgentHeatmapProps) {
+function AgentHeatmap({
+  agents,
+  gbest_cost,
+  activeIdx,
+  kbest,
+}: AgentHeatmapProps) {
   if (!agents.length) return null
-  const costs = agents.map(a => a.cost)
+  const costs = agents.map((a) => a.cost)
   const minC = Math.min(...costs)
   const maxC = Math.max(...costs)
   const range = maxC - minC || 1
@@ -36,16 +41,22 @@ function AgentHeatmap({ agents, gbest_cost, activeIdx, kbest }: AgentHeatmapProp
         const isKbest = kbestSet.has(i)
         const isGbest = Math.abs(ag.cost - gbest_cost) < 0.01
         const outline = isActive
-          ? "2px solid #d97706"
+          ? '2px solid #d97706'
           : isGbest
-            ? "2px solid #16a34a"
-            : "2px solid transparent"
-        const borderLeft = isKbest && !isActive ? "3px solid #16a34a" : undefined
+            ? '2px solid #16a34a'
+            : '2px solid transparent'
+        const borderLeft =
+          isKbest && !isActive ? '3px solid #16a34a' : undefined
         return (
           <div
             key={i}
             className="gsa-heatmap-cell"
-            style={{ background: bg, outline, outlineOffset: "1px", borderLeft }}
+            style={{
+              background: bg,
+              outline,
+              outlineOffset: '1px',
+              borderLeft,
+            }}
           >
             <span className="gsa-heatmap-idx">{i}</span>
             <span className="gsa-heatmap-cost">{ag.cost.toFixed(0)}</span>
@@ -71,21 +82,38 @@ interface TourSVGProps {
 function TourSVG({ agents, gbest, activeIdx, newGbest }: TourSVGProps) {
   if (!agents.length) return null
   return (
-    <svg viewBox="0 0 300 300" className="gsa-canvas" role="img" aria-label="GSA tour canvas">
+    <svg
+      viewBox="0 0 300 300"
+      className="gsa-canvas"
+      role="img"
+      aria-label="GSA tour canvas"
+    >
       <rect x={0} y={0} width={300} height={300} className="gsa-bg" />
-      {agents.map((ag, i) => i !== activeIdx && (
-        <polyline key={i} className="gsa-ghost" points={polyPts(ag.position)} />
-      ))}
-      <polyline className="gsa-active" points={polyPts(agents[activeIdx].position)} />
+      {agents.map(
+        (ag, i) =>
+          i !== activeIdx && (
+            <polyline
+              key={i}
+              className="gsa-ghost"
+              points={polyPts(ag.position)}
+            />
+          ),
+      )}
       <polyline
-        className={`gsa-gbest${newGbest ? " gsa-gbest-pulse" : ""}`}
+        className="gsa-active"
+        points={polyPts(agents[activeIdx].position)}
+      />
+      <polyline
+        className={`gsa-gbest${newGbest ? ' gsa-gbest-pulse' : ''}`}
         points={polyPts(gbest)}
       />
       {CITIES.map(([x, y], i) => (
         <circle key={i} cx={x} cy={y} r={4} className="gsa-city" />
       ))}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="gsa-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="gsa-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -101,13 +129,18 @@ interface ForceChipProps {
 }
 function ForceChip({ breakdown, agentIdx, newGbest }: ForceChipProps) {
   if (!breakdown) {
-    return <div className="gsa-chip gsa-chip-idle">Press Step or Run to begin</div>
+    return (
+      <div className="gsa-chip gsa-chip-idle">Press Step or Run to begin</div>
+    )
   }
   const { pulls, totalApplied, G } = breakdown
-  const prefix = newGbest ? "⭐ new gbest!  " : ""
+  const prefix = newGbest ? '⭐ new gbest!  ' : ''
   return (
-    <div className={`gsa-chip ${newGbest ? "gsa-chip-gbest" : "gsa-chip-normal"}`}>
-      {prefix}Agent {agentIdx} · G={G.toFixed(1)} · {pulls.length} pulls → {totalApplied} swaps applied
+    <div
+      className={`gsa-chip ${newGbest ? 'gsa-chip-gbest' : 'gsa-chip-normal'}`}
+    >
+      {prefix}Agent {agentIdx} · G={G.toFixed(1)} · {pulls.length} pulls →{' '}
+      {totalApplied} swaps applied
     </div>
   )
 }
@@ -118,16 +151,21 @@ function ForceChip({ breakdown, agentIdx, newGbest }: ForceChipProps) {
 function GGauge({ G }: { G: number }) {
   const pct = (G / G0) * 100
   const hint =
-    G > 15 ? "High — broad exploration" :
-    G > 8  ? "Mid — balanced" :
-    "Low — exploitation focus"
+    G > 15
+      ? 'High — broad exploration'
+      : G > 8
+        ? 'Mid — balanced'
+        : 'Low — exploitation focus'
   return (
     <div className="gsa-gauge">
       <div className="gsa-gauge-label">
         G (gravitational constant) = <strong>{G.toFixed(2)}</strong>
       </div>
       <div className="gsa-gauge-track">
-        <div className="gsa-gauge-fill" style={{ width: `${Math.max(0, pct).toFixed(1)}%` }} />
+        <div
+          className="gsa-gauge-fill"
+          style={{ width: `${Math.max(0, pct).toFixed(1)}%` }}
+        />
       </div>
       <div className="gsa-gauge-hint">{hint}</div>
     </div>
@@ -192,11 +230,12 @@ export default function GSAExplainer() {
 
   const avgDist = agents.length
     ? (agents.reduce((s, a) => s + a.cost, 0) / agents.length).toFixed(0)
-    : "—"
+    : '—'
 
-  const displayAgentIdx = breakdown ? simRef.current.agentIdx === 0
-    ? nAgents - 1
-    : (simRef.current.agentIdx - 1 + nAgents) % nAgents
+  const displayAgentIdx = breakdown
+    ? simRef.current.agentIdx === 0
+      ? nAgents - 1
+      : (simRef.current.agentIdx - 1 + nAgents) % nAgents
     : 0
 
   return (
@@ -207,32 +246,56 @@ export default function GSAExplainer() {
         <div className="gsa-eyebrow">teeline · algorithms/gsa</div>
         <h2 className="gsa-title">Gravitational Search Algorithm</h2>
         <p className="gsa-sub">
-          Each candidate TSP tour is an <strong>agent</strong> with a{" "}
+          Each candidate TSP tour is an <strong>agent</strong> with a{' '}
           <strong>mass</strong> proportional to its fitness — better tours weigh
-          more. Every step, the active agent is pulled toward the{" "}
-          <strong>k-best</strong> (heaviest) neighbours via swap-move{" "}
-          <strong>velocity</strong>. The gravitational constant{" "}
-          <code>G</code> decays over epochs, shifting the swarm from broad
-          exploration toward fine-grained exploitation.
+          more. Every step, the active agent is pulled toward the{' '}
+          <strong>k-best</strong> (heaviest) neighbours via swap-move{' '}
+          <strong>velocity</strong>. The gravitational constant <code>G</code>{' '}
+          decays over epochs, shifting the swarm from broad exploration toward
+          fine-grained exploitation.
         </p>
       </header>
 
       <div className="gsa-viz-row">
         <div className="gsa-canvas-wrap">
-          <TourSVG agents={agents} gbest={gbest} activeIdx={agentIdx} newGbest={newGbest} />
+          <TourSVG
+            agents={agents}
+            gbest={gbest}
+            activeIdx={agentIdx}
+            newGbest={newGbest}
+          />
         </div>
-        <AgentHeatmap agents={agents} gbest_cost={gbest_cost} activeIdx={agentIdx} kbest={kbest} />
+        <AgentHeatmap
+          agents={agents}
+          gbest_cost={gbest_cost}
+          activeIdx={agentIdx}
+          kbest={kbest}
+        />
       </div>
 
       <div className="gsa-legend">
-        <span><span className="gsa-dot gsa-dot-gbest">●</span> gbest tour</span>
-        <span><span className="gsa-dot gsa-dot-active">●</span> active agent</span>
-        <span><span className="gsa-dot gsa-dot-ghost">●</span> swarm</span>
-        <span><span className="gsa-dot gsa-dot-city">●</span> city</span>
-        <span><span className="gsa-kbest-marker" /> kbest source</span>
+        <span>
+          <span className="gsa-dot gsa-dot-gbest">●</span> gbest tour
+        </span>
+        <span>
+          <span className="gsa-dot gsa-dot-active">●</span> active agent
+        </span>
+        <span>
+          <span className="gsa-dot gsa-dot-ghost">●</span> swarm
+        </span>
+        <span>
+          <span className="gsa-dot gsa-dot-city">●</span> city
+        </span>
+        <span>
+          <span className="gsa-kbest-marker" /> kbest source
+        </span>
       </div>
 
-      <ForceChip breakdown={breakdown} agentIdx={displayAgentIdx} newGbest={newGbest} />
+      <ForceChip
+        breakdown={breakdown}
+        agentIdx={displayAgentIdx}
+        newGbest={newGbest}
+      />
 
       <GGauge G={G} />
 
@@ -243,7 +306,9 @@ export default function GSAExplainer() {
         </div>
         <div>
           <div className="gsa-statlabel">step</div>
-          <div className="gsa-mono">{agentIdx}/{nAgents}</div>
+          <div className="gsa-mono">
+            {agentIdx}/{nAgents}
+          </div>
         </div>
         <div>
           <div className="gsa-statlabel">gbest dist</div>
@@ -261,7 +326,11 @@ export default function GSAExplainer() {
             Agents = <strong>{nAgents}</strong>
           </label>
           <input
-            type="range" min={4} max={12} step={1} value={nAgents}
+            type="range"
+            min={4}
+            max={12}
+            step={1}
+            value={nAgents}
             className="gsa-slider"
             onInput={(e) => {
               const n = Number((e.target as HTMLInputElement).value)
@@ -271,31 +340,41 @@ export default function GSAExplainer() {
           />
           <div className="gsa-hint">
             {nAgents <= 5
-              ? "Small swarm — fast but low diversity"
+              ? 'Small swarm — fast but low diversity'
               : nAgents >= 10
-                ? "Large swarm — high diversity, slower per epoch"
-                : "Balanced swarm size"}
+                ? 'Large swarm — high diversity, slower per epoch'
+                : 'Balanced swarm size'}
           </div>
         </div>
         <div className="gsa-config-row">
           <label className="gsa-config-label">Speed</label>
           <input
-            type="range" min={1} max={10} step={1} value={speed}
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="gsa-slider"
-            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
 
       <div className="gsa-controls">
-        <button className="gsa-btn" onClick={stepOnce} disabled={running}>◀ Step</button>
-        <button
-          className={`gsa-btn ${!running ? "gsa-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}
-        >
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button className="gsa-btn" onClick={stepOnce} disabled={running}>
+          ◀ Step
         </button>
-        <button className="gsa-btn" onClick={() => reinit(nAgents)}>↺ Reset</button>
+        <button
+          className={`gsa-btn ${!running ? 'gsa-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button className="gsa-btn" onClick={() => reinit(nAgents)}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="gsa-footer">
@@ -303,7 +382,9 @@ export default function GSAExplainer() {
         <span className="gsa-mono">agents: {nAgents}</span>
         <span className="gsa-mono">G₀: {G0}</span>
         <span className="gsa-mono">α: 1</span>
-        <span className="gsa-mono">kbest: ⌈{nAgents}/2⌉={Math.ceil(nAgents / 2)}</span>
+        <span className="gsa-mono">
+          kbest: ⌈{nAgents}/2⌉={Math.ceil(nAgents / 2)}
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/lk.test.ts
+++ b/teeline-web/src/explainers/lk.test.ts
@@ -1,8 +1,16 @@
 // teeline-web/src/explainers/lk.test.ts
 import { describe, it, expect } from 'vitest'
 import {
-  CITIES, euclidDist, buildDistMatrix, tourDist, DIST, INIT_TOUR,
-  doubleBridge, lcgRand, computeLocalSearchFrames, computeILSFrames,
+  CITIES,
+  euclidDist,
+  buildDistMatrix,
+  tourDist,
+  DIST,
+  INIT_TOUR,
+  doubleBridge,
+  lcgRand,
+  computeLocalSearchFrames,
+  computeILSFrames,
 } from './lk'
 
 describe('euclidDist', () => {
@@ -15,7 +23,11 @@ describe('euclidDist', () => {
 })
 
 describe('buildDistMatrix', () => {
-  const cities: [number, number][] = [[0, 0], [3, 4], [6, 8]]
+  const cities: [number, number][] = [
+    [0, 0],
+    [3, 4],
+    [6, 8],
+  ]
   const m = buildDistMatrix(cities)
   it('is symmetric', () => {
     expect(m[0][1]).toBeCloseTo(m[1][0])
@@ -32,7 +44,11 @@ describe('buildDistMatrix', () => {
 
 describe('tourDist', () => {
   it('sums edges correctly for 3-city tour', () => {
-    const cities: [number, number][] = [[0, 0], [3, 0], [3, 4]]
+    const cities: [number, number][] = [
+      [0, 0],
+      [3, 0],
+      [3, 4],
+    ]
     const dist = buildDistMatrix(cities)
     // tour [0,1,2]: 0→1=3, 1→2=4, 2→0=5 → total 12
     expect(tourDist([0, 1, 2], dist)).toBeCloseTo(12)
@@ -121,13 +137,13 @@ describe('computeLocalSearchFrames', () => {
   })
 
   it('swap frames have isScan = false', () => {
-    const swapFrames = frames.filter(f => f.swapEdges !== null)
-    expect(swapFrames.every(f => !f.isScan)).toBe(true)
+    const swapFrames = frames.filter((f) => f.swapEdges !== null)
+    expect(swapFrames.every((f) => !f.isScan)).toBe(true)
   })
 
   it('scan frames have isScan = true', () => {
-    const scanFrames = frames.filter(f => f.scanEdges !== null)
-    expect(scanFrames.every(f => f.isScan)).toBe(true)
+    const scanFrames = frames.filter((f) => f.scanEdges !== null)
+    expect(scanFrames.every((f) => f.isScan)).toBe(true)
   })
 
   it('final tour distance is no worse than initial', () => {
@@ -137,7 +153,7 @@ describe('computeLocalSearchFrames', () => {
   })
 
   it('all swap frames have improving dist (each swap reduces distance)', () => {
-    const swapFrames = frames.filter(f => f.swapEdges !== null)
+    const swapFrames = frames.filter((f) => f.swapEdges !== null)
     expect(swapFrames.length).toBeGreaterThan(0) // NN tour should have crossings
     for (let i = 1; i < swapFrames.length; i++) {
       expect(swapFrames[i].dist).toBeLessThan(swapFrames[i - 1].dist + 1e-9)
@@ -154,7 +170,7 @@ describe('computeILSFrames', () => {
   })
 
   it('has at least one bridge_cut frame (highlight === "bridge")', () => {
-    expect(frames.some(f => f.highlight === 'bridge')).toBe(true)
+    expect(frames.some((f) => f.highlight === 'bridge')).toBe(true)
   })
 
   it('bestDist is non-increasing across frames', () => {
@@ -171,6 +187,6 @@ describe('computeILSFrames', () => {
   })
 
   it('all tour arrays have length 15', () => {
-    expect(frames.every(f => f.tour.length === 15)).toBe(true)
+    expect(frames.every((f) => f.tour.length === 15)).toBe(true)
   })
 })

--- a/teeline-web/src/explainers/lk.ts
+++ b/teeline-web/src/explainers/lk.ts
@@ -4,177 +4,230 @@
 // Ring of 12 + 3 interior: NN tour creates crossing edges (2-opt fodder);
 // ring structure gives clean 4-segment double-bridge cuts.
 export const CITIES: [number, number][] = [
-  [ 40,  60], [ 80,  30], [140,  20], [200,  40], [250,  70],
-  [270, 130], [250, 200], [200, 250], [140, 270], [ 80, 250],
-  [ 40, 200], [ 20, 130], [150, 150], [100, 100], [200, 100],
-];
+  [40, 60],
+  [80, 30],
+  [140, 20],
+  [200, 40],
+  [250, 70],
+  [270, 130],
+  [250, 200],
+  [200, 250],
+  [140, 270],
+  [80, 250],
+  [40, 200],
+  [20, 130],
+  [150, 150],
+  [100, 100],
+  [200, 100],
+]
 
 export function euclidDist(a: [number, number], b: [number, number]): number {
-  return Math.hypot(a[0] - b[0], a[1] - b[1]);
+  return Math.hypot(a[0] - b[0], a[1] - b[1])
 }
 
 export function buildDistMatrix(cities: [number, number][]): number[][] {
-  const n = cities.length;
+  const n = cities.length
   return Array.from({ length: n }, (_, i) =>
-    Array.from({ length: n }, (_, j) => euclidDist(cities[i], cities[j]))
-  );
+    Array.from({ length: n }, (_, j) => euclidDist(cities[i], cities[j])),
+  )
 }
 
 export function tourDist(tour: number[], dist: number[][]): number {
-  const n = tour.length;
-  let total = 0;
+  const n = tour.length
+  let total = 0
   for (let i = 0; i < n; i++) {
-    total += dist[tour[i]][tour[(i + 1) % n]];
+    total += dist[tour[i]][tour[(i + 1) % n]]
   }
-  return total;
+  return total
 }
 
 export function nnTour(cities: [number, number][], dist: number[][]): number[] {
-  const n = cities.length;
-  const visited = new Array<boolean>(n).fill(false);
-  const tour = [0];
-  visited[0] = true;
+  const n = cities.length
+  const visited = new Array<boolean>(n).fill(false)
+  const tour = [0]
+  visited[0] = true
   for (let step = 1; step < n; step++) {
-    const last = tour[step - 1];
-    let bestJ = -1, bestD = Infinity;
+    const last = tour[step - 1]
+    let bestJ = -1,
+      bestD = Infinity
     for (let j = 0; j < n; j++) {
       if (!visited[j] && dist[last][j] < bestD) {
-        bestD = dist[last][j];
-        bestJ = j;
+        bestD = dist[last][j]
+        bestJ = j
       }
     }
-    tour.push(bestJ);
-    visited[bestJ] = true;
+    tour.push(bestJ)
+    visited[bestJ] = true
   }
-  return tour;
+  return tour
 }
 
 // Linear congruential generator — seeded for reproducible animations.
 export function lcgRand(seed: number): () => number {
-  let s = seed >>> 0;
+  let s = seed >>> 0
   return () => {
-    s = (Math.imul(1664525, s) + 1013904223) >>> 0;
-    return s / 0x100000000;
-  };
+    s = (Math.imul(1664525, s) + 1013904223) >>> 0
+    return s / 0x100000000
+  }
 }
 
 // Pre-computed constants used by both tabs.
-export const DIST = buildDistMatrix(CITIES);
-export const INIT_TOUR = nnTour(CITIES, DIST);
+export const DIST = buildDistMatrix(CITIES)
+export const INIT_TOUR = nnTour(CITIES, DIST)
 
 // Port of lin_kernighan.rs::double_bridge.
 // Returns the kicked tour plus the three cut positions used,
 // so callers can highlight the cut cities in the animation.
 export function doubleBridge(
   tour: number[],
-  rand: () => number
+  rand: () => number,
 ): { result: number[]; p1: number; p2: number; p3: number } {
-  const n = tour.length;
-  const p1 = 1 + Math.floor(rand() * Math.floor(n / 4));
-  const p2 = p1 + 1 + Math.floor(rand() * Math.floor(n / 4));
-  const p3 = p2 + 1 + Math.floor(rand() * Math.floor(n / 4));
+  const n = tour.length
+  const p1 = 1 + Math.floor(rand() * Math.floor(n / 4))
+  const p2 = p1 + 1 + Math.floor(rand() * Math.floor(n / 4))
+  const p3 = p2 + 1 + Math.floor(rand() * Math.floor(n / 4))
   const result = [
     ...tour.slice(0, p1),
     ...tour.slice(p2, p3),
     ...tour.slice(p1, p2),
     ...tour.slice(p3),
-  ];
-  return { result, p1, p2, p3 };
+  ]
+  return { result, p1, p2, p3 }
 }
 
 // Each [from, to] pair is a city index pair forming one edge.
-export type EdgePair = [[number, number], [number, number]];
+export type EdgePair = [[number, number], [number, number]]
 
 export interface LSFrame {
-  tour: number[];
-  scanEdges: EdgePair | null;   // edges being considered (gray dashed in Step mode)
-  swapEdges: EdgePair | null;   // new edges just accepted (green flash)
-  dist: number;
-  overlay: string | null;       // label overlaid on SVG ("Local optimum")
-  isScan: boolean;              // true → skip this frame in Run mode
+  tour: number[]
+  scanEdges: EdgePair | null // edges being considered (gray dashed in Step mode)
+  swapEdges: EdgePair | null // new edges just accepted (green flash)
+  dist: number
+  overlay: string | null // label overlaid on SVG ("Local optimum")
+  isScan: boolean // true → skip this frame in Run mode
 }
 
 // Pre-computes all 2-opt animation frames (first-improvement, single restart per swap).
 // scan events are interleaved so Step mode can show them; Run mode skips isScan frames.
 // How many non-improving "miss" scan frames to show before each accepted swap.
-const PREVIEW_SCANS = 2;
+const PREVIEW_SCANS = 2
 
 export function computeLocalSearchFrames(
   initTour: number[],
-  dist: number[][]
+  dist: number[][],
 ): LSFrame[] {
-  const frames: LSFrame[] = [];
-  const tour = [...initTour];
-  const n = tour.length;
-  let currentDist = tourDist(tour, dist);
+  const frames: LSFrame[] = []
+  const tour = [...initTour]
+  const n = tour.length
+  let currentDist = tourDist(tour, dist)
 
-  let foundImprovement = true;
+  let foundImprovement = true
   while (foundImprovement) {
-    foundImprovement = false;
+    foundImprovement = false
 
     // First pass: collect up to PREVIEW_SCANS non-improving pairs, then find the winner.
-    const misses: EdgePair[] = [];
-    let winI = -1, winJ = -1;
+    const misses: EdgePair[] = []
+    let winI = -1,
+      winJ = -1
 
-    outer:
-    for (let i = 0; i < n - 1; i++) {
+    outer: for (let i = 0; i < n - 1; i++) {
       for (let j = i + 2; j < n; j++) {
-        if (i === 0 && j === n - 1) continue;
-        const removed = dist[tour[i]][tour[i + 1]] + dist[tour[j]][tour[(j + 1) % n]];
-        const added   = dist[tour[i]][tour[j]]     + dist[tour[i + 1]][tour[(j + 1) % n]];
-        if (removed - added > 1e-10) { winI = i; winJ = j; break outer; }
+        if (i === 0 && j === n - 1) continue
+        const removed =
+          dist[tour[i]][tour[i + 1]] + dist[tour[j]][tour[(j + 1) % n]]
+        const added =
+          dist[tour[i]][tour[j]] + dist[tour[i + 1]][tour[(j + 1) % n]]
+        if (removed - added > 1e-10) {
+          winI = i
+          winJ = j
+          break outer
+        }
         if (misses.length < PREVIEW_SCANS) {
-          misses.push([[tour[i], tour[i + 1]], [tour[j], tour[(j + 1) % n]]]);
+          misses.push([
+            [tour[i], tour[i + 1]],
+            [tour[j], tour[(j + 1) % n]],
+          ])
         }
       }
     }
 
-    if (winI === -1) break; // no improvement found in this pass
+    if (winI === -1) break // no improvement found in this pass
 
     // Emit miss scan frames (showing "still looking...")
     for (const edges of misses) {
-      frames.push({ tour: [...tour], scanEdges: edges, swapEdges: null, dist: currentDist, overlay: null, isScan: true });
+      frames.push({
+        tour: [...tour],
+        scanEdges: edges,
+        swapEdges: null,
+        dist: currentDist,
+        overlay: null,
+        isScan: true,
+      })
     }
 
     // Emit winning pair as scan frame (showing "found it!")
     frames.push({
       tour: [...tour],
-      scanEdges: [[tour[winI], tour[winI + 1]], [tour[winJ], tour[(winJ + 1) % n]]],
-      swapEdges: null, dist: currentDist, overlay: null, isScan: true,
-    });
+      scanEdges: [
+        [tour[winI], tour[winI + 1]],
+        [tour[winJ], tour[(winJ + 1) % n]],
+      ],
+      swapEdges: null,
+      dist: currentDist,
+      overlay: null,
+      isScan: true,
+    })
 
     // Apply 2-opt reversal and emit swap frame
-    const newEdge1: [number, number] = [tour[winI],     tour[winJ]];
-    const newEdge2: [number, number] = [tour[winI + 1], tour[(winJ + 1) % n]];
-    tour.splice(winI + 1, winJ - winI, ...tour.slice(winI + 1, winJ + 1).reverse());
-    currentDist = tourDist(tour, dist);
-    frames.push({ tour: [...tour], scanEdges: null, swapEdges: [newEdge1, newEdge2], dist: currentDist, overlay: null, isScan: false });
+    const newEdge1: [number, number] = [tour[winI], tour[winJ]]
+    const newEdge2: [number, number] = [tour[winI + 1], tour[(winJ + 1) % n]]
+    tour.splice(
+      winI + 1,
+      winJ - winI,
+      ...tour.slice(winI + 1, winJ + 1).reverse(),
+    )
+    currentDist = tourDist(tour, dist)
+    frames.push({
+      tour: [...tour],
+      scanEdges: null,
+      swapEdges: [newEdge1, newEdge2],
+      dist: currentDist,
+      overlay: null,
+      isScan: false,
+    })
 
-    foundImprovement = true;
+    foundImprovement = true
   }
 
   // Terminal frame
-  frames.push({ tour: [...tour], scanEdges: null, swapEdges: null, dist: currentDist, overlay: "Local optimum", isScan: false });
+  frames.push({
+    tour: [...tour],
+    scanEdges: null,
+    swapEdges: null,
+    dist: currentDist,
+    overlay: 'Local optimum',
+    isScan: false,
+  })
 
-  return frames;
+  return frames
 }
 
 export interface ILSFrame {
-  tour: number[];
-  bestTour: number[];
-  swapEdges: EdgePair | null;
-  bridgePoints: [number, number, number] | null; // city indices at cut positions
-  phase: string;
-  currentDist: number;
-  bestDist: number;
-  restarts: number;
-  plateauCount: number;
-  overlay: string | null;
-  highlight: 'swap' | 'bridge' | 'best' | null;
+  tour: number[]
+  bestTour: number[]
+  swapEdges: EdgePair | null
+  bridgePoints: [number, number, number] | null // city indices at cut positions
+  phase: string
+  currentDist: number
+  bestDist: number
+  restarts: number
+  plateauCount: number
+  overlay: string | null
+  highlight: 'swap' | 'bridge' | 'best' | null
 }
 
 // Number of duplicate frames for visual hold on bridge_cut and new_best events.
-const ILS_HOLD = 3;
+const ILS_HOLD = 3
 
 // Pre-computes all ILS animation frames: NN → 2-opt → [kick → 2-opt → accept/reject]*.
 // No scan events — Tab 2 shows only accepted swaps and ILS events.
@@ -183,42 +236,48 @@ export function computeILSFrames(
   dist: number[][],
   maxEpochs: number,
   plateauLimit: number,
-  rand: () => number
+  rand: () => number,
 ): ILSFrame[] {
-  const frames: ILSFrame[] = [];
+  const frames: ILSFrame[] = []
 
-  let currentTour = [...initTour];
-  let bestTour = [...initTour];
-  let currentDist = tourDist(currentTour, dist);
-  let bestDist = currentDist;
-  let restarts = 0;
-  let plateauCount = 0;
-  const n = currentTour.length;
+  let currentTour = [...initTour]
+  let bestTour = [...initTour]
+  let currentDist = tourDist(currentTour, dist)
+  let bestDist = currentDist
+  let restarts = 0
+  let plateauCount = 0
+  const n = currentTour.length
 
   // Helper: run first-improvement 2-opt on `t` in place, emitting swap frames.
   function runPass(t: number[], phase: string): void {
-    let improved = true;
+    let improved = true
     while (improved) {
-      improved = false;
-      outer:
-      for (let i = 0; i < n - 1; i++) {
+      improved = false
+      outer: for (let i = 0; i < n - 1; i++) {
         for (let j = i + 2; j < n; j++) {
-          if (i === 0 && j === n - 1) continue;
-          const removed = dist[t[i]][t[i + 1]] + dist[t[j]][t[(j + 1) % n]];
-          const added   = dist[t[i]][t[j]]     + dist[t[i + 1]][t[(j + 1) % n]];
+          if (i === 0 && j === n - 1) continue
+          const removed = dist[t[i]][t[i + 1]] + dist[t[j]][t[(j + 1) % n]]
+          const added = dist[t[i]][t[j]] + dist[t[i + 1]][t[(j + 1) % n]]
           if (removed - added > 1e-10) {
-            const e1: [number, number] = [t[i],     t[j]];
-            const e2: [number, number] = [t[i + 1], t[(j + 1) % n]];
-            t.splice(i + 1, j - i, ...t.slice(i + 1, j + 1).reverse());
-            currentDist = tourDist(t, dist);
+            const e1: [number, number] = [t[i], t[j]]
+            const e2: [number, number] = [t[i + 1], t[(j + 1) % n]]
+            t.splice(i + 1, j - i, ...t.slice(i + 1, j + 1).reverse())
+            currentDist = tourDist(t, dist)
             frames.push({
-              tour: [...t], bestTour: [...bestTour],
-              swapEdges: [e1, e2], bridgePoints: null,
-              phase, currentDist, bestDist, restarts, plateauCount,
-              overlay: null, highlight: 'swap',
-            });
-            improved = true;
-            break outer;
+              tour: [...t],
+              bestTour: [...bestTour],
+              swapEdges: [e1, e2],
+              bridgePoints: null,
+              phase,
+              currentDist,
+              bestDist,
+              restarts,
+              plateauCount,
+              overlay: null,
+              highlight: 'swap',
+            })
+            improved = true
+            break outer
           }
         }
       }
@@ -227,102 +286,169 @@ export function computeILSFrames(
 
   // Initial pass
   frames.push({
-    tour: [...currentTour], bestTour: [...bestTour],
-    swapEdges: null, bridgePoints: null,
-    phase: 'LK pass', currentDist, bestDist, restarts, plateauCount,
-    overlay: null, highlight: null,
-  });
-  runPass(currentTour, 'LK pass');
-  currentDist = tourDist(currentTour, dist);
+    tour: [...currentTour],
+    bestTour: [...bestTour],
+    swapEdges: null,
+    bridgePoints: null,
+    phase: 'LK pass',
+    currentDist,
+    bestDist,
+    restarts,
+    plateauCount,
+    overlay: null,
+    highlight: null,
+  })
+  runPass(currentTour, 'LK pass')
+  currentDist = tourDist(currentTour, dist)
 
   if (currentDist < bestDist) {
-    bestDist = currentDist;
-    bestTour = [...currentTour];
-    plateauCount = 0;
+    bestDist = currentDist
+    bestTour = [...currentTour]
+    plateauCount = 0
   }
   for (let h = 0; h < ILS_HOLD; h++) {
     frames.push({
-      tour: [...currentTour], bestTour: [...bestTour],
-      swapEdges: null, bridgePoints: null,
-      phase: 'New best!', currentDist, bestDist, restarts, plateauCount,
-      overlay: null, highlight: 'best',
-    });
+      tour: [...currentTour],
+      bestTour: [...bestTour],
+      swapEdges: null,
+      bridgePoints: null,
+      phase: 'New best!',
+      currentDist,
+      bestDist,
+      restarts,
+      plateauCount,
+      overlay: null,
+      highlight: 'best',
+    })
   }
 
   // ILS loop
   for (let epoch = 0; epoch < maxEpochs; epoch++) {
     // Kick
-    const { result: kicked, p1, p2, p3 } = doubleBridge(bestTour, rand);
-    currentTour = kicked;
-    currentDist = tourDist(currentTour, dist);
-    restarts++;
-    const bridgePoints: [number, number, number] = [bestTour[p1], bestTour[p2], bestTour[p3]];
+    const { result: kicked, p1, p2, p3 } = doubleBridge(bestTour, rand)
+    currentTour = kicked
+    currentDist = tourDist(currentTour, dist)
+    restarts++
+    const bridgePoints: [number, number, number] = [
+      bestTour[p1],
+      bestTour[p2],
+      bestTour[p3],
+    ]
 
     for (let h = 0; h < ILS_HOLD; h++) {
       frames.push({
-        tour: [...currentTour], bestTour: [...bestTour],
-        swapEdges: null, bridgePoints,
-        phase: 'Double-bridge kick', currentDist, bestDist, restarts, plateauCount,
-        overlay: null, highlight: 'bridge',
-      });
+        tour: [...currentTour],
+        bestTour: [...bestTour],
+        swapEdges: null,
+        bridgePoints,
+        phase: 'Double-bridge kick',
+        currentDist,
+        bestDist,
+        restarts,
+        plateauCount,
+        overlay: null,
+        highlight: 'bridge',
+      })
     }
 
     // Optimise kicked tour
     frames.push({
-      tour: [...currentTour], bestTour: [...bestTour],
-      swapEdges: null, bridgePoints: null,
-      phase: 'LK pass', currentDist, bestDist, restarts, plateauCount,
-      overlay: null, highlight: null,
-    });
-    runPass(currentTour, 'LK pass');
-    currentDist = tourDist(currentTour, dist);
+      tour: [...currentTour],
+      bestTour: [...bestTour],
+      swapEdges: null,
+      bridgePoints: null,
+      phase: 'LK pass',
+      currentDist,
+      bestDist,
+      restarts,
+      plateauCount,
+      overlay: null,
+      highlight: null,
+    })
+    runPass(currentTour, 'LK pass')
+    currentDist = tourDist(currentTour, dist)
 
     // Local optimum label
     frames.push({
-      tour: [...currentTour], bestTour: [...bestTour],
-      swapEdges: null, bridgePoints: null,
-      phase: 'Local optimum', currentDist, bestDist, restarts, plateauCount,
-      overlay: 'Local optimum', highlight: null,
-    });
+      tour: [...currentTour],
+      bestTour: [...bestTour],
+      swapEdges: null,
+      bridgePoints: null,
+      phase: 'Local optimum',
+      currentDist,
+      bestDist,
+      restarts,
+      plateauCount,
+      overlay: 'Local optimum',
+      highlight: null,
+    })
 
     // Accept / reject
     if (currentDist < bestDist - 1e-10) {
-      bestDist = currentDist;
-      bestTour = [...currentTour];
-      plateauCount = 0;
+      bestDist = currentDist
+      bestTour = [...currentTour]
+      plateauCount = 0
       for (let h = 0; h < ILS_HOLD; h++) {
         frames.push({
-          tour: [...currentTour], bestTour: [...bestTour],
-          swapEdges: null, bridgePoints: null,
-          phase: 'New best!', currentDist, bestDist, restarts, plateauCount,
-          overlay: null, highlight: 'best',
-        });
+          tour: [...currentTour],
+          bestTour: [...bestTour],
+          swapEdges: null,
+          bridgePoints: null,
+          phase: 'New best!',
+          currentDist,
+          bestDist,
+          restarts,
+          plateauCount,
+          overlay: null,
+          highlight: 'best',
+        })
       }
     } else {
-      plateauCount++;
+      plateauCount++
       frames.push({
-        tour: [...currentTour], bestTour: [...bestTour],
-        swapEdges: null, bridgePoints: null,
-        phase: 'Plateau', currentDist, bestDist, restarts, plateauCount,
-        overlay: null, highlight: null,
-      });
+        tour: [...currentTour],
+        bestTour: [...bestTour],
+        swapEdges: null,
+        bridgePoints: null,
+        phase: 'Plateau',
+        currentDist,
+        bestDist,
+        restarts,
+        plateauCount,
+        overlay: null,
+        highlight: null,
+      })
       if (plateauCount >= plateauLimit) {
         frames.push({
-          tour: [...bestTour], bestTour: [...bestTour],
-          swapEdges: null, bridgePoints: null,
-          phase: 'Done', currentDist: bestDist, bestDist, restarts, plateauCount,
-          overlay: 'Done — plateau limit reached', highlight: null,
-        });
-        return frames;
+          tour: [...bestTour],
+          bestTour: [...bestTour],
+          swapEdges: null,
+          bridgePoints: null,
+          phase: 'Done',
+          currentDist: bestDist,
+          bestDist,
+          restarts,
+          plateauCount,
+          overlay: 'Done — plateau limit reached',
+          highlight: null,
+        })
+        return frames
       }
     }
   }
 
   frames.push({
-    tour: [...bestTour], bestTour: [...bestTour],
-    swapEdges: null, bridgePoints: null,
-    phase: 'Done', currentDist: bestDist, bestDist, restarts, plateauCount,
-    overlay: 'Done — max epochs', highlight: null,
-  });
-  return frames;
+    tour: [...bestTour],
+    bestTour: [...bestTour],
+    swapEdges: null,
+    bridgePoints: null,
+    phase: 'Done',
+    currentDist: bestDist,
+    bestDist,
+    restarts,
+    plateauCount,
+    overlay: 'Done — max epochs',
+    highlight: null,
+  })
+  return frames
 }

--- a/teeline-web/src/explainers/lk.tsx
+++ b/teeline-web/src/explainers/lk.tsx
@@ -2,8 +2,11 @@
 import { useState, useCallback, useMemo } from 'preact/hooks'
 import type { LSFrame, ILSFrame } from './lk'
 import {
-  CITIES, DIST, INIT_TOUR,
-  computeLocalSearchFrames, computeILSFrames,
+  CITIES,
+  DIST,
+  INIT_TOUR,
+  computeLocalSearchFrames,
+  computeILSFrames,
   lcgRand,
 } from './lk'
 
@@ -20,8 +23,13 @@ interface TourSVGProps {
 }
 
 function TourSVG({
-  tour, scanEdges = null, swapEdges = null,
-  bestTour = null, bridgePoints = null, highlight = null, overlay = null,
+  tour,
+  scanEdges = null,
+  swapEdges = null,
+  bestTour = null,
+  bridgePoints = null,
+  highlight = null,
+  overlay = null,
 }: TourSVGProps) {
   const cities = CITIES
 
@@ -47,39 +55,83 @@ function TourSVG({
   const tourColor = highlight === 'best' ? '#e8a000' : '#e0626b'
 
   return (
-    <svg viewBox="0 0 300 300" className="lk-canvas" role="img" aria-label="TSP tour visualisation">
+    <svg
+      viewBox="0 0 300 300"
+      className="lk-canvas"
+      role="img"
+      aria-label="TSP tour visualisation"
+    >
       <rect x="0" y="0" width="300" height="300" className="lk-bg" />
 
       {/* Best-tour underlay (thin dashed) */}
-      {bestEdges.map(e => (
-        <line key={e.key} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2} className="lk-best-edge" />
+      {bestEdges.map((e) => (
+        <line
+          key={e.key}
+          x1={e.x1}
+          y1={e.y1}
+          x2={e.x2}
+          y2={e.y2}
+          className="lk-best-edge"
+        />
       ))}
 
       {/* Current tour */}
-      {tourEdges.map(e => (
-        <line key={e.key} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2}
+      {tourEdges.map((e) => (
+        <line
+          key={e.key}
+          x1={e.x1}
+          y1={e.y1}
+          x2={e.x2}
+          y2={e.y2}
           className="lk-tour-edge"
-          style={{ stroke: tourColor, transition: 'stroke 0.25s ease' }} />
+          style={{ stroke: tourColor, transition: 'stroke 0.25s ease' }}
+        />
       ))}
 
       {/* Scan edges (gray dashed — shown in Step mode) */}
       {scanEdges?.map(([a, b], idx) => {
         const [x1, y1] = cities[a]
         const [x2, y2] = cities[b]
-        return <line key={idx} x1={x1} y1={y1} x2={x2} y2={y2} className="lk-scan-edge" />
+        return (
+          <line
+            key={idx}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            className="lk-scan-edge"
+          />
+        )
       })}
 
       {/* Swap edges (green — new edges accepted) */}
       {swapEdges?.map(([a, b], idx) => {
         const [x1, y1] = cities[a]
         const [x2, y2] = cities[b]
-        return <line key={idx} x1={x1} y1={y1} x2={x2} y2={y2} className="lk-swap-edge" />
+        return (
+          <line
+            key={idx}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            className="lk-swap-edge"
+          />
+        )
       })}
 
       {/* Bridge cut circles */}
       {bridgePoints?.map((cityId, idx) => {
         const [cx, cy] = cities[cityId]
-        return <circle key={idx} cx={cx} cy={cy} r="10" className="lk-bridge-circle" />
+        return (
+          <circle
+            key={idx}
+            cx={cx}
+            cy={cy}
+            r="10"
+            className="lk-bridge-circle"
+          />
+        )
       })}
 
       {/* City dots */}
@@ -89,7 +141,9 @@ function TourSVG({
 
       {/* Overlay label */}
       {overlay && (
-        <text x="150" y="155" className="lk-overlay">{overlay}</text>
+        <text x="150" y="155" className="lk-overlay">
+          {overlay}
+        </text>
       )}
     </svg>
   )
@@ -209,19 +263,38 @@ interface ControlsProps {
   onReset: () => void
 }
 
-function Controls({ done, canStepBack, onStepBack, onStep, onReset }: ControlsProps) {
+function Controls({
+  done,
+  canStepBack,
+  onStepBack,
+  onStep,
+  onReset,
+}: ControlsProps) {
   return (
     <div className="lk-controls">
-      <button className="lk-btn" onClick={onStepBack} disabled={!canStepBack}>◀ Back</button>
-      <button className="lk-btn lk-btn-primary" onClick={onStep} disabled={done}>Step ▶</button>
-      <button className="lk-btn" onClick={onReset}>↺ Reset</button>
+      <button className="lk-btn" onClick={onStepBack} disabled={!canStepBack}>
+        ◀ Back
+      </button>
+      <button
+        className="lk-btn lk-btn-primary"
+        onClick={onStep}
+        disabled={done}
+      >
+        Step ▶
+      </button>
+      <button className="lk-btn" onClick={onReset}>
+        ↺ Reset
+      </button>
     </div>
   )
 }
 
 // ── StatsPanel ────────────────────────────────────────────────────────────────
 
-interface StatEntry { label: string; value: string | number }
+interface StatEntry {
+  label: string
+  value: string | number
+}
 
 function StatsPanel({ stats }: { stats: StatEntry[] }) {
   return (
@@ -231,7 +304,9 @@ function StatsPanel({ stats }: { stats: StatEntry[] }) {
           <div className="lk-statlabel">{label}</div>
           <div className="lk-mono">
             {typeof value === 'number'
-              ? Number.isInteger(value) ? value : value.toFixed(1)
+              ? Number.isInteger(value)
+                ? value
+                : value.toFixed(1)
               : value}
           </div>
         </div>
@@ -243,10 +318,13 @@ function StatsPanel({ stats }: { stats: StatEntry[] }) {
 // ── PhaseIndicator ────────────────────────────────────────────────────────────
 
 function PhaseIndicator({ phase }: { phase: string }) {
-  const cls = phase.includes('bridge') ? 'lk-phase-bridge'
-    : phase.includes('best') || phase.includes('New') ? 'lk-phase-best'
-    : phase.includes('LK') ? 'lk-phase-pass'
-    : ''
+  const cls = phase.includes('bridge')
+    ? 'lk-phase-bridge'
+    : phase.includes('best') || phase.includes('New')
+      ? 'lk-phase-best'
+      : phase.includes('LK')
+        ? 'lk-phase-pass'
+        : ''
   return <div className={`lk-phase ${cls}`}>{phase}</div>
 }
 
@@ -256,27 +334,66 @@ function TourLegend({ mode }: { mode: 'ls' | 'ils' }) {
   return (
     <div className="lk-legend">
       <span className="lk-legend-item">
-        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#e0626b" strokeWidth="2" /></svg>
+        <svg width="22" height="10">
+          <line x1="1" y1="5" x2="21" y2="5" stroke="#e0626b" strokeWidth="2" />
+        </svg>
         Tour
       </span>
       <span className="lk-legend-item">
-        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#e8a000" strokeWidth="4" opacity="0.55" /></svg>
+        <svg width="22" height="10">
+          <line
+            x1="1"
+            y1="5"
+            x2="21"
+            y2="5"
+            stroke="#e8a000"
+            strokeWidth="4"
+            opacity="0.55"
+          />
+        </svg>
         Candidate pair
       </span>
       <span className="lk-legend-item">
-        <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#1a7f37" strokeWidth="2.5" /></svg>
+        <svg width="22" height="10">
+          <line
+            x1="1"
+            y1="5"
+            x2="21"
+            y2="5"
+            stroke="#1a7f37"
+            strokeWidth="2.5"
+          />
+        </svg>
         Accepted swap
       </span>
       {mode === 'ils' && (
         <span className="lk-legend-item">
-          <svg width="22" height="10"><line x1="1" y1="5" x2="21" y2="5" stroke="#aaa" strokeWidth="1" strokeDasharray="4 3" /></svg>
+          <svg width="22" height="10">
+            <line
+              x1="1"
+              y1="5"
+              x2="21"
+              y2="5"
+              stroke="#aaa"
+              strokeWidth="1"
+              strokeDasharray="4 3"
+            />
+          </svg>
           Best tour
         </span>
       )}
       {mode === 'ils' && (
         <span className="lk-legend-item">
           <svg width="16" height="16" style={{ marginRight: 2 }}>
-            <circle cx="8" cy="8" r="5" fill="none" stroke="#cf222e" strokeWidth="1.5" strokeDasharray="3 2" />
+            <circle
+              cx="8"
+              cy="8"
+              r="5"
+              fill="none"
+              stroke="#cf222e"
+              strokeWidth="1.5"
+              strokeDasharray="3 2"
+            />
           </svg>
           Bridge cut
         </span>
@@ -288,28 +405,42 @@ function TourLegend({ mode }: { mode: 'ls' | 'ils' }) {
 // ── Status lines ─────────────────────────────────────────────────────────────
 
 function LSStatusLine({ frame }: { frame: LSFrame }) {
-  const cls = frame.overlay ? 'lk-status-done'
-    : frame.swapEdges ? 'lk-status-swap'
-    : ''
-  const msg = frame.overlay
-    ?? (frame.swapEdges ? 'Improvement found — swapping edges ✓'
-    : 'Scanning candidate pair — no improvement yet, step further')
+  const cls = frame.overlay
+    ? 'lk-status-done'
+    : frame.swapEdges
+      ? 'lk-status-swap'
+      : ''
+  const msg =
+    frame.overlay ??
+    (frame.swapEdges
+      ? 'Improvement found — swapping edges ✓'
+      : 'Scanning candidate pair — no improvement yet, step further')
   return <div className={`lk-status ${cls}`}>{msg}</div>
 }
 
 function ILSStatusLine({ frame }: { frame: ILSFrame }) {
-  const cls = frame.overlay ? 'lk-status-done'
-    : frame.highlight === 'best' ? 'lk-status-best'
-    : frame.highlight === 'bridge' ? 'lk-status-bridge'
-    : frame.highlight === 'swap' ? 'lk-status-swap'
-    : ''
-  const msg = frame.overlay
-    ?? (frame.highlight === 'best' ? 'New best tour found! ✓'
-    : frame.highlight === 'bridge' ? 'Double-bridge kick applied — escaping local optimum'
-    : frame.highlight === 'swap' ? 'Improvement found — swapping edges ✓'
-    : frame.phase === 'Plateau' ? `Plateau ${frame.plateauCount} of 5 — no improvement, will kick again`
-    : frame.phase === 'Local optimum' ? 'Local optimum reached — comparing to best tour'
-    : 'Running 2-opt local search...')
+  const cls = frame.overlay
+    ? 'lk-status-done'
+    : frame.highlight === 'best'
+      ? 'lk-status-best'
+      : frame.highlight === 'bridge'
+        ? 'lk-status-bridge'
+        : frame.highlight === 'swap'
+          ? 'lk-status-swap'
+          : ''
+  const msg =
+    frame.overlay ??
+    (frame.highlight === 'best'
+      ? 'New best tour found! ✓'
+      : frame.highlight === 'bridge'
+        ? 'Double-bridge kick applied — escaping local optimum'
+        : frame.highlight === 'swap'
+          ? 'Improvement found — swapping edges ✓'
+          : frame.phase === 'Plateau'
+            ? `Plateau ${frame.plateauCount} of 5 — no improvement, will kick again`
+            : frame.phase === 'Local optimum'
+              ? 'Local optimum reached — comparing to best tour'
+              : 'Running 2-opt local search...')
   return <div className={`lk-status ${cls}`}>{msg}</div>
 }
 
@@ -323,12 +454,17 @@ function LocalSearchTab() {
   const done = idx >= frames.length - 1
 
   const handleStep = useCallback(() => {
-    setIdx(i => Math.min(i + 1, frames.length - 1))
+    setIdx((i) => Math.min(i + 1, frames.length - 1))
   }, [frames])
-  const handleStepBack = useCallback(() => setIdx(i => Math.max(0, i - 1)), [frames])
+  const handleStepBack = useCallback(
+    () => setIdx((i) => Math.max(0, i - 1)),
+    [frames],
+  )
   const handleReset = useCallback(() => setIdx(0), [])
 
-  const swapCount = frames.slice(0, idx + 1).filter(f => f.swapEdges !== null).length
+  const swapCount = frames
+    .slice(0, idx + 1)
+    .filter((f) => f.swapEdges !== null).length
 
   return (
     <div className="lk-tab">
@@ -343,19 +479,24 @@ function LocalSearchTab() {
       </div>
       <div className="lk-prose">
         <Controls
-          done={done} canStepBack={idx > 0}
-          onStepBack={handleStepBack} onStep={handleStep} onReset={handleReset}
+          done={done}
+          canStepBack={idx > 0}
+          onStepBack={handleStepBack}
+          onStep={handleStep}
+          onReset={handleReset}
         />
         <LSStatusLine frame={frame} />
-        <StatsPanel stats={[
-          { label: 'Distance', value: frame.dist },
-          { label: 'Swaps accepted', value: swapCount },
-          { label: 'Step', value: `${idx + 1} / ${frames.length}` },
-        ]} />
+        <StatsPanel
+          stats={[
+            { label: 'Distance', value: frame.dist },
+            { label: 'Swaps accepted', value: swapCount },
+            { label: 'Step', value: `${idx + 1} / ${frames.length}` },
+          ]}
+        />
         <p className="lk-note">
-          This shows simplified <strong>2-opt</strong> local search: scan candidate
-          pairs, swap when one improves the tour, repeat until no gain is found.{' '}
-          The actual LK solver chains deeper moves —{' '}
+          This shows simplified <strong>2-opt</strong> local search: scan
+          candidate pairs, swap when one improves the tour, repeat until no gain
+          is found. The actual LK solver chains deeper moves —{' '}
           <a href="/algorithms/lk/">see the docs</a>.
         </p>
       </div>
@@ -370,7 +511,7 @@ const ILS_RAND_SEED = 2026
 function ILSTab() {
   const frames = useMemo(
     () => computeILSFrames(INIT_TOUR, DIST, 30, 5, lcgRand(ILS_RAND_SEED)),
-    []
+    [],
   )
   const [idx, setIdx] = useState(0)
 
@@ -378,9 +519,12 @@ function ILSTab() {
   const done = idx >= frames.length - 1
 
   const handleStep = useCallback(() => {
-    setIdx(i => Math.min(i + 1, frames.length - 1))
+    setIdx((i) => Math.min(i + 1, frames.length - 1))
   }, [frames])
-  const handleStepBack = useCallback(() => setIdx(i => Math.max(0, i - 1)), [])
+  const handleStepBack = useCallback(
+    () => setIdx((i) => Math.max(0, i - 1)),
+    [],
+  )
   const handleReset = useCallback(() => setIdx(0), [])
 
   return (
@@ -399,19 +543,25 @@ function ILSTab() {
       <div className="lk-prose">
         <PhaseIndicator phase={frame.phase} />
         <Controls
-          done={done} canStepBack={idx > 0}
-          onStepBack={handleStepBack} onStep={handleStep} onReset={handleReset}
+          done={done}
+          canStepBack={idx > 0}
+          onStepBack={handleStepBack}
+          onStep={handleStep}
+          onReset={handleReset}
         />
         <ILSStatusLine frame={frame} />
-        <StatsPanel stats={[
-          { label: 'Current dist', value: frame.currentDist },
-          { label: 'Best dist', value: frame.bestDist },
-          { label: 'Epoch', value: frame.restarts },
-          { label: `Plateau (limit ${5})`, value: frame.plateauCount },
-          { label: 'Step', value: `${idx + 1} / ${frames.length}` },
-        ]} />
+        <StatsPanel
+          stats={[
+            { label: 'Current dist', value: frame.currentDist },
+            { label: 'Best dist', value: frame.bestDist },
+            { label: 'Epoch', value: frame.restarts },
+            { label: `Plateau (limit ${5})`, value: frame.plateauCount },
+            { label: 'Step', value: `${idx + 1} / ${frames.length}` },
+          ]}
+        />
         <p className="lk-note">
-          Gold tour = new best found. Red dashed circles mark the double-bridge cut points.
+          Gold tour = new best found. Red dashed circles mark the double-bridge
+          cut points.
         </p>
       </div>
     </div>
@@ -438,9 +588,16 @@ export default function LKExplainer() {
       </header>
 
       <nav className="lk-tabs" role="tablist">
-        {([['ls', 'Local Search'], ['ils', 'ILS']] as [TabId, string][]).map(([id, label]) => (
+        {(
+          [
+            ['ls', 'Local Search'],
+            ['ils', 'ILS'],
+          ] as [TabId, string][]
+        ).map(([id, label]) => (
           <button
-            key={id} role="tab" aria-selected={tab === id}
+            key={id}
+            role="tab"
+            aria-selected={tab === id}
             className={'lk-tabbtn' + (tab === id ? ' lk-tabbtn-active' : '')}
             onClick={() => setTab(id)}
           >
@@ -450,8 +607,12 @@ export default function LKExplainer() {
       </nav>
 
       {/* Keep both tabs mounted so per-tab playback state is preserved on switch */}
-      <div style={{ display: tab === 'ls' ? 'block' : 'none' }}><LocalSearchTab /></div>
-      <div style={{ display: tab === 'ils' ? 'block' : 'none' }}><ILSTab /></div>
+      <div style={{ display: tab === 'ls' ? 'block' : 'none' }}>
+        <LocalSearchTab />
+      </div>
+      <div style={{ display: tab === 'ils' ? 'block' : 'none' }}>
+        <ILSTab />
+      </div>
 
       <footer className="lk-footer">
         <span className="lk-mono">cities: {CITIES.length}</span>

--- a/teeline-web/src/explainers/nearest-neighbor-algo.ts
+++ b/teeline-web/src/explainers/nearest-neighbor-algo.ts
@@ -15,13 +15,13 @@ export interface Candidate {
 }
 
 export interface SimState {
-  tour: number[]             // ordered path, grows from [start] to [start,...,start]
-  unvisited: number[]        // cities not yet added to tour
+  tour: number[] // ordered path, grows from [start] to [start,...,start]
+  unvisited: number[] // cities not yet added to tour
   step: number
   done: boolean
   lastEvent: EventMode | null
-  lastCity: number | null    // most recently visited city (or start on closing)
-  lastDist: number           // distance of the most recent edge
+  lastCity: number | null // most recently visited city (or start on closing)
+  lastDist: number // distance of the most recent edge
   candidateDists: Candidate[] | null // distances from current city to all unvisited
 }
 
@@ -33,7 +33,10 @@ export function tourLength(tour: number[]): number {
   return d
 }
 
-export const SCENARIOS: Record<string, { label: string; desc: string; startCity: number }> = {
+export const SCENARIOS: Record<
+  string,
+  { label: string; desc: string; startCity: number }
+> = {
   balanced: {
     label: 'Balanced',
     desc: 'Start from city 0 (top) — walks clockwise, decent result',
@@ -91,7 +94,7 @@ export function stepOnce(state: SimState): SimState {
 
   // Find nearest unvisited
   const cands: Candidate[] = state.unvisited
-    .map(c => ({ city: c, dist: dist(current, c) }))
+    .map((c) => ({ city: c, dist: dist(current, c) }))
     .sort((a, b) => a.dist - b.dist)
 
   const nearest = cands[0]
@@ -99,7 +102,7 @@ export function stepOnce(state: SimState): SimState {
   return {
     ...state,
     tour: [...state.tour, nearest.city],
-    unvisited: state.unvisited.filter(c => c !== nearest.city),
+    unvisited: state.unvisited.filter((c) => c !== nearest.city),
     step: state.step + 1,
     lastEvent: 'visited',
     lastCity: nearest.city,

--- a/teeline-web/src/explainers/nearest-neighbor.test.ts
+++ b/teeline-web/src/explainers/nearest-neighbor.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, SCENARIOS,
-  dist, tourLength, makeInitState, stepOnce,
+  N_CITIES,
+  SCENARIOS,
+  dist,
+  tourLength,
+  makeInitState,
+  stepOnce,
 } from './nearest-neighbor-algo'
 
 describe('dist', () => {
@@ -109,7 +113,9 @@ describe('stepOnce', () => {
     expect(s1.candidateDists).not.toBeNull()
     expect(s1.candidateDists!.length).toBe(s.unvisited.length)
     for (let i = 1; i < s1.candidateDists!.length; i++) {
-      expect(s1.candidateDists![i - 1].dist).toBeLessThanOrEqual(s1.candidateDists![i].dist + 0.001)
+      expect(s1.candidateDists![i - 1].dist).toBeLessThanOrEqual(
+        s1.candidateDists![i].dist + 0.001,
+      )
     }
   })
 })

--- a/teeline-web/src/explainers/nearest-neighbor.tsx
+++ b/teeline-web/src/explainers/nearest-neighbor.tsx
@@ -1,19 +1,28 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, SCENARIOS,
-  tourLength, makeInitState, stepOnce,
-} from "./nearest-neighbor-algo"
-import type { EventMode, Candidate } from "./nearest-neighbor-algo"
+  CITIES,
+  N_CITIES,
+  SCENARIOS,
+  tourLength,
+  makeInitState,
+  stepOnce,
+} from './nearest-neighbor-algo'
+import type { EventMode, Candidate } from './nearest-neighbor-algo'
 
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 const DEFAULT_START = SCENARIOS.balanced.startCity
 
 // ---------------------------------------------------------------
 // NNCanvas — tour edges, visited/unvisited cities, candidate edges
 // ---------------------------------------------------------------
-function NNCanvas({ tour, candidateDists, done, lastEvent }: {
+function NNCanvas({
+  tour,
+  candidateDists,
+  done,
+  lastEvent,
+}: {
   tour: number[]
   candidateDists: Candidate[] | null
   done: boolean
@@ -40,39 +49,62 @@ function NNCanvas({ tour, candidateDists, done, lastEvent }: {
   const showCandidates = !done && candidateDists && candidateDists.length > 0
 
   return (
-    <svg viewBox="0 0 300 300" className="nn-canvas" role="img" aria-label="Nearest Neighbor tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="nn-canvas"
+      role="img"
+      aria-label="Nearest Neighbor tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="nn-bg" />
 
       {/* candidate edges — faint dashed from current to all unvisited */}
-      {showCandidates && candidateDists!.map((c) => (
-        <line key={c.city}
-          className={c === candidateDists![0] ? "nn-cand-best" : "nn-cand-edge"}
-          x1={CITIES[current][0]} y1={CITIES[current][1]}
-          x2={CITIES[c.city][0]} y2={CITIES[c.city][1]} />
-      ))}
+      {showCandidates &&
+        candidateDists!.map((c) => (
+          <line
+            key={c.city}
+            className={
+              c === candidateDists![0] ? 'nn-cand-best' : 'nn-cand-edge'
+            }
+            x1={CITIES[current][0]}
+            y1={CITIES[current][1]}
+            x2={CITIES[c.city][0]}
+            y2={CITIES[c.city][1]}
+          />
+        ))}
 
       {/* tour edges — solid green for visited path */}
       {edges.map(([a, b], i) => {
-        const isLast = !done && i === edges.length - 1 && lastEvent === 'visited'
+        const isLast =
+          !done && i === edges.length - 1 && lastEvent === 'visited'
         return (
-          <line key={`${a}-${b}`}
-            className={isLast ? "nn-edge-last" : "nn-edge"}
-            x1={CITIES[a][0]} y1={CITIES[a][1]}
-            x2={CITIES[b][0]} y2={CITIES[b][1]} />
+          <line
+            key={`${a}-${b}`}
+            className={isLast ? 'nn-edge-last' : 'nn-edge'}
+            x1={CITIES[a][0]}
+            y1={CITIES[a][1]}
+            x2={CITIES[b][0]}
+            y2={CITIES[b][1]}
+          />
         )
       })}
 
       {/* closing edge */}
-      {done && tour.length >= 2 && (() => {
-        const last = tour[tour.length - 1]
-        const prev = tour[tour.length - 2]
-        return (
-          <line key="closing"
-            className="nn-edge-closing"
-            x1={CITIES[prev][0]} y1={CITIES[prev][1]}
-            x2={CITIES[last][0]} y2={CITIES[last][1]} />
-        )
-      })()}
+      {done &&
+        tour.length >= 2 &&
+        (() => {
+          const last = tour[tour.length - 1]
+          const prev = tour[tour.length - 2]
+          return (
+            <line
+              key="closing"
+              className="nn-edge-closing"
+              x1={CITIES[prev][0]}
+              y1={CITIES[prev][1]}
+              x2={CITIES[last][0]}
+              y2={CITIES[last][1]}
+            />
+          )
+        })()}
 
       {/* cities */}
       {Array.from({ length: N_CITIES }, (_, i) => {
@@ -80,19 +112,21 @@ function NNCanvas({ tour, candidateDists, done, lastEvent }: {
         const isCurrent = i === current && !done
         const order = orderMap.get(i)
 
-        let cls = "nn-city"
-        if (isCurrent) cls += " nn-city-current"
-        else if (isVisited) cls += " nn-city-visited"
-        else cls += " nn-city-unvisited"
+        let cls = 'nn-city'
+        if (isCurrent) cls += ' nn-city-current'
+        else if (isVisited) cls += ' nn-city-visited'
+        else cls += ' nn-city-unvisited'
 
         return (
           <g key={i}>
             <circle className={cls} cx={CITIES[i][0]} cy={CITIES[i][1]} r={6} />
-            <text className="nn-label"
-              x={CITIES[i][0]} y={CITIES[i][1] + 16}>{i}</text>
+            <text className="nn-label" x={CITIES[i][0]} y={CITIES[i][1] + 16}>
+              {i}
+            </text>
             {order && (
-              <text className="nn-order"
-                x={CITIES[i][0]} y={CITIES[i][1] + 3}>{order}</text>
+              <text className="nn-order" x={CITIES[i][0]} y={CITIES[i][1] + 3}>
+                {order}
+              </text>
             )}
           </g>
         )
@@ -106,7 +140,8 @@ function NNCanvas({ tour, candidateDists, done, lastEvent }: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 46
+  const W = 300,
+    H = 46
   const minV = Math.min(...values)
   const maxV = Math.max(...values)
   const range = maxV - minV || 1
@@ -118,8 +153,13 @@ function Sparkline({ values }: { values: number[] }) {
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="nn-spark">
       <rect x={0} y={0} width={W} height={H} className="nn-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
-        strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -175,7 +215,7 @@ export default function NNExplainer() {
     setCandidateDists(next.candidateDists ? [...next.candidateDists] : null)
     setStep(next.step)
     if (next.lastEvent === 'visited' || next.lastEvent === 'closing') {
-      setCostHistory(h => [...h, tourLength(next.tour)])
+      setCostHistory((h) => [...h, tourLength(next.tour)])
     }
     if (next.done) setRunning(false)
   }, [])
@@ -203,18 +243,27 @@ export default function NNExplainer() {
 
   const currentDist = tour.length >= 2 ? tourLength(tour) : 0
 
-  let chipText = "Click Step to start — NN picks the closest unvisited city"
-  let chipClass = "nn-chip nn-chip-idle"
-  if (lastEvent === 'visited' && lastCity !== null && candidateDists && candidateDists.length > 0) {
+  let chipText = 'Click Step to start — NN picks the closest unvisited city'
+  let chipClass = 'nn-chip nn-chip-idle'
+  if (
+    lastEvent === 'visited' &&
+    lastCity !== null &&
+    candidateDists &&
+    candidateDists.length > 0
+  ) {
     const next = candidateDists[0]
     chipText = `NN picks city ${lastCity} (dist=${lastDist.toFixed(0)}) — next closest: ${next.city} at ${next.dist.toFixed(0)}`
-    chipClass = "nn-chip nn-chip-visit"
-  } else if (lastEvent === 'visited' && lastCity !== null && (!candidateDists || candidateDists.length === 0)) {
+    chipClass = 'nn-chip nn-chip-visit'
+  } else if (
+    lastEvent === 'visited' &&
+    lastCity !== null &&
+    (!candidateDists || candidateDists.length === 0)
+  ) {
     chipText = `Last city ${lastCity} visited (dist=${lastDist.toFixed(0)}) — closing to start`
-    chipClass = "nn-chip nn-chip-visit"
+    chipClass = 'nn-chip nn-chip-visit'
   } else if (lastEvent === 'closing') {
     chipText = `Tour closed — final edge  ${lastDist.toFixed(0)}  — total distance  ${currentDist.toFixed(0)}`
-    chipClass = "nn-chip nn-chip-done"
+    chipClass = 'nn-chip nn-chip-done'
   }
 
   return (
@@ -225,10 +274,10 @@ export default function NNExplainer() {
         <div className="nn-eyebrow">teeline · algorithms/nn</div>
         <h2 className="nn-title">Nearest Neighbor Construction</h2>
         <p className="nn-sub">
-          The simplest constructive TSP heuristic: start from a chosen city, repeatedly
-          move to the <strong>closest unvisited city</strong>, then close the tour back to
-          the start. Each step is a single greedy decision — easy to follow, but the
-          final tour can be far from optimal.
+          The simplest constructive TSP heuristic: start from a chosen city,
+          repeatedly move to the <strong>closest unvisited city</strong>, then
+          close the tour back to the start. Each step is a single greedy
+          decision — easy to follow, but the final tour can be far from optimal.
         </p>
       </header>
 
@@ -236,17 +285,29 @@ export default function NNExplainer() {
         <div className="nn-canvas-wrap">
           <NNCanvas
             tour={tour}
-            candidateDists={candidateDists} done={done} lastEvent={lastEvent}
+            candidateDists={candidateDists}
+            done={done}
+            lastEvent={lastEvent}
           />
         </div>
       </div>
 
       <div className="nn-legend">
-        <span><span className="nn-swatch nn-swatch-path" /> visited path</span>
-        <span><span className="nn-swatch nn-swatch-last" /> last edge</span>
-        <span><span className="nn-swatch nn-swatch-cand" /> candidate edge</span>
-        <span><span className="nn-swatch nn-swatch-best" /> nearest candidate</span>
-        <span><span className="nn-swatch nn-swatch-curr" /> current city</span>
+        <span>
+          <span className="nn-swatch nn-swatch-path" /> visited path
+        </span>
+        <span>
+          <span className="nn-swatch nn-swatch-last" /> last edge
+        </span>
+        <span>
+          <span className="nn-swatch nn-swatch-cand" /> candidate edge
+        </span>
+        <span>
+          <span className="nn-swatch nn-swatch-best" /> nearest candidate
+        </span>
+        <span>
+          <span className="nn-swatch nn-swatch-curr" /> current city
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -254,7 +315,9 @@ export default function NNExplainer() {
       <div className="nn-statgrid">
         <div>
           <div className="nn-statlabel">visited</div>
-          <div className="nn-mono">{new Set(tour).size - (done ? 1 : 0)}/{N_CITIES}</div>
+          <div className="nn-mono">
+            {new Set(tour).size - (done ? 1 : 0)}/{N_CITIES}
+          </div>
         </div>
         <div>
           <div className="nn-statlabel">remaining</div>
@@ -282,9 +345,12 @@ export default function NNExplainer() {
           <label className="nn-label">Speed</label>
           <div className="nn-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l}
+              <button
+                key={l}
                 className={`nn-speed-btn ${i === speedIdx ? 'nn-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
                 {l}
               </button>
             ))}
@@ -293,24 +359,38 @@ export default function NNExplainer() {
       </div>
 
       <div className="nn-controls">
-        <button className="nn-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+        <button
+          className="nn-btn"
+          onClick={stepBack}
+          disabled={running || historyRef.current.length === 0}
+        >
           ⏴ Back
         </button>
         <button className="nn-btn" onClick={step_fn} disabled={running || done}>
           ⏵ Step
         </button>
-        <button className="nn-btn" onClick={() => setRunning(!running)} disabled={done}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="nn-btn"
+          onClick={() => setRunning(!running)}
+          disabled={done}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
-        <button className="nn-btn" onClick={() => reinit(tour[0])}>↺ Reset</button>
+        <button className="nn-btn" onClick={() => reinit(tour[0])}>
+          ↺ Reset
+        </button>
       </div>
 
       <div className="nn-scenarios">
         <div className="nn-section-label">Scenarios</div>
         <div className="nn-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
-            <button key={key} className="nn-scenario-btn" title={s.desc}
-              onClick={() => reinit(s.startCity)}>
+            <button
+              key={key}
+              className="nn-scenario-btn"
+              title={s.desc}
+              onClick={() => reinit(s.startCity)}
+            >
               {s.label}
             </button>
           ))}
@@ -319,7 +399,11 @@ export default function NNExplainer() {
 
       <footer className="nn-footer">
         <span className="nn-mono">cities: {N_CITIES}</span>
-        <span className="nn-mono">{done ? `total: ${currentDist.toFixed(0)}` : `partial: ${currentDist.toFixed(0)}`}</span>
+        <span className="nn-mono">
+          {done
+            ? `total: ${currentDist.toFixed(0)}`
+            : `partial: ${currentDist.toFixed(0)}`}
+        </span>
         <span className="nn-mono">greedy nearest neighbor</span>
       </footer>
     </div>

--- a/teeline-web/src/explainers/or-opt-algo.ts
+++ b/teeline-web/src/explainers/or-opt-algo.ts
@@ -20,17 +20,17 @@ export type Phase = 'idle' | 'candidate' | 'move_applied' | 'local_optimum'
 // The candidate move (Rust find_best_move + apply_relocation port)
 // ---------------------------------------------------------------
 export interface MoveEvent {
-  i: number             // segment start index (original tour indexing)
+  i: number // segment start index (original tour indexing)
   segLen: 1 | 2 | 3
-  j: number             // insert after original position j
-  reversed: boolean     // reversed insertion (Or-2 / Or-3 only)
-  delta: number         // new tour length − old tour length (negative = improvement)
-  segCities: number[]   // cities in the segment, in tour order
-  insertAfter: number   // city the segment lands after (path[j])
-  insertBefore: number  // city the segment lands before (path[(j+1) % n])
-  cutEdges: [number, number][]   // edges removed: prev→first, last→after, x→y
+  j: number // insert after original position j
+  reversed: boolean // reversed insertion (Or-2 / Or-3 only)
+  delta: number // new tour length − old tour length (negative = improvement)
+  segCities: number[] // cities in the segment, in tour order
+  insertAfter: number // city the segment lands after (path[j])
+  insertBefore: number // city the segment lands before (path[(j+1) % n])
+  cutEdges: [number, number][] // edges removed: prev→first, last→after, x→y
   pasteEdges: [number, number][] // edges added: prev→after, x→first, last→y (or reversed)
-  improvingGaps: number[]        // original positions j with any improving move (scan ticks)
+  improvingGaps: number[] // original positions j with any improving move (scan ticks)
 }
 
 export interface SimState {
@@ -38,8 +38,8 @@ export interface SimState {
   tour: number[]
   bestTour: number[]
   bestCost: number
-  pass: number          // completed scans (one per applied move + final local-optimum scan)
-  moves: number         // applied relocations
+  pass: number // completed scans (one per applied move + final local-optimum scan)
+  moves: number // applied relocations
   pending: MoveEvent | null // candidate awaiting its apply phase
   lastMove: MoveEvent | null // most recently applied move (for the flash)
   costHistory: number[] // best cost after each pass (sparkline)
@@ -81,7 +81,8 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
         const y = tour[(j + 1) % n]
         const edgeXY = dist(x, y)
 
-        const fwdDelta = -removeGain + dist(x, firstSeg) + dist(lastSeg, y) - edgeXY
+        const fwdDelta =
+          -removeGain + dist(x, firstSeg) + dist(lastSeg, y) - edgeXY
         if (fwdDelta < bestDelta) {
           bestDelta = fwdDelta
           best = { i, segLen, j, reversed: false, delta: fwdDelta }
@@ -89,7 +90,8 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
         if (fwdDelta < -1e-3) improvingGaps.add(j)
 
         if (segLen > 1) {
-          const revDelta = -removeGain + dist(x, lastSeg) + dist(firstSeg, y) - edgeXY
+          const revDelta =
+            -removeGain + dist(x, lastSeg) + dist(firstSeg, y) - edgeXY
           if (revDelta < bestDelta) {
             bestDelta = revDelta
             best = { i, segLen, j, reversed: true, delta: revDelta }
@@ -126,7 +128,11 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
       ]
 
   return {
-    i, segLen, j, reversed, delta,
+    i,
+    segLen,
+    j,
+    reversed,
+    delta,
     segCities,
     insertAfter: x,
     insertBefore: y,

--- a/teeline-web/src/explainers/or-opt.test.ts
+++ b/teeline-web/src/explainers/or-opt.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, SCENARIOS,
-  dist, tourLength, scanBestMove, applyRelocation, makeInitState, stepOnce,
+  N_CITIES,
+  SCENARIOS,
+  dist,
+  tourLength,
+  scanBestMove,
+  applyRelocation,
+  makeInitState,
+  stepOnce,
 } from './or-opt-algo'
 import type { SimState } from './or-opt-algo'
 import { scanOnePass, makeInitState as twoOptInit } from './two-opt-algo'
@@ -40,23 +46,33 @@ describe('dist / tourLength', () => {
 // ---------------------------------------------------------------
 describe('applyRelocation (ported from Rust)', () => {
   it('or-1 forward: move city at index 1 to after index 3', () => {
-    expect(applyRelocation([0, 1, 2, 3, 4], 1, 1, 3, false)).toEqual([0, 2, 3, 1, 4])
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 1, 3, false)).toEqual([
+      0, 2, 3, 1, 4,
+    ])
   })
 
   it('or-1 backward: move city at index 3 to after index 0', () => {
-    expect(applyRelocation([0, 1, 2, 3, 4], 3, 1, 0, false)).toEqual([0, 3, 1, 2, 4])
+    expect(applyRelocation([0, 1, 2, 3, 4], 3, 1, 0, false)).toEqual([
+      0, 3, 1, 2, 4,
+    ])
   })
 
   it('or-2 forward: move pair [1,2] to after index 3', () => {
-    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, false)).toEqual([0, 3, 1, 2, 4])
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, false)).toEqual([
+      0, 3, 1, 2, 4,
+    ])
   })
 
   it('or-2 reversed: move pair [1,2] as [2,1] to after index 3', () => {
-    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, true)).toEqual([0, 3, 2, 1, 4])
+    expect(applyRelocation([0, 1, 2, 3, 4], 1, 2, 3, true)).toEqual([
+      0, 3, 2, 1, 4,
+    ])
   })
 
   it('or-3 forward: move triple [1,2,3] to after index 4', () => {
-    expect(applyRelocation([0, 1, 2, 3, 4, 5], 1, 3, 4, false)).toEqual([0, 4, 1, 2, 3, 5])
+    expect(applyRelocation([0, 1, 2, 3, 4, 5], 1, 3, 4, false)).toEqual([
+      0, 4, 1, 2, 3, 5,
+    ])
   })
 
   it('never mutates the input', () => {
@@ -91,7 +107,13 @@ describe('scanBestMove', () => {
     expect(move.segCities).toEqual([8])
     expect(move.reversed).toBe(false)
     // applying it reaches the optimum
-    const after = applyRelocation(SCENARIOS.single_segment.tour, move.i, move.segLen, move.j, move.reversed)
+    const after = applyRelocation(
+      SCENARIOS.single_segment.tour,
+      move.i,
+      move.segLen,
+      move.j,
+      move.reversed,
+    )
     expect(tourLength(after)).toBeCloseTo(OPT, 3)
   })
 
@@ -100,7 +122,13 @@ describe('scanBestMove', () => {
     expect(move.segLen).toBe(3)
     expect(move.segCities).toEqual([8, 5, 4])
     expect(move.reversed).toBe(true)
-    const after = applyRelocation(SCENARIOS.triplet_move.tour, move.i, move.segLen, move.j, move.reversed)
+    const after = applyRelocation(
+      SCENARIOS.triplet_move.tour,
+      move.i,
+      move.segLen,
+      move.j,
+      move.reversed,
+    )
     expect(tourLength(after)).toBeCloseTo(OPT, 3)
   })
 
@@ -113,7 +141,9 @@ describe('scanBestMove', () => {
     expect(move.insertBefore).toBe(tour[(move.j + 1) % N_CITIES])
     // improvingGaps lists positions with some improving move
     expect(move.improvingGaps.length).toBeGreaterThan(0)
-    expect(move.improvingGaps).toEqual([...new Set(move.improvingGaps)].sort((a, b) => a - b))
+    expect(move.improvingGaps).toEqual(
+      [...new Set(move.improvingGaps)].sort((a, b) => a - b),
+    )
   })
 
   it('delta matches the measured cost change (Rust debug assertion)', () => {
@@ -121,7 +151,9 @@ describe('scanBestMove', () => {
       if (key === 'already_optimal') continue
       const move = scanBestMove(s.tour)!
       const before = tourLength(s.tour)
-      const after = tourLength(applyRelocation(s.tour, move.i, move.segLen, move.j, move.reversed))
+      const after = tourLength(
+        applyRelocation(s.tour, move.i, move.segLen, move.j, move.reversed),
+      )
       expect(after - before, `${key} delta mismatch`).toBeCloseTo(move.delta, 3)
     }
   })
@@ -159,7 +191,15 @@ describe('stepOnce phase machine', () => {
     expect(s2.phase).toBe('move_applied')
     expect(s2.pass).toBe(1)
     expect(s2.moves).toBe(1)
-    expect(s2.tour).toEqual(applyRelocation(s0.tour, s1.pending!.i, s1.pending!.segLen, s1.pending!.j, s1.pending!.reversed))
+    expect(s2.tour).toEqual(
+      applyRelocation(
+        s0.tour,
+        s1.pending!.i,
+        s1.pending!.segLen,
+        s1.pending!.j,
+        s1.pending!.reversed,
+      ),
+    )
     expect(s2.costHistory).toHaveLength(2)
     expect(s2.step).toBe(2)
   })

--- a/teeline-web/src/explainers/or-opt.tsx
+++ b/teeline-web/src/explainers/or-opt.tsx
@@ -1,19 +1,28 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, SCENARIOS,
-  tourLength, makeInitState, stepOnce,
-} from "./or-opt-algo"
-import type { Phase, MoveEvent, Scenario } from "./or-opt-algo"
+  CITIES,
+  N_CITIES,
+  SCENARIOS,
+  tourLength,
+  makeInitState,
+  stepOnce,
+} from './or-opt-algo'
+import type { Phase, MoveEvent, Scenario } from './or-opt-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.single_segment
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 function edgeKey(a: number, b: number): string {
   return `${Math.min(a, b)}-${Math.max(a, b)}`
 }
 
-function midTick(x1: number, y1: number, x2: number, y2: number): [number, number, number, number] {
+function midTick(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): [number, number, number, number] {
   const dx = x2 - x1
   const dy = y2 - y1
   const len = Math.hypot(dx, dy) || 1
@@ -29,7 +38,13 @@ function midTick(x1: number, y1: number, x2: number, y2: number): [number, numbe
 // faint scan ticks at improving insertion gaps, and a CSS morph
 // that makes the tour flow to its new shape when a move applies.
 // ---------------------------------------------------------------
-function TourCanvas({ tour, pending, lastMove, phase, morph }: {
+function TourCanvas({
+  tour,
+  pending,
+  lastMove,
+  phase,
+  morph,
+}: {
   tour: number[]
   pending: MoveEvent | null
   lastMove: MoveEvent | null
@@ -68,50 +83,88 @@ function TourCanvas({ tour, pending, lastMove, phase, morph }: {
     edges.push({ from: a, to: b, key: edgeKey(a, b) })
   }
 
-  const ticks: Array<{ key: string; x1: number; y1: number; x2: number; y2: number }> = []
+  const ticks: Array<{
+    key: string
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+  }> = []
   if (showCandidate && pending) {
     for (const j of pending.improvingGaps) {
       if (j === pending.j) continue // the best gap gets the strong paste highlight
       const a = tour[j]
       const b = tour[(j + 1) % tour.length]
-      const [x1, y1, x2, y2] = midTick(CITIES[a][0], CITIES[a][1], CITIES[b][0], CITIES[b][1])
+      const [x1, y1, x2, y2] = midTick(
+        CITIES[a][0],
+        CITIES[a][1],
+        CITIES[b][0],
+        CITIES[b][1],
+      )
       ticks.push({ key: `t${j}`, x1, y1, x2, y2 })
     }
   }
 
   return (
-    <svg viewBox="0 0 300 300"
+    <svg
+      viewBox="0 0 300 300"
       className={`or-canvas ${morph && showApplied ? 'or-morph' : ''}`}
-      role="img" aria-label="Or-opt tour">
+      role="img"
+      aria-label="Or-opt tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="or-bg" />
 
       {/* Faint ticks at every improving insertion gap (the scan) */}
       {ticks.map((t) => (
-        <line key={t.key} className="or-scan-tick" x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
+        <line
+          key={t.key}
+          className="or-scan-tick"
+          x1={t.x1}
+          y1={t.y1}
+          x2={t.x2}
+          y2={t.y2}
+        />
       ))}
 
       {/* Best insertion gap marker */}
       {showCandidate && pending && (
-        <line className="or-gap-marker"
-          x1={CITIES[pending.insertAfter][0]} y1={CITIES[pending.insertAfter][1]}
-          x2={CITIES[pending.insertBefore][0]} y2={CITIES[pending.insertBefore][1]} />
+        <line
+          className="or-gap-marker"
+          x1={CITIES[pending.insertAfter][0]}
+          y1={CITIES[pending.insertAfter][1]}
+          x2={CITIES[pending.insertBefore][0]}
+          y2={CITIES[pending.insertBefore][1]}
+        />
       )}
 
       <g className="or-tour">
         {edges.map(({ from, to, key }) => {
           let cls = 'or-edge'
           if (cutSet.has(key)) cls += showCandidate ? ' or-cand-cut' : ' or-cut'
-          else if (pasteSet.has(key)) cls += showCandidate ? ' or-cand-paste' : ' or-paste'
-          return <line key={key} className={cls}
-            x1={CITIES[from][0]} y1={CITIES[from][1]}
-            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+          else if (pasteSet.has(key))
+            cls += showCandidate ? ' or-cand-paste' : ' or-paste'
+          return (
+            <line
+              key={key}
+              className={cls}
+              x1={CITIES[from][0]}
+              y1={CITIES[from][1]}
+              x2={CITIES[to][0]}
+              y2={CITIES[to][1]}
+            />
+          )
         })}
         {tour.map((id) => (
           <g key={id}>
-            <circle className={`or-city ${segSet.has(id) ? 'or-city-seg' : ''}`}
-              cx={CITIES[id][0]} cy={CITIES[id][1]} r={segSet.has(id) ? 8 : 6} />
-            <text className="or-label"
-              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+            <circle
+              className={`or-city ${segSet.has(id) ? 'or-city-seg' : ''}`}
+              cx={CITIES[id][0]}
+              cy={CITIES[id][1]}
+              r={segSet.has(id) ? 8 : 6}
+            />
+            <text className="or-label" x={CITIES[id][0]} y={CITIES[id][1] + 16}>
+              {id}
+            </text>
           </g>
         ))}
       </g>
@@ -124,7 +177,8 @@ function TourCanvas({ tour, pending, lastMove, phase, morph }: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 46
+  const W = 300,
+    H = 46
   const minV = Math.min(...values)
   const maxV = Math.max(...values)
   const range = maxV - minV || 1
@@ -134,10 +188,19 @@ function Sparkline({ values }: { values: number[] }) {
     return `${x.toFixed(1)},${y.toFixed(1)}`
   })
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="or-spark" aria-label="cost over passes">
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="or-spark"
+      aria-label="cost over passes"
+    >
       <rect x={0} y={0} width={W} height={H} className="or-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
-        strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -150,10 +213,14 @@ export default function OrOptExplainer() {
   const [phase, setPhase] = useState<Phase>('idle')
   const [pass, setPass] = useState(0)
   const [moves, setMoves] = useState(0)
-  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.tour))
+  const [bestCost, setBestCost] = useState(() =>
+    tourLength(DEFAULT_SCENARIO.tour),
+  )
   const [pending, setPending] = useState<MoveEvent | null>(null)
   const [lastMove, setLastMove] = useState<MoveEvent | null>(null)
-  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.tour)])
+  const [costHistory, setCostHistory] = useState<number[]>(() => [
+    tourLength(DEFAULT_SCENARIO.tour),
+  ])
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(2) // 3x default
@@ -227,19 +294,19 @@ export default function OrOptExplainer() {
   const distance = tourLength(tour)
 
   // Status chip
-  let chipText = "Click Step to scan for the best Or-1/2/3 relocation"
-  let chipClass = "or-chip or-chip-idle"
+  let chipText = 'Click Step to scan for the best Or-1/2/3 relocation'
+  let chipClass = 'or-chip or-chip-idle'
   if (phase === 'candidate' && pending) {
     const rev = pending.reversed ? ' ↺ reversed' : ''
     chipText = `Candidate — move ${pending.segCities.join('→')} (k=${pending.segLen}) after ${pending.insertAfter}${rev}  (Δ=${pending.delta.toFixed(0)})`
-    chipClass = "or-chip or-chip-candidate"
+    chipClass = 'or-chip or-chip-candidate'
   } else if (phase === 'move_applied' && lastMove) {
     const rev = lastMove.reversed ? ' ↺ reversed' : ''
     chipText = `Moved — ${lastMove.segCities.join('→')} relocated after ${lastMove.insertAfter}${rev}  (Δ=${lastMove.delta.toFixed(0)})`
-    chipClass = "or-chip or-chip-applied"
+    chipClass = 'or-chip or-chip-applied'
   } else if (phase === 'local_optimum') {
     chipText = `Local optimum — no improving Or-1/2/3 relocation exists (${moves} moves, ${pass} passes)`
-    chipClass = "or-chip or-chip-done"
+    chipClass = 'or-chip or-chip-done'
   }
 
   return (
@@ -250,27 +317,47 @@ export default function OrOptExplainer() {
         <div className="or-eyebrow">teeline · algorithms/or_opt</div>
         <h2 className="or-title">Or-opt Local Search</h2>
         <p className="or-sub">
-          Or-opt relocates <strong>segments of 1–3 consecutive cities</strong> to a better position
-          elsewhere in the tour — a <em>cut-and-paste</em> move, unlike 2-opt's edge reversal.
-          Each pass scans every segment size (Or-1, Or-2, Or-3) and every insertion point, applying
-          the single <strong>best-improving</strong> relocation (reversed insertions are also tried
-          for Or-2/Or-3). Repeats until no relocation improves the tour.
+          Or-opt relocates <strong>segments of 1–3 consecutive cities</strong>{' '}
+          to a better position elsewhere in the tour — a <em>cut-and-paste</em>{' '}
+          move, unlike 2-opt's edge reversal. Each pass scans every segment size
+          (Or-1, Or-2, Or-3) and every insertion point, applying the single{' '}
+          <strong>best-improving</strong> relocation (reversed insertions are
+          also tried for Or-2/Or-3). Repeats until no relocation improves the
+          tour.
         </p>
       </header>
 
       <div className="or-viz-row">
         <div className="or-canvas-wrap">
-          <TourCanvas tour={tour} pending={pending} lastMove={lastMove} phase={phase} morph={morphOn} />
+          <TourCanvas
+            tour={tour}
+            pending={pending}
+            lastMove={lastMove}
+            phase={phase}
+            morph={morphOn}
+          />
         </div>
       </div>
 
       <div className="or-legend">
-        <span><span className="or-swatch or-swatch-normal" /> tour edge</span>
-        <span><span className="or-swatch or-swatch-seg" /> segment (relocating)</span>
-        <span><span className="or-swatch or-swatch-cut" /> cut edge</span>
-        <span><span className="or-swatch or-swatch-paste" /> paste edge</span>
-        <span><span className="or-swatch or-swatch-gap" /> insertion gap</span>
-        <span><span className="or-swatch or-swatch-tick" /> improving gap (scan)</span>
+        <span>
+          <span className="or-swatch or-swatch-normal" /> tour edge
+        </span>
+        <span>
+          <span className="or-swatch or-swatch-seg" /> segment (relocating)
+        </span>
+        <span>
+          <span className="or-swatch or-swatch-cut" /> cut edge
+        </span>
+        <span>
+          <span className="or-swatch or-swatch-paste" /> paste edge
+        </span>
+        <span>
+          <span className="or-swatch or-swatch-gap" /> insertion gap
+        </span>
+        <span>
+          <span className="or-swatch or-swatch-tick" /> improving gap (scan)
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -297,7 +384,12 @@ export default function OrOptExplainer() {
         </div>
         <div>
           <div className="or-statlabel">last Δ</div>
-          <div className="or-mono" style={{ color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit' }}>
+          <div
+            className="or-mono"
+            style={{
+              color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit',
+            }}
+          >
             {lastMove ? lastMove.delta.toFixed(0) : '—'}
           </div>
         </div>
@@ -312,9 +404,12 @@ export default function OrOptExplainer() {
           <label className="or-label">Speed</label>
           <div className="or-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l}
+              <button
+                key={l}
                 className={`or-speed-btn ${i === speedIdx ? 'or-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
                 {l}
               </button>
             ))}
@@ -323,24 +418,47 @@ export default function OrOptExplainer() {
       </div>
 
       <div className="or-controls">
-        <button className="or-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+        <button
+          className="or-btn"
+          onClick={stepBack}
+          disabled={running || historyRef.current.length === 0}
+        >
           ⏴ Back
         </button>
-        <button className="or-btn" onClick={stepForward} disabled={running || phase === 'local_optimum'}>
+        <button
+          className="or-btn"
+          onClick={stepForward}
+          disabled={running || phase === 'local_optimum'}
+        >
           ⏵ Step
         </button>
-        <button className="or-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="or-btn"
+          onClick={() => setRunning(!running)}
+          disabled={phase === 'local_optimum'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
-        <button className="or-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="or-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="or-scenarios">
         <div className="or-section-label">Scenarios</div>
         <div className="or-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
-            <button key={key} className="or-scenario-btn" title={s.desc}
-              onClick={() => reinit(s)} disabled={running}>
+            <button
+              key={key}
+              className="or-scenario-btn"
+              title={s.desc}
+              onClick={() => reinit(s)}
+              disabled={running}
+            >
               {s.label}
             </button>
           ))}
@@ -349,7 +467,9 @@ export default function OrOptExplainer() {
 
       <footer className="or-footer">
         <span className="or-mono">cities: {N_CITIES}</span>
-        <span className="or-mono">Or-1/2/3 relocation · best-improvement · runs to local optimum</span>
+        <span className="or-mono">
+          Or-1/2/3 relocation · best-improvement · runs to local optimum
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/pso-algo.ts
+++ b/teeline-web/src/explainers/pso-algo.ts
@@ -1,5 +1,9 @@
 // Fixed 12-city demo (same layout as SA / CS / FPA / GA explainers)
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, tourLength12 as tourLength } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  tourLength12 as tourLength,
+} from './explainer-cities'
 export { CITIES, N_CITIES, tourLength }
 
 // PSO constants (mirrors particle_swarm.rs)
@@ -25,10 +29,10 @@ export type Particle = {
 }
 
 export type VelocityBreakdown = {
-  inertia: number    // total inertia swaps kept across all particles this epoch
-  cognitive: number  // total cognitive swaps added (toward pbest)
-  social: number     // total social swaps added (toward gbest)
-  applied: number    // total swaps applied after v_max cap
+  inertia: number // total inertia swaps kept across all particles this epoch
+  cognitive: number // total cognitive swaps added (toward pbest)
+  social: number // total social swaps added (toward gbest)
+  applied: number // total swaps applied after v_max cap
 }
 
 export type SimState = {
@@ -86,9 +90,18 @@ export function makeInitState(nParticles: number): SimState {
   const particles: Particle[] = Array.from({ length: nParticles }, () => {
     const position = shuffle(N_CITIES)
     const cost = tourLength(position)
-    return { position, velocity: [], pbest: position.slice(), pbest_cost: cost, cost }
+    return {
+      position,
+      velocity: [],
+      pbest: position.slice(),
+      pbest_cost: cost,
+      cost,
+    }
   })
-  const gbestIdx = particles.reduce((b, p, i) => p.cost < particles[b].cost ? i : b, 0)
+  const gbestIdx = particles.reduce(
+    (b, p, i) => (p.cost < particles[b].cost ? i : b),
+    0,
+  )
   return {
     particles,
     gbest: particles[gbestIdx].position.slice(),
@@ -110,9 +123,12 @@ export function stepEpoch(s: SimState): SimState {
   let gbest_cost = s.gbest_cost
   let newGbest = false
 
-  let totalInertia = 0, totalCognitive = 0, totalSocial = 0, totalApplied = 0
+  let totalInertia = 0,
+    totalCognitive = 0,
+    totalSocial = 0,
+    totalApplied = 0
 
-  const particles: Particle[] = s.particles.map(p => {
+  const particles: Particle[] = s.particles.map((p) => {
     const r1 = Math.random()
     const r2 = Math.random()
 
@@ -153,8 +169,17 @@ export function stepEpoch(s: SimState): SimState {
   })
 
   return {
-    particles, gbest, gbest_cost, epoch, w,
-    lastBreakdown: { inertia: totalInertia, cognitive: totalCognitive, social: totalSocial, applied: totalApplied },
+    particles,
+    gbest,
+    gbest_cost,
+    epoch,
+    w,
+    lastBreakdown: {
+      inertia: totalInertia,
+      cognitive: totalCognitive,
+      social: totalSocial,
+      applied: totalApplied,
+    },
     newGbest,
   }
 }

--- a/teeline-web/src/explainers/pso.test.ts
+++ b/teeline-web/src/explainers/pso.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, tourLength, swapSequence, applySwaps,
-  makeInitState, stepEpoch,
+  N_CITIES,
+  tourLength,
+  swapSequence,
+  applySwaps,
+  makeInitState,
+  stepEpoch,
 } from './pso-algo'
 
 describe('tourLength', () => {
@@ -37,7 +41,16 @@ describe('swapSequence', () => {
 
 describe('applySwaps', () => {
   it('returns original tour when n=0', () => {
-    expect(applySwaps([0, 1, 2, 3], [[0, 1], [1, 2]], 0)).toEqual([0, 1, 2, 3])
+    expect(
+      applySwaps(
+        [0, 1, 2, 3],
+        [
+          [0, 1],
+          [1, 2],
+        ],
+        0,
+      ),
+    ).toEqual([0, 1, 2, 3])
   })
 
   it('does not mutate the input tour', () => {
@@ -62,7 +75,9 @@ describe('makeInitState', () => {
   })
 
   it('each particle position is a valid permutation of 0..N_CITIES-1', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     for (const p of makeInitState(4).particles) {
       expect(p.position.slice().sort((a, b) => a - b)).toEqual(expected)
     }
@@ -77,7 +92,7 @@ describe('makeInitState', () => {
 
   it('gbest_cost equals minimum particle cost', () => {
     const s = makeInitState(6)
-    const min = Math.min(...s.particles.map(p => p.cost))
+    const min = Math.min(...s.particles.map((p) => p.cost))
     expect(s.gbest_cost).toBeCloseTo(min, 1)
   })
 
@@ -103,7 +118,9 @@ describe('stepEpoch', () => {
   })
 
   it('each particle position remains a valid permutation', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     let s = makeInitState(4)
     s = stepEpoch(s)
     for (const p of s.particles) {

--- a/teeline-web/src/explainers/pso.tsx
+++ b/teeline-web/src/explainers/pso.tsx
@@ -1,9 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
-import type { Particle, VelocityBreakdown, SimState } from "./pso-algo"
-import {
-  CITIES, N_CITIES,
-  makeInitState, stepEpoch,
-} from "./pso-algo"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
+import type { Particle, VelocityBreakdown, SimState } from './pso-algo'
+import { CITIES, N_CITIES, makeInitState, stepEpoch } from './pso-algo'
 
 // PSO display constants — for UI labels and gauge only
 const W_MAX = 0.9
@@ -15,7 +12,7 @@ const V_MAX = Math.max(1, Math.ceil(N_CITIES * 0.35))
 // SVG helpers
 // ---------------------------------------------------------------
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
   return pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
 }
 
@@ -28,7 +25,7 @@ interface SwarmHeatmapProps {
 }
 function SwarmHeatmap({ particles, gbest_cost }: SwarmHeatmapProps) {
   if (!particles.length) return null
-  const costs = particles.map(p => p.cost)
+  const costs = particles.map((p) => p.cost)
   const minC = Math.min(...costs)
   const maxC = Math.max(...costs)
   const range = maxC - minC || 1
@@ -40,16 +37,18 @@ function SwarmHeatmap({ particles, gbest_cost }: SwarmHeatmapProps) {
         const hue = Math.round(norm * 120)
         const bg = `hsl(${hue},55%,42%)`
         const isGbest = Math.abs(p.cost - gbest_cost) < 0.01
-        const outline = isGbest ? "2px solid #16a34a" : "2px solid transparent"
+        const outline = isGbest ? '2px solid #16a34a' : '2px solid transparent'
         return (
           <div
             key={i}
             className="pso-heatmap-cell"
-            style={{ background: bg, outline, outlineOffset: "1px" }}
+            style={{ background: bg, outline, outlineOffset: '1px' }}
           >
             <span className="pso-heatmap-idx">{i}</span>
             <span className="pso-heatmap-cost">{p.cost.toFixed(0)}</span>
-            <div className="pso-heatmap-overlay">{isGbest ? "gbest" : `dist ${p.cost.toFixed(0)}`}</div>
+            <div className="pso-heatmap-overlay">
+              {isGbest ? 'gbest' : `dist ${p.cost.toFixed(0)}`}
+            </div>
           </div>
         )
       })}
@@ -67,23 +66,43 @@ interface TourSVGProps {
 }
 function TourSVG({ particles, gbest, newGbest }: TourSVGProps) {
   if (!particles.length) return null
-  const bestIdx = particles.reduce((b, p, i) => p.cost < particles[b].cost ? i : b, 0)
+  const bestIdx = particles.reduce(
+    (b, p, i) => (p.cost < particles[b].cost ? i : b),
+    0,
+  )
   return (
-    <svg viewBox="0 0 300 300" className="pso-canvas" role="img" aria-label="PSO tour canvas">
+    <svg
+      viewBox="0 0 300 300"
+      className="pso-canvas"
+      role="img"
+      aria-label="PSO tour canvas"
+    >
       <rect x={0} y={0} width={300} height={300} className="pso-bg" />
-      {particles.map((p, i) => i !== bestIdx && (
-        <polyline key={i} className="pso-ghost" points={polyPts(p.position)} />
-      ))}
-      <polyline className="pso-active" points={polyPts(particles[bestIdx].position)} />
+      {particles.map(
+        (p, i) =>
+          i !== bestIdx && (
+            <polyline
+              key={i}
+              className="pso-ghost"
+              points={polyPts(p.position)}
+            />
+          ),
+      )}
       <polyline
-        className={`pso-gbest${newGbest ? " pso-gbest-pulse" : ""}`}
+        className="pso-active"
+        points={polyPts(particles[bestIdx].position)}
+      />
+      <polyline
+        className={`pso-gbest${newGbest ? ' pso-gbest-pulse' : ''}`}
         points={polyPts(gbest)}
       />
       {CITIES.map(([x, y], i) => (
         <circle key={i} cx={x} cy={y} r={4} className="pso-city" />
       ))}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="pso-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="pso-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -92,14 +111,25 @@ function TourSVG({ particles, gbest, newGbest }: TourSVGProps) {
 // ---------------------------------------------------------------
 // VelocityChip — epoch-level aggregate breakdown of ω / C₁ / C₂ swaps
 // ---------------------------------------------------------------
-function VelocityChip({ breakdown, newGbest }: { breakdown: VelocityBreakdown | null; newGbest: boolean }) {
+function VelocityChip({
+  breakdown,
+  newGbest,
+}: {
+  breakdown: VelocityBreakdown | null
+  newGbest: boolean
+}) {
   if (!breakdown) {
-    return <div className="pso-chip pso-chip-idle">Press Step or Run to begin</div>
+    return (
+      <div className="pso-chip pso-chip-idle">Press Step or Run to begin</div>
+    )
   }
   return (
-    <div className={`pso-chip ${newGbest ? "pso-chip-gbest" : "pso-chip-normal"}`}>
-      {newGbest ? "⭐ new gbest!  " : ""}
-      ω: {breakdown.inertia} · C₁: {breakdown.cognitive} · C₂: {breakdown.social} → {breakdown.applied} swaps applied
+    <div
+      className={`pso-chip ${newGbest ? 'pso-chip-gbest' : 'pso-chip-normal'}`}
+    >
+      {newGbest ? '⭐ new gbest!  ' : ''}
+      ω: {breakdown.inertia} · C₁: {breakdown.cognitive} · C₂:{' '}
+      {breakdown.social} → {breakdown.applied} swaps applied
     </div>
   )
 }
@@ -110,16 +140,21 @@ function VelocityChip({ breakdown, newGbest }: { breakdown: VelocityBreakdown | 
 function InertiaGauge({ w }: { w: number }) {
   const pct = ((w - W_MIN) / (W_MAX - W_MIN)) * 100
   const hint =
-    w > 0.7 ? "High — broad exploration" :
-    w < 0.5 ? "Low — local exploitation" :
-    "Mid — balanced"
+    w > 0.7
+      ? 'High — broad exploration'
+      : w < 0.5
+        ? 'Low — local exploitation'
+        : 'Mid — balanced'
   return (
     <div className="pso-gauge">
       <div className="pso-gauge-label">
         ω (inertia) = <strong>{w.toFixed(3)}</strong>
       </div>
       <div className="pso-gauge-track">
-        <div className="pso-gauge-fill" style={{ width: `${Math.max(0, pct).toFixed(1)}%` }} />
+        <div
+          className="pso-gauge-fill"
+          style={{ width: `${Math.max(0, pct).toFixed(1)}%` }}
+        />
       </div>
       <div className="pso-gauge-hint">{hint}</div>
     </div>
@@ -135,7 +170,9 @@ export default function PSOExplainer() {
 
   const simRef = useRef<SimState>(makeInitState(6))
 
-  const [particles, setParticles] = useState<Particle[]>(() => simRef.current.particles)
+  const [particles, setParticles] = useState<Particle[]>(
+    () => simRef.current.particles,
+  )
   const [gbest, setGbest] = useState<number[]>(() => simRef.current.gbest)
   const [gbest_cost, setGbestCost] = useState(() => simRef.current.gbest_cost)
   const [epoch, setEpoch] = useState(0)
@@ -178,7 +215,7 @@ export default function PSOExplainer() {
 
   const avgDist = particles.length
     ? (particles.reduce((s, p) => s + p.cost, 0) / particles.length).toFixed(0)
-    : "—"
+    : '—'
 
   return (
     <div className="pso-root">
@@ -188,12 +225,13 @@ export default function PSOExplainer() {
         <div className="pso-eyebrow">teeline · algorithms/pso</div>
         <h2 className="pso-title">Particle Swarm Optimisation</h2>
         <p className="pso-sub">
-          A swarm of tour-particles updates each epoch. Each particle's{" "}
-          <strong>velocity</strong> is a list of city-swap moves built from three
-          components: <code>ω</code> keeps momentum from the previous epoch,{" "}
-          <code>C₁</code> pulls toward the particle's own personal best, and{" "}
-          <code>C₂</code> pulls toward the global best. Inertia <code>ω</code>{" "}
-          decays over time, shifting the swarm from exploration toward exploitation.
+          A swarm of tour-particles updates each epoch. Each particle's{' '}
+          <strong>velocity</strong> is a list of city-swap moves built from
+          three components: <code>ω</code> keeps momentum from the previous
+          epoch, <code>C₁</code> pulls toward the particle's own personal best,
+          and <code>C₂</code> pulls toward the global best. Inertia{' '}
+          <code>ω</code> decays over time, shifting the swarm from exploration
+          toward exploitation.
         </p>
       </header>
 
@@ -205,10 +243,18 @@ export default function PSOExplainer() {
       </div>
 
       <div className="pso-legend">
-        <span><span className="pso-dot pso-dot-gbest">●</span> gbest tour</span>
-        <span><span className="pso-dot pso-dot-active">●</span> best particle</span>
-        <span><span className="pso-dot pso-dot-ghost">●</span> swarm</span>
-        <span><span className="pso-dot pso-dot-city">●</span> city</span>
+        <span>
+          <span className="pso-dot pso-dot-gbest">●</span> gbest tour
+        </span>
+        <span>
+          <span className="pso-dot pso-dot-active">●</span> best particle
+        </span>
+        <span>
+          <span className="pso-dot pso-dot-ghost">●</span> swarm
+        </span>
+        <span>
+          <span className="pso-dot pso-dot-city">●</span> city
+        </span>
       </div>
 
       <VelocityChip breakdown={breakdown} newGbest={newGbest} />
@@ -240,7 +286,11 @@ export default function PSOExplainer() {
             Particles = <strong>{nParticles}</strong>
           </label>
           <input
-            type="range" min={3} max={12} step={1} value={nParticles}
+            type="range"
+            min={3}
+            max={12}
+            step={1}
+            value={nParticles}
             className="pso-slider"
             onInput={(e) => {
               const n = Number((e.target as HTMLInputElement).value)
@@ -250,38 +300,50 @@ export default function PSOExplainer() {
           />
           <div className="pso-hint">
             {nParticles <= 4
-              ? "Small swarm — fast but low diversity"
+              ? 'Small swarm — fast but low diversity'
               : nParticles >= 10
-                ? "Large swarm — high diversity, slower per epoch"
-                : "Balanced swarm size"}
+                ? 'Large swarm — high diversity, slower per epoch'
+                : 'Balanced swarm size'}
           </div>
         </div>
 
         <div className="pso-config-row">
           <label className="pso-config-label">Speed</label>
           <input
-            type="range" min={1} max={10} step={1} value={speed}
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="pso-slider"
-            onInput={(e) => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
 
       <div className="pso-controls">
-        <button className="pso-btn" onClick={stepOnce} disabled={running}>◀ Step</button>
-        <button
-          className={`pso-btn ${!running ? "pso-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}
-        >
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button className="pso-btn" onClick={stepOnce} disabled={running}>
+          ◀ Step
         </button>
-        <button className="pso-btn" onClick={() => reinit(nParticles)}>↺ Reset</button>
+        <button
+          className={`pso-btn ${!running ? 'pso-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button className="pso-btn" onClick={() => reinit(nParticles)}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="pso-footer">
         <span className="pso-mono">cities: {N_CITIES}</span>
         <span className="pso-mono">particles: {nParticles}</span>
-        <span className="pso-mono">ω: {W_MIN}→{W_MAX}</span>
+        <span className="pso-mono">
+          ω: {W_MIN}→{W_MAX}
+        </span>
         <span className="pso-mono">C₁=C₂={C1}</span>
         <span className="pso-mono">v_max: {V_MAX}</span>
       </footer>

--- a/teeline-web/src/explainers/registry.ts
+++ b/teeline-web/src/explainers/registry.ts
@@ -51,7 +51,8 @@ export const EXPLAINER_META: Record<string, ExplainerMeta> = {
   },
   lk: {
     title: 'Lin-Kernighan ILS — Interactive Explainer — Teeline',
-    description: 'Watch simplified 2-opt local search and double-bridge perturbation run step-by-step in your browser.',
+    description:
+      'Watch simplified 2-opt local search and double-bridge perturbation run step-by-step in your browser.',
     backLabel: 'LK',
   },
   sa: {

--- a/teeline-web/src/explainers/sa.tsx
+++ b/teeline-web/src/explainers/sa.tsx
@@ -1,12 +1,21 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
 
 // ---------------------------------------------------------------
 // Fixed 12-city demo (same layout as CS / FPA explainers)
 // ---------------------------------------------------------------
 const CITIES: [number, number][] = [
-  [45, 45], [155, 18], [265, 45], [285, 150],
-  [255, 265], [150, 285], [40, 260], [18, 150],
-  [110, 115], [200, 95], [220, 210], [95, 215],
+  [45, 45],
+  [155, 18],
+  [265, 45],
+  [285, 150],
+  [255, 265],
+  [150, 285],
+  [40, 260],
+  [18, 150],
+  [110, 115],
+  [200, 95],
+  [220, 210],
+  [95, 215],
 ]
 const N_CITIES = CITIES.length
 const T_MIN = 0.5
@@ -41,10 +50,12 @@ function twoOptSwap(tour: number[]): { tour: number[]; i: number; j: number } {
   if (j >= n) j = n - 1
   const next = tour.slice()
   // reverse segment [i..j]
-  let lo = i, hi = j
+  let lo = i,
+    hi = j
   while (lo < hi) {
     ;[next[lo], next[hi]] = [next[hi], next[lo]]
-    lo++; hi--
+    lo++
+    hi--
   }
   return { tour: next, i, j }
 }
@@ -73,12 +84,22 @@ function computeEdgeDiff(before: number[], after: number[]): EdgeDiff {
   const added: [number, number][] = []
   const changedCities = new Set<number>()
   for (let i = 0; i < before.length; i++) {
-    const a = before[i], b = before[(i + 1) % before.length]
-    if (!aSet.has(edgeKey(a, b))) { removed.push([a, b]); changedCities.add(a); changedCities.add(b) }
+    const a = before[i],
+      b = before[(i + 1) % before.length]
+    if (!aSet.has(edgeKey(a, b))) {
+      removed.push([a, b])
+      changedCities.add(a)
+      changedCities.add(b)
+    }
   }
   for (let i = 0; i < after.length; i++) {
-    const a = after[i], b = after[(i + 1) % after.length]
-    if (!bSet.has(edgeKey(a, b))) { added.push([a, b]); changedCities.add(a); changedCities.add(b) }
+    const a = after[i],
+      b = after[(i + 1) % after.length]
+    if (!bSet.has(edgeKey(a, b))) {
+      added.push([a, b])
+      changedCities.add(a)
+      changedCities.add(b)
+    }
   }
   return { removed, added, changedCities }
 }
@@ -86,7 +107,7 @@ function computeEdgeDiff(before: number[], after: number[]): EdgeDiff {
 // ---------------------------------------------------------------
 // Simulation state
 // ---------------------------------------------------------------
-type MoveMode = "improvement" | "accepted" | "rejected" | "converged"
+type MoveMode = 'improvement' | 'accepted' | 'rejected' | 'converged'
 
 type SimState = {
   tour: number[]
@@ -97,15 +118,21 @@ type SimState = {
   iter: number
   accepted: number
   rejected: number
-  recentOutcomes: boolean[]  // last 100 for acceptance rate
+  recentOutcomes: boolean[] // last 100 for acceptance rate
 }
 
 function makeInitState(initTemp: number): SimState {
   const tour = shuffle(N_CITIES)
   const cost = tourLength(tour)
   return {
-    tour, best: tour.slice(), bestCost: cost, currentCost: cost,
-    temperature: initTemp, iter: 0, accepted: 0, rejected: 0,
+    tour,
+    best: tour.slice(),
+    bestCost: cost,
+    currentCost: cost,
+    temperature: initTemp,
+    iter: 0,
+    accepted: 0,
+    rejected: 0,
     recentOutcomes: [],
   }
 }
@@ -114,8 +141,10 @@ function makeInitState(initTemp: number): SimState {
 // SVG helpers
 // ---------------------------------------------------------------
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
-  return tour.length > 0 ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}` : pts
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
+  return tour.length > 0
+    ? pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : pts
 }
 
 // ---------------------------------------------------------------
@@ -129,41 +158,63 @@ interface TourSVGProps {
 }
 function TourSVG({ tour, best, diff, converged }: TourSVGProps) {
   return (
-    <svg viewBox="0 0 300 300" className="sa-canvas" role="img" aria-label="SA tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="sa-canvas"
+      role="img"
+      aria-label="SA tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="sa-bg" />
       {/* best tour underlay */}
       <polyline
         points={polyPts(best)}
-        className={converged ? "sa-best-converged" : "sa-best"}
+        className={converged ? 'sa-best-converged' : 'sa-best'}
       />
       {/* removed edges from proposed swap */}
-      {diff && diff.removed.map(([a, b], i) => (
-        <line key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
-          className="sa-edge-removed"
-        />
-      ))}
+      {diff &&
+        diff.removed.map(([a, b], i) => (
+          <line
+            key={i}
+            x1={CITIES[a][0]}
+            y1={CITIES[a][1]}
+            x2={CITIES[b][0]}
+            y2={CITIES[b][1]}
+            className="sa-edge-removed"
+          />
+        ))}
       {/* current tour */}
       <polyline points={polyPts(tour)} className="sa-tour" />
       {/* added edges from proposed swap */}
-      {diff && diff.added.map(([a, b], i) => (
-        <line key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
-          className="sa-edge-added"
-        />
-      ))}
+      {diff &&
+        diff.added.map(([a, b], i) => (
+          <line
+            key={i}
+            x1={CITIES[a][0]}
+            y1={CITIES[a][1]}
+            x2={CITIES[b][0]}
+            y2={CITIES[b][1]}
+            className="sa-edge-added"
+          />
+        ))}
       {/* city dots */}
       {CITIES.map(([x, y], i) => (
-        <circle key={i} cx={x} cy={y}
+        <circle
+          key={i}
+          cx={x}
+          cy={y}
           r={diff && diff.changedCities.has(i) ? 7 : 4}
-          className={diff && diff.changedCities.has(i) ? "sa-city sa-city-changed" : "sa-city"}
+          className={
+            diff && diff.changedCities.has(i)
+              ? 'sa-city sa-city-changed'
+              : 'sa-city'
+          }
         />
       ))}
       {/* city labels */}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="sa-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="sa-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -178,7 +229,8 @@ interface TDecayCurveProps {
   alpha: number
 }
 function TDecayCurve({ tHistory, initTemp, alpha }: TDecayCurveProps) {
-  const W = 200, H = 54
+  const W = 200,
+    H = 54
   // expected total steps to reach T_MIN
   const totalSteps = Math.ceil(Math.log(T_MIN / initTemp) / Math.log(1 - alpha))
   const xMax = Math.max(totalSteps, tHistory.length, 1)
@@ -189,14 +241,14 @@ function TDecayCurve({ tHistory, initTemp, alpha }: TDecayCurveProps) {
     const t = (k / 60) * totalSteps
     const temp = initTemp * Math.pow(1 - alpha, t)
     const x = (t / xMax) * W
-    const y = H - 4 - ((Math.max(temp - T_MIN, 0)) / (initTemp - T_MIN)) * (H - 8)
+    const y = H - 4 - (Math.max(temp - T_MIN, 0) / (initTemp - T_MIN)) * (H - 8)
     arcPts.push(`${x.toFixed(1)},${y.toFixed(1)}`)
   }
 
   // actual T history polyline with colour segments (warm→cool gradient approximation)
   const histPts = tHistory.map((temp, idx) => {
     const x = (idx / xMax) * W
-    const y = H - 4 - ((Math.max(temp - T_MIN, 0)) / (initTemp - T_MIN)) * (H - 8)
+    const y = H - 4 - (Math.max(temp - T_MIN, 0) / (initTemp - T_MIN)) * (H - 8)
     return `${x.toFixed(1)},${y.toFixed(1)}`
   })
 
@@ -204,7 +256,8 @@ function TDecayCurve({ tHistory, initTemp, alpha }: TDecayCurveProps) {
   const curIdx = tHistory.length - 1
   const curTemp = curIdx >= 0 ? tHistory[curIdx] : initTemp
   const dotX = curIdx >= 0 ? (curIdx / xMax) * W : 0
-  const dotY = H - 4 - ((Math.max(curTemp - T_MIN, 0)) / (initTemp - T_MIN)) * (H - 8)
+  const dotY =
+    H - 4 - (Math.max(curTemp - T_MIN, 0) / (initTemp - T_MIN)) * (H - 8)
   // colour of dot: red when hot, blue when cool
   const norm = Math.max(curTemp - T_MIN, 0) / (initTemp - T_MIN)
   const r = Math.round(norm * 220)
@@ -214,15 +267,24 @@ function TDecayCurve({ tHistory, initTemp, alpha }: TDecayCurveProps) {
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="sa-tdecay">
       {/* theoretical arc */}
-      <polyline points={arcPts.join(" ")} fill="none" stroke="#d0d7de" strokeWidth={1} />
+      <polyline
+        points={arcPts.join(' ')}
+        fill="none"
+        stroke="#d0d7de"
+        strokeWidth={1}
+      />
       {/* actual history */}
       {histPts.length > 1 && (
-        <polyline points={histPts.join(" ")} fill="none" stroke="#d97706" strokeWidth={1.5} opacity={0.7} />
+        <polyline
+          points={histPts.join(' ')}
+          fill="none"
+          stroke="#d97706"
+          strokeWidth={1.5}
+          opacity={0.7}
+        />
       )}
       {/* current position dot */}
-      {curIdx >= 0 && (
-        <circle cx={dotX} cy={dotY} r={4} fill={dotColor} />
-      )}
+      {curIdx >= 0 && <circle cx={dotX} cy={dotY} r={4} fill={dotColor} />}
     </svg>
   )
 }
@@ -233,26 +295,31 @@ function TDecayCurve({ tHistory, initTemp, alpha }: TDecayCurveProps) {
 type SparkEntry = { prob: number; mode: MoveMode }
 
 function AcceptanceSparkline({ history }: { history: SparkEntry[] }) {
-  const W = 180, H = 54
+  const W = 180,
+    H = 54
   const visible = history.slice(-30)
-  if (!visible.length) return <svg viewBox={`0 0 ${W} ${H}`} className="sa-spark" />
+  if (!visible.length)
+    return <svg viewBox={`0 0 ${W} ${H}`} className="sa-spark" />
   const slotW = W / 30
   const barW = Math.max(1, slotW - 1)
   const modeColor: Record<string, string> = {
-    improvement: "#16a34a",
-    accepted: "#d97706",
-    rejected: "#dc2626",
-    converged: "#0969da",
+    improvement: '#16a34a',
+    accepted: '#d97706',
+    rejected: '#dc2626',
+    converged: '#0969da',
   }
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="sa-spark">
       {visible.map((h, i) => {
         const bh = Math.max(2, h.prob * (H - 4))
         return (
-          <rect key={i}
-            x={i * slotW} y={H - bh - 2}
-            width={barW} height={bh}
-            fill={modeColor[h.mode] ?? "#9ca3af"}
+          <rect
+            key={i}
+            x={i * slotW}
+            y={H - bh - 2}
+            width={barW}
+            height={bh}
+            fill={modeColor[h.mode] ?? '#9ca3af'}
             opacity={0.85}
           />
         )
@@ -276,8 +343,12 @@ export default function SAExplainer() {
   const [tour, setTour] = useState<number[]>(() => simRef.current.tour)
   const [best, setBest] = useState<number[]>(() => simRef.current.best)
   const [bestCost, setBestCost] = useState(() => simRef.current.bestCost)
-  const [currentCost, setCurrentCost] = useState(() => simRef.current.currentCost)
-  const [temperature, setTemperature] = useState(() => simRef.current.temperature)
+  const [currentCost, setCurrentCost] = useState(
+    () => simRef.current.currentCost,
+  )
+  const [temperature, setTemperature] = useState(
+    () => simRef.current.temperature,
+  )
   const [iter, setIter] = useState(0)
 
   const [mode, setMode] = useState<MoveMode | null>(null)
@@ -310,7 +381,7 @@ export default function SAExplainer() {
   const stepOnce = useCallback(() => {
     const s = simRef.current
     if (s.temperature < T_MIN) {
-      setMode("converged")
+      setMode('converged')
       setRunning(false)
       return
     }
@@ -328,11 +399,11 @@ export default function SAExplainer() {
     if (delta < 0) {
       accepted = true
       prob = 1.0
-      stepMode = "improvement"
+      stepMode = 'improvement'
     } else {
       prob = Math.exp(-delta / s.temperature)
       accepted = Math.random() < prob
-      stepMode = accepted ? "accepted" : "rejected"
+      stepMode = accepted ? 'accepted' : 'rejected'
     }
 
     const nextTour = accepted ? proposed : s.tour
@@ -365,12 +436,12 @@ export default function SAExplainer() {
     setCurrentCost(nextCost)
     setTemperature(nextTemp)
     setIter(simRef.current.iter)
-    setMode(nextTemp < T_MIN ? "converged" : stepMode)
+    setMode(nextTemp < T_MIN ? 'converged' : stepMode)
     setLastDelta(delta)
     setLastProb(prob)
     setDiff(edgeDiff)
-    setSparkHistory(h => [...h.slice(-29), { prob, mode: stepMode }])
-    setTHistory(h => [...h, nextTemp])
+    setSparkHistory((h) => [...h.slice(-29), { prob, mode: stepMode }])
+    setTHistory((h) => [...h, nextTemp])
 
     if (nextTemp < T_MIN) {
       setRunning(false)
@@ -385,27 +456,32 @@ export default function SAExplainer() {
     return () => clearInterval(id)
   }, [running, speed, stepOnce])
 
-  const acceptanceRate = simRef.current.recentOutcomes.length > 0
-    ? (simRef.current.recentOutcomes.filter(Boolean).length / simRef.current.recentOutcomes.length * 100).toFixed(0)
-    : "—"
+  const acceptanceRate =
+    simRef.current.recentOutcomes.length > 0
+      ? (
+          (simRef.current.recentOutcomes.filter(Boolean).length /
+            simRef.current.recentOutcomes.length) *
+          100
+        ).toFixed(0)
+      : '—'
 
-  const converged = mode === "converged"
+  const converged = mode === 'converged'
 
   // event chip
-  let chipText = ""
-  let chipClass = "sa-chip"
-  if (mode === "improvement") {
-    chipText = `✅ improved  ΔE = ${lastDelta !== null ? lastDelta.toFixed(1) : "—"}`
-    chipClass = "sa-chip sa-chip-improve"
-  } else if (mode === "accepted") {
-    chipText = `⚠️ worsening accepted  p = ${lastProb !== null ? lastProb.toFixed(2) : "—"}  ΔE = +${lastDelta !== null ? lastDelta.toFixed(1) : "—"}`
-    chipClass = "sa-chip sa-chip-accepted"
-  } else if (mode === "rejected") {
-    chipText = `❌ rejected  p = ${lastProb !== null ? lastProb.toFixed(2) : "—"}  ΔE = +${lastDelta !== null ? lastDelta.toFixed(1) : "—"}`
-    chipClass = "sa-chip sa-chip-rejected"
-  } else if (mode === "converged") {
-    chipText = "🏁 Converged — best tour highlighted"
-    chipClass = "sa-chip sa-chip-converged"
+  let chipText = ''
+  let chipClass = 'sa-chip'
+  if (mode === 'improvement') {
+    chipText = `✅ improved  ΔE = ${lastDelta !== null ? lastDelta.toFixed(1) : '—'}`
+    chipClass = 'sa-chip sa-chip-improve'
+  } else if (mode === 'accepted') {
+    chipText = `⚠️ worsening accepted  p = ${lastProb !== null ? lastProb.toFixed(2) : '—'}  ΔE = +${lastDelta !== null ? lastDelta.toFixed(1) : '—'}`
+    chipClass = 'sa-chip sa-chip-accepted'
+  } else if (mode === 'rejected') {
+    chipText = `❌ rejected  p = ${lastProb !== null ? lastProb.toFixed(2) : '—'}  ΔE = +${lastDelta !== null ? lastDelta.toFixed(1) : '—'}`
+    chipClass = 'sa-chip sa-chip-rejected'
+  } else if (mode === 'converged') {
+    chipText = '🏁 Converged — best tour highlighted'
+    chipClass = 'sa-chip sa-chip-converged'
   }
 
   return (
@@ -416,9 +492,11 @@ export default function SAExplainer() {
         <div className="sa-eyebrow">teeline · algorithms/sa</div>
         <h2 className="sa-title">Simulated Annealing</h2>
         <p className="sa-sub">
-          A single tour evolves by random 2-opt swaps. Improvements always accepted;
-          worsenings accepted with probability <code>exp(−ΔE / T)</code>.
-          As temperature <code>T</code> cools, acceptance of bad moves drops — shifting from exploration to exploitation.
+          A single tour evolves by random 2-opt swaps. Improvements always
+          accepted; worsenings accepted with probability{' '}
+          <code>exp(−ΔE / T)</code>. As temperature <code>T</code> cools,
+          acceptance of bad moves drops — shifting from exploration to
+          exploitation.
         </p>
       </div>
 
@@ -446,19 +524,39 @@ export default function SAExplainer() {
       {mode !== null && <div className={chipClass}>{chipText}</div>}
 
       <div className="sa-stats">
-        <div className="sa-stat"><span className="sa-stat-val">{iter}</span><span className="sa-stat-label">iter</span></div>
-        <div className="sa-stat"><span className="sa-stat-val">{temperature.toFixed(2)}</span><span className="sa-stat-label">T</span></div>
-        <div className="sa-stat"><span className="sa-stat-val">{currentCost.toFixed(0)}</span><span className="sa-stat-label">current</span></div>
-        <div className="sa-stat"><span className="sa-stat-val">{bestCost.toFixed(0)}</span><span className="sa-stat-label">best</span></div>
-        <div className="sa-stat"><span className="sa-stat-val">{acceptanceRate}%</span><span className="sa-stat-label">acc rate</span></div>
+        <div className="sa-stat">
+          <span className="sa-stat-val">{iter}</span>
+          <span className="sa-stat-label">iter</span>
+        </div>
+        <div className="sa-stat">
+          <span className="sa-stat-val">{temperature.toFixed(2)}</span>
+          <span className="sa-stat-label">T</span>
+        </div>
+        <div className="sa-stat">
+          <span className="sa-stat-val">{currentCost.toFixed(0)}</span>
+          <span className="sa-stat-label">current</span>
+        </div>
+        <div className="sa-stat">
+          <span className="sa-stat-val">{bestCost.toFixed(0)}</span>
+          <span className="sa-stat-label">best</span>
+        </div>
+        <div className="sa-stat">
+          <span className="sa-stat-val">{acceptanceRate}%</span>
+          <span className="sa-stat-label">acc rate</span>
+        </div>
       </div>
 
       <div className="sa-config">
         <label className="sa-label">
           T₀ = {initTemp}
-          <input type="range" min={10} max={500} step={10} value={initTemp}
+          <input
+            type="range"
+            min={10}
+            max={500}
+            step={10}
+            value={initTemp}
             className="sa-slider"
-            onInput={e => {
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
               setInitTemp(v)
               initTempRef.current = v
@@ -468,9 +566,14 @@ export default function SAExplainer() {
         </label>
         <label className="sa-label">
           α = {alpha.toFixed(3)}
-          <input type="range" min={0.005} max={0.10} step={0.005} value={alpha}
+          <input
+            type="range"
+            min={0.005}
+            max={0.1}
+            step={0.005}
+            value={alpha}
             className="sa-slider"
-            onInput={e => {
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
               setAlpha(v)
               alphaRef.current = v
@@ -480,29 +583,43 @@ export default function SAExplainer() {
         </label>
         <label className="sa-label">
           speed = {speed}
-          <input type="range" min={1} max={10} step={1} value={speed}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="sa-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </label>
       </div>
 
       <div className="sa-controls">
-        <button className="sa-btn"
+        <button
+          className="sa-btn"
           onClick={stepOnce}
           disabled={running || converged}
-        >Step</button>
-        <button className="sa-btn sa-btn-primary"
-          onClick={() => setRunning(r => !r)}
+        >
+          Step
+        </button>
+        <button
+          className="sa-btn sa-btn-primary"
+          onClick={() => setRunning((r) => !r)}
           disabled={converged}
-        >{running ? "Pause" : "Run"}</button>
-        <button className="sa-btn"
-          onClick={() => reinit(initTempRef.current)}
-        >Reset</button>
+        >
+          {running ? 'Pause' : 'Run'}
+        </button>
+        <button className="sa-btn" onClick={() => reinit(initTempRef.current)}>
+          Reset
+        </button>
       </div>
 
       <div className="sa-footer">
-        {N_CITIES} cities · T₀ = {initTemp} · α = {alpha.toFixed(3)} · T_min = {T_MIN}
+        {N_CITIES} cities · T₀ = {initTemp} · α = {alpha.toFixed(3)} · T_min ={' '}
+        {T_MIN}
       </div>
     </div>
   )

--- a/teeline-web/src/explainers/savings-algo.ts
+++ b/teeline-web/src/explainers/savings-algo.ts
@@ -5,27 +5,32 @@
 // instead of raw distance (ascending). A hub city (nearest the centroid) is
 // computed and highlighted but visited like every other city.
 
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, dist12 as dist } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  dist12 as dist,
+} from './explainer-cities'
 export { CITIES, N_CITIES, dist }
 
 export type Edge = { u: number; v: number; dist: number; val: number }
 
 export type RejectReason = 'degree' | 'cycle'
-export type EventMode = 'accepted' | 'closing' | 'rejected-degree' | 'rejected-cycle' | 'done'
+export type EventMode =
+  'accepted' | 'closing' | 'rejected-degree' | 'rejected-cycle' | 'done'
 
 export type SimState = {
-  sortedEdges: Edge[]        // all n(n-1)/2 pairs, descending by savings
-  hubIndex: number           // city nearest the coordinate centroid
-  scanIndex: number          // next edge to evaluate
-  parent: number[]           // union-find: parent[i]
-  degree: number[]           // degree[i]
-  accepted: Edge[]           // accepted edges, in scan order
+  sortedEdges: Edge[] // all n(n-1)/2 pairs, descending by savings
+  hubIndex: number // city nearest the coordinate centroid
+  scanIndex: number // next edge to evaluate
+  parent: number[] // union-find: parent[i]
+  degree: number[] // degree[i]
+  accepted: Edge[] // accepted edges, in scan order
   rejected: Array<{ edge: Edge; reason: RejectReason }>
   step: number
-  lastEdge: Edge | null      // edge evaluated on the most recent step
+  lastEdge: Edge | null // edge evaluated on the most recent step
   lastEvent: EventMode | null
   done: boolean
-  tour: number[] | null      // ordered path once the cycle closes (null until done)
+  tour: number[] | null // ordered path once the cycle closes (null until done)
 }
 
 // Savings for edge (i, j) relative to hub h: s(i,j) = d(h,i) + d(h,j) - d(i,j).
@@ -37,14 +42,23 @@ function savings(i: number, j: number, hub: number): number {
 
 // City nearest the coordinate centroid — matches the Rust `hub_position`.
 export function hubIndex(): number {
-  let cx = 0, cy = 0
-  for (const [x, y] of CITIES) { cx += x; cy += y }
-  cx /= N_CITIES; cy /= N_CITIES
-  let best = 0, bestD2 = Infinity
+  let cx = 0,
+    cy = 0
+  for (const [x, y] of CITIES) {
+    cx += x
+    cy += y
+  }
+  cx /= N_CITIES
+  cy /= N_CITIES
+  let best = 0,
+    bestD2 = Infinity
   for (let i = 0; i < N_CITIES; i++) {
     const [x, y] = CITIES[i]
     const d2 = (x - cx) ** 2 + (y - cy) ** 2
-    if (d2 < bestD2) { bestD2 = d2; best = i }
+    if (d2 < bestD2) {
+      bestD2 = d2
+      best = i
+    }
   }
   return best
 }
@@ -93,7 +107,7 @@ export function components(parent: number[]): number[][] {
     const r = find(parent, i)
     ;(groups[r] ??= []).push(i)
   }
-  return Object.values(groups).map(g => g.sort((a, b) => a - b))
+  return Object.values(groups).map((g) => g.sort((a, b) => a - b))
 }
 
 export function makeInitState(): SimState {
@@ -128,7 +142,7 @@ function walkCycle(accepted: Edge[]): number[] {
   for (let i = 0; i < n; i++) {
     path.push(cur)
     seen[cur] = true
-    const next = adj[cur].find(x => x !== prev && !seen[x]) ?? adj[cur][0]
+    const next = adj[cur].find((x) => x !== prev && !seen[x]) ?? adj[cur][0]
     prev = cur
     cur = next
   }

--- a/teeline-web/src/explainers/savings.test.ts
+++ b/teeline-web/src/explainers/savings.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, hubIndex,
-  components, makeInitState, stepOnce, runToCompletion,
+  N_CITIES,
+  hubIndex,
+  components,
+  makeInitState,
+  stepOnce,
+  runToCompletion,
 } from './savings-algo'
 
 describe('hubIndex', () => {
@@ -25,7 +29,7 @@ describe('makeInitState', () => {
   it('starts with zero accepted edges and zero degree everywhere', () => {
     const s = makeInitState()
     expect(s.accepted).toHaveLength(0)
-    expect(s.degree.every(d => d === 0)).toBe(true)
+    expect(s.degree.every((d) => d === 0)).toBe(true)
     expect(s.done).toBe(false)
     expect(s.step).toBe(0)
   })

--- a/teeline-web/src/explainers/savings.tsx
+++ b/teeline-web/src/explainers/savings.tsx
@@ -1,14 +1,26 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES,
-  components, makeInitState, stepOnce,
-} from "./savings-algo"
-import type { Edge, EventMode, RejectReason } from "./savings-algo"
+  CITIES,
+  N_CITIES,
+  components,
+  makeInitState,
+  stepOnce,
+} from './savings-algo'
+import type { Edge, EventMode, RejectReason } from './savings-algo'
 
 const COMP_PALETTE = [
-  "#0d9488", "#2563eb", "#7c3aed", "#db2777", "#ea580c",
-  "#16a34a", "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
-  "#0f766e", "#9333ea",
+  '#0d9488',
+  '#2563eb',
+  '#7c3aed',
+  '#db2777',
+  '#ea580c',
+  '#16a34a',
+  '#0891b2',
+  '#ca8a04',
+  '#dc2626',
+  '#4f46e5',
+  '#0f766e',
+  '#9333ea',
 ]
 function compColor(rootIndex: number): string {
   return COMP_PALETTE[rootIndex % COMP_PALETTE.length]
@@ -28,51 +40,81 @@ interface ScanCanvasProps {
   hubIdx: number
   tour: number[] | null
 }
-function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, parent, hubIdx, tour }: ScanCanvasProps) {
+function ScanCanvas({
+  accepted,
+  lastEdge,
+  lastEvent,
+  rejectedTrail,
+  degree,
+  parent,
+  hubIdx,
+  tour,
+}: ScanCanvasProps) {
   const comps = useMemo(() => components(parent), [parent])
   const rootOf = useMemo(() => {
     const m = new Map<number, number>()
-    comps.forEach((group, gi) => group.forEach(c => m.set(c, gi)))
+    comps.forEach((group, gi) => group.forEach((c) => m.set(c, gi)))
     return m
   }, [comps])
 
   const acceptedSet = useMemo(() => new Set(accepted.map(edgeKey)), [accepted])
 
   const tourPts = tour
-    ? tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ") + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
-    : ""
+    ? tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ') +
+      ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
+    : ''
 
   return (
-    <svg viewBox="0 0 300 300" className="sav-canvas" role="img" aria-label="Savings edge scan">
+    <svg
+      viewBox="0 0 300 300"
+      className="sav-canvas"
+      role="img"
+      aria-label="Savings edge scan"
+    >
       <rect x={0} y={0} width={300} height={300} className="sav-bg" />
 
       {tour && <polygon points={tourPts} className="sav-tour" />}
 
       {accepted.map((e, i) => (
-        <line key={"a" + i}
-          x1={CITIES[e.u][0]} y1={CITIES[e.u][1]}
-          x2={CITIES[e.v][0]} y2={CITIES[e.v][1]}
+        <line
+          key={'a' + i}
+          x1={CITIES[e.u][0]}
+          y1={CITIES[e.u][1]}
+          x2={CITIES[e.v][0]}
+          y2={CITIES[e.v][1]}
           className="sav-accepted"
         />
       ))}
 
       {rejectedTrail.map((r, i) => (
-        <line key={"r" + i}
-          x1={CITIES[r.edge.u][0]} y1={CITIES[r.edge.u][1]}
-          x2={CITIES[r.edge.v][0]} y2={CITIES[r.edge.v][1]}
-          className={r.reason === "degree" ? "sav-rejected sav-rejected-degree" : "sav-rejected sav-rejected-cycle"}
+        <line
+          key={'r' + i}
+          x1={CITIES[r.edge.u][0]}
+          y1={CITIES[r.edge.u][1]}
+          x2={CITIES[r.edge.v][0]}
+          y2={CITIES[r.edge.v][1]}
+          className={
+            r.reason === 'degree'
+              ? 'sav-rejected sav-rejected-degree'
+              : 'sav-rejected sav-rejected-cycle'
+          }
         />
       ))}
 
       {lastEdge && !acceptedSet.has(edgeKey(lastEdge)) && !tour && (
         <line
-          x1={CITIES[lastEdge.u][0]} y1={CITIES[lastEdge.u][1]}
-          x2={CITIES[lastEdge.v][0]} y2={CITIES[lastEdge.v][1]}
+          x1={CITIES[lastEdge.u][0]}
+          y1={CITIES[lastEdge.u][1]}
+          x2={CITIES[lastEdge.v][0]}
+          y2={CITIES[lastEdge.v][1]}
           className={
-            lastEvent === "rejected-degree" ? "sav-cand sav-cand-degree"
-            : lastEvent === "rejected-cycle" ? "sav-cand sav-cand-cycle"
-            : lastEvent === "closing" ? "sav-cand sav-cand-closing"
-            : "sav-cand sav-cand-accept"
+            lastEvent === 'rejected-degree'
+              ? 'sav-cand sav-cand-degree'
+              : lastEvent === 'rejected-cycle'
+                ? 'sav-cand sav-cand-cycle'
+                : lastEvent === 'closing'
+                  ? 'sav-cand sav-cand-closing'
+                  : 'sav-cand sav-cand-accept'
           }
         />
       )}
@@ -85,16 +127,29 @@ function ScanCanvas({ accepted, lastEdge, lastEvent, rejectedTrail, degree, pare
             {i === hubIdx && (
               <circle cx={x} cy={y} r={11} className="sav-hub-ring" />
             )}
-            <circle cx={x} cy={y} r={5.5}
+            <circle
+              cx={x}
+              cy={y}
+              r={5.5}
               fill={compColor(gi)}
-              className={full ? "sav-city sav-city-full" : "sav-city"}
+              className={full ? 'sav-city sav-city-full' : 'sav-city'}
             />
             {i === hubIdx && (
-              <text x={x} y={y + 3} className="sav-hub-star">★</text>
+              <text x={x} y={y + 3} className="sav-hub-star">
+                ★
+              </text>
             )}
-            <text x={x + 7} y={y - 6} className="sav-city-label">{i}</text>
-            <text x={x} y={y + 18} className="sav-degree-badge"
-              style={{ opacity: degree[i] > 0 ? 1 : 0.25 }}>{degree[i]}</text>
+            <text x={x + 7} y={y - 6} className="sav-city-label">
+              {i}
+            </text>
+            <text
+              x={x}
+              y={y + 18}
+              className="sav-degree-badge"
+              style={{ opacity: degree[i] > 0 ? 1 : 0.25 }}
+            >
+              {degree[i]}
+            </text>
           </g>
         )
       })}
@@ -107,10 +162,16 @@ function ComponentPanel({ parent }: { parent: number[] }) {
   return (
     <div className="sav-list-panel">
       <div className="sav-list-title">Union-Find</div>
-      <div className="sav-list-subtitle">{comps.length} component{comps.length === 1 ? "" : "s"}</div>
+      <div className="sav-list-subtitle">
+        {comps.length} component{comps.length === 1 ? '' : 's'}
+      </div>
       {comps.map((g, i) => (
-        <div key={i} className="sav-comp-badge" style={{ borderLeftColor: compColor(i) }}>
-          {"{" + g.join(",") + "}"}
+        <div
+          key={i}
+          className="sav-comp-badge"
+          style={{ borderLeftColor: compColor(i) }}
+        >
+          {'{' + g.join(',') + '}'}
         </div>
       ))}
     </div>
@@ -122,9 +183,15 @@ export default function SavingsExplainer() {
 
   const simRef = useRef(makeInitState())
   const [accepted, setAccepted] = useState<Edge[]>(() => [])
-  const [rejected, setRejected] = useState<Array<{ edge: Edge; reason: RejectReason }>>(() => [])
-  const [degree, setDegree] = useState<number[]>(() => new Array(N_CITIES).fill(0))
-  const [parent, setParent] = useState<number[]>(() => simRef.current.parent.slice())
+  const [rejected, setRejected] = useState<
+    Array<{ edge: Edge; reason: RejectReason }>
+  >(() => [])
+  const [degree, setDegree] = useState<number[]>(() =>
+    new Array(N_CITIES).fill(0),
+  )
+  const [parent, setParent] = useState<number[]>(() =>
+    simRef.current.parent.slice(),
+  )
   const [hubIdx, setHubIdx] = useState<number>(() => simRef.current.hubIndex)
   const [lastEdge, setLastEdge] = useState<Edge | null>(null)
   const [lastEvent, setLastEvent] = useState<EventMode | null>(null)
@@ -135,10 +202,17 @@ export default function SavingsExplainer() {
 
   const reinit = useCallback(() => {
     simRef.current = makeInitState()
-    setAccepted([]); setRejected([]); setDegree(new Array(N_CITIES).fill(0))
-    setParent(simRef.current.parent.slice()); setLastEdge(null); setLastEvent(null)
+    setAccepted([])
+    setRejected([])
+    setDegree(new Array(N_CITIES).fill(0))
+    setParent(simRef.current.parent.slice())
+    setLastEdge(null)
+    setLastEvent(null)
     setHubIdx(simRef.current.hubIndex)
-    setStep(0); setDone(false); setTour(null); setRunning(false)
+    setStep(0)
+    setDone(false)
+    setTour(null)
+    setRunning(false)
   }, [])
 
   const step_fn = useCallback(() => {
@@ -148,8 +222,11 @@ export default function SavingsExplainer() {
     setRejected(next.rejected.slice(-6))
     setDegree(next.degree.slice())
     setParent(next.parent.slice())
-    setLastEdge(next.lastEdge); setLastEvent(next.lastEvent)
-    setStep(next.step); setDone(next.done); setTour(next.tour)
+    setLastEdge(next.lastEdge)
+    setLastEvent(next.lastEvent)
+    setStep(next.step)
+    setDone(next.done)
+    setTour(next.tour)
     if (next.done) setRunning(false)
   }, [])
 
@@ -165,20 +242,20 @@ export default function SavingsExplainer() {
     [accepted],
   )
 
-  let chipText = "Press Step or Run to scan the highest-savings edges first"
-  let chipClass = "sav-chip sav-chip-idle"
-  if (lastEvent === "accepted" && lastEdge) {
+  let chipText = 'Press Step or Run to scan the highest-savings edges first'
+  let chipClass = 'sav-chip sav-chip-idle'
+  if (lastEvent === 'accepted' && lastEdge) {
     chipText = `✅ accepted  (${lastEdge.u}, ${lastEdge.v})  — saving = +${lastEdge.val.toFixed(1)}`
-    chipClass = "sav-chip sav-chip-accept"
-  } else if (lastEvent === "rejected-degree" && lastEdge) {
+    chipClass = 'sav-chip sav-chip-accept'
+  } else if (lastEvent === 'rejected-degree' && lastEdge) {
     chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — would give a city degree 3`
-    chipClass = "sav-chip sav-chip-degree"
-  } else if (lastEvent === "rejected-cycle" && lastEdge) {
+    chipClass = 'sav-chip sav-chip-degree'
+  } else if (lastEvent === 'rejected-cycle' && lastEdge) {
     chipText = `✗ rejected  (${lastEdge.u}, ${lastEdge.v})  — premature sub-cycle`
-    chipClass = "sav-chip sav-chip-cycle"
-  } else if (lastEvent === "closing" && lastEdge) {
+    chipClass = 'sav-chip sav-chip-cycle'
+  } else if (lastEvent === 'closing' && lastEdge) {
     chipText = `🔒 closing edge  (${lastEdge.u}, ${lastEdge.v})  — the path becomes a cycle`
-    chipClass = "sav-chip sav-chip-closing"
+    chipClass = 'sav-chip sav-chip-closing'
   }
 
   const totalEdges = (N_CITIES * (N_CITIES - 1)) / 2
@@ -193,31 +270,53 @@ export default function SavingsExplainer() {
         <div className="sav-eyebrow">teeline · algorithms/savings</div>
         <h2 className="sav-title">Savings Construction</h2>
         <p className="sav-sub">
-          Every pairwise edge is ranked by <strong>Clarke-Wright savings</strong> s(i,j) = d(hub,i) + d(hub,j) − d(i,j)
-          and scanned highest-first. The <strong>hub city</strong> (★, nearest the centroid) is visited like any other
-          city — it only biases the <em>ordering</em> of candidate merges. Acceptance rules reuse the same
-          Kruskal-style scan as Greedy Edge (degree ≤ 2, no premature sub-cycle).
+          Every pairwise edge is ranked by{' '}
+          <strong>Clarke-Wright savings</strong> s(i,j) = d(hub,i) + d(hub,j) −
+          d(i,j) and scanned highest-first. The <strong>hub city</strong> (★,
+          nearest the centroid) is visited like any other city — it only biases
+          the <em>ordering</em> of candidate merges. Acceptance rules reuse the
+          same Kruskal-style scan as Greedy Edge (degree ≤ 2, no premature
+          sub-cycle).
         </p>
       </header>
 
       <div className="sav-viz-row">
         <div className="sav-canvas-wrap">
           <ScanCanvas
-            accepted={accepted} lastEdge={lastEdge} lastEvent={lastEvent}
-            rejectedTrail={rejected} degree={degree} parent={parent}
-            hubIdx={hubIdx} tour={tour}
+            accepted={accepted}
+            lastEdge={lastEdge}
+            lastEvent={lastEvent}
+            rejectedTrail={rejected}
+            degree={degree}
+            parent={parent}
+            hubIdx={hubIdx}
+            tour={tour}
           />
         </div>
         <ComponentPanel parent={parent} />
       </div>
 
       <div className="sav-legend">
-        <span><span className="sav-swatch sav-swatch-accepted" /> accepted edge</span>
-        <span><span className="sav-swatch sav-swatch-degree" /> rejected — degree</span>
-        <span><span className="sav-swatch sav-swatch-cycle" /> rejected — cycle</span>
-        <span><span className="sav-swatch sav-swatch-closing" /> closing edge</span>
-        <span><span className="sav-swatch sav-swatch-hub" /> hub (city {hubCityId})</span>
-        {done && <span><span className="sav-swatch sav-swatch-tour" /> final tour</span>}
+        <span>
+          <span className="sav-swatch sav-swatch-accepted" /> accepted edge
+        </span>
+        <span>
+          <span className="sav-swatch sav-swatch-degree" /> rejected — degree
+        </span>
+        <span>
+          <span className="sav-swatch sav-swatch-cycle" /> rejected — cycle
+        </span>
+        <span>
+          <span className="sav-swatch sav-swatch-closing" /> closing edge
+        </span>
+        <span>
+          <span className="sav-swatch sav-swatch-hub" /> hub (city {hubCityId})
+        </span>
+        {done && (
+          <span>
+            <span className="sav-swatch sav-swatch-tour" /> final tour
+          </span>
+        )}
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -225,15 +324,21 @@ export default function SavingsExplainer() {
       <div className="sav-statgrid">
         <div>
           <div className="sav-statlabel">edges scanned</div>
-          <div className="sav-mono">{accepted.length + rejected.length}/{totalEdges}</div>
+          <div className="sav-mono">
+            {accepted.length + rejected.length}/{totalEdges}
+          </div>
         </div>
         <div>
           <div className="sav-statlabel">accepted</div>
-          <div className="sav-mono">{accepted.length}/{N_CITIES}</div>
+          <div className="sav-mono">
+            {accepted.length}/{N_CITIES}
+          </div>
         </div>
         <div>
           <div className="sav-statlabel">rejected</div>
-          <div className="sav-mono">{step > 0 ? simRef.current.rejected.length : 0}</div>
+          <div className="sav-mono">
+            {step > 0 ? simRef.current.rejected.length : 0}
+          </div>
         </div>
         <div>
           <div className="sav-statlabel">components</div>
@@ -252,21 +357,41 @@ export default function SavingsExplainer() {
       <div className="sav-config">
         <div className="sav-config-row">
           <label className="sav-config-label">Speed</label>
-          <input type="range" min={1} max={10} step={1} value={speed}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="sav-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
-          <div className="sav-hint">Savings is parameter-free — no other knobs to tune.</div>
+          <div className="sav-hint">
+            Savings is parameter-free — no other knobs to tune.
+          </div>
         </div>
       </div>
 
       <div className="sav-controls">
-        <button className="sav-btn" onClick={step_fn} disabled={running || done}>◀ Step</button>
-        <button className={`sav-btn ${!running ? "sav-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)} disabled={done}>
-          {running ? "⏸ Pause" : done ? "✓ Done" : "▶ Run"}
+        <button
+          className="sav-btn"
+          onClick={step_fn}
+          disabled={running || done}
+        >
+          ◀ Step
         </button>
-        <button className="sav-btn" onClick={reinit}>↺ Reset</button>
+        <button
+          className={`sav-btn ${!running ? 'sav-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+          disabled={done}
+        >
+          {running ? '⏸ Pause' : done ? '✓ Done' : '▶ Run'}
+        </button>
+        <button className="sav-btn" onClick={reinit}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="sav-footer">

--- a/teeline-web/src/explainers/som-algo.ts
+++ b/teeline-web/src/explainers/som-algo.ts
@@ -1,12 +1,20 @@
 // 12 cities on a circle, canvas 300×300
-const CX = 150, CY = 150, CITY_R = 110
+const CX = 150,
+  CY = 150,
+  CITY_R = 110
 export const N_CITIES = 12
-export const CITIES: [number, number][] = Array.from({ length: N_CITIES }, (_, i) => {
-  const theta = (2 * Math.PI * i) / N_CITIES
-  return [CX + CITY_R * Math.cos(theta), CY + CITY_R * Math.sin(theta)] as [number, number]
-})
+export const CITIES: [number, number][] = Array.from(
+  { length: N_CITIES },
+  (_, i) => {
+    const theta = (2 * Math.PI * i) / N_CITIES
+    return [CX + CITY_R * Math.cos(theta), CY + CITY_R * Math.sin(theta)] as [
+      number,
+      number,
+    ]
+  },
+)
 
-export const N_NEURONS = Math.round(N_CITIES * 1.5)  // 18
+export const N_NEURONS = Math.round(N_CITIES * 1.5) // 18
 export const ALPHA0 = 0.8
 export const SIGMA0 = 4.0
 const SIGMA_FLOOR = 1.0
@@ -28,7 +36,10 @@ export type SomState = {
   lastTourLength: number | null
 }
 
-export function dist([x1, y1]: [number, number], [x2, y2]: [number, number]): number {
+export function dist(
+  [x1, y1]: [number, number],
+  [x2, y2]: [number, number],
+): number {
   return Math.hypot(x2 - x1, y2 - y1)
 }
 
@@ -52,22 +63,32 @@ function gaussian(dRing: number, sigma: number): number {
 }
 
 function extractTour(neurons: [number, number][]): number[] {
-  const cityBmu = CITIES.map(city =>
-    neurons
-      .map((n, ni) => ({ ni, d: dist(n, city) }))
-      .sort((a, b) => a.d - b.d || a.ni - b.ni)[0].ni
+  const cityBmu = CITIES.map(
+    (city) =>
+      neurons
+        .map((n, ni) => ({ ni, d: dist(n, city) }))
+        .sort((a, b) => a.d - b.d || a.ni - b.ni)[0].ni,
   )
   return Array.from({ length: N_CITIES }, (_, ci) => ci).sort((a, b) => {
     if (cityBmu[a] !== cityBmu[b]) return cityBmu[a] - cityBmu[b]
-    return dist(neurons[cityBmu[a]], CITIES[a]) - dist(neurons[cityBmu[b]], CITIES[b])
+    return (
+      dist(neurons[cityBmu[a]], CITIES[a]) -
+      dist(neurons[cityBmu[b]], CITIES[b])
+    )
   })
 }
 
 export function makeInitState(): SomState {
-  const neurons: [number, number][] = Array.from({ length: N_NEURONS }, (_, i) => {
-    const theta = (2 * Math.PI * i) / N_NEURONS
-    return [CX + 15 * Math.cos(theta), CY + 15 * Math.sin(theta)] as [number, number]
-  })
+  const neurons: [number, number][] = Array.from(
+    { length: N_NEURONS },
+    (_, i) => {
+      const theta = (2 * Math.PI * i) / N_NEURONS
+      return [CX + 15 * Math.cos(theta), CY + 15 * Math.sin(theta)] as [
+        number,
+        number,
+      ]
+    },
+  )
   return {
     neurons,
     step: 0,
@@ -106,10 +127,14 @@ export function stepOnce(s: SomState): SomState {
   const city = CITIES[cityIdx]
 
   // Find BMU (closest neuron to city)
-  let bmu = 0, bmuD = Infinity
+  let bmu = 0,
+    bmuD = Infinity
   for (let i = 0; i < N_NEURONS; i++) {
     const d = dist(s.neurons[i], city)
-    if (d < bmuD) { bmuD = d; bmu = i }
+    if (d < bmuD) {
+      bmuD = d
+      bmu = i
+    }
   }
 
   // Update all neurons via Gaussian neighbourhood kernel (ring topology)
@@ -126,29 +151,54 @@ export function stepOnce(s: SomState): SomState {
   }
 
   const phase: Phase =
-    sigma > SIGMA0 * 0.5 ? 'expanding'
-    : sigma > SIGMA_FLOOR * 1.5 ? 'converging'
-    : 'fine-tuning'
+    sigma > SIGMA0 * 0.5
+      ? 'expanding'
+      : sigma > SIGMA_FLOOR * 1.5
+        ? 'converging'
+        : 'fine-tuning'
 
-  return { ...s, neurons: newNeurons, step: t, alpha, sigma, bmu, neighbors, lastCityIdx: cityIdx, phase }
+  return {
+    ...s,
+    neurons: newNeurons,
+    step: t,
+    alpha,
+    sigma,
+    bmu,
+    neighbors,
+    lastCityIdx: cityIdx,
+    phase,
+  }
 }
 
 // Convert σ (neuron-ring-index units) to canvas pixels for the radius circle.
 // Uses average neuron ring radius so the circle scales as the ring expands.
-export function neighbourRadiusPx(sigma: number, neurons: [number, number][]): number {
+export function neighbourRadiusPx(
+  sigma: number,
+  neurons: [number, number][],
+): number {
   const cx = neurons.reduce((s, [x]) => s + x, 0) / neurons.length
   const cy = neurons.reduce((s, [, y]) => s + y, 0) / neurons.length
-  const avgR = neurons.reduce((s, [x, y]) => s + Math.hypot(x - cx, y - cy), 0) / neurons.length
+  const avgR =
+    neurons.reduce((s, [x, y]) => s + Math.hypot(x - cx, y - cy), 0) /
+    neurons.length
   const arcPerNeuron = (2 * Math.PI * Math.max(avgR, 10)) / N_NEURONS
   return sigma * arcPerNeuron
 }
 
-export function phaseLabel(phase: Phase, lastTourLength: number | null): string {
+export function phaseLabel(
+  phase: Phase,
+  lastTourLength: number | null,
+): string {
   switch (phase) {
-    case 'init':        return 'Neurons initialised in a small ring around the centroid.'
-    case 'expanding':   return 'Wide neighbourhood — ring expands and rotates to cover city clusters.'
-    case 'converging':  return 'Neighbourhood shrinking — neurons approach individual cities.'
-    case 'fine-tuning': return 'Fine-tuning — neurons lock onto city positions.'
-    case 'done':        return `Tour extracted from ring order. Length: ${lastTourLength?.toFixed(0) ?? '—'}`
+    case 'init':
+      return 'Neurons initialised in a small ring around the centroid.'
+    case 'expanding':
+      return 'Wide neighbourhood — ring expands and rotates to cover city clusters.'
+    case 'converging':
+      return 'Neighbourhood shrinking — neurons approach individual cities.'
+    case 'fine-tuning':
+      return 'Fine-tuning — neurons lock onto city positions.'
+    case 'done':
+      return `Tour extracted from ring order. Length: ${lastTourLength?.toFixed(0) ?? '—'}`
   }
 }

--- a/teeline-web/src/explainers/som.test.ts
+++ b/teeline-web/src/explainers/som.test.ts
@@ -1,7 +1,14 @@
 import { describe, test, expect } from 'vitest'
 import {
-  N_CITIES, N_NEURONS, SIGMA0, MAX_STEPS,
-  makeInitState, stepOnce, tourLength, neighbourRadiusPx, phaseLabel,
+  N_CITIES,
+  N_NEURONS,
+  SIGMA0,
+  MAX_STEPS,
+  makeInitState,
+  stepOnce,
+  tourLength,
+  neighbourRadiusPx,
+  phaseLabel,
 } from './som-algo'
 
 describe('tourLength', () => {
@@ -94,7 +101,9 @@ describe('neighbourRadiusPx', () => {
   })
   test('larger sigma gives larger radius', () => {
     const { neurons } = makeInitState()
-    expect(neighbourRadiusPx(4, neurons)).toBeGreaterThan(neighbourRadiusPx(2, neurons))
+    expect(neighbourRadiusPx(4, neurons)).toBeGreaterThan(
+      neighbourRadiusPx(2, neurons),
+    )
   })
 })
 

--- a/teeline-web/src/explainers/som.tsx
+++ b/teeline-web/src/explainers/som.tsx
@@ -1,20 +1,28 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
-import type { SomState, Phase } from "./som-algo"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
+import type { SomState, Phase } from './som-algo'
 import {
-  CITIES, ALPHA0, SIGMA0, MAX_STEPS, N_CITIES, N_NEURONS,
-  makeInitState, stepOnce, neighbourRadiusPx, phaseLabel,
-} from "./som-algo"
+  CITIES,
+  ALPHA0,
+  SIGMA0,
+  MAX_STEPS,
+  N_CITIES,
+  N_NEURONS,
+  makeInitState,
+  stepOnce,
+  neighbourRadiusPx,
+  phaseLabel,
+} from './som-algo'
 
 function polyPts(pts: [number, number][]): string {
   return pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
 }
 
 const PHASE_COLOR: Record<Phase, string> = {
-  'init':        '#6b7280',
-  'expanding':   '#7c3aed',
-  'converging':  '#a855f7',
+  init: '#6b7280',
+  expanding: '#7c3aed',
+  converging: '#a855f7',
   'fine-tuning': '#c084fc',
-  'done':        '#16a34a',
+  done: '#16a34a',
 }
 
 export default function SomExplainer() {
@@ -71,9 +79,10 @@ export default function SomExplainer() {
   const nbRadiusPx = bmuPos ? neighbourRadiusPx(sigma, neurons) : 0
 
   // Tour polyline: cities in ring order, closed
-  const tourPts = tour !== null
-    ? polyPts([...tour.map(i => CITIES[i]), CITIES[tour[0]]])
-    : null
+  const tourPts =
+    tour !== null
+      ? polyPts([...tour.map((i) => CITIES[i]), CITIES[tour[0]]])
+      : null
 
   // Neuron ring polyline: close the ring back to first neuron
   const neuronRingPts = polyPts([...neurons, neurons[0]])
@@ -88,18 +97,21 @@ export default function SomExplainer() {
         <span class="som-emoji">🧠</span>
         <div>
           <h2 class="som-title">Kohonen SOM</h2>
-          <p class="som-subtitle">Self-Organising Map — topology-preserving TSP heuristic</p>
+          <p class="som-subtitle">
+            Self-Organising Map — topology-preserving TSP heuristic
+          </p>
         </div>
       </header>
 
       <div class="som-viz-row">
         {/* 300×300 SVG canvas */}
-        <svg class="som-canvas" viewBox="0 0 300 300" aria-label="SOM visualisation">
-
+        <svg
+          class="som-canvas"
+          viewBox="0 0 300 300"
+          aria-label="SOM visualisation"
+        >
           {/* 1. Tour overlay (only when done) */}
-          {tourPts && (
-            <polyline points={tourPts} class="som-tour" />
-          )}
+          {tourPts && <polyline points={tourPts} class="som-tour" />}
 
           {/* 2. Neuron ring polyline */}
           <polyline points={neuronRingPts} class="som-neuron-ring" />
@@ -126,15 +138,16 @@ export default function SomExplainer() {
           )}
 
           {/* 5. Active neighbour circles */}
-          {!isDone && neighbors.map(ni => (
-            <circle
-              key={ni}
-              cx={neurons[ni][0].toFixed(1)}
-              cy={neurons[ni][1].toFixed(1)}
-              r="5.5"
-              class="som-nb-neuron"
-            />
-          ))}
+          {!isDone &&
+            neighbors.map((ni) => (
+              <circle
+                key={ni}
+                cx={neurons[ni][0].toFixed(1)}
+                cy={neurons[ni][1].toFixed(1)}
+                r="5.5"
+                class="som-nb-neuron"
+              />
+            ))}
 
           {/* 6. All neuron circles (BMU rendered larger) */}
           {neurons.map(([nx, ny], ni) => (
@@ -142,7 +155,7 @@ export default function SomExplainer() {
               key={ni}
               cx={nx.toFixed(1)}
               cy={ny.toFixed(1)}
-              r={ni === bmu ? "8" : "4"}
+              r={ni === bmu ? '8' : '4'}
               class={ni === bmu ? 'som-neuron som-neuron-bmu' : 'som-neuron'}
             />
           ))}
@@ -154,31 +167,66 @@ export default function SomExplainer() {
               cx={cx.toFixed(1)}
               cy={cy.toFixed(1)}
               r="7"
-              class={ci === lastCityIdx && !isDone ? 'som-city som-city-active' : 'som-city'}
+              class={
+                ci === lastCityIdx && !isDone
+                  ? 'som-city som-city-active'
+                  : 'som-city'
+              }
             />
           ))}
         </svg>
 
         {/* Right panel */}
         <div class="som-panel">
-
           {/* Phase chip */}
-          <div class="som-phase-chip" style={`border-color: ${PHASE_COLOR[phase]}`}>
-            <span class="som-phase-dot" style={`background: ${PHASE_COLOR[phase]}`} />
-            <span class="som-phase-text">{phaseLabel(phase, lastTourLength)}</span>
+          <div
+            class="som-phase-chip"
+            style={`border-color: ${PHASE_COLOR[phase]}`}
+          >
+            <span
+              class="som-phase-dot"
+              style={`background: ${PHASE_COLOR[phase]}`}
+            />
+            <span class="som-phase-text">
+              {phaseLabel(phase, lastTourLength)}
+            </span>
           </div>
 
           {/* Stats grid */}
           <div class="som-statgrid">
-            <div class="som-stat"><span>Step</span><strong>{step}/{MAX_STEPS}</strong></div>
-            <div class="som-stat"><span>α</span><strong>{alpha.toFixed(3)}</strong></div>
-            <div class="som-stat"><span>σ</span><strong>{sigma.toFixed(2)}</strong></div>
-            <div class="som-stat"><span>Tour</span><strong>{lastTourLength !== null ? lastTourLength.toFixed(0) : '—'}</strong></div>
+            <div class="som-stat">
+              <span>Step</span>
+              <strong>
+                {step}/{MAX_STEPS}
+              </strong>
+            </div>
+            <div class="som-stat">
+              <span>α</span>
+              <strong>{alpha.toFixed(3)}</strong>
+            </div>
+            <div class="som-stat">
+              <span>σ</span>
+              <strong>{sigma.toFixed(2)}</strong>
+            </div>
+            <div class="som-stat">
+              <span>Tour</span>
+              <strong>
+                {lastTourLength !== null ? lastTourLength.toFixed(0) : '—'}
+              </strong>
+            </div>
           </div>
 
           {/* Progress bar */}
-          <div class="som-progress-track" role="progressbar" aria-valuenow={step} aria-valuemax={MAX_STEPS}>
-            <div class="som-progress-bar" style={`width: ${(Math.min(step, MAX_STEPS) / MAX_STEPS * 100).toFixed(1)}%`} />
+          <div
+            class="som-progress-track"
+            role="progressbar"
+            aria-valuenow={step}
+            aria-valuemax={MAX_STEPS}
+          >
+            <div
+              class="som-progress-bar"
+              style={`width: ${((Math.min(step, MAX_STEPS) / MAX_STEPS) * 100).toFixed(1)}%`}
+            />
           </div>
 
           {/* Speed slider */}
@@ -186,8 +234,13 @@ export default function SomExplainer() {
             <label class="som-label">
               Speed
               <input
-                type="range" min="1" max="10" value={speed}
-                onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+                type="range"
+                min="1"
+                max="10"
+                value={speed}
+                onInput={(e) =>
+                  setSpeed(Number((e.target as HTMLInputElement).value))
+                }
               />
               <span>{speed}</span>
             </label>
@@ -199,13 +252,19 @@ export default function SomExplainer() {
               class="som-btn som-btn-step"
               onClick={stepFn}
               disabled={running || isDone}
-            >Step</button>
+            >
+              Step
+            </button>
             <button
               class="som-btn som-btn-run"
-              onClick={() => setRunning(r => !r)}
+              onClick={() => setRunning((r) => !r)}
               disabled={isDone}
-            >{running ? 'Pause' : 'Run'}</button>
-            <button class="som-btn som-btn-reset" onClick={reinit}>Reset</button>
+            >
+              {running ? 'Pause' : 'Run'}
+            </button>
+            <button class="som-btn som-btn-reset" onClick={reinit}>
+              Reset
+            </button>
           </div>
         </div>
       </div>
@@ -213,33 +272,69 @@ export default function SomExplainer() {
       {/* Legend */}
       <div class="som-legend">
         <span class="som-leg-item">
-          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="#f97316" /></svg>
+          <svg width="14" height="14">
+            <circle cx="7" cy="7" r="6" fill="#f97316" />
+          </svg>
           City
         </span>
         <span class="som-leg-item">
-          <svg width="14" height="14"><circle cx="7" cy="7" r="5" fill="#7c3aed" /></svg>
+          <svg width="14" height="14">
+            <circle cx="7" cy="7" r="5" fill="#7c3aed" />
+          </svg>
           Neuron
         </span>
         <span class="som-leg-item">
-          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="#4f46e5" /></svg>
+          <svg width="14" height="14">
+            <circle cx="7" cy="7" r="6" fill="#4f46e5" />
+          </svg>
           BMU
         </span>
         <span class="som-leg-item">
-          <svg width="14" height="14"><circle cx="7" cy="7" r="6" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="3,2" /></svg>
+          <svg width="14" height="14">
+            <circle
+              cx="7"
+              cy="7"
+              r="6"
+              fill="none"
+              stroke="#7c3aed"
+              stroke-width="1.5"
+              stroke-dasharray="3,2"
+            />
+          </svg>
           σ radius
         </span>
         <span class="som-leg-item">
-          <svg width="18" height="4"><line x1="0" y1="2" x2="18" y2="2" stroke="#f97316" stroke-width="1.5" stroke-dasharray="4,2" /></svg>
+          <svg width="18" height="4">
+            <line
+              x1="0"
+              y1="2"
+              x2="18"
+              y2="2"
+              stroke="#f97316"
+              stroke-width="1.5"
+              stroke-dasharray="4,2"
+            />
+          </svg>
           Attraction
         </span>
         <span class="som-leg-item">
-          <svg width="18" height="4"><line x1="0" y1="2" x2="18" y2="2" stroke="#16a34a" stroke-width="2" /></svg>
+          <svg width="18" height="4">
+            <line
+              x1="0"
+              y1="2"
+              x2="18"
+              y2="2"
+              stroke="#16a34a"
+              stroke-width="2"
+            />
+          </svg>
           Tour
         </span>
       </div>
 
       <footer class="som-footer">
-        {N_CITIES} cities · {N_NEURONS} neurons · η₀={ALPHA0} · σ₀={SIGMA0} · {MAX_STEPS} steps
+        {N_CITIES} cities · {N_NEURONS} neurons · η₀={ALPHA0} · σ₀={SIGMA0} ·{' '}
+        {MAX_STEPS} steps
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/stochastic-hill-algo.ts
+++ b/teeline-web/src/explainers/stochastic-hill-algo.ts
@@ -17,10 +17,16 @@
 // small enough that a full scenario run stays short, which suits an explainer
 // whose job is to show the mechanics (random 2-opt, accept-if-better,
 // restart-when-stale), not to solve the instance.
-import { CITIES_8 as CITIES, N_CITIES_8 as N_CITIES, dist8 as dist, tourLength8 as tourLength } from './explainer-cities'
+import {
+  CITIES_8 as CITIES,
+  N_CITIES_8 as N_CITIES,
+  dist8 as dist,
+  tourLength8 as tourLength,
+} from './explainer-cities'
 export { CITIES, N_CITIES, dist, tourLength }
 
-export type Phase = 'idle' | 'propose' | 'accepted' | 'rejected' | 'restart' | 'done'
+export type Phase =
+  'idle' | 'propose' | 'accepted' | 'rejected' | 'restart' | 'done'
 
 // ---------------------------------------------------------------
 // Seeded RNG — pure (seed, counter) → [0, 1), so it can be
@@ -49,7 +55,10 @@ export function nextRand(rng: RngState): { value: number; rng: RngState } {
 // ---------------------------------------------------------------
 // Moves — Rust route.rs semantics
 // ---------------------------------------------------------------
-export function seededShuffle(rng: RngState): { tour: number[]; rng: RngState } {
+export function seededShuffle(rng: RngState): {
+  tour: number[]
+  rng: RngState
+} {
   const tour = Array.from({ length: N_CITIES }, (_, i) => i)
   let r = rng
   for (let i = N_CITIES - 1; i > 0; i--) {
@@ -78,7 +87,10 @@ export function reverseSegment(tour: number[], i: number, j: number): number[] {
 // Rust random_successor(): draw a random pair with positions > 1 apart (the
 // wrap pair (0, n−1) is allowed), then reverse the inclusive segment [i..=j].
 // Returns the candidate tour plus the removed/added edge pairs for display.
-export function randomSuccessor(tour: number[], rng: RngState): {
+export function randomSuccessor(
+  tour: number[],
+  rng: RngState,
+): {
   tour: number[]
   i: number
   j: number
@@ -144,22 +156,22 @@ export interface CandidateEvent {
   j: number
   removed: [number, number][]
   added: [number, number][]
-  delta: number            // candidateCost − currentCost (visual Δ on screen)
+  delta: number // candidateCost − currentCost (visual Δ on screen)
   candidateTour: number[]
   candidateCost: number
-  accepted: boolean        // candidateCost < bestCost (Rust: < best_distance)
-  restart: boolean         // this rejection pushes nStale past patience
+  accepted: boolean // candidateCost < bestCost (Rust: < best_distance)
+  restart: boolean // this rejection pushes nStale past patience
   restartTour: number[] | null // fresh random tour if restarting
 }
 
 export interface SimState {
   phase: Phase
-  tour: number[]           // current tour (== bestTour except right after a restart)
+  tour: number[] // current tour (== bestTour except right after a restart)
   bestTour: number[]
   bestCost: number
   currentCost: number
-  epoch: number            // completed candidate evaluations (verdicts)
-  nStale: number           // consecutive rejections since last accept/restart
+  epoch: number // completed candidate evaluations (verdicts)
+  nStale: number // consecutive rejections since last accept/restart
   restarts: number
   acceptedCount: number
   rejectedCount: number
@@ -167,7 +179,7 @@ export interface SimState {
   patience: number
   rng: RngState
   pending: CandidateEvent | null // drawn candidate awaiting its verdict phase
-  costHistory: number[]    // best cost after each epoch (sparkline)
+  costHistory: number[] // best cost after each epoch (sparkline)
   step: number
 }
 
@@ -287,7 +299,14 @@ export function stepOnce(state: SimState): SimState {
   if (state.epoch >= state.maxEpochs) {
     return { ...state, phase: 'done', step: state.step + 1 }
   }
-  const { tour: candidateTour, i, j, removed, added, rng } = randomSuccessor(state.tour, state.rng)
+  const {
+    tour: candidateTour,
+    i,
+    j,
+    removed,
+    added,
+    rng,
+  } = randomSuccessor(state.tour, state.rng)
   const candidateCost = tourLength(candidateTour)
   const delta = candidateCost - state.currentCost
   const accepted = candidateCost < state.bestCost
@@ -307,7 +326,11 @@ export function stepOnce(state: SimState): SimState {
     phase: 'propose',
     rng: rng2,
     pending: {
-      i, j, removed, added, delta,
+      i,
+      j,
+      removed,
+      added,
+      delta,
       candidateTour,
       candidateCost,
       accepted,

--- a/teeline-web/src/explainers/stochastic-hill.test.ts
+++ b/teeline-web/src/explainers/stochastic-hill.test.ts
@@ -1,16 +1,36 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, SCENARIOS,
-  dist, tourLength, makeRng, nextRand, seededShuffle,
-  reverseSegment, randomSuccessor, makeInitState, stepOnce,
+  N_CITIES,
+  SCENARIOS,
+  dist,
+  tourLength,
+  makeRng,
+  nextRand,
+  seededShuffle,
+  reverseSegment,
+  randomSuccessor,
+  makeInitState,
+  stepOnce,
 } from './stochastic-hill-algo'
 import type { SimState } from './stochastic-hill-algo'
 
 // True optimum for the shared 8-city layout (brute-forced; verified below).
 const OPT = 827.774076596031
 
-function runToDone(seed: number, epochs: number, patience: number, initTour?: number[]): SimState {
-  let s = makeInitState({ label: '', desc: '', seed, epochs, patience, initTour })
+function runToDone(
+  seed: number,
+  epochs: number,
+  patience: number,
+  initTour?: number[],
+): SimState {
+  let s = makeInitState({
+    label: '',
+    desc: '',
+    seed,
+    epochs,
+    patience,
+    initTour,
+  })
   let guard = epochs + 1000
   while (s.phase !== 'done' && guard-- > 0) s = stepOnce(s)
   expect(s.phase, 'runToDone must reach done').toBe('done')
@@ -51,7 +71,10 @@ describe('tourLength', () => {
   })
 
   it('matches the known length of the crafted quick-start tour', () => {
-    expect(tourLength(SCENARIOS.quick_convergence.initTour!)).toBeCloseTo(1128.8, 1)
+    expect(tourLength(SCENARIOS.quick_convergence.initTour!)).toBeCloseTo(
+      1128.8,
+      1,
+    )
   })
 })
 
@@ -174,12 +197,16 @@ describe('randomSuccessor', () => {
   it('handles the (0, n−1) full-tour reversal with a single wrap edge (no self-loops)', () => {
     const tour = [0, 1, 2, 3, 4, 5, 6, 7]
     const n = tour.length
-    let hit: { removed: [number, number][]; added: [number, number][] } | null = null
+    let hit: { removed: [number, number][]; added: [number, number][] } | null =
+      null
     for (let seed = 1; seed <= 5000 && !hit; seed++) {
       const { i, j, removed, added } = randomSuccessor(tour, makeRng(seed))
       if (i === 0 && j === n - 1) hit = { removed, added }
     }
-    expect(hit, 'expected a seed producing the (0, n−1) full-tour reversal').not.toBeNull()
+    expect(
+      hit,
+      'expected a seed producing the (0, n−1) full-tour reversal',
+    ).not.toBeNull()
     expect(hit!.removed).toEqual([[tour[n - 1], tour[0]]])
     expect(hit!.added).toEqual([[tour[n - 1], tour[0]]])
   })
@@ -190,9 +217,15 @@ describe('SCENARIOS', () => {
   it('every tour (init or shuffle) is a valid permutation', () => {
     for (const [key, s] of Object.entries(SCENARIOS)) {
       const init = makeInitState(s)
-      expect(isPermutation(init.tour), `${key} tour must be a permutation`).toBe(true)
+      expect(
+        isPermutation(init.tour),
+        `${key} tour must be a permutation`,
+      ).toBe(true)
       if (s.initTour) {
-        expect(isPermutation(s.initTour), `${key} initTour must be a permutation`).toBe(true)
+        expect(
+          isPermutation(s.initTour),
+          `${key} initTour must be a permutation`,
+        ).toBe(true)
       }
     }
   })
@@ -274,7 +307,12 @@ describe('stepOnce phase machine', () => {
     let guard = 200
     while (guard-- > 0 && s.phase !== 'done') {
       const next = stepOnce(s)
-      if (next.phase !== 'propose' && next.pending && !next.pending.accepted && !next.pending.restart) {
+      if (
+        next.phase !== 'propose' &&
+        next.pending &&
+        !next.pending.accepted &&
+        !next.pending.restart
+      ) {
         expect(next.tour).toEqual(s.tour)
         expect(next.bestCost).toBe(s.bestCost)
         expect(next.nStale).toBe(s.nStale + 1)
@@ -286,7 +324,12 @@ describe('stepOnce phase machine', () => {
   })
 
   it('done is a no-op apart from the step counter', () => {
-    const done = runToDone(SCENARIOS.quick_convergence.seed, 10, 5, SCENARIOS.quick_convergence.initTour)
+    const done = runToDone(
+      SCENARIOS.quick_convergence.seed,
+      10,
+      5,
+      SCENARIOS.quick_convergence.initTour,
+    )
     const again = stepOnce(done)
     expect(again.phase).toBe('done')
     expect(again.epoch).toBe(done.epoch)
@@ -326,7 +369,10 @@ describe('Rust-faithful acceptance (candidate must beat best-so-far)', () => {
       s = next
     }
     expect(sawRestart).toBe(true)
-    expect(sawQuirk, 'expected a delta<0-but-rejected candidate after a restart').toBe(true)
+    expect(
+      sawQuirk,
+      'expected a delta<0-but-rejected candidate after a restart',
+    ).toBe(true)
   })
 
   it('acceptedCount + rejectedCount + restarts == epoch (verdicts partition)', () => {
@@ -387,7 +433,12 @@ describe('cost bookkeeping', () => {
 // ---------------------------------------------------------------
 describe('pinned scenario behaviour', () => {
   it('quick_convergence: reaches the optimum with no restarts, first improvement at epoch 1', () => {
-    const s = runToDone(SCENARIOS.quick_convergence.seed, SCENARIOS.quick_convergence.epochs, SCENARIOS.quick_convergence.patience, SCENARIOS.quick_convergence.initTour)
+    const s = runToDone(
+      SCENARIOS.quick_convergence.seed,
+      SCENARIOS.quick_convergence.epochs,
+      SCENARIOS.quick_convergence.patience,
+      SCENARIOS.quick_convergence.initTour,
+    )
     expect(s.restarts).toBeLessThanOrEqual(1)
     expect(s.bestCost).toBeCloseTo(OPT, 3)
     // ≥ 2 accepts — was 3 before dist moved to the shared Math.hypot helper;
@@ -397,7 +448,11 @@ describe('pinned scenario behaviour', () => {
   })
 
   it('rugged_landscape: many restarts and a poor final result', () => {
-    const s = runToDone(SCENARIOS.rugged_landscape.seed, SCENARIOS.rugged_landscape.epochs, SCENARIOS.rugged_landscape.patience)
+    const s = runToDone(
+      SCENARIOS.rugged_landscape.seed,
+      SCENARIOS.rugged_landscape.epochs,
+      SCENARIOS.rugged_landscape.patience,
+    )
     expect(s.restarts).toBeGreaterThanOrEqual(6)
     expect(s.bestCost).toBeGreaterThanOrEqual(OPT * 1.2)
   })
@@ -411,7 +466,11 @@ describe('pinned scenario behaviour', () => {
     while (s.phase !== 'done' && guard-- > 0) {
       const before = s
       s = stepOnce(s)
-      if (before.phase === 'propose' && s.phase !== 'propose' && s.bestCost < before.bestCost) {
+      if (
+        before.phase === 'propose' &&
+        s.phase !== 'propose' &&
+        s.bestCost < before.bestCost
+      ) {
         finalBestEpoch = s.epoch
         restartsBeforeFinal = s.restarts
       }

--- a/teeline-web/src/explainers/stochastic-hill.tsx
+++ b/teeline-web/src/explainers/stochastic-hill.tsx
@@ -1,13 +1,17 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, SCENARIOS,
-  tourLength, makeInitState, stepOnce,
-} from "./stochastic-hill-algo"
-import type { Phase, CandidateEvent, Scenario } from "./stochastic-hill-algo"
+  CITIES,
+  N_CITIES,
+  SCENARIOS,
+  tourLength,
+  makeInitState,
+  stepOnce,
+} from './stochastic-hill-algo'
+import type { Phase, CandidateEvent, Scenario } from './stochastic-hill-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.quick_convergence
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 function sameTour(a: number[], b: number[]): boolean {
   if (a.length !== b.length) return false
@@ -22,7 +26,12 @@ function edgeKey(a: number, b: number): string {
 // TourCanvas — ghost best tour behind the current tour, with
 // candidate/verdict edge highlighting and a restart fade.
 // ---------------------------------------------------------------
-function TourCanvas({ tour, bestTour, pending, phase }: {
+function TourCanvas({
+  tour,
+  bestTour,
+  pending,
+  phase,
+}: {
   tour: number[]
   bestTour: number[]
   pending: CandidateEvent | null
@@ -52,8 +61,12 @@ function TourCanvas({ tour, bestTour, pending, phase }: {
   const isRestarting = phase === 'restart'
 
   return (
-    <svg viewBox="0 0 300 300" className={`shc-canvas ${isAccepted ? 'shc-glow' : ''}`}
-      role="img" aria-label="Stochastic hill climbing tour">
+    <svg
+      viewBox="0 0 300 300"
+      className={`shc-canvas ${isAccepted ? 'shc-glow' : ''}`}
+      role="img"
+      aria-label="Stochastic hill climbing tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="shc-bg" />
 
       {/* Ghost of the best tour found so far (visible when it differs — i.e. after a restart) */}
@@ -62,9 +75,16 @@ function TourCanvas({ tour, bestTour, pending, phase }: {
           {bestTour.map((_id, k) => {
             const a = bestTour[k]
             const b = bestTour[(k + 1) % bestTour.length]
-            return <line key={`g${edgeKey(a, b)}`} className="shc-edge-ghost"
-              x1={CITIES[a][0]} y1={CITIES[a][1]}
-              x2={CITIES[b][0]} y2={CITIES[b][1]} />
+            return (
+              <line
+                key={`g${edgeKey(a, b)}`}
+                className="shc-edge-ghost"
+                x1={CITIES[a][0]}
+                y1={CITIES[a][1]}
+                x2={CITIES[b][0]}
+                y2={CITIES[b][1]}
+              />
+            )
           })}
         </g>
       )}
@@ -81,16 +101,32 @@ function TourCanvas({ tour, bestTour, pending, phase }: {
           } else if (isRejected) {
             if (removedSet.has(key)) cls += ' shc-rejected'
           }
-          return <line key={key} className={cls}
-            x1={CITIES[from][0]} y1={CITIES[from][1]}
-            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+          return (
+            <line
+              key={key}
+              className={cls}
+              x1={CITIES[from][0]}
+              y1={CITIES[from][1]}
+              x2={CITIES[to][0]}
+              y2={CITIES[to][1]}
+            />
+          )
         })}
         {tour.map((id) => (
           <g key={id}>
-            <circle className="shc-city"
-              cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
-            <text className="shc-label"
-              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+            <circle
+              className="shc-city"
+              cx={CITIES[id][0]}
+              cy={CITIES[id][1]}
+              r={6}
+            />
+            <text
+              className="shc-label"
+              x={CITIES[id][0]}
+              y={CITIES[id][1] + 16}
+            >
+              {id}
+            </text>
           </g>
         ))}
       </g>
@@ -103,7 +139,8 @@ function TourCanvas({ tour, bestTour, pending, phase }: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 46
+  const W = 300,
+    H = 46
   const minV = Math.min(...values)
   const maxV = Math.max(...values)
   const range = maxV - minV || 1
@@ -113,10 +150,19 @@ function Sparkline({ values }: { values: number[] }) {
     return `${x.toFixed(1)},${y.toFixed(1)}`
   })
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="shc-spark" aria-label="best cost over epochs">
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="shc-spark"
+      aria-label="best cost over epochs"
+    >
       <rect x={0} y={0} width={W} height={H} className="shc-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
-        strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -125,18 +171,28 @@ function Sparkline({ values }: { values: number[] }) {
 // Root component
 // ---------------------------------------------------------------
 export default function StochasticHillExplainer() {
-  const [tour, setTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.initTour!])
-  const [bestTour, setBestTour] = useState<number[]>(() => [...DEFAULT_SCENARIO.initTour!])
+  const [tour, setTour] = useState<number[]>(() => [
+    ...DEFAULT_SCENARIO.initTour!,
+  ])
+  const [bestTour, setBestTour] = useState<number[]>(() => [
+    ...DEFAULT_SCENARIO.initTour!,
+  ])
   const [phase, setPhase] = useState<Phase>('idle')
   const [epoch, setEpoch] = useState(0)
   const [nStale, setNStale] = useState(0)
   const [restarts, setRestarts] = useState(0)
-  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.initTour!))
-  const [currentCost, setCurrentCost] = useState(() => tourLength(DEFAULT_SCENARIO.initTour!))
+  const [bestCost, setBestCost] = useState(() =>
+    tourLength(DEFAULT_SCENARIO.initTour!),
+  )
+  const [currentCost, setCurrentCost] = useState(() =>
+    tourLength(DEFAULT_SCENARIO.initTour!),
+  )
   const [acceptedCount, setAcceptedCount] = useState(0)
   const [rejectedCount, setRejectedCount] = useState(0)
   const [pending, setPending] = useState<CandidateEvent | null>(null)
-  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.initTour!)])
+  const [costHistory, setCostHistory] = useState<number[]>(() => [
+    tourLength(DEFAULT_SCENARIO.initTour!),
+  ])
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(3) // 4x default — 8-city runs are short; keep them snappy
@@ -221,40 +277,48 @@ export default function StochasticHillExplainer() {
 
   // Restart-pace params are per-scenario defaults, user-adjustable; changing
   // them restarts the run with the new values (keeps the current scenario).
-  const applyParams = useCallback((epochs: number, patience: number) => {
-    const sc = scenarioRef.current
-    // Math.floor(x) || 1 guards against NaN (a partially-typed number input
-    // like "-" or ".") and 0 — either would otherwise break the epoch cap /
-    // restart threshold (e.g. maxEpochs: NaN never triggers 'done').
-    const clampedEpochs = Math.max(1, Math.min(500, Math.floor(epochs) || 1))
-    const clampedPatience = Math.max(1, Math.min(100, Math.floor(patience) || 1))
-    setEpochsInput(clampedEpochs)
-    setPatienceInput(clampedPatience)
-    reinit({ ...sc, epochs: clampedEpochs, patience: clampedPatience })
-  }, [reinit])
+  const applyParams = useCallback(
+    (epochs: number, patience: number) => {
+      const sc = scenarioRef.current
+      // Math.floor(x) || 1 guards against NaN (a partially-typed number input
+      // like "-" or ".") and 0 — either would otherwise break the epoch cap /
+      // restart threshold (e.g. maxEpochs: NaN never triggers 'done').
+      const clampedEpochs = Math.max(1, Math.min(500, Math.floor(epochs) || 1))
+      const clampedPatience = Math.max(
+        1,
+        Math.min(100, Math.floor(patience) || 1),
+      )
+      setEpochsInput(clampedEpochs)
+      setPatienceInput(clampedPatience)
+      reinit({ ...sc, epochs: clampedEpochs, patience: clampedPatience })
+    },
+    [reinit],
+  )
 
-  const acceptRate = acceptedCount + rejectedCount > 0
-    ? Math.round((acceptedCount / (acceptedCount + rejectedCount)) * 100)
-    : null
+  const acceptRate =
+    acceptedCount + rejectedCount > 0
+      ? Math.round((acceptedCount / (acceptedCount + rejectedCount)) * 100)
+      : null
 
   // Status chip
-  let chipText = "Click Step to draw a random 2-opt candidate"
-  let chipClass = "shc-chip shc-chip-idle"
+  let chipText = 'Click Step to draw a random 2-opt candidate'
+  let chipClass = 'shc-chip shc-chip-idle'
   if (phase === 'propose' && pending) {
     chipText = `Candidate — reverse ${pending.i}…${pending.j}  (Δ=${pending.delta.toFixed(0)}, ${pending.accepted ? 'beats best' : 'won’t beat best'})`
-    chipClass = "shc-chip shc-chip-candidate"
+    chipClass = 'shc-chip shc-chip-candidate'
   } else if (phase === 'accepted' && pending) {
     chipText = `Accepted — new best ${bestCost.toFixed(0)}  (Δ=${pending.delta.toFixed(0)})`
-    chipClass = "shc-chip shc-chip-accepted"
+    chipClass = 'shc-chip shc-chip-accepted'
   } else if (phase === 'rejected' && pending) {
     chipText = `Rejected — Δ=${pending.delta.toFixed(0)}, candidate ${pending.candidateCost.toFixed(0)} ≥ best ${bestCost.toFixed(0)}  (${nStale} stale)`
-    chipClass = "shc-chip shc-chip-rejected"
+    chipClass = 'shc-chip shc-chip-rejected'
   } else if (phase === 'restart') {
-    chipText = "Restarting… search went stale — fresh random tour appears (best survives)"
-    chipClass = "shc-chip shc-chip-restart"
+    chipText =
+      'Restarting… search went stale — fresh random tour appears (best survives)'
+    chipClass = 'shc-chip shc-chip-restart'
   } else if (phase === 'done') {
     chipText = `Done — ${epoch} epochs · ${restarts} restarts · best ${bestCost.toFixed(0)}`
-    chipClass = "shc-chip shc-chip-done"
+    chipClass = 'shc-chip shc-chip-done'
   }
 
   return (
@@ -265,27 +329,47 @@ export default function StochasticHillExplainer() {
         <div className="shc-eyebrow">teeline · algorithms/stochastic_hill</div>
         <h2 className="shc-title">Stochastic Hill Climbing</h2>
         <p className="shc-sub">
-          Each step draws a <strong>random 2-opt candidate</strong> — a random segment reversal.
-          The candidate is accepted only if it <strong>beats the best tour found so far</strong>;
-          otherwise it is rejected and the tour stays. When the search goes stale (too many
-          rejections in a row), it <strong>restarts from a fresh random tour</strong> — the best
-          tour survives. Random restarts are what rescue the search from mediocre local optima.
+          Each step draws a <strong>random 2-opt candidate</strong> — a random
+          segment reversal. The candidate is accepted only if it{' '}
+          <strong>beats the best tour found so far</strong>; otherwise it is
+          rejected and the tour stays. When the search goes stale (too many
+          rejections in a row), it{' '}
+          <strong>restarts from a fresh random tour</strong> — the best tour
+          survives. Random restarts are what rescue the search from mediocre
+          local optima.
         </p>
       </header>
 
       <div className="shc-viz-row">
         <div className="shc-canvas-wrap">
-          <TourCanvas tour={tour} bestTour={bestTour} pending={pending} phase={phase} />
+          <TourCanvas
+            tour={tour}
+            bestTour={bestTour}
+            pending={pending}
+            phase={phase}
+          />
         </div>
       </div>
 
       <div className="shc-legend">
-        <span><span className="shc-swatch shc-swatch-normal" /> tour edge</span>
-        <span><span className="shc-swatch shc-swatch-ghost" /> best tour (ghost)</span>
-        <span><span className="shc-swatch shc-swatch-cand-rm" /> candidate (remove)</span>
-        <span><span className="shc-swatch shc-swatch-cand-ad" /> candidate (add)</span>
-        <span><span className="shc-swatch shc-swatch-removed" /> removed</span>
-        <span><span className="shc-swatch shc-swatch-added" /> new edge</span>
+        <span>
+          <span className="shc-swatch shc-swatch-normal" /> tour edge
+        </span>
+        <span>
+          <span className="shc-swatch shc-swatch-ghost" /> best tour (ghost)
+        </span>
+        <span>
+          <span className="shc-swatch shc-swatch-cand-rm" /> candidate (remove)
+        </span>
+        <span>
+          <span className="shc-swatch shc-swatch-cand-ad" /> candidate (add)
+        </span>
+        <span>
+          <span className="shc-swatch shc-swatch-removed" /> removed
+        </span>
+        <span>
+          <span className="shc-swatch shc-swatch-added" /> new edge
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -312,7 +396,9 @@ export default function StochasticHillExplainer() {
         </div>
         <div>
           <div className="shc-statlabel">accept rate</div>
-          <div className="shc-mono">{acceptRate === null ? '—' : `${acceptRate}%`}</div>
+          <div className="shc-mono">
+            {acceptRate === null ? '—' : `${acceptRate}%`}
+          </div>
         </div>
         <div>
           <div className="shc-statlabel">step</div>
@@ -322,24 +408,47 @@ export default function StochasticHillExplainer() {
 
       <div className="shc-config">
         <div className="shc-config-row">
-          <label className="shc-label" htmlFor="shc-epochs">Epochs</label>
-          <input id="shc-epochs" className="shc-input" type="number" min={1} max={500}
+          <label className="shc-label" htmlFor="shc-epochs">
+            Epochs
+          </label>
+          <input
+            id="shc-epochs"
+            className="shc-input"
+            type="number"
+            min={1}
+            max={500}
             value={epochsInput}
-            onInput={(e) => setEpochsInput(Number((e.target as HTMLInputElement).value))}
-            onBlur={() => applyParams(epochsInput, patienceInput)} />
-          <label className="shc-label" htmlFor="shc-patience">Restart patience</label>
-          <input id="shc-patience" className="shc-input" type="number" min={1} max={100}
+            onInput={(e) =>
+              setEpochsInput(Number((e.target as HTMLInputElement).value))
+            }
+            onBlur={() => applyParams(epochsInput, patienceInput)}
+          />
+          <label className="shc-label" htmlFor="shc-patience">
+            Restart patience
+          </label>
+          <input
+            id="shc-patience"
+            className="shc-input"
+            type="number"
+            min={1}
+            max={100}
             value={patienceInput}
-            onInput={(e) => setPatienceInput(Number((e.target as HTMLInputElement).value))}
-            onBlur={() => applyParams(epochsInput, patienceInput)} />
+            onInput={(e) =>
+              setPatienceInput(Number((e.target as HTMLInputElement).value))
+            }
+            onBlur={() => applyParams(epochsInput, patienceInput)}
+          />
         </div>
         <div className="shc-config-row">
           <label className="shc-label">Speed</label>
           <div className="shc-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l}
+              <button
+                key={l}
                 className={`shc-speed-btn ${i === speedIdx ? 'shc-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
                 {l}
               </button>
             ))}
@@ -348,24 +457,47 @@ export default function StochasticHillExplainer() {
       </div>
 
       <div className="shc-controls">
-        <button className="shc-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+        <button
+          className="shc-btn"
+          onClick={stepBack}
+          disabled={running || historyRef.current.length === 0}
+        >
           ⏴ Back
         </button>
-        <button className="shc-btn" onClick={stepForward} disabled={running || phase === 'done'}>
+        <button
+          className="shc-btn"
+          onClick={stepForward}
+          disabled={running || phase === 'done'}
+        >
           ⏵ Step
         </button>
-        <button className="shc-btn" onClick={() => setRunning(!running)} disabled={phase === 'done'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="shc-btn"
+          onClick={() => setRunning(!running)}
+          disabled={phase === 'done'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
-        <button className="shc-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="shc-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="shc-scenarios">
         <div className="shc-section-label">Scenarios</div>
         <div className="shc-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
-            <button key={key} className="shc-scenario-btn" title={s.desc}
-              onClick={() => reinit(s)} disabled={running}>
+            <button
+              key={key}
+              className="shc-scenario-btn"
+              title={s.desc}
+              onClick={() => reinit(s)}
+              disabled={running}
+            >
               {s.label}
             </button>
           ))}
@@ -374,7 +506,9 @@ export default function StochasticHillExplainer() {
 
       <footer className="shc-footer">
         <span className="shc-mono">cities: {N_CITIES}</span>
-        <span className="shc-mono">random 2-opt · accept only if &lt; best · random restart</span>
+        <span className="shc-mono">
+          random 2-opt · accept only if &lt; best · random restart
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/tabu-algo.ts
+++ b/teeline-web/src/explainers/tabu-algo.ts
@@ -1,4 +1,8 @@
-import { CITIES_12 as CITIES, N_CITIES_12 as N_CITIES, tourLength12 as tourLength } from './explainer-cities'
+import {
+  CITIES_12 as CITIES,
+  N_CITIES_12 as N_CITIES,
+  tourLength12 as tourLength,
+} from './explainer-cities'
 export { CITIES, N_CITIES, tourLength }
 
 export type Move = [number, number]
@@ -39,8 +43,13 @@ export function shuffle(n: number): number[] {
 
 export function twoOptSwap(tour: number[], i: number, j: number): number[] {
   const t = tour.slice()
-  let lo = i, hi = j
-  while (lo < hi) { ;[t[lo], t[hi]] = [t[hi], t[lo]]; lo++; hi-- }
+  let lo = i,
+    hi = j
+  while (lo < hi) {
+    ;[t[lo], t[hi]] = [t[hi], t[lo]]
+    lo++
+    hi--
+  }
   return t
 }
 
@@ -50,7 +59,7 @@ export function moveKey(i: number, j: number): string {
 
 export function sampleNeighbours(
   tour: number[],
-  k: number
+  k: number,
 ): Array<{ tour: number[]; move: Move; cost: number }> {
   const n = tour.length
   const results = []
@@ -92,17 +101,23 @@ export function makeInitState(tenure: number, sampleSize: number): SimState {
 
 export function stepOnce(s: SimState): SimState {
   const candidates = sampleNeighbours(s.tour, s.sampleSize)
-  const tabuKeys = new Set(s.tabuList.map(e => e.key))
+  const tabuKeys = new Set(s.tabuList.map((e) => e.key))
 
-  const nonTabu = candidates.filter(c => !tabuKeys.has(moveKey(c.move[0], c.move[1])))
-  const tabuCands = candidates.filter(c => tabuKeys.has(moveKey(c.move[0], c.move[1])))
+  const nonTabu = candidates.filter(
+    (c) => !tabuKeys.has(moveKey(c.move[0], c.move[1])),
+  )
+  const tabuCands = candidates.filter((c) =>
+    tabuKeys.has(moveKey(c.move[0], c.move[1])),
+  )
 
-  const aspirationCand = tabuCands
-    .filter(c => c.cost < s.bestCost)
-    .sort((a, b) => a.cost - b.cost)[0] ?? null
+  const aspirationCand =
+    tabuCands
+      .filter((c) => c.cost < s.bestCost)
+      .sort((a, b) => a.cost - b.cost)[0] ?? null
 
-  const bestNonTabu = nonTabu.sort((a, b) => a.cost - b.cost)[0]
-    ?? candidates.sort((a, b) => a.cost - b.cost)[0]
+  const bestNonTabu =
+    nonTabu.sort((a, b) => a.cost - b.cost)[0] ??
+    candidates.sort((a, b) => a.cost - b.cost)[0]
 
   const chosen = aspirationCand ?? bestNonTabu
   const newCost = chosen.cost

--- a/teeline-web/src/explainers/tabu.test.ts
+++ b/teeline-web/src/explainers/tabu.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, tourLength, twoOptSwap, moveKey,
-  sampleNeighbours, makeInitState, stepOnce,
+  N_CITIES,
+  tourLength,
+  twoOptSwap,
+  moveKey,
+  sampleNeighbours,
+  makeInitState,
+  stepOnce,
 } from './tabu-algo'
 
 describe('tourLength', () => {
   it('is positive for a full tour', () => {
-    expect(tourLength(Array.from({ length: N_CITIES }, (_, i) => i))).toBeGreaterThan(0)
+    expect(
+      tourLength(Array.from({ length: N_CITIES }, (_, i) => i)),
+    ).toBeGreaterThan(0)
   })
   it('returns 0 for a single city', () => {
     expect(tourLength([0])).toBe(0)
@@ -62,7 +69,9 @@ describe('sampleNeighbours', () => {
 describe('makeInitState', () => {
   it('tour is a valid permutation', () => {
     const s = makeInitState(7, 10)
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     expect(s.tour.slice().sort((a, b) => a - b)).toEqual(expected)
   })
   it('initial tabu list is empty', () => {
@@ -105,7 +114,9 @@ describe('stepOnce', () => {
     }
   })
   it('tour remains a valid permutation after step', () => {
-    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort((a, b) => a - b)
+    const expected = Array.from({ length: N_CITIES }, (_, i) => i).sort(
+      (a, b) => a - b,
+    )
     let s = makeInitState(7, 10)
     s = stepOnce(s)
     expect(s.tour.slice().sort((a, b) => a - b)).toEqual(expected)
@@ -117,7 +128,9 @@ describe('stepOnce', () => {
   })
   it('lastEventMode is set after first step', () => {
     const s = stepOnce(makeInitState(7, 10))
-    expect(['improvement', 'admissible', 'aspiration']).toContain(s.lastEventMode)
+    expect(['improvement', 'admissible', 'aspiration']).toContain(
+      s.lastEventMode,
+    )
   })
   it('improvements counter matches improvement events', () => {
     let s = makeInitState(7, 10)

--- a/teeline-web/src/explainers/tabu.tsx
+++ b/teeline-web/src/explainers/tabu.tsx
@@ -1,21 +1,35 @@
-import { useState, useRef, useEffect, useCallback } from "preact/hooks"
-import type { Move, TabuEntry, EventMode, SimState } from "./tabu-algo"
-import { CITIES, N_CITIES, makeInitState, stepOnce } from "./tabu-algo"
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks'
+import type { Move, TabuEntry, EventMode, SimState } from './tabu-algo'
+import { CITIES, N_CITIES, makeInitState, stepOnce } from './tabu-algo'
 
 function polyPts(tour: number[]): string {
-  const pts = tour.map(i => `${CITIES[i][0]},${CITIES[i][1]}`).join(" ")
+  const pts = tour.map((i) => `${CITIES[i][0]},${CITIES[i][1]}`).join(' ')
   return pts + ` ${CITIES[tour[0]][0]},${CITIES[tour[0]][1]}`
 }
 
-function getEdgeDiff(tour: number[], move: Move): {
+function getEdgeDiff(
+  tour: number[],
+  move: Move,
+): {
   removed: [[number, number], [number, number]]
   added: [[number, number], [number, number]]
 } {
   const n = tour.length
   const [i, j] = move
-  const a = tour[(i - 1 + n) % n], b = tour[i]
-  const c = tour[j], d = tour[(j + 1) % n]
-  return { removed: [[a, b], [c, d]], added: [[a, c], [b, d]] }
+  const a = tour[(i - 1 + n) % n],
+    b = tour[i]
+  const c = tour[j],
+    d = tour[(j + 1) % n]
+  return {
+    removed: [
+      [a, b],
+      [c, d],
+    ],
+    added: [
+      [a, c],
+      [b, d],
+    ],
+  }
 }
 
 // ---------------------------------------------------------------
@@ -27,36 +41,72 @@ interface CurrentTourSVGProps {
   lastMove: Move | null
   showBest: boolean
 }
-function CurrentTourSVG({ tour, best, lastMove, showBest }: CurrentTourSVGProps) {
+function CurrentTourSVG({
+  tour,
+  best,
+  lastMove,
+  showBest,
+}: CurrentTourSVGProps) {
   const diff = lastMove ? getEdgeDiff(tour, lastMove) : null
-  const changedCities = lastMove ? new Set([lastMove[0], lastMove[1]]) : new Set<number>()
+  const changedCities = lastMove
+    ? new Set([lastMove[0], lastMove[1]])
+    : new Set<number>()
   return (
-    <svg viewBox="0 0 300 300" className="tabu-canvas" role="img" aria-label="Current tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="tabu-canvas"
+      role="img"
+      aria-label="Current tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="tabu-bg" />
-      {showBest && <polyline points={polyPts(best)} className="tabu-best-tour" />}
-      <polyline points={polyPts(tour)} className={showBest ? "tabu-current-tour tabu-current-faded" : "tabu-current-tour"} />
-      {diff && diff.removed.map(([a, b], i) => (
-        <line key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
-          className="tabu-edge-removed"
-        />
-      ))}
-      {diff && diff.added.map(([a, b], i) => (
-        <line key={i}
-          x1={CITIES[a][0]} y1={CITIES[a][1]}
-          x2={CITIES[b][0]} y2={CITIES[b][1]}
-          className="tabu-edge-added"
-        />
-      ))}
+      {showBest && (
+        <polyline points={polyPts(best)} className="tabu-best-tour" />
+      )}
+      <polyline
+        points={polyPts(tour)}
+        className={
+          showBest
+            ? 'tabu-current-tour tabu-current-faded'
+            : 'tabu-current-tour'
+        }
+      />
+      {diff &&
+        diff.removed.map(([a, b], i) => (
+          <line
+            key={i}
+            x1={CITIES[a][0]}
+            y1={CITIES[a][1]}
+            x2={CITIES[b][0]}
+            y2={CITIES[b][1]}
+            className="tabu-edge-removed"
+          />
+        ))}
+      {diff &&
+        diff.added.map(([a, b], i) => (
+          <line
+            key={i}
+            x1={CITIES[a][0]}
+            y1={CITIES[a][1]}
+            x2={CITIES[b][0]}
+            y2={CITIES[b][1]}
+            className="tabu-edge-added"
+          />
+        ))}
       {CITIES.map(([x, y], i) => (
-        <circle key={i} cx={x} cy={y}
+        <circle
+          key={i}
+          cx={x}
+          cy={y}
           r={changedCities.has(i) ? 7 : 4}
-          className={changedCities.has(i) ? "tabu-city tabu-city-changed" : "tabu-city"}
+          className={
+            changedCities.has(i) ? 'tabu-city tabu-city-changed' : 'tabu-city'
+          }
         />
       ))}
       {CITIES.map(([x, y], i) => (
-        <text key={i} x={x + 6} y={y - 5} className="tabu-city-label">{i}</text>
+        <text key={i} x={x + 6} y={y - 5} className="tabu-city-label">
+          {i}
+        </text>
       ))}
     </svg>
   )
@@ -75,18 +125,23 @@ function TabuListPanel({ tabuList, tenure, step }: TabuListPanelProps) {
     <div className="tabu-list-panel">
       <div className="tabu-list-title">Tabu List</div>
       <div className="tabu-list-subtitle">(tenure={tenure})</div>
-      {tabuList.length === 0
-        ? <div className="tabu-list-empty">no forbidden moves yet</div>
-        : tabuList.map((entry, idx) => {
-            const age = step - entry.addedAtStep
-            const opacity = 1 - (age / tenure) * 0.75
-            return (
-              <div key={idx} className="tabu-badge" style={{ opacity: Math.max(0.25, opacity) }}>
-                ({entry.move[0]},{entry.move[1]})
-              </div>
-            )
-          })
-      }
+      {tabuList.length === 0 ? (
+        <div className="tabu-list-empty">no forbidden moves yet</div>
+      ) : (
+        tabuList.map((entry, idx) => {
+          const age = step - entry.addedAtStep
+          const opacity = 1 - (age / tenure) * 0.75
+          return (
+            <div
+              key={idx}
+              className="tabu-badge"
+              style={{ opacity: Math.max(0.25, opacity) }}
+            >
+              ({entry.move[0]},{entry.move[1]})
+            </div>
+          )
+        })
+      )}
     </div>
   )
 }
@@ -95,12 +150,18 @@ function TabuListPanel({ tabuList, tenure, step }: TabuListPanelProps) {
 // CostSparkline — cost per step
 // ---------------------------------------------------------------
 function CostSparkline({ costHistory }: { costHistory: number[] }) {
-  const W = 300, H = 54
+  const W = 300,
+    H = 54
   if (costHistory.length < 2) {
     return (
       <svg viewBox={`0 0 ${W} ${H}`} className="tabu-spark">
         <rect x={0} y={0} width={W} height={H} className="tabu-bg" rx={4} />
-        <text x={W / 2} y={H / 2 + 4} textAnchor="middle" className="tabu-spark-idle">
+        <text
+          x={W / 2}
+          y={H / 2 + 4}
+          textAnchor="middle"
+          className="tabu-spark-idle"
+        >
           Run a few steps to see cost history
         </text>
       </svg>
@@ -113,14 +174,23 @@ function CostSparkline({ costHistory }: { costHistory: number[] }) {
   const xScale = (W - pad * 2) / (costHistory.length - 1)
   const yScale = (H - pad * 2) / range
   const pts = costHistory
-    .map((c, i) => `${(pad + i * xScale).toFixed(1)},${(H - pad - (c - minC) * yScale).toFixed(1)}`)
-    .join(" ")
+    .map(
+      (c, i) =>
+        `${(pad + i * xScale).toFixed(1)},${(H - pad - (c - minC) * yScale).toFixed(1)}`,
+    )
+    .join(' ')
   const lastX = pad + (costHistory.length - 1) * xScale
   const lastY = H - pad - (costHistory[costHistory.length - 1] - minC) * yScale
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="tabu-spark">
       <rect x={0} y={0} width={W} height={H} className="tabu-bg" rx={4} />
-      <polyline points={pts} fill="none" stroke="#0d9488" strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
       <circle cx={lastX} cy={lastY} r={3} fill="#0d9488" />
     </svg>
   )
@@ -139,7 +209,9 @@ export default function TabuExplainer() {
   const [tour, setTour] = useState(() => simRef.current.tour)
   const [best, setBest] = useState<number[]>(() => simRef.current.best)
   const [bestCost, setBestCost] = useState(() => simRef.current.bestCost)
-  const [currentCost, setCurrentCost] = useState(() => simRef.current.currentCost)
+  const [currentCost, setCurrentCost] = useState(
+    () => simRef.current.currentCost,
+  )
   const [tabuList, setTabuList] = useState<TabuEntry[]>([])
   const [step, setStep] = useState(0)
   const [lastMove, setLastMove] = useState<Move | null>(null)
@@ -153,21 +225,36 @@ export default function TabuExplainer() {
   const reinit = useCallback((t: number, ss: number) => {
     const s = makeInitState(t, ss)
     simRef.current = s
-    setTour(s.tour.slice()); setBest(s.best.slice()); setBestCost(s.bestCost)
-    setCurrentCost(s.currentCost); setTabuList([]); setStep(0)
-    setLastMove(null); setEventMode(null); setLastDelta(null)
-    setAspirationHits(0); setImprovements(0); setCostHistory([])
+    setTour(s.tour.slice())
+    setBest(s.best.slice())
+    setBestCost(s.bestCost)
+    setCurrentCost(s.currentCost)
+    setTabuList([])
+    setStep(0)
+    setLastMove(null)
+    setEventMode(null)
+    setLastDelta(null)
+    setAspirationHits(0)
+    setImprovements(0)
+    setCostHistory([])
     setRunning(false)
   }, [])
 
   const step_fn = useCallback(() => {
     const next = stepOnce(simRef.current)
     simRef.current = next
-    setTour(next.tour.slice()); setBest(next.best.slice()); setBestCost(next.bestCost)
-    setCurrentCost(next.currentCost); setTabuList(next.tabuList.slice())
-    setStep(next.step); setLastMove(next.lastMove); setEventMode(next.lastEventMode)
-    setLastDelta(next.lastDelta); setAspirationHits(next.aspirationHits)
-    setImprovements(next.improvements); setCostHistory(next.costHistory.slice())
+    setTour(next.tour.slice())
+    setBest(next.best.slice())
+    setBestCost(next.bestCost)
+    setCurrentCost(next.currentCost)
+    setTabuList(next.tabuList.slice())
+    setStep(next.step)
+    setLastMove(next.lastMove)
+    setEventMode(next.lastEventMode)
+    setLastDelta(next.lastDelta)
+    setAspirationHits(next.aspirationHits)
+    setImprovements(next.improvements)
+    setCostHistory(next.costHistory.slice())
   }, [])
 
   useEffect(() => {
@@ -177,17 +264,17 @@ export default function TabuExplainer() {
     return () => clearInterval(id)
   }, [running, speed, step_fn])
 
-  let chipText = "Press Step or Run to begin"
-  let chipClass = "tabu-chip tabu-chip-idle"
+  let chipText = 'Press Step or Run to begin'
+  let chipClass = 'tabu-chip tabu-chip-idle'
   if (eventMode === 'improvement' && lastMove !== null) {
-    chipText = `✅ improved  Δ = ${lastDelta !== null ? lastDelta.toFixed(1) : "—"}  (${lastMove[0]},${lastMove[1]})`
-    chipClass = "tabu-chip tabu-chip-improve"
+    chipText = `✅ improved  Δ = ${lastDelta !== null ? lastDelta.toFixed(1) : '—'}  (${lastMove[0]},${lastMove[1]})`
+    chipClass = 'tabu-chip tabu-chip-improve'
   } else if (eventMode === 'admissible' && lastMove !== null) {
-    chipText = `➡️ best admissible  Δ = +${lastDelta !== null ? Math.abs(lastDelta).toFixed(1) : "—"}  (tabu avoided)`
-    chipClass = "tabu-chip tabu-chip-admissible"
+    chipText = `➡️ best admissible  Δ = +${lastDelta !== null ? Math.abs(lastDelta).toFixed(1) : '—'}  (tabu avoided)`
+    chipClass = 'tabu-chip tabu-chip-admissible'
   } else if (eventMode === 'aspiration' && lastMove !== null) {
     chipText = `⭐ aspiration — new global best!  (${lastMove[0]},${lastMove[1]})`
-    chipClass = "tabu-chip tabu-chip-aspiration"
+    chipClass = 'tabu-chip tabu-chip-aspiration'
   }
 
   return (
@@ -198,25 +285,41 @@ export default function TabuExplainer() {
         <div className="tabu-eyebrow">teeline · algorithms/tabu</div>
         <h2 className="tabu-title">Tabu Search</h2>
         <p className="tabu-sub">
-          A single tour improves via <strong>best-admissible 2-opt</strong> moves. Recent moves are
-          added to the <strong>tabu list</strong> and forbidden for <code>tenure</code> steps —
-          preventing cycles. If a forbidden move beats the global best, the{" "}
+          A single tour improves via <strong>best-admissible 2-opt</strong>{' '}
+          moves. Recent moves are added to the <strong>tabu list</strong> and
+          forbidden for <code>tenure</code> steps — preventing cycles. If a
+          forbidden move beats the global best, the{' '}
           <strong>aspiration criterion</strong> overrides the ban.
         </p>
       </header>
 
       <div className="tabu-viz-row">
         <div className="tabu-canvas-wrap">
-          <CurrentTourSVG tour={tour} best={best} lastMove={lastMove} showBest={!running && step > 0} />
+          <CurrentTourSVG
+            tour={tour}
+            best={best}
+            lastMove={lastMove}
+            showBest={!running && step > 0}
+          />
         </div>
         <TabuListPanel tabuList={tabuList} tenure={tenure} step={step} />
       </div>
 
       <div className="tabu-legend">
-        <span><span className="tabu-swatch tabu-swatch-current" /> current tour</span>
-        <span><span className="tabu-swatch tabu-swatch-removed" /> removed edge</span>
-        <span><span className="tabu-swatch tabu-swatch-added" /> added edge</span>
-        {!running && step > 0 && <span><span className="tabu-swatch tabu-swatch-best" /> best tour</span>}
+        <span>
+          <span className="tabu-swatch tabu-swatch-current" /> current tour
+        </span>
+        <span>
+          <span className="tabu-swatch tabu-swatch-removed" /> removed edge
+        </span>
+        <span>
+          <span className="tabu-swatch tabu-swatch-added" /> added edge
+        </span>
+        {!running && step > 0 && (
+          <span>
+            <span className="tabu-swatch tabu-swatch-best" /> best tour
+          </span>
+        )}
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -231,7 +334,9 @@ export default function TabuExplainer() {
         </div>
         <div>
           <div className="tabu-statlabel">tabu size</div>
-          <div className="tabu-mono">{tabuList.length}/{tenure}</div>
+          <div className="tabu-mono">
+            {tabuList.length}/{tenure}
+          </div>
         </div>
         <div>
           <div className="tabu-statlabel">best cost</div>
@@ -253,43 +358,72 @@ export default function TabuExplainer() {
 
       <div className="tabu-config">
         <div className="tabu-config-row">
-          <label className="tabu-config-label">Tenure = <strong>{tenure}</strong></label>
-          <input type="range" min={3} max={15} step={1} value={tenure}
+          <label className="tabu-config-label">
+            Tenure = <strong>{tenure}</strong>
+          </label>
+          <input
+            type="range"
+            min={3}
+            max={15}
+            step={1}
+            value={tenure}
             className="tabu-slider"
-            onInput={e => {
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
-              setTenure(v); reinit(v, sampleSize)
+              setTenure(v)
+              reinit(v, sampleSize)
             }}
           />
           <div className="tabu-hint">Steps a move stays forbidden</div>
         </div>
         <div className="tabu-config-row">
-          <label className="tabu-config-label">Sample size = <strong>{sampleSize}</strong></label>
-          <input type="range" min={5} max={30} step={5} value={sampleSize}
+          <label className="tabu-config-label">
+            Sample size = <strong>{sampleSize}</strong>
+          </label>
+          <input
+            type="range"
+            min={5}
+            max={30}
+            step={5}
+            value={sampleSize}
             className="tabu-slider"
-            onInput={e => {
+            onInput={(e) => {
               const v = Number((e.target as HTMLInputElement).value)
-              setSampleSize(v); reinit(tenure, v)
+              setSampleSize(v)
+              reinit(tenure, v)
             }}
           />
           <div className="tabu-hint">Neighbours evaluated per step</div>
         </div>
         <div className="tabu-config-row">
           <label className="tabu-config-label">Speed</label>
-          <input type="range" min={1} max={10} step={1} value={speed}
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={speed}
             className="tabu-slider"
-            onInput={e => setSpeed(Number((e.target as HTMLInputElement).value))}
+            onInput={(e) =>
+              setSpeed(Number((e.target as HTMLInputElement).value))
+            }
           />
         </div>
       </div>
 
       <div className="tabu-controls">
-        <button className="tabu-btn" onClick={step_fn} disabled={running}>◀ Step</button>
-        <button className={`tabu-btn ${!running ? "tabu-btn-primary" : ""}`}
-          onClick={() => setRunning(r => !r)}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button className="tabu-btn" onClick={step_fn} disabled={running}>
+          ◀ Step
         </button>
-        <button className="tabu-btn" onClick={() => reinit(tenure, sampleSize)}>↺ Reset</button>
+        <button
+          className={`tabu-btn ${!running ? 'tabu-btn-primary' : ''}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
+        </button>
+        <button className="tabu-btn" onClick={() => reinit(tenure, sampleSize)}>
+          ↺ Reset
+        </button>
       </div>
 
       <footer className="tabu-footer">

--- a/teeline-web/src/explainers/three-opt-algo.ts
+++ b/teeline-web/src/explainers/three-opt-algo.ts
@@ -33,13 +33,13 @@ export const CASE_LABELS: Record<CaseNo, string> = {
 }
 
 export interface MoveEvent {
-  i: number             // A = path[i]
-  j: number             // C = path[j]
-  k: number             // E = path[k]
+  i: number // A = path[i]
+  j: number // C = path[j]
+  k: number // E = path[k]
   caseNo: CaseNo
-  delta: number         // new tour length − old tour length (negative = improvement)
-  removedEdges: [number, number][]  // [A,B], [C,D], [E,F] — the three cut edges
-  addedEdges: [number, number][]    // the three reconnection edges for this case
+  delta: number // new tour length − old tour length (negative = improvement)
+  removedEdges: [number, number][] // [A,B], [C,D], [E,F] — the three cut edges
+  addedEdges: [number, number][] // the three reconnection edges for this case
 }
 
 export interface SimState {
@@ -47,8 +47,8 @@ export interface SimState {
   tour: number[]
   bestTour: number[]
   bestCost: number
-  pass: number          // completed scans (one per applied swap + final scan)
-  swaps: number         // applied 3-opt moves
+  pass: number // completed scans (one per applied swap + final scan)
+  swaps: number // applied 3-opt moves
   pending: MoveEvent | null
   lastMove: MoveEvent | null
   costHistory: number[] // best cost after each pass (sparkline)
@@ -56,15 +56,58 @@ export interface SimState {
 }
 
 // New edge sets for the 7 reconnection cases (Rust reconnection_costs table).
-function addedEdgesForCase(a: number, b: number, c: number, d: number, e: number, f: number, caseNo: CaseNo): [number, number][] {
+function addedEdgesForCase(
+  a: number,
+  b: number,
+  c: number,
+  d: number,
+  e: number,
+  f: number,
+  caseNo: CaseNo,
+): [number, number][] {
   switch (caseNo) {
-    case 1: return [[a, c], [b, d], [e, f]]
-    case 2: return [[a, b], [c, e], [d, f]]
-    case 3: return [[a, c], [b, e], [d, f]]
-    case 4: return [[a, d], [e, b], [c, f]]
-    case 5: return [[a, d], [e, c], [b, f]]
-    case 6: return [[a, e], [d, b], [c, f]]
-    case 7: return [[a, e], [d, c], [b, f]]
+    case 1:
+      return [
+        [a, c],
+        [b, d],
+        [e, f],
+      ]
+    case 2:
+      return [
+        [a, b],
+        [c, e],
+        [d, f],
+      ]
+    case 3:
+      return [
+        [a, c],
+        [b, e],
+        [d, f],
+      ]
+    case 4:
+      return [
+        [a, d],
+        [e, b],
+        [c, f],
+      ]
+    case 5:
+      return [
+        [a, d],
+        [e, c],
+        [b, f],
+      ]
+    case 6:
+      return [
+        [a, e],
+        [d, b],
+        [c, f],
+      ]
+    case 7:
+      return [
+        [a, e],
+        [d, c],
+        [b, f],
+      ]
   }
 }
 
@@ -73,7 +116,13 @@ function addedEdgesForCase(a: number, b: number, c: number, d: number, e: number
 // lowest-index best case; overall the first move with the max savings.
 export function scanBestMove(tour: number[]): MoveEvent | null {
   const n = tour.length
-  let bestMove: { i: number; j: number; k: number; caseNo: CaseNo; delta: number } | null = null
+  let bestMove: {
+    i: number
+    j: number
+    k: number
+    caseNo: CaseNo
+    delta: number
+  } | null = null
   let bestSavings = 0
 
   for (let i = 0; i < n - 2; i++) {
@@ -132,28 +181,49 @@ export function scanBestMove(tour: number[]): MoveEvent | null {
   const e = tour[k]
   const f = tour[(k + 1) % n]
   return {
-    i, j, k, caseNo, delta,
-    removedEdges: [[a, b], [c, dt], [e, f]],
+    i,
+    j,
+    k,
+    caseNo,
+    delta,
+    removedEdges: [
+      [a, b],
+      [c, dt],
+      [e, f],
+    ],
     addedEdges: addedEdgesForCase(a, b, c, dt, e, f, caseNo),
   }
 }
 
 // Rust apply_3opt: cases 1–3 reverse segments, cases 4–7 swap/reverse the two
 // middle segments into [i+1..=k].
-export function apply3Opt(tour: number[], i: number, j: number, k: number, caseNo: CaseNo): number[] {
+export function apply3Opt(
+  tour: number[],
+  i: number,
+  j: number,
+  k: number,
+  caseNo: CaseNo,
+): number[] {
   const rev = (arr: number[]) => [...arr].reverse()
   const s1 = tour.slice(i + 1, j + 1) // [i+1..=j]
   const s2 = tour.slice(j + 1, k + 1) // [j+1..=k]
   const head = tour.slice(0, i + 1)
   const tail = tour.slice(k + 1)
   switch (caseNo) {
-    case 1: return [...head, ...rev(s1), ...s2, ...tail]
-    case 2: return [...head, ...s1, ...rev(s2), ...tail]
-    case 3: return [...head, ...rev(s1), ...rev(s2), ...tail]
-    case 4: return [...head, ...s2, ...s1, ...tail]
-    case 5: return [...head, ...s2, ...rev(s1), ...tail]
-    case 6: return [...head, ...rev(s2), ...s1, ...tail]
-    case 7: return [...head, ...rev(s2), ...rev(s1), ...tail]
+    case 1:
+      return [...head, ...rev(s1), ...s2, ...tail]
+    case 2:
+      return [...head, ...s1, ...rev(s2), ...tail]
+    case 3:
+      return [...head, ...rev(s1), ...rev(s2), ...tail]
+    case 4:
+      return [...head, ...s2, ...s1, ...tail]
+    case 5:
+      return [...head, ...s2, ...rev(s1), ...tail]
+    case 6:
+      return [...head, ...rev(s2), ...s1, ...tail]
+    case 7:
+      return [...head, ...rev(s2), ...rev(s1), ...tail]
   }
 }
 

--- a/teeline-web/src/explainers/three-opt.test.ts
+++ b/teeline-web/src/explainers/three-opt.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, SCENARIOS, CASE_LABELS,
-  dist, tourLength, scanBestMove, apply3Opt, makeInitState, stepOnce,
+  N_CITIES,
+  SCENARIOS,
+  CASE_LABELS,
+  dist,
+  tourLength,
+  scanBestMove,
+  apply3Opt,
+  makeInitState,
+  stepOnce,
 } from './three-opt-algo'
 import type { SimState } from './three-opt-algo'
 import { scanOnePass, makeInitState as twoOptInit } from './two-opt-algo'
@@ -108,7 +115,13 @@ describe('scanBestMove', () => {
     expect(move.j).toBe(2)
     expect(move.k).toBe(4)
     // applying it reaches the optimum
-    const after = apply3Opt(SCENARIOS.single_3opt.tour, move.i, move.j, move.k, move.caseNo)
+    const after = apply3Opt(
+      SCENARIOS.single_3opt.tour,
+      move.i,
+      move.j,
+      move.k,
+      move.caseNo,
+    )
     expect(tourLength(after)).toBeCloseTo(OPT, 3)
   })
 
@@ -127,7 +140,9 @@ describe('scanBestMove', () => {
       if (key === 'already_3optimal') continue
       const move = scanBestMove(s.tour)!
       const before = tourLength(s.tour)
-      const after = tourLength(apply3Opt(s.tour, move.i, move.j, move.k, move.caseNo))
+      const after = tourLength(
+        apply3Opt(s.tour, move.i, move.j, move.k, move.caseNo),
+      )
       expect(after - before, `${key} delta mismatch`).toBeCloseTo(move.delta, 3)
     }
   })
@@ -153,7 +168,15 @@ describe('stepOnce phase machine', () => {
     expect(s2.phase).toBe('swap_applied')
     expect(s2.pass).toBe(1)
     expect(s2.swaps).toBe(1)
-    expect(s2.tour).toEqual(apply3Opt(s0.tour, s1.pending!.i, s1.pending!.j, s1.pending!.k, s1.pending!.caseNo))
+    expect(s2.tour).toEqual(
+      apply3Opt(
+        s0.tour,
+        s1.pending!.i,
+        s1.pending!.j,
+        s1.pending!.k,
+        s1.pending!.caseNo,
+      ),
+    )
     expect(s2.costHistory).toHaveLength(2)
     expect(s2.step).toBe(2)
   })
@@ -238,7 +261,9 @@ describe('purity & determinism', () => {
   it('all scenario tours are valid permutations', () => {
     for (const [key, s] of Object.entries(SCENARIOS)) {
       const sorted = s.tour.slice().sort((a, b) => a - b)
-      expect(sorted, `${key} must be a permutation`).toEqual(Array.from({ length: N_CITIES }, (_, i) => i))
+      expect(sorted, `${key} must be a permutation`).toEqual(
+        Array.from({ length: N_CITIES }, (_, i) => i),
+      )
     }
   })
 })

--- a/teeline-web/src/explainers/three-opt.tsx
+++ b/teeline-web/src/explainers/three-opt.tsx
@@ -1,13 +1,18 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, SCENARIOS, CASE_LABELS,
-  tourLength, makeInitState, stepOnce,
-} from "./three-opt-algo"
-import type { Phase, MoveEvent, Scenario, CaseNo } from "./three-opt-algo"
+  CITIES,
+  N_CITIES,
+  SCENARIOS,
+  CASE_LABELS,
+  tourLength,
+  makeInitState,
+  stepOnce,
+} from './three-opt-algo'
+import type { Phase, MoveEvent, Scenario, CaseNo } from './three-opt-algo'
 
 const DEFAULT_SCENARIO = SCENARIOS.single_3opt
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 const CASES: CaseNo[] = [1, 2, 3, 4, 5, 6, 7]
 
 function edgeKey(a: number, b: number): string {
@@ -28,37 +33,95 @@ const NODE_POS: Record<string, [number, number]> = {
   E: [7, 27],
   F: [7, 13],
 }
-const REMOVED_LABEL_PAIRS: [string, string][] = [['A', 'B'], ['C', 'D'], ['E', 'F']]
+const REMOVED_LABEL_PAIRS: [string, string][] = [
+  ['A', 'B'],
+  ['C', 'D'],
+  ['E', 'F'],
+]
 
 function caseLabelPairs(caseNo: CaseNo): [string, string][] {
   switch (caseNo) {
-    case 1: return [['A', 'C'], ['B', 'D'], ['E', 'F']]
-    case 2: return [['A', 'B'], ['C', 'E'], ['D', 'F']]
-    case 3: return [['A', 'C'], ['B', 'E'], ['D', 'F']]
-    case 4: return [['A', 'D'], ['E', 'B'], ['C', 'F']]
-    case 5: return [['A', 'D'], ['E', 'C'], ['B', 'F']]
-    case 6: return [['A', 'E'], ['D', 'B'], ['C', 'F']]
-    case 7: return [['A', 'E'], ['D', 'C'], ['B', 'F']]
+    case 1:
+      return [
+        ['A', 'C'],
+        ['B', 'D'],
+        ['E', 'F'],
+      ]
+    case 2:
+      return [
+        ['A', 'B'],
+        ['C', 'E'],
+        ['D', 'F'],
+      ]
+    case 3:
+      return [
+        ['A', 'C'],
+        ['B', 'E'],
+        ['D', 'F'],
+      ]
+    case 4:
+      return [
+        ['A', 'D'],
+        ['E', 'B'],
+        ['C', 'F'],
+      ]
+    case 5:
+      return [
+        ['A', 'D'],
+        ['E', 'C'],
+        ['B', 'F'],
+      ]
+    case 6:
+      return [
+        ['A', 'E'],
+        ['D', 'B'],
+        ['C', 'F'],
+      ]
+    case 7:
+      return [
+        ['A', 'E'],
+        ['D', 'C'],
+        ['B', 'F'],
+      ]
   }
 }
 
 function PatternCell({ caseNo, active }: { caseNo: CaseNo; active: boolean }) {
   const pairs = caseLabelPairs(caseNo)
   return (
-    <div className={`t3-pattern-cell ${active ? 't3-pattern-active' : ''}`} title={CASE_LABELS[caseNo]}>
-      <svg viewBox="0 0 48 40" className="t3-pattern-svg" aria-label={`case ${caseNo}: ${CASE_LABELS[caseNo]}`}>
+    <div
+      className={`t3-pattern-cell ${active ? 't3-pattern-active' : ''}`}
+      title={CASE_LABELS[caseNo]}
+    >
+      <svg
+        viewBox="0 0 48 40"
+        className="t3-pattern-svg"
+        aria-label={`case ${caseNo}: ${CASE_LABELS[caseNo]}`}
+      >
         {REMOVED_LABEL_PAIRS.map(([a, b]) => (
-          <line key={`r${a}${b}`} className="t3-pattern-removed"
-            x1={NODE_POS[a][0]} y1={NODE_POS[a][1]}
-            x2={NODE_POS[b][0]} y2={NODE_POS[b][1]} />
+          <line
+            key={`r${a}${b}`}
+            className="t3-pattern-removed"
+            x1={NODE_POS[a][0]}
+            y1={NODE_POS[a][1]}
+            x2={NODE_POS[b][0]}
+            y2={NODE_POS[b][1]}
+          />
         ))}
         {pairs.map(([a, b]) => (
-          <line key={`n${a}${b}`} className="t3-pattern-new"
-            x1={NODE_POS[a][0]} y1={NODE_POS[a][1]}
-            x2={NODE_POS[b][0]} y2={NODE_POS[b][1]} />
+          <line
+            key={`n${a}${b}`}
+            className="t3-pattern-new"
+            x1={NODE_POS[a][0]}
+            y1={NODE_POS[a][1]}
+            x2={NODE_POS[b][0]}
+            y2={NODE_POS[b][1]}
+          />
         ))}
         {Object.entries(NODE_POS).map(([label, [x, y]]) => (
-          <text key={label} className="t3-pattern-node" x={x} y={y}>{label}</text>
+          <text key={label} className="t3-pattern-node" x={x} y={y}>
+            {label}
+          </text>
         ))}
       </svg>
       <div className="t3-pattern-case">{caseNo}</div>
@@ -70,7 +133,13 @@ function PatternCell({ caseNo, active }: { caseNo: CaseNo; active: boolean }) {
 // TourCanvas — the current tour with 3 removed / 3 added edges and a
 // CSS morph that makes the tour flow to its new shape on apply.
 // ---------------------------------------------------------------
-function TourCanvas({ tour, pending, lastMove, phase, morph }: {
+function TourCanvas({
+  tour,
+  pending,
+  lastMove,
+  phase,
+  morph,
+}: {
   tour: number[]
   pending: MoveEvent | null
   lastMove: MoveEvent | null
@@ -103,25 +172,42 @@ function TourCanvas({ tour, pending, lastMove, phase, morph }: {
   }
 
   return (
-    <svg viewBox="0 0 300 300"
+    <svg
+      viewBox="0 0 300 300"
       className={`t3-canvas ${morph && showApplied ? 't3-morph' : ''}`}
-      role="img" aria-label="3-opt tour">
+      role="img"
+      aria-label="3-opt tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="t3-bg" />
       <g className="t3-tour">
         {edges.map(({ from, to, key }) => {
           let cls = 't3-edge'
-          if (addedSet.has(key)) cls += showCandidate ? ' t3-cand-new' : ' t3-new'
-          else if (removedSet.has(key)) cls += showCandidate ? ' t3-cand-removed' : ' t3-removed'
-          return <line key={key} className={cls}
-            x1={CITIES[from][0]} y1={CITIES[from][1]}
-            x2={CITIES[to][0]} y2={CITIES[to][1]} />
+          if (addedSet.has(key))
+            cls += showCandidate ? ' t3-cand-new' : ' t3-new'
+          else if (removedSet.has(key))
+            cls += showCandidate ? ' t3-cand-removed' : ' t3-removed'
+          return (
+            <line
+              key={key}
+              className={cls}
+              x1={CITIES[from][0]}
+              y1={CITIES[from][1]}
+              x2={CITIES[to][0]}
+              y2={CITIES[to][1]}
+            />
+          )
         })}
         {tour.map((id) => (
           <g key={id}>
-            <circle className="t3-city"
-              cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
-            <text className="t3-label"
-              x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+            <circle
+              className="t3-city"
+              cx={CITIES[id][0]}
+              cy={CITIES[id][1]}
+              r={6}
+            />
+            <text className="t3-label" x={CITIES[id][0]} y={CITIES[id][1] + 16}>
+              {id}
+            </text>
           </g>
         ))}
       </g>
@@ -134,7 +220,8 @@ function TourCanvas({ tour, pending, lastMove, phase, morph }: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 46
+  const W = 300,
+    H = 46
   const minV = Math.min(...values)
   const maxV = Math.max(...values)
   const range = maxV - minV || 1
@@ -144,10 +231,19 @@ function Sparkline({ values }: { values: number[] }) {
     return `${x.toFixed(1)},${y.toFixed(1)}`
   })
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="t3-spark" aria-label="cost over passes">
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="t3-spark"
+      aria-label="cost over passes"
+    >
       <rect x={0} y={0} width={W} height={H} className="t3-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
-        strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -160,10 +256,14 @@ export default function ThreeOptExplainer() {
   const [phase, setPhase] = useState<Phase>('idle')
   const [pass, setPass] = useState(0)
   const [swaps, setSwaps] = useState(0)
-  const [bestCost, setBestCost] = useState(() => tourLength(DEFAULT_SCENARIO.tour))
+  const [bestCost, setBestCost] = useState(() =>
+    tourLength(DEFAULT_SCENARIO.tour),
+  )
   const [pending, setPending] = useState<MoveEvent | null>(null)
   const [lastMove, setLastMove] = useState<MoveEvent | null>(null)
-  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_SCENARIO.tour)])
+  const [costHistory, setCostHistory] = useState<number[]>(() => [
+    tourLength(DEFAULT_SCENARIO.tour),
+  ])
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(2) // 3x default
@@ -242,18 +342,18 @@ export default function ThreeOptExplainer() {
   }
 
   // Status chip
-  let chipText = "Click Step to scan triples for the best 3-opt reconnection"
-  let chipClass = "t3-chip t3-chip-idle"
+  let chipText = 'Click Step to scan triples for the best 3-opt reconnection'
+  let chipClass = 't3-chip t3-chip-idle'
   if (phase === 'candidate' && pending) {
     const [[a, b], [c, d], [e, f]] = pending.removedEdges
     chipText = `Candidate — remove ${a}→${b} · ${c}→${d} · ${e}→${f}, case ${pending.caseNo} (${CASE_LABELS[pending.caseNo]})  (Δ=${pending.delta.toFixed(0)})`
-    chipClass = "t3-chip t3-chip-candidate"
+    chipClass = 't3-chip t3-chip-candidate'
   } else if (phase === 'swap_applied' && lastMove) {
     chipText = `Applied — case ${lastMove.caseNo} (${CASE_LABELS[lastMove.caseNo]})  (Δ=${lastMove.delta.toFixed(0)})`
-    chipClass = "t3-chip t3-chip-applied"
+    chipClass = 't3-chip t3-chip-applied'
   } else if (phase === 'local_optimum') {
     chipText = `Local optimum — no improving 3-opt move (${swaps} swaps, ${pass} passes)`
-    chipClass = "t3-chip t3-chip-done"
+    chipClass = 't3-chip t3-chip-done'
   }
 
   return (
@@ -264,17 +364,24 @@ export default function ThreeOptExplainer() {
         <div className="t3-eyebrow">teeline · algorithms/3opt</div>
         <h2 className="t3-title">3-opt Local Search</h2>
         <p className="t3-sub">
-          3-opt removes <strong>three edges</strong> and reconnects the three resulting segments in
-          one of <strong>seven ways</strong> (2-opt only has one). Cases 1–3 reverse segments; cases
-          4–7 <em>swap</em> segments — the moves 2-opt cannot express. Each pass scans all triples
-          and applies the single <strong>best-improving</strong> reconnection, repeating until no
-          triple yields an improvement.
+          3-opt removes <strong>three edges</strong> and reconnects the three
+          resulting segments in one of <strong>seven ways</strong> (2-opt only
+          has one). Cases 1–3 reverse segments; cases 4–7 <em>swap</em> segments
+          — the moves 2-opt cannot express. Each pass scans all triples and
+          applies the single <strong>best-improving</strong> reconnection,
+          repeating until no triple yields an improvement.
         </p>
       </header>
 
       <div className="t3-viz-row">
         <div className="t3-canvas-wrap">
-          <TourCanvas tour={tour} pending={pending} lastMove={lastMove} phase={phase} morph={morphOn} />
+          <TourCanvas
+            tour={tour}
+            pending={pending}
+            lastMove={lastMove}
+            phase={phase}
+            morph={morphOn}
+          />
         </div>
         <div className="t3-pattern-wrap">
           <div className="t3-section-label">Reconnection patterns</div>
@@ -287,10 +394,18 @@ export default function ThreeOptExplainer() {
       </div>
 
       <div className="t3-legend">
-        <span><span className="t3-swatch t3-swatch-normal" /> tour edge</span>
-        <span><span className="t3-swatch t3-swatch-removed" /> removed</span>
-        <span><span className="t3-swatch t3-swatch-new" /> new edge</span>
-        <span><span className="t3-swatch t3-swatch-pattern" /> chosen pattern</span>
+        <span>
+          <span className="t3-swatch t3-swatch-normal" /> tour edge
+        </span>
+        <span>
+          <span className="t3-swatch t3-swatch-removed" /> removed
+        </span>
+        <span>
+          <span className="t3-swatch t3-swatch-new" /> new edge
+        </span>
+        <span>
+          <span className="t3-swatch t3-swatch-pattern" /> chosen pattern
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -317,7 +432,12 @@ export default function ThreeOptExplainer() {
         </div>
         <div>
           <div className="t3-statlabel">last Δ</div>
-          <div className="t3-mono" style={{ color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit' }}>
+          <div
+            className="t3-mono"
+            style={{
+              color: lastMove && lastMove.delta < 0 ? '#16a34a' : 'inherit',
+            }}
+          >
             {lastMove ? lastMove.delta.toFixed(0) : '—'}
           </div>
         </div>
@@ -332,9 +452,12 @@ export default function ThreeOptExplainer() {
           <label className="t3-label">Speed</label>
           <div className="t3-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l}
+              <button
+                key={l}
                 className={`t3-speed-btn ${i === speedIdx ? 't3-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
                 {l}
               </button>
             ))}
@@ -343,24 +466,47 @@ export default function ThreeOptExplainer() {
       </div>
 
       <div className="t3-controls">
-        <button className="t3-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+        <button
+          className="t3-btn"
+          onClick={stepBack}
+          disabled={running || historyRef.current.length === 0}
+        >
           ⏴ Back
         </button>
-        <button className="t3-btn" onClick={stepForward} disabled={running || phase === 'local_optimum'}>
+        <button
+          className="t3-btn"
+          onClick={stepForward}
+          disabled={running || phase === 'local_optimum'}
+        >
           ⏵ Step
         </button>
-        <button className="t3-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="t3-btn"
+          onClick={() => setRunning(!running)}
+          disabled={phase === 'local_optimum'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
-        <button className="t3-btn" onClick={() => reinit(scenarioRef.current)} disabled={running}>↺ Reset</button>
+        <button
+          className="t3-btn"
+          onClick={() => reinit(scenarioRef.current)}
+          disabled={running}
+        >
+          ↺ Reset
+        </button>
       </div>
 
       <div className="t3-scenarios">
         <div className="t3-section-label">Scenarios</div>
         <div className="t3-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
-            <button key={key} className="t3-scenario-btn" title={s.desc}
-              onClick={() => reinit(s)} disabled={running}>
+            <button
+              key={key}
+              className="t3-scenario-btn"
+              title={s.desc}
+              onClick={() => reinit(s)}
+              disabled={running}
+            >
               {s.label}
             </button>
           ))}
@@ -369,7 +515,9 @@ export default function ThreeOptExplainer() {
 
       <footer className="t3-footer">
         <span className="t3-mono">cities: {N_CITIES}</span>
-        <span className="t3-mono">O(n³) triple scan · 7 reconnections · best-improvement</span>
+        <span className="t3-mono">
+          O(n³) triple scan · 7 reconnections · best-improvement
+        </span>
       </footer>
     </div>
   )

--- a/teeline-web/src/explainers/two-opt-algo.ts
+++ b/teeline-web/src/explainers/two-opt-algo.ts
@@ -28,7 +28,10 @@ export interface SimState {
 }
 
 // Predefined scenario tours
-export const SCENARIOS: Record<string, { label: string; desc: string; tour: number[] }> = {
+export const SCENARIOS: Record<
+  string,
+  { label: string; desc: string; tour: number[] }
+> = {
   single_crossing: {
     label: 'Single crossing',
     desc: 'One pair of edges cross — one swap fixes it',
@@ -115,8 +118,7 @@ export function applySwap(tour: number[], i: number, j: number): number[] {
 // One step: if in candidate phase, apply the pending swap.
 // Otherwise scan for the best improving swap and show it as a candidate.
 export function stepOnce(state: SimState): SimState {
-  if (state.phase === 'local_optimum')
-    return { ...state, step: state.step + 1 }
+  if (state.phase === 'local_optimum') return { ...state, step: state.step + 1 }
 
   // Second click — apply the candidate swap
   if (state.phase === 'candidate' && state.lastSwap) {

--- a/teeline-web/src/explainers/two-opt.test.ts
+++ b/teeline-web/src/explainers/two-opt.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import {
-  N_CITIES, SCENARIOS,
-  dist, tourLength, makeInitState, stepOnce,
-  scanOnePass, applySwap,
+  N_CITIES,
+  SCENARIOS,
+  dist,
+  tourLength,
+  makeInitState,
+  stepOnce,
+  scanOnePass,
+  applySwap,
 } from './two-opt-algo'
 
 describe('dist', () => {
@@ -121,12 +126,12 @@ describe('stepOnce', () => {
     expect(s1.lastSwap).not.toBeNull()
     expect(s1.lastSwap!.delta).toBeLessThan(0)
     expect(s1.tour).toEqual(s.tour) // tour unchanged
-    expect(s1.totalSwaps).toBe(0)   // not applied yet
+    expect(s1.totalSwaps).toBe(0) // not applied yet
   })
 
   it('second click applies the candidate swap', () => {
     const s = makeInitState(SCENARIOS.bad_shuffle.tour)
-    const s1 = stepOnce(s)  // candidate
+    const s1 = stepOnce(s) // candidate
     const s2 = stepOnce(s1) // apply
     expect(s2.phase).toBe('swap_found')
     expect(s2.totalSwaps).toBe(1)
@@ -157,7 +162,7 @@ describe('stepOnce', () => {
 
   it('produces valid swap event fields when applied', () => {
     const s = makeInitState(SCENARIOS.bad_shuffle.tour)
-    const s1 = stepOnce(s)  // candidate
+    const s1 = stepOnce(s) // candidate
     const s2 = stepOnce(s1) // apply
     expect(s2.lastSwap).not.toBeNull()
     expect(s2.lastSwap!.i).toBeGreaterThanOrEqual(0)

--- a/teeline-web/src/explainers/two-opt.tsx
+++ b/teeline-web/src/explainers/two-opt.tsx
@@ -1,29 +1,41 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "preact/hooks"
+import { useState, useRef, useEffect, useCallback, useMemo } from 'preact/hooks'
 import {
-  CITIES, N_CITIES, SCENARIOS,
-  tourLength, makeInitState, stepOnce,
-} from "./two-opt-algo"
-import type { Phase } from "./two-opt-algo"
+  CITIES,
+  N_CITIES,
+  SCENARIOS,
+  tourLength,
+  makeInitState,
+  stepOnce,
+} from './two-opt-algo'
+import type { Phase } from './two-opt-algo'
 
 const DEFAULT_TOUR = SCENARIOS.bad_shuffle.tour
 const SPEEDS = [600, 420, 280, 180, 100, 50, 25]
-const SPEED_LABELS = ["1x", "2x", "3x", "4x", "5x", "6x", "7x"]
+const SPEED_LABELS = ['1x', '2x', '3x', '4x', '5x', '6x', '7x']
 
 // ---------------------------------------------------------------
 // TourCanvas — current tour with highlighted swap edges
 // ---------------------------------------------------------------
-function TourCanvas({ tour, lastSwap, phase }: {
+function TourCanvas({
+  tour,
+  lastSwap,
+  phase,
+}: {
   tour: number[]
   lastSwap: { removed: [number, number][]; added: [number, number][] } | null
   phase: Phase
 }) {
   const removeSet = useMemo(() => {
     if (!lastSwap) return new Set<string>()
-    return new Set(lastSwap.removed.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`))
+    return new Set(
+      lastSwap.removed.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`),
+    )
   }, [lastSwap])
   const addSet = useMemo(() => {
     if (!lastSwap) return new Set<string>()
-    return new Set(lastSwap.added.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`))
+    return new Set(
+      lastSwap.added.map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`),
+    )
   }, [lastSwap])
 
   const edges: Array<{ from: number; to: number; key: string }> = []
@@ -37,27 +49,44 @@ function TourCanvas({ tour, lastSwap, phase }: {
   const showApplied = phase === 'swap_found' && lastSwap
 
   return (
-    <svg viewBox="0 0 300 300" className="topt-canvas" role="img" aria-label="2-opt tour">
+    <svg
+      viewBox="0 0 300 300"
+      className="topt-canvas"
+      role="img"
+      aria-label="2-opt tour"
+    >
       <rect x={0} y={0} width={300} height={300} className="topt-bg" />
       {edges.map(({ from, to, key }) => {
-        let cls = "topt-edge"
+        let cls = 'topt-edge'
         if (showCandidate) {
-          if (removeSet.has(key)) cls += " topt-cand-removed"
-          else if (addSet.has(key)) cls += " topt-cand-added"
+          if (removeSet.has(key)) cls += ' topt-cand-removed'
+          else if (addSet.has(key)) cls += ' topt-cand-added'
         } else if (showApplied) {
-          if (removeSet.has(key)) cls += " topt-removed"
-          else if (addSet.has(key)) cls += " topt-added"
+          if (removeSet.has(key)) cls += ' topt-removed'
+          else if (addSet.has(key)) cls += ' topt-added'
         }
-        return <line key={key} className={cls}
-          x1={CITIES[from][0]} y1={CITIES[from][1]}
-          x2={CITIES[to][0]} y2={CITIES[to][1]} />
+        return (
+          <line
+            key={key}
+            className={cls}
+            x1={CITIES[from][0]}
+            y1={CITIES[from][1]}
+            x2={CITIES[to][0]}
+            y2={CITIES[to][1]}
+          />
+        )
       })}
       {tour.map((id) => (
         <g key={id}>
-          <circle className="topt-city"
-            cx={CITIES[id][0]} cy={CITIES[id][1]} r={6} />
-          <text className="topt-label"
-            x={CITIES[id][0]} y={CITIES[id][1] + 16}>{id}</text>
+          <circle
+            className="topt-city"
+            cx={CITIES[id][0]}
+            cy={CITIES[id][1]}
+            r={6}
+          />
+          <text className="topt-label" x={CITIES[id][0]} y={CITIES[id][1] + 16}>
+            {id}
+          </text>
         </g>
       ))}
     </svg>
@@ -69,7 +98,8 @@ function TourCanvas({ tour, lastSwap, phase }: {
 // ---------------------------------------------------------------
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null
-  const W = 300, H = 46
+  const W = 300,
+    H = 46
   const minV = Math.min(...values)
   const maxV = Math.max(...values)
   const range = maxV - minV || 1
@@ -81,8 +111,13 @@ function Sparkline({ values }: { values: number[] }) {
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="topt-spark">
       <rect x={0} y={0} width={W} height={H} className="topt-bg" rx={4} />
-      <polyline points={pts.join(" ")} fill="none" stroke="#0d9488"
-        strokeWidth={1.5} strokeLinejoin="round" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="#0d9488"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
@@ -97,9 +132,15 @@ export default function TwoOptExplainer() {
   const [pass, setPass] = useState(0)
   const [totalSwaps, setTotalSwaps] = useState(0)
   const [lastSwap, setLastSwap] = useState<{
-    i: number; j: number; removed: [number, number][]; added: [number, number][]; delta: number
+    i: number
+    j: number
+    removed: [number, number][]
+    added: [number, number][]
+    delta: number
   } | null>(null)
-  const [costHistory, setCostHistory] = useState<number[]>(() => [tourLength(DEFAULT_TOUR)])
+  const [costHistory, setCostHistory] = useState<number[]>(() => [
+    tourLength(DEFAULT_TOUR),
+  ])
   const [step, setStep] = useState(0)
   const [running, setRunning] = useState(false)
   const [speedIdx, setSpeedIdx] = useState(0) // 1x = 600ms — slow enough to observe swaps
@@ -158,21 +199,21 @@ export default function TwoOptExplainer() {
     return () => clearInterval(id)
   }, [running, speedIdx, step_fn])
 
-  let chipText = "Click Step to scan for improving swaps"
-  let chipClass = "topt-chip topt-chip-idle"
+  let chipText = 'Click Step to scan for improving swaps'
+  let chipClass = 'topt-chip topt-chip-idle'
   if (phase === 'candidate' && lastSwap) {
     const [r0a, r0b] = lastSwap.removed[0]
     const [r1a, r1b] = lastSwap.removed[1]
     chipText = `Candidate — edges to remove: ${r0a}→${r0b} and ${r1a}→${r1b}  (Δ=${lastSwap.delta.toFixed(0)})`
-    chipClass = "topt-chip topt-chip-candidate"
+    chipClass = 'topt-chip topt-chip-candidate'
   } else if (phase === 'swap_found' && lastSwap) {
     const [r0a, r0b] = lastSwap.removed[0]
     const [a0a, a0b] = lastSwap.added[0]
     chipText = `Swapped — removed ${r0a}→${r0b}, added ${a0a}→${a0b}  (Δ=${lastSwap.delta.toFixed(0)})`
-    chipClass = "topt-chip topt-chip-swap"
+    chipClass = 'topt-chip topt-chip-swap'
   } else if (phase === 'local_optimum') {
     chipText = `Local optimum reached — no improving swap exists (${totalSwaps} swaps, ${pass} passes)`
-    chipClass = "topt-chip topt-chip-done"
+    chipClass = 'topt-chip topt-chip-done'
   }
 
   return (
@@ -184,9 +225,9 @@ export default function TwoOptExplainer() {
         <h2 className="topt-title">2-opt Local Search</h2>
         <p className="topt-sub">
           2-opt iteratively improves a tour by removing two edges and
-          reconnecting the resulting segments in the only other valid way
-          — reversing the segment between the two removed edges. Each pass
-          scans all edge pairs and applies the <strong>best-improving</strong> swap;
+          reconnecting the resulting segments in the only other valid way —
+          reversing the segment between the two removed edges. Each pass scans
+          all edge pairs and applies the <strong>best-improving</strong> swap;
           the algorithm stops when no improving swap exists (local optimum).
         </p>
       </header>
@@ -198,11 +239,22 @@ export default function TwoOptExplainer() {
       </div>
 
       <div className="topt-legend">
-        <span><span className="topt-swatch topt-swatch-normal" /> tour edge</span>
-        <span><span className="topt-swatch topt-swatch-cand-rm" /> candidate (remove)</span>
-        <span><span className="topt-swatch topt-swatch-cand-ad" /> candidate (add)</span>
-        <span><span className="topt-swatch topt-swatch-removed" /> removed</span>
-        <span><span className="topt-swatch topt-swatch-added" /> new edge</span>
+        <span>
+          <span className="topt-swatch topt-swatch-normal" /> tour edge
+        </span>
+        <span>
+          <span className="topt-swatch topt-swatch-cand-rm" /> candidate
+          (remove)
+        </span>
+        <span>
+          <span className="topt-swatch topt-swatch-cand-ad" /> candidate (add)
+        </span>
+        <span>
+          <span className="topt-swatch topt-swatch-removed" /> removed
+        </span>
+        <span>
+          <span className="topt-swatch topt-swatch-added" /> new edge
+        </span>
       </div>
 
       <div className={chipClass}>{chipText}</div>
@@ -230,7 +282,10 @@ export default function TwoOptExplainer() {
         {lastSwap && (
           <div>
             <div className="topt-statlabel">last Δ</div>
-            <div className="topt-mono" style={{ color: lastSwap.delta < 0 ? "#16a34a" : "inherit" }}>
+            <div
+              className="topt-mono"
+              style={{ color: lastSwap.delta < 0 ? '#16a34a' : 'inherit' }}
+            >
               {lastSwap.delta.toFixed(0)}
             </div>
           </div>
@@ -242,9 +297,12 @@ export default function TwoOptExplainer() {
           <label className="topt-label">Speed</label>
           <div className="topt-speed-btns">
             {SPEED_LABELS.map((l, i) => (
-              <button key={l}
+              <button
+                key={l}
                 className={`topt-speed-btn ${i === speedIdx ? 'topt-speed-btn-sel' : ''}`}
-                onClick={() => setSpeedIdx(i)} disabled={running}>
+                onClick={() => setSpeedIdx(i)}
+                disabled={running}
+              >
                 {l}
               </button>
             ))}
@@ -253,24 +311,42 @@ export default function TwoOptExplainer() {
       </div>
 
       <div className="topt-controls">
-        <button className="topt-btn" onClick={stepBack} disabled={running || historyRef.current.length === 0}>
+        <button
+          className="topt-btn"
+          onClick={stepBack}
+          disabled={running || historyRef.current.length === 0}
+        >
           ⏴ Back
         </button>
-        <button className="topt-btn" onClick={step_fn} disabled={running || phase === 'local_optimum'}>
+        <button
+          className="topt-btn"
+          onClick={step_fn}
+          disabled={running || phase === 'local_optimum'}
+        >
           ⏵ Step
         </button>
-        <button className="topt-btn" onClick={() => setRunning(!running)} disabled={phase === 'local_optimum'}>
-          {running ? "⏸ Pause" : "▶ Run"}
+        <button
+          className="topt-btn"
+          onClick={() => setRunning(!running)}
+          disabled={phase === 'local_optimum'}
+        >
+          {running ? '⏸ Pause' : '▶ Run'}
         </button>
-        <button className="topt-btn" onClick={() => reinit([...tour])}>↺ Reset</button>
+        <button className="topt-btn" onClick={() => reinit([...tour])}>
+          ↺ Reset
+        </button>
       </div>
 
       <div className="topt-scenarios">
         <div className="topt-section-label">Scenarios</div>
         <div className="topt-scenario-row">
           {Object.entries(SCENARIOS).map(([key, s]) => (
-            <button key={key} className="topt-scenario-btn" title={s.desc}
-              onClick={() => reinit([...s.tour])}>
+            <button
+              key={key}
+              className="topt-scenario-btn"
+              title={s.desc}
+              onClick={() => reinit([...s.tour])}
+            >
               {s.label}
             </button>
           ))}

--- a/teeline-web/src/lib/benchmark-data.ts
+++ b/teeline-web/src/lib/benchmark-data.ts
@@ -49,4 +49,11 @@ export const FAMILY_LABELS: Record<Family, string> = {
 }
 
 // Solver ids to label explicitly on the chart (notable points).
-export const LABELED_IDS = new Set(['hk', 'nn', 'christofides', '2opt', 'lk', 'cs'])
+export const LABELED_IDS = new Set([
+  'hk',
+  'nn',
+  'christofides',
+  '2opt',
+  'lk',
+  'cs',
+])

--- a/teeline-web/src/lib/hero-canvas.ts
+++ b/teeline-web/src/lib/hero-canvas.ts
@@ -1,7 +1,9 @@
 import { berlin52, type HeroCity } from './hero-cities'
 
 export function initHeroCanvas(): void {
-  const svg = document.getElementById('hero-canvas') as unknown as SVGSVGElement | null
+  const svg = document.getElementById(
+    'hero-canvas',
+  ) as unknown as SVGSVGElement | null
   const lengthEl = document.getElementById('hero-tour-length')
   const iterEl = document.getElementById('hero-iterations')
   const bestEl = document.getElementById('hero-best')
@@ -13,7 +15,6 @@ export function initHeroCanvas(): void {
 
   const NS = 'http://www.w3.org/2000/svg'
   const cities: HeroCity[] = berlin52.map((c) => ({ id: c.id, x: c.x, y: c.y }))
-  
 
   function dist(a: number, b: number): number {
     const dx = cities[a].x - cities[b].x
@@ -148,7 +149,9 @@ export function initHeroCanvas(): void {
     nodeEls[dragging]?.setAttribute('cy', String(cities[dragging].y))
     frames = buildFrames()
     best = Math.min(best, ...frames.map((f) => f.cost))
-    bestNode.textContent = best.toLocaleString('en-US', { maximumFractionDigits: 0 })
+    bestNode.textContent = best.toLocaleString('en-US', {
+      maximumFractionDigits: 0,
+    })
     renderRoute(frames[0].route)
     length.textContent = Math.round(frames[0].cost).toLocaleString('en-US')
     iterations.textContent = '0'

--- a/teeline-web/src/main.ts
+++ b/teeline-web/src/main.ts
@@ -1,15 +1,40 @@
 import type { ParsedProblem } from 'teeline-wasm'
 import { type SolveOptions } from './solver-options'
-import type { SolveResult, SolveError, ParseResult, AlgorithmsResult, VersionResult, WorkerReadyMessage, CompareToursResult } from './worker'
+import type {
+  SolveResult,
+  SolveError,
+  ParseResult,
+  AlgorithmsResult,
+  VersionResult,
+  WorkerReadyMessage,
+  CompareToursResult,
+} from './worker'
 import { initUpload, resetUpload } from './upload'
 import { initSolverConfig } from './solver-form'
 import { initWebMCP } from './webmcp'
-import { initResults, updateOptRoute, showRunning, showResult, showGapFromOptCost, patchComparison, setTourProblemName, setTourSolverName } from './results'
-import { buildTourText, buildCsvText, buildJsonText, serializeSvg, triggerDownload } from './download'
+import {
+  initResults,
+  updateOptRoute,
+  showRunning,
+  showResult,
+  showGapFromOptCost,
+  patchComparison,
+  setTourProblemName,
+  setTourSolverName,
+} from './results'
+import {
+  buildTourText,
+  buildCsvText,
+  buildJsonText,
+  serializeSvg,
+  triggerDownload,
+} from './download'
 
 window.addEventListener('load', () => import('./sentry'), { once: true })
 
-const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+const worker = new Worker(new URL('./worker.ts', import.meta.url), {
+  type: 'module',
+})
 
 export function runSolver(
   solver: string,
@@ -22,13 +47,19 @@ export function runSolver(
       if (e.data.type === 'result') {
         resolve(e.data.solution)
         document.dispatchEvent(
-          new CustomEvent('solver:result', { detail: e.data.solution, bubbles: true }),
+          new CustomEvent('solver:result', {
+            detail: e.data.solution,
+            bubbles: true,
+          }),
         )
       } else {
         const err = new Error(e.data.message)
         reject(err)
         document.dispatchEvent(
-          new CustomEvent('solver:error', { detail: e.data.message, bubbles: true }),
+          new CustomEvent('solver:error', {
+            detail: e.data.message,
+            bubbles: true,
+          }),
         )
       }
     }
@@ -80,7 +111,7 @@ function setWasmStatus(state: 'loading' | 'ready' | 'error'): void {
 // ---- Results (init before solver config so showRunning is ready) ----
 
 initResults(
-  [],          // cities injected per-run via showResult; updated below
+  [], // cities injected per-run via showResult; updated below
   () => optTourRoute,
   () => {
     // "try another solver" — solver-form re-shows step-02 via its own stepper logic
@@ -95,122 +126,144 @@ if (versionEl) versionEl.textContent = 'Connecting…'
 
 worker.addEventListener('error', () => {
   setWasmStatus('error')
-  if (versionEl) versionEl.textContent = 'WASM failed to load — try refreshing the page'
+  if (versionEl)
+    versionEl.textContent = 'WASM failed to load — try refreshing the page'
 })
 
 let gotAlgorithms = false
 let gotVersion = false
 
-worker.addEventListener('message', function onInit(e: MessageEvent<WorkerReadyMessage | AlgorithmsResult | VersionResult>) {
-  const data = e.data
+worker.addEventListener(
+  'message',
+  function onInit(
+    e: MessageEvent<WorkerReadyMessage | AlgorithmsResult | VersionResult>,
+  ) {
+    const data = e.data
 
-  if (data.type === 'worker-ready') {
-    // WASM is fully initialised — safe to call listAlgorithms / getVersion now
-    worker.postMessage({ type: 'list-algorithms' })
-    worker.postMessage({ type: 'get-version' })
-    return
-  }
+    if (data.type === 'worker-ready') {
+      // WASM is fully initialised — safe to call listAlgorithms / getVersion now
+      worker.postMessage({ type: 'list-algorithms' })
+      worker.postMessage({ type: 'get-version' })
+      return
+    }
 
-  if (data.type === 'algorithms') {
-    solverConfig = initSolverConfig(
-      data.algorithms,
-      () => parsedProblem !== null,
-      (solver, options) => {
-        if (!parsedProblem) return
+    if (data.type === 'algorithms') {
+      solverConfig = initSolverConfig(
+        data.algorithms,
+        () => parsedProblem !== null,
+        (solver, options) => {
+          if (!parsedProblem) return
 
-        // Re-init results with current cities so renderTour has the right data
-        initResults(
-          parsedProblem.cities,
-          () => optTourRoute,
-          () => {
-            const step04 = document.getElementById('step-04') as HTMLElement
-            const step02 = document.getElementById('step-02') as HTMLElement
-            step04.hidden = true
-            step02.hidden = false
-            ;(document.getElementById('download-actions') as HTMLElement).hidden = true
-          },
-        )
+          // Re-init results with current cities so renderTour has the right data
+          initResults(
+            parsedProblem.cities,
+            () => optTourRoute,
+            () => {
+              const step04 = document.getElementById('step-04') as HTMLElement
+              const step02 = document.getElementById('step-02') as HTMLElement
+              step04.hidden = true
+              step02.hidden = false
+              ;(
+                document.getElementById('download-actions') as HTMLElement
+              ).hidden = true
+            },
+          )
 
-        setTourSolverName(solver)
-        showRunning()
+          setTourSolverName(solver)
+          showRunning()
 
-        const start = Date.now()
-        runSolver(solver, parsedProblem.cities, options)
-          .then((result) => {
-            const runtime = Date.now() - start
-            const record = { solver, total: result.total, runtime, route: result.route }
-            showResult(record)
-            showDownloadButtons(record, parsedProblem!)
-            clearCompareError()
+          const start = Date.now()
+          runSolver(solver, parsedProblem.cities, options)
+            .then((result) => {
+              const runtime = Date.now() - start
+              const record = {
+                solver,
+                total: result.total,
+                runtime,
+                route: result.route,
+              }
+              showResult(record)
+              showDownloadButtons(record, parsedProblem!)
+              clearCompareError()
 
-            // Show gap from ?opt= query param if we have optimal cost but no route
-            showGapFromOptCost(record.total)
+              // Show gap from ?opt= query param if we have optimal cost but no route
+              showGapFromOptCost(record.total)
 
-            if (optTourRoute) {
-              const compareId = crypto.randomUUID()
-              const compareHandler = (e: MessageEvent<CompareToursResult>) => {
-                if (e.data.type !== 'compare-tours-result') return
-                if (e.data.id !== compareId) return
-                worker.removeEventListener('message', compareHandler)
-                if (e.data.stats) {
-                  patchComparison(record, e.data.stats)
+              if (optTourRoute) {
+                const compareId = crypto.randomUUID()
+                const compareHandler = (
+                  e: MessageEvent<CompareToursResult>,
+                ) => {
+                  if (e.data.type !== 'compare-tours-result') return
+                  if (e.data.id !== compareId) return
+                  worker.removeEventListener('message', compareHandler)
+                  if (e.data.stats) {
+                    patchComparison(record, e.data.stats)
+                  } else {
+                    showCompareError(e.data.error ?? 'Comparison failed')
+                  }
+                }
+                worker.addEventListener('message', compareHandler)
+                if (rawInput) {
+                  worker.postMessage({
+                    type: 'compare-tours-from-input',
+                    id: compareId,
+                    solverRoute: result.route,
+                    optRoute: optTourRoute,
+                    input: rawInput,
+                  })
                 } else {
-                  showCompareError(e.data.error ?? 'Comparison failed')
+                  worker.postMessage({
+                    type: 'compare-tours',
+                    id: compareId,
+                    solverRoute: result.route,
+                    optRoute: optTourRoute,
+                    cities: parsedProblem!.cities,
+                  })
                 }
               }
-              worker.addEventListener('message', compareHandler)
-              if (rawInput) {
-                worker.postMessage({
-                  type: 'compare-tours-from-input',
-                  id: compareId,
-                  solverRoute: result.route,
-                  optRoute: optTourRoute,
-                  input: rawInput,
-                })
-              } else {
-                worker.postMessage({
-                  type: 'compare-tours',
-                  id: compareId,
-                  solverRoute: result.route,
-                  optRoute: optTourRoute,
-                  cities: parsedProblem!.cities,
-                })
-              }
-            }
-          })
-          .catch((err: Error) => {
-            const overlay = document.getElementById('solving-overlay') as HTMLElement
-            overlay.hidden = true
-            console.error('Solver error:', err)
-          })
-      },
-    )
+            })
+            .catch((err: Error) => {
+              const overlay = document.getElementById(
+                'solving-overlay',
+              ) as HTMLElement
+              overlay.hidden = true
+              console.error('Solver error:', err)
+            })
+        },
+      )
 
-    // Upload depends on solverConfig.refresh — must be wired after solverConfig exists
-    initUpload(
-      parseFile,
-      (p, input) => { parsedProblem = p; rawInput = input; solverConfig!.refresh(); setTourProblemName(p.name || 'unnamed') },
-      (route) => {
-        optTourRoute = route.length > 0 ? route : null
-        updateOptRoute(optTourRoute)
-      },
-    )
+      // Upload depends on solverConfig.refresh — must be wired after solverConfig exists
+      initUpload(
+        parseFile,
+        (p, input) => {
+          parsedProblem = p
+          rawInput = input
+          solverConfig!.refresh()
+          setTourProblemName(p.name || 'unnamed')
+        },
+        (route) => {
+          optTourRoute = route.length > 0 ? route : null
+          updateOptRoute(optTourRoute)
+        },
+      )
 
-    initWebMCP(worker)
-    setWasmStatus('ready')
-    gotAlgorithms = true
-  }
+      initWebMCP(worker)
+      setWasmStatus('ready')
+      gotAlgorithms = true
+    }
 
-  if (data.type === 'version') {
-    const versionEl = document.getElementById('wasm-version')
-    if (versionEl) versionEl.textContent = `teeline-solver ${data.version}`
-    gotVersion = true
-  }
+    if (data.type === 'version') {
+      const versionEl = document.getElementById('wasm-version')
+      if (versionEl) versionEl.textContent = `teeline-solver ${data.version}`
+      gotVersion = true
+    }
 
-  if (gotAlgorithms && gotVersion) {
-    worker.removeEventListener('message', onInit)
-  }
-})
+    if (gotAlgorithms && gotVersion) {
+      worker.removeEventListener('message', onInit)
+    }
+  },
+)
 
 // ---- Comparison error banner ----
 
@@ -223,7 +276,10 @@ function showCompareError(msg: string): void {
 
 function clearCompareError(): void {
   const el = document.getElementById('comparison-error') as HTMLElement | null
-  if (el) { el.hidden = true; el.textContent = '' }
+  if (el) {
+    el.hidden = true
+    el.textContent = ''
+  }
 }
 
 // ---- Reset / new dataset ----
@@ -240,19 +296,29 @@ function resetToStep01(): void {
   const gapM = document.getElementById('result-gap-metric')
   if (lenM) lenM.textContent = '—'
   if (rtM) rtM.textContent = '—'
-  if (gapM) { gapM.textContent = '—'; gapM.className = 'mt-0.5 font-mono text-lg text-positive' }
+  if (gapM) {
+    gapM.textContent = '—'
+    gapM.className = 'mt-0.5 font-mono text-lg text-positive'
+  }
   ;(document.getElementById('step-01') as HTMLElement).hidden = false
   ;(document.getElementById('step-02') as HTMLElement).hidden = true
   ;(document.getElementById('step-04') as HTMLElement).hidden = true
   ;(document.getElementById('download-actions') as HTMLElement).hidden = true
 }
 
-document.getElementById('btn-change-file')!.addEventListener('click', resetToStep01)
-document.getElementById('btn-new-dataset')!.addEventListener('click', resetToStep01)
+document
+  .getElementById('btn-change-file')!
+  .addEventListener('click', resetToStep01)
+document
+  .getElementById('btn-new-dataset')!
+  .addEventListener('click', resetToStep01)
 
 // ---- Download wiring ----
 
-function showDownloadButtons(record: import('./results').RunRecord, problem: ParsedProblem): void {
+function showDownloadButtons(
+  record: import('./results').RunRecord,
+  problem: ParsedProblem,
+): void {
   const actions = document.getElementById('download-actions') as HTMLElement
   actions.hidden = false
 
@@ -263,13 +329,21 @@ function showDownloadButtons(record: import('./results').RunRecord, problem: Par
   const sessionId = crypto.randomUUID()
 
   document.getElementById('btn-download-tour')!.onclick = () =>
-    triggerDownload(buildTourText(name, route), `${sessionId}.tour`, 'text/plain')
+    triggerDownload(
+      buildTourText(name, route),
+      `${sessionId}.tour`,
+      'text/plain',
+    )
 
   document.getElementById('btn-download-csv')!.onclick = () =>
     triggerDownload(buildCsvText(route, cities), `${sessionId}.csv`, 'text/csv')
 
   document.getElementById('btn-download-json')!.onclick = () =>
-    triggerDownload(buildJsonText(name, record, cities, ts), `${sessionId}.json`, 'application/json')
+    triggerDownload(
+      buildJsonText(name, record, cities, ts),
+      `${sessionId}.json`,
+      'application/json',
+    )
 
   document.getElementById('btn-download-svg')!.onclick = () =>
     triggerDownload(serializeSvg(svgEl), `${sessionId}.svg`, 'image/svg+xml')

--- a/teeline-web/src/nav-data.test.ts
+++ b/teeline-web/src/nav-data.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { SOLVER_META, SOLVER_GROUPS, PAGED_SOLVERS, EXPLAINER_SOLVERS } from './nav-data'
+import {
+  SOLVER_META,
+  SOLVER_GROUPS,
+  PAGED_SOLVERS,
+  EXPLAINER_SOLVERS,
+} from './nav-data'
 
 describe('SOLVER_META', () => {
   it('contains exactly 21 solvers', () => {
@@ -27,19 +32,22 @@ describe('SOLVER_GROUPS', () => {
   })
 
   it('has no duplicate IDs across groups', () => {
-    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    const allIds = SOLVER_GROUPS.flatMap((g) => g.ids)
     expect(allIds).toHaveLength(new Set(allIds).size)
   })
 
   it('every ID in groups exists in SOLVER_META', () => {
-    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    const allIds = SOLVER_GROUPS.flatMap((g) => g.ids)
     for (const id of allIds) {
-      expect(SOLVER_META, `missing SOLVER_META entry for "${id}"`).toHaveProperty(id)
+      expect(
+        SOLVER_META,
+        `missing SOLVER_META entry for "${id}"`,
+      ).toHaveProperty(id)
     }
   })
 
   it('every SOLVER_META entry appears in exactly one group', () => {
-    const allIds = SOLVER_GROUPS.flatMap(g => g.ids)
+    const allIds = SOLVER_GROUPS.flatMap((g) => g.ids)
     for (const id of Object.keys(SOLVER_META)) {
       expect(allIds, `"${id}" not found in any group`).toContain(id)
     }
@@ -49,7 +57,11 @@ describe('SOLVER_GROUPS', () => {
 describe('complexity', () => {
   it('matches each docs page Complexity row (so index and docs agree)', () => {
     // Vite ?raw glob — no node:fs needed
-    const docs = import.meta.glob<string>('../../docs/algorithms/*.md', { query: '?raw', import: 'default', eager: true })
+    const docs = import.meta.glob<string>('../../docs/algorithms/*.md', {
+      query: '?raw',
+      import: 'default',
+      eager: true,
+    })
     const files = Object.keys(docs)
     expect(files.length).toBeGreaterThan(0)
     let checked = 0
@@ -59,7 +71,9 @@ describe('complexity', () => {
       if (!id || !(id in SOLVER_META)) continue
       const row = md.match(/^\| \*\*Complexity\*\* \| (.*) \|$/m)?.[1]
       expect(row, `${f} must have a Complexity row`).not.toBeUndefined()
-      expect(row, `${f} Complexity row must match nav-data`).toBe(SOLVER_META[id].complexity)
+      expect(row, `${f} Complexity row must match nav-data`).toBe(
+        SOLVER_META[id].complexity,
+      )
       checked++
     }
     expect(checked).toBe(Object.keys(SOLVER_META).length)
@@ -75,13 +89,30 @@ describe('PAGED_SOLVERS', () => {
 describe('EXPLAINER_SOLVERS', () => {
   it('contains exactly the 13 ids with an interactive explainer', () => {
     expect(EXPLAINER_SOLVERS).toEqual(
-      new Set(['pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings', 'aco']),
+      new Set([
+        'pso',
+        'gsa',
+        'tabu',
+        'ga',
+        'cs',
+        'fpa',
+        'lk',
+        'sa',
+        'som',
+        'fourier',
+        'greedy_edge',
+        'savings',
+        'aco',
+      ]),
     )
   })
 
   it('every explainer ID exists in SOLVER_META', () => {
     for (const id of EXPLAINER_SOLVERS) {
-      expect(SOLVER_META, `EXPLAINER_SOLVERS has "${id}" but SOLVER_META does not`).toHaveProperty(id)
+      expect(
+        SOLVER_META,
+        `EXPLAINER_SOLVERS has "${id}" but SOLVER_META does not`,
+      ).toHaveProperty(id)
     }
   })
 })

--- a/teeline-web/src/nav-data.ts
+++ b/teeline-web/src/nav-data.ts
@@ -12,27 +12,84 @@ export interface SolverMeta {
 }
 
 export const SOLVER_META: Record<string, SolverMeta> = {
-  bhk: { id: 'bhk', name: 'Bellman-Held-Karp', complexity: 'O(2ⁿ · n²) time, O(2ⁿ · n) space' },
-  branch_bound: { id: 'branch_bound', name: 'Branch & Bound', complexity: 'Exponential worst-case; effective pruning often makes it practical for small instances' },
-  nn: { id: 'nn', name: 'Nearest Neighbor', complexity: 'O(n log n) with KD-tree' },
-  fourier: { id: 'fourier', name: 'Fourier', complexity: 'O(K_max · epochs · (n + M) log M) per run' },
-  christofides: { id: 'christofides', name: 'Christofides', complexity: 'O(n²)' },
-  greedy_edge: { id: 'greedy_edge', name: 'Greedy Edge', complexity: 'O(n² log n) edge sort + O(n² α(n)) scan' },
+  bhk: {
+    id: 'bhk',
+    name: 'Bellman-Held-Karp',
+    complexity: 'O(2ⁿ · n²) time, O(2ⁿ · n) space',
+  },
+  branch_bound: {
+    id: 'branch_bound',
+    name: 'Branch & Bound',
+    complexity:
+      'Exponential worst-case; effective pruning often makes it practical for small instances',
+  },
+  nn: {
+    id: 'nn',
+    name: 'Nearest Neighbor',
+    complexity: 'O(n log n) with KD-tree',
+  },
+  fourier: {
+    id: 'fourier',
+    name: 'Fourier',
+    complexity: 'O(K_max · epochs · (n + M) log M) per run',
+  },
+  christofides: {
+    id: 'christofides',
+    name: 'Christofides',
+    complexity: 'O(n²)',
+  },
+  greedy_edge: {
+    id: 'greedy_edge',
+    name: 'Greedy Edge',
+    complexity: 'O(n² log n) edge sort + O(n² α(n)) scan',
+  },
   '2opt': { id: '2opt', name: '2-opt', complexity: 'O(n²) / pass' },
   '3opt': { id: '3opt', name: '3-opt', complexity: 'O(n³) / pass' },
   or_opt: { id: 'or_opt', name: 'Or-opt', complexity: 'O(n²) / pass' },
-  stochastic_hill: { id: 'stochastic_hill', name: 'Stochastic Hill Climbing', complexity: 'O(epochs · n)' },
+  stochastic_hill: {
+    id: 'stochastic_hill',
+    name: 'Stochastic Hill Climbing',
+    complexity: 'O(epochs · n)',
+  },
   lk: { id: 'lk', name: 'Lin-Kernighan', complexity: 'O(epochs · n²)' },
   sa: { id: 'sa', name: 'Simulated Annealing', complexity: 'O(epochs · n)' },
   tabu: { id: 'tabu', name: 'Tabu Search', complexity: 'O(epochs · n)' },
-  ga: { id: 'ga', name: 'Genetic Algorithm', complexity: 'O(epochs · pop · n)' },
-  pso: { id: 'pso', name: 'Particle Swarm', complexity: 'O(epochs · swarm · n)' },
+  ga: {
+    id: 'ga',
+    name: 'Genetic Algorithm',
+    complexity: 'O(epochs · pop · n)',
+  },
+  pso: {
+    id: 'pso',
+    name: 'Particle Swarm',
+    complexity: 'O(epochs · swarm · n)',
+  },
   cs: { id: 'cs', name: 'Cuckoo Search', complexity: 'O(epochs · nests · n)' },
-  fpa: { id: 'fpa', name: 'Flower Pollination', complexity: 'O(epochs · pop · n)' },
-  gsa: { id: 'gsa', name: 'Gravitational Search', complexity: 'O(epochs · pop²)' },
-  som: { id: 'som', name: 'Kohonen SOM', complexity: 'O(epochs · N · n) per run' },
-  aco: { id: 'aco', name: 'Ant Colony Optimization', complexity: 'O(epochs · ants · n²)' },
-  savings: { id: 'savings', name: 'Savings', complexity: 'O(n² log n) edge sort + O(n² α(n)) scan' },
+  fpa: {
+    id: 'fpa',
+    name: 'Flower Pollination',
+    complexity: 'O(epochs · pop · n)',
+  },
+  gsa: {
+    id: 'gsa',
+    name: 'Gravitational Search',
+    complexity: 'O(epochs · pop²)',
+  },
+  som: {
+    id: 'som',
+    name: 'Kohonen SOM',
+    complexity: 'O(epochs · N · n) per run',
+  },
+  aco: {
+    id: 'aco',
+    name: 'Ant Colony Optimization',
+    complexity: 'O(epochs · ants · n²)',
+  },
+  savings: {
+    id: 'savings',
+    name: 'Savings',
+    complexity: 'O(n² log n) edge sort + O(n² α(n)) scan',
+  },
 }
 
 export interface SolverGroup {
@@ -42,9 +99,18 @@ export interface SolverGroup {
 
 export const SOLVER_GROUPS: SolverGroup[] = [
   { label: 'Exact', ids: ['bhk', 'branch_bound'] },
-  { label: 'Constructive', ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'savings', 'som'] },
-  { label: 'Local search', ids: ['2opt', '3opt', 'or_opt', 'stochastic_hill', 'lk'] },
-  { label: 'Metaheuristic', ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa', 'aco'] },
+  {
+    label: 'Constructive',
+    ids: ['nn', 'fourier', 'christofides', 'greedy_edge', 'savings', 'som'],
+  },
+  {
+    label: 'Local search',
+    ids: ['2opt', '3opt', 'or_opt', 'stochastic_hill', 'lk'],
+  },
+  {
+    label: 'Metaheuristic',
+    ids: ['sa', 'tabu', 'ga', 'pso', 'cs', 'fpa', 'gsa', 'aco'],
+  },
 ]
 
 // Every id in SOLVER_META has a generated doc page under /algorithms/<id>/.
@@ -52,7 +118,19 @@ export const PAGED_SOLVERS = new Set(Object.keys(SOLVER_META))
 
 // The subset of ids with an interactive explainer under /algorithms/<id>/explainer/.
 export const EXPLAINER_SOLVERS = new Set([
-  'pso', 'gsa', 'tabu', 'ga', 'cs', 'fpa', 'lk', 'sa', 'som', 'fourier', 'greedy_edge', 'savings', 'aco',
+  'pso',
+  'gsa',
+  'tabu',
+  'ga',
+  'cs',
+  'fpa',
+  'lk',
+  'sa',
+  'som',
+  'fourier',
+  'greedy_edge',
+  'savings',
+  'aco',
 ])
 
 // ── Problem (dataset) navigation ───────────────────────────────────────
@@ -64,34 +142,34 @@ export interface ProblemMeta {
 }
 
 export const PROBLEM_META: Record<string, ProblemMeta> = {
-  att48:          { id: 'att48', name: 'ATT 48', cities: 48 },
-  bayg29:         { id: 'bayg29', name: 'Bayg 29', cities: 29 },
-  bays29:         { id: 'bays29', name: 'Bays 29', cities: 29 },
-  berlin52:       { id: 'berlin52', name: 'Berlin 52', cities: 52 },
-  brazil58:       { id: 'brazil58', name: 'Brazil 58', cities: 58 },
-  burma14:        { id: 'burma14', name: 'Burma 14', cities: 14 },
-  dantzig42:      { id: 'dantzig42', name: 'Dantzig 42', cities: 42 },
-  eil51:          { id: 'eil51', name: 'Eil 51', cities: 51 },
-  eil76:          { id: 'eil76', name: 'Eil 76', cities: 76 },
-  fri26:          { id: 'fri26', name: 'Fri 26', cities: 26 },
-  gr17:           { id: 'gr17', name: 'Gr 17', cities: 17 },
-  gr21:           { id: 'gr21', name: 'Gr 21', cities: 21 },
-  gr24:           { id: 'gr24', name: 'Gr 24', cities: 24 },
-  gr48:           { id: 'gr48', name: 'Gr 48', cities: 48 },
-  gr96:           { id: 'gr96', name: 'Gr 96', cities: 96 },
-  hk48:           { id: 'hk48', name: 'HK 48', cities: 48 },
-  kroA100:        { id: 'kroA100', name: 'KroA 100', cities: 100 },
-  kroB100:        { id: 'kroB100', name: 'KroB 100', cities: 100 },
-  kroC100:        { id: 'kroC100', name: 'KroC 100', cities: 100 },
-  kroD100:        { id: 'kroD100', name: 'KroD 100', cities: 100 },
-  kroE100:        { id: 'kroE100', name: 'KroE 100', cities: 100 },
-  pr76:           { id: 'pr76', name: 'Pr 76', cities: 76 },
-  rat99:          { id: 'rat99', name: 'Rat 99', cities: 99 },
-  rd100:          { id: 'rd100', name: 'Rd 100', cities: 100 },
-  st70:           { id: 'st70', name: 'St 70', cities: 70 },
-  swiss42:        { id: 'swiss42', name: 'Swiss 42', cities: 42 },
-  ulysses16:      { id: 'ulysses16', name: 'Ulysses 16', cities: 16 },
-  ulysses22:      { id: 'ulysses22', name: 'Ulysses 22', cities: 22 },
+  att48: { id: 'att48', name: 'ATT 48', cities: 48 },
+  bayg29: { id: 'bayg29', name: 'Bayg 29', cities: 29 },
+  bays29: { id: 'bays29', name: 'Bays 29', cities: 29 },
+  berlin52: { id: 'berlin52', name: 'Berlin 52', cities: 52 },
+  brazil58: { id: 'brazil58', name: 'Brazil 58', cities: 58 },
+  burma14: { id: 'burma14', name: 'Burma 14', cities: 14 },
+  dantzig42: { id: 'dantzig42', name: 'Dantzig 42', cities: 42 },
+  eil51: { id: 'eil51', name: 'Eil 51', cities: 51 },
+  eil76: { id: 'eil76', name: 'Eil 76', cities: 76 },
+  fri26: { id: 'fri26', name: 'Fri 26', cities: 26 },
+  gr17: { id: 'gr17', name: 'Gr 17', cities: 17 },
+  gr21: { id: 'gr21', name: 'Gr 21', cities: 21 },
+  gr24: { id: 'gr24', name: 'Gr 24', cities: 24 },
+  gr48: { id: 'gr48', name: 'Gr 48', cities: 48 },
+  gr96: { id: 'gr96', name: 'Gr 96', cities: 96 },
+  hk48: { id: 'hk48', name: 'HK 48', cities: 48 },
+  kroA100: { id: 'kroA100', name: 'KroA 100', cities: 100 },
+  kroB100: { id: 'kroB100', name: 'KroB 100', cities: 100 },
+  kroC100: { id: 'kroC100', name: 'KroC 100', cities: 100 },
+  kroD100: { id: 'kroD100', name: 'KroD 100', cities: 100 },
+  kroE100: { id: 'kroE100', name: 'KroE 100', cities: 100 },
+  pr76: { id: 'pr76', name: 'Pr 76', cities: 76 },
+  rat99: { id: 'rat99', name: 'Rat 99', cities: 99 },
+  rd100: { id: 'rd100', name: 'Rd 100', cities: 100 },
+  st70: { id: 'st70', name: 'St 70', cities: 70 },
+  swiss42: { id: 'swiss42', name: 'Swiss 42', cities: 42 },
+  ulysses16: { id: 'ulysses16', name: 'Ulysses 16', cities: 16 },
+  ulysses22: { id: 'ulysses22', name: 'Ulysses 22', cities: 22 },
 }
 
 export const PROBLEM_GROUPS = [

--- a/teeline-web/src/pages/rss.xml.js
+++ b/teeline-web/src/pages/rss.xml.js
@@ -4,10 +4,14 @@ import { getCollection } from 'astro:content'
 export async function GET(context) {
   // Standard Astro draft handling: `astro dev` shows drafts (for preview),
   // production builds (`astro build`/preview) exclude them.
-  const posts = await getCollection('blog', ({ data }) => !data.draft || !import.meta.env.PROD)
+  const posts = await getCollection(
+    'blog',
+    ({ data }) => !data.draft || !import.meta.env.PROD,
+  )
   return rss({
     title: 'Teeline Blog',
-    description: 'Notes on TSP algorithms, teeline development, and the occasional deep dive.',
+    description:
+      'Notes on TSP algorithms, teeline development, and the occasional deep dive.',
     site: context.site,
     items: posts
       .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())

--- a/teeline-web/src/results.test.ts
+++ b/teeline-web/src/results.test.ts
@@ -41,7 +41,12 @@ describe('RunRecord type', () => {
   })
 
   it('allows comparison to be absent', () => {
-    const record: RunRecord = { solver: 'nn', total: 8296, runtime: 12, route: [1, 2, 3] }
+    const record: RunRecord = {
+      solver: 'nn',
+      total: 8296,
+      runtime: 12,
+      route: [1, 2, 3],
+    }
     expect(record.comparison).toBeUndefined()
   })
 })

--- a/teeline-web/src/results.ts
+++ b/teeline-web/src/results.ts
@@ -61,7 +61,10 @@ export function setTourSolverName(name: string): void {
   if (el) el.textContent = name
 }
 
-function setTourStatus(status: string, state: 'accent' | 'positive' = 'accent'): void {
+function setTourStatus(
+  status: string,
+  state: 'accent' | 'positive' = 'accent',
+): void {
   const el = document.getElementById('tour-status')
   if (!el) return
   el.textContent = status
@@ -92,11 +95,20 @@ export function showResult(record: RunRecord): void {
   }
 
   const svgEl = document.getElementById('tour-svg') as unknown as SVGSVGElement
-  renderTour(svgEl, citiesRef, record.route, record.comparison !== undefined ? optRouteRef : undefined)
+  renderTour(
+    svgEl,
+    citiesRef,
+    record.route,
+    record.comparison !== undefined ? optRouteRef : undefined,
+  )
 
   document.getElementById('result-total')!.textContent = record.total.toFixed(1)
-  document.getElementById('result-gap')!.textContent = formatGapPct(record.comparison)
-  document.getElementById('result-runtime')!.textContent = formatRuntime(record.runtime)
+  document.getElementById('result-gap')!.textContent = formatGapPct(
+    record.comparison,
+  )
+  document.getElementById('result-runtime')!.textContent = formatRuntime(
+    record.runtime,
+  )
   applyComparisonCells(record.comparison)
 
   runHistory.unshift(record)
@@ -107,7 +119,7 @@ export function showResult(record: RunRecord): void {
 export function showGapFromOptCost(solverCost: number): void {
   const optCost = (window as any).__teelineOptCost as number | undefined
   if (optCost && optCost > 0) {
-    const gap = ((solverCost - optCost) / optCost * 100)
+    const gap = ((solverCost - optCost) / optCost) * 100
     document.getElementById('result-gap')!.textContent = `${gap.toFixed(1)}%`
     const gapMetric = document.getElementById('result-gap-metric')
     if (gapMetric) {
@@ -117,7 +129,10 @@ export function showGapFromOptCost(solverCost: number): void {
   }
 }
 
-export function patchComparison(record: RunRecord, stats: ComparisonStats): void {
+export function patchComparison(
+  record: RunRecord,
+  stats: ComparisonStats,
+): void {
   record.comparison = stats
   document.getElementById('result-gap')!.textContent = formatGapPct(stats)
   applyComparisonCells(stats)
@@ -132,9 +147,12 @@ export function patchComparison(record: RunRecord, stats: ComparisonStats): void
 
 function applyComparisonCells(c: ComparisonStats | undefined): void {
   const dash = '—'
-  document.getElementById('result-shared-edges')!.textContent = c !== undefined ? String(c.sharedEdges) : dash
-  document.getElementById('result-solver-only-edges')!.textContent = c !== undefined ? String(c.solverOnlyEdges) : dash
-  document.getElementById('result-optimal-only-edges')!.textContent = c !== undefined ? String(c.optimalOnlyEdges) : dash
+  document.getElementById('result-shared-edges')!.textContent =
+    c !== undefined ? String(c.sharedEdges) : dash
+  document.getElementById('result-solver-only-edges')!.textContent =
+    c !== undefined ? String(c.solverOnlyEdges) : dash
+  document.getElementById('result-optimal-only-edges')!.textContent =
+    c !== undefined ? String(c.optimalOnlyEdges) : dash
 }
 
 function renderHistoryRow(record: RunRecord): void {
@@ -145,17 +163,28 @@ function renderHistoryRow(record: RunRecord): void {
   li.setAttribute('role', 'button')
   li.setAttribute('tabindex', '0')
   li.addEventListener('click', () => replayRecord(record))
-  li.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') replayRecord(record) })
+  li.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') replayRecord(record)
+  })
   list.prepend(li)
 }
 
 function replayRecord(record: RunRecord): void {
   const svgEl = document.getElementById('tour-svg') as unknown as SVGSVGElement
-  renderTour(svgEl, citiesRef, record.route, record.comparison !== undefined ? optRouteRef : undefined)
+  renderTour(
+    svgEl,
+    citiesRef,
+    record.route,
+    record.comparison !== undefined ? optRouteRef : undefined,
+  )
 
   document.getElementById('result-total')!.textContent = record.total.toFixed(1)
-  document.getElementById('result-gap')!.textContent = formatGapPct(record.comparison)
-  document.getElementById('result-runtime')!.textContent = formatRuntime(record.runtime)
+  document.getElementById('result-gap')!.textContent = formatGapPct(
+    record.comparison,
+  )
+  document.getElementById('result-runtime')!.textContent = formatRuntime(
+    record.runtime,
+  )
   applyComparisonCells(record.comparison)
 }
 

--- a/teeline-web/src/sentry.ts
+++ b/teeline-web/src/sentry.ts
@@ -1,9 +1,9 @@
-import * as Sentry from "@sentry/browser";
+import * as Sentry from '@sentry/browser'
 
 Sentry.init({
-  dsn: "https://ec76cc3371026e1e4feb8ececea14aee@o4511523471228928.ingest.de.sentry.io/4511523482107984",
+  dsn: 'https://ec76cc3371026e1e4feb8ececea14aee@o4511523471228928.ingest.de.sentry.io/4511523482107984',
   // Setting this option to true will send default PII data to Sentry.
   // For example, automatic IP address collection on events
   sendDefaultPii: true,
-  tunnel: "/tunnel",
-});
+  tunnel: '/tunnel',
+})

--- a/teeline-web/src/solver-form.ts
+++ b/teeline-web/src/solver-form.ts
@@ -6,12 +6,14 @@ export function initSolverConfig(
   isProblemLoaded: () => boolean,
   onSolverReady: (solver: string, options: SolveOptions) => void,
 ): { refresh: () => void } {
-  const step02       = document.getElementById('step-02') as HTMLElement
-  const solverSelect = document.getElementById('solver-select') as HTMLSelectElement
-  const configPanel  = document.getElementById('config-panel') as HTMLElement
-  const btnRun       = document.getElementById('btn-run') as HTMLButtonElement
+  const step02 = document.getElementById('step-02') as HTMLElement
+  const solverSelect = document.getElementById(
+    'solver-select',
+  ) as HTMLSelectElement
+  const configPanel = document.getElementById('config-panel') as HTMLElement
+  const btnRun = document.getElementById('btn-run') as HTMLButtonElement
   const checkProblem = document.getElementById('check-problem') as HTMLElement
-  const checkSolver  = document.getElementById('check-solver') as HTMLElement
+  const checkSolver = document.getElementById('check-solver') as HTMLElement
 
   let selectedId: string | null = null
   let currentOptions: SolveOptions = defaultSolveOptions()
@@ -37,10 +39,12 @@ export function initSolverConfig(
   }
 
   function highlightActivePill(id: string): void {
-    document.querySelectorAll<HTMLButtonElement>('.pill[data-solver]').forEach((btn) => {
-      btn.classList.toggle('pill--active', btn.dataset.solver === id)
-      btn.ariaCurrent = btn.dataset.solver === id ? 'true' : 'false'
-    })
+    document
+      .querySelectorAll<HTMLButtonElement>('.pill[data-solver]')
+      .forEach((btn) => {
+        btn.classList.toggle('pill--active', btn.dataset.solver === id)
+        btn.ariaCurrent = btn.dataset.solver === id ? 'true' : 'false'
+      })
   }
 
   // ---- Config panel rendering ----
@@ -86,7 +90,8 @@ export function initSolverConfig(
       input.addEventListener('input', () => {
         const raw = parseFloat(input.value)
         if (!isNaN(raw)) {
-          ;(currentOptions as unknown as Record<string, number>)[param.key] = raw
+          ;(currentOptions as unknown as Record<string, number>)[param.key] =
+            raw
         }
       })
 
@@ -101,7 +106,7 @@ export function initSolverConfig(
 
   function updateChecklist(): void {
     const problemMet = isProblemLoaded()
-    const solverMet  = selectedId !== null
+    const solverMet = selectedId !== null
 
     checkProblem.classList.toggle('checklist-item--met', problemMet)
     checkSolver.classList.toggle('checklist-item--met', solverMet)
@@ -121,12 +126,14 @@ export function initSolverConfig(
 
   // ---- Wire pills ----
 
-  document.querySelectorAll<HTMLButtonElement>('.pill[data-solver]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const id = btn.dataset.solver!
-      selectSolver(id)
+  document
+    .querySelectorAll<HTMLButtonElement>('.pill[data-solver]')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.solver!
+        selectSolver(id)
+      })
     })
-  })
 
   // ---- Wire dropdown ----
 

--- a/teeline-web/src/styles/global.css
+++ b/teeline-web/src/styles/global.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 
 /* Design tokens — Tailwind v4 is CSS-first: the @theme block below generates
@@ -6,17 +6,17 @@
    variables (--color-accent, …) on :root, so raw var() references in
    component rules (e.g. SVG strokes) keep working. */
 @theme {
-  --color-canvas: #0A0A0B;
+  --color-canvas: #0a0a0b;
   --color-surface: #141416;
-  --color-surface-2: #1C1C20;
+  --color-surface-2: #1c1c20;
   --color-border: #232327;
-  --color-border-hover: #3A3A40;
-  --color-text: #F5F5F6;
-  --color-text-dim: #8A8A92;
-  --color-accent: #6366F1;
+  --color-border-hover: #3a3a40;
+  --color-text: #f5f5f6;
+  --color-text-dim: #8a8a92;
+  --color-accent: #6366f1;
   --color-accent-dim: rgba(99, 102, 241, 0.12);
-  --color-positive: #22D3A5;
-  --color-negative: #F87171;
+  --color-positive: #22d3a5;
+  --color-negative: #f87171;
 
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
@@ -171,8 +171,12 @@
   .drop-zone {
     @apply flex min-h-36 flex-col items-center justify-center rounded-lg border-2 border-border p-4 text-center transition-colors;
   }
-  .drop-zone--required { @apply border-solid; }
-  .drop-zone--optional { @apply border-dashed; }
+  .drop-zone--required {
+    @apply border-solid;
+  }
+  .drop-zone--optional {
+    @apply border-dashed;
+  }
   .drop-zone--dragover {
     @apply border-accent bg-accent-dim;
   }
@@ -182,51 +186,87 @@
   .drop-zone__idle {
     @apply flex flex-col items-center gap-1;
   }
-  .drop-zone__hint { @apply m-0; }
-  .drop-zone__or { @apply m-0 text-text-dim; }
-  .drop-zone__hint-secondary { @apply mt-1 text-text-dim; }
+  .drop-zone__hint {
+    @apply m-0;
+  }
+  .drop-zone__or {
+    @apply m-0 text-text-dim;
+  }
+  .drop-zone__hint-secondary {
+    @apply mt-1 text-text-dim;
+  }
 
   /* ---- File chip ---- */
   .drop-zone__chip {
     @apply flex flex-wrap items-center justify-center gap-2;
   }
-  .chip-icon { @apply text-lg text-positive; }
-  .chip-name { @apply break-all font-semibold; }
-  .chip-replace { @apply m-0 px-2 py-0.5 text-xs; }
+  .chip-icon {
+    @apply text-lg text-positive;
+  }
+  .chip-name {
+    @apply break-all font-semibold;
+  }
+  .chip-replace {
+    @apply m-0 px-2 py-0.5 text-xs;
+  }
 
   /* ---- Metadata / error ---- */
-  .metadata-line { @apply mb-0 mt-1 text-sm text-text-dim; }
-  .upload-error { @apply mb-0 mt-1 text-sm text-negative; }
+  .metadata-line {
+    @apply mb-0 mt-1 text-sm text-text-dim;
+  }
+  .upload-error {
+    @apply mb-0 mt-1 text-sm text-negative;
+  }
 
   /* ---- Example buttons ---- */
-  .example-buttons { @apply mt-2 flex flex-wrap gap-2; }
-  .example-buttons button { @apply m-0; }
+  .example-buttons {
+    @apply mt-2 flex flex-wrap gap-2;
+  }
+  .example-buttons button {
+    @apply m-0;
+  }
 
   /* ---- Step actions ---- */
-  .step-actions { @apply mt-4 flex justify-end; }
-  .step-actions--spread { @apply justify-between; }
+  .step-actions {
+    @apply mt-4 flex justify-end;
+  }
+  .step-actions--spread {
+    @apply justify-between;
+  }
 
   /* ---- Solver pills ---- */
   .solver-pills {
     @apply mb-4 flex flex-wrap items-center gap-2;
   }
-  .pill { @apply m-0 px-3 py-1 text-sm; }
+  .pill {
+    @apply m-0 px-3 py-1 text-sm;
+  }
   .pill--active {
     @apply border-accent bg-accent text-white;
   }
-  #solver-select { @apply m-0 h-auto px-2 py-1 text-sm; }
+  #solver-select {
+    @apply m-0 h-auto px-2 py-1 text-sm;
+  }
 
   /* ---- Config panel ---- */
   .config-panel {
     @apply mb-4 min-h-20 rounded-lg border border-border p-4;
   }
-  .solver-kind-badge { @apply mb-4 text-xs text-text-dim; }
-  .config-no-params { @apply m-0; }
+  .solver-kind-badge {
+    @apply mb-4 text-xs text-text-dim;
+  }
+  .config-no-params {
+    @apply m-0;
+  }
   .config-grid {
     @apply grid grid-cols-1 items-center gap-x-4 gap-y-2 sm:grid-cols-[max-content_1fr];
   }
-  .config-grid label { @apply m-0 whitespace-nowrap text-sm; }
-  .config-grid input[type='number'] { @apply m-0 h-auto px-2 py-1 text-sm; }
+  .config-grid label {
+    @apply m-0 whitespace-nowrap text-sm;
+  }
+  .config-grid input[type='number'] {
+    @apply m-0 h-auto px-2 py-1 text-sm;
+  }
 
   /* ---- Checklist ---- */
   .checklist {
@@ -239,9 +279,15 @@
     content: '○';
     @apply shrink-0 text-base;
   }
-  .checklist-item--met { @apply text-positive; }
-  .checklist-item--met::before { content: '✓'; }
-  .checklist-item--optional { font-style: italic; }
+  .checklist-item--met {
+    @apply text-positive;
+  }
+  .checklist-item--met::before {
+    content: '✓';
+  }
+  .checklist-item--optional {
+    font-style: italic;
+  }
   .checklist-item--optional::after {
     content: ' (optional)';
     @apply text-xs text-text-dim;
@@ -266,7 +312,9 @@
   .step-04-actions {
     @apply mx-auto w-full max-w-3xl;
   }
-  .tour-svg { @apply block h-auto w-full; }
+  .tour-svg {
+    @apply block h-auto w-full;
+  }
   .tour-svg polyline.tour-solver {
     fill: none;
     stroke: var(--color-accent);
@@ -278,9 +326,17 @@
     stroke-width: 1;
     stroke-dasharray: 4 3;
   }
-  .tour-svg circle.city-dot { fill: var(--color-accent); }
-  .tour-svg .legend-solver { font-size: 11px; fill: var(--color-accent); }
-  .tour-svg .legend-optimal { font-size: 11px; fill: #555; }
+  .tour-svg circle.city-dot {
+    fill: var(--color-accent);
+  }
+  .tour-svg .legend-solver {
+    font-size: 11px;
+    fill: var(--color-accent);
+  }
+  .tour-svg .legend-optimal {
+    font-size: 11px;
+    fill: #555;
+  }
 
   /* ---- Solving overlay ---- */
   .solving-overlay {
@@ -305,18 +361,24 @@
   }
 
   /* ---- Run history ---- */
-  .run-history-list { @apply mb-4 list-none p-0; }
+  .run-history-list {
+    @apply mb-4 list-none p-0;
+  }
   .run-history-item {
     @apply cursor-pointer rounded px-2 py-1 font-mono text-sm tabular-nums;
   }
-  .run-history-item:hover { @apply bg-accent-dim; }
+  .run-history-item:hover {
+    @apply bg-accent-dim;
+  }
   .run-history-item:empty::before {
     content: 'No runs yet.';
     @apply text-text-dim;
   }
 
   /* ---- Download actions ---- */
-  .download-actions { @apply mb-4 flex flex-wrap gap-2; }
+  .download-actions {
+    @apply mb-4 flex flex-wrap gap-2;
+  }
 
   /* ---- WASM status footer ---- */
   #app-footer {
@@ -325,22 +387,42 @@
   .status-dot {
     @apply inline-block h-2 w-2 shrink-0 rounded-full;
   }
-  .status-dot--loading { background: #888; }
-  .status-dot--ready { background: #2da44e; }
-  .status-dot--error { background: #cf222e; }
+  .status-dot--loading {
+    background: #888;
+  }
+  .status-dot--ready {
+    background: #2da44e;
+  }
+  .status-dot--error {
+    background: #cf222e;
+  }
 
   /* ---- Phone overrides ---- */
   @media (max-width: 576px) {
-    .stepper-label { display: none; }
-    #btn-run { width: 100%; }
-    .download-actions { flex-direction: column; }
-    .results-table { font-size: 0.85rem; }
+    .stepper-label {
+      display: none;
+    }
+    #btn-run {
+      width: 100%;
+    }
+    .download-actions {
+      flex-direction: column;
+    }
+    .results-table {
+      font-size: 0.85rem;
+    }
   }
 
   /* ---- Generic helper components (PicoCSS replacement aliases) ---- */
-  .step-panel { @apply my-4; }
-  .muted { @apply text-text-dim; }
-  .comparison-error { @apply my-3 text-sm text-negative; }
+  .step-panel {
+    @apply my-4;
+  }
+  .muted {
+    @apply text-text-dim;
+  }
+  .comparison-error {
+    @apply my-3 text-sm text-negative;
+  }
   .outline {
     @apply inline-flex items-center justify-center rounded-md border border-border bg-transparent px-4 py-2 font-medium text-text transition-colors hover:border-border-hover hover:bg-surface;
   }

--- a/teeline-web/src/teeline-wasm.d.ts
+++ b/teeline-web/src/teeline-wasm.d.ts
@@ -45,8 +45,16 @@ declare module 'teeline-wasm' {
     kind: string
     params: Array<ParamSpec>
   }
-  export function solve(solver: string, cities: Array<City>, options: SolveOptions): Solution
-  export function parseAndSolve(solver: string, input: string, options: SolveOptions): Solution
+  export function solve(
+    solver: string,
+    cities: Array<City>,
+    options: SolveOptions,
+  ): Solution
+  export function parseAndSolve(
+    solver: string,
+    input: string,
+    options: SolveOptions,
+  ): Solution
   export function parse(input: string): ParsedProblem
   export function listAlgorithms(): Array<AlgorithmInfo>
   export function getVersion(): string
@@ -58,9 +66,20 @@ declare module 'teeline-wasm' {
     solverOnlyEdges: number
     optimalOnlyEdges: number
   }
-  export function compareTours(solverRoute: Uint32Array, optRoute: Uint32Array, cities: Array<City>): ComparisonStats
+  export function compareTours(
+    solverRoute: Uint32Array,
+    optRoute: Uint32Array,
+    cities: Array<City>,
+  ): ComparisonStats
   export function tourDistance(route: Uint32Array, cities: Array<City>): number
-  export function compareToursFromInput(solverRoute: Uint32Array, optRoute: Uint32Array, input: string): ComparisonStats
-  export function tourDistanceFromInput(route: Uint32Array, input: string): number
+  export function compareToursFromInput(
+    solverRoute: Uint32Array,
+    optRoute: Uint32Array,
+    input: string,
+  ): ComparisonStats
+  export function tourDistanceFromInput(
+    route: Uint32Array,
+    input: string,
+  ): number
   export type Result<T, E> = { tag: 'ok'; val: T } | { tag: 'err'; val: E }
 }

--- a/teeline-web/src/upload.test.ts
+++ b/teeline-web/src/upload.test.ts
@@ -12,7 +12,9 @@ import type { ParsedProblem } from 'teeline-wasm'
 const cities = (n: number) =>
   Array.from({ length: n }, (_, i) => ({ id: i, x: 0, y: 0 }))
 
-const makeProblem = (overrides: Partial<ParsedProblem> = {}): ParsedProblem => ({
+const makeProblem = (
+  overrides: Partial<ParsedProblem> = {},
+): ParsedProblem => ({
   name: 'berlin52',
   comment: '',
   distanceType: 'EUC_2D',
@@ -26,19 +28,21 @@ describe('formatMetadata', () => {
   })
 
   it('omits distance type separator when distanceType is empty', () => {
-    expect(formatMetadata(makeProblem({ distanceType: '', cities: cities(5) }))).toBe(
-      'parsed: 5 cities',
-    )
+    expect(
+      formatMetadata(makeProblem({ distanceType: '', cities: cities(5) })),
+    ).toBe('parsed: 5 cities')
   })
 
   it('uses the cities array length, not the name', () => {
-    expect(formatMetadata(makeProblem({ cities: cities(14) }))).toBe('parsed: 14 cities · EUC_2D')
+    expect(formatMetadata(makeProblem({ cities: cities(14) }))).toBe(
+      'parsed: 14 cities · EUC_2D',
+    )
   })
 
   it('handles GEO distance type', () => {
-    expect(formatMetadata(makeProblem({ distanceType: 'GEO', cities: cities(22) }))).toBe(
-      'parsed: 22 cities · GEO',
-    )
+    expect(
+      formatMetadata(makeProblem({ distanceType: 'GEO', cities: cities(22) })),
+    ).toBe('parsed: 22 cities · GEO')
   })
 })
 
@@ -81,7 +85,9 @@ describe('dataset URLs', () => {
   it('uses the dev proxy prefix in dev', () => {
     expect(datasetBaseUrl(true)).toBe('/tsplib')
     expect(datasetTspUrl('berlin52', true)).toBe('/tsplib/berlin52.tsp')
-    expect(datasetOptTourUrl('berlin52', true)).toBe('/tsplib/berlin52.opt.tour')
+    expect(datasetOptTourUrl('berlin52', true)).toBe(
+      '/tsplib/berlin52.opt.tour',
+    )
   })
 
   it('uses the static host in production', () => {

--- a/teeline-web/src/upload.ts
+++ b/teeline-web/src/upload.ts
@@ -31,7 +31,10 @@ export function parseOptTour(text: string): number[] {
   const route: number[] = []
   for (const raw of lines) {
     const line = raw.trim()
-    if (line === 'TOUR_SECTION') { inSection = true; continue }
+    if (line === 'TOUR_SECTION') {
+      inSection = true
+      continue
+    }
     if (!inSection) continue
     const n = parseInt(line, 10)
     if (isNaN(n) || n < 0) break
@@ -52,27 +55,29 @@ export function initUpload(
   onOptTourLoaded?: (route: number[]) => void,
 ): void {
   // DOM elements — all pre-built in index.html
-  const zoneTsp       = document.getElementById('zone-tsp')!
-  const tspIdle       = document.getElementById('zone-tsp-idle')!
-  const tspChip       = document.getElementById('zone-tsp-chip') as HTMLElement
-  const tspChipName   = document.getElementById('tsp-chip-name')!
-  const btnBrowse     = document.getElementById('btn-browse-tsp')!
-  const inputTsp      = document.getElementById('input-tsp') as HTMLInputElement
+  const zoneTsp = document.getElementById('zone-tsp')!
+  const tspIdle = document.getElementById('zone-tsp-idle')!
+  const tspChip = document.getElementById('zone-tsp-chip') as HTMLElement
+  const tspChipName = document.getElementById('tsp-chip-name')!
+  const btnBrowse = document.getElementById('btn-browse-tsp')!
+  const inputTsp = document.getElementById('input-tsp') as HTMLInputElement
   const btnReplaceTsp = document.getElementById('btn-replace-tsp')!
 
-  const zoneOpt       = document.getElementById('zone-opt')!
-  const optIdle       = document.getElementById('zone-opt-idle')!
-  const optChip       = document.getElementById('zone-opt-chip') as HTMLElement
-  const optChipName   = document.getElementById('opt-chip-name')!
-  const btnBrowseOpt  = document.getElementById('btn-browse-opt')!
-  const inputOpt      = document.getElementById('input-opt') as HTMLInputElement
+  const zoneOpt = document.getElementById('zone-opt')!
+  const optIdle = document.getElementById('zone-opt-idle')!
+  const optChip = document.getElementById('zone-opt-chip') as HTMLElement
+  const optChipName = document.getElementById('opt-chip-name')!
+  const btnBrowseOpt = document.getElementById('btn-browse-opt')!
+  const inputOpt = document.getElementById('input-opt') as HTMLInputElement
   const btnReplaceOpt = document.getElementById('btn-replace-opt')!
 
-  const metaLine   = document.getElementById('metadata-line') as HTMLElement
-  const errorLine  = document.getElementById('error-line') as HTMLElement
-  const btnContinue = document.getElementById('btn-continue') as HTMLButtonElement
-  const step01     = document.getElementById('step-01') as HTMLElement
-  const step02     = document.getElementById('step-02') as HTMLElement
+  const metaLine = document.getElementById('metadata-line') as HTMLElement
+  const errorLine = document.getElementById('error-line') as HTMLElement
+  const btnContinue = document.getElementById(
+    'btn-continue',
+  ) as HTMLButtonElement
+  const step01 = document.getElementById('step-01') as HTMLElement
+  const step02 = document.getElementById('step-02') as HTMLElement
 
   // ---- TSP zone state transitions ----
 
@@ -83,7 +88,8 @@ export function initUpload(
     zoneTsp.classList.add('drop-zone--loaded')
     let meta = formatMetadata(parsed)
     const optCost = (window as any).__teelineOptCost as number | undefined
-    if (optCost && optCost > 0) meta += ` · optimal: ${optCost.toLocaleString()}`
+    if (optCost && optCost > 0)
+      meta += ` · optimal: ${optCost.toLocaleString()}`
     metaLine.textContent = meta
     metaLine.hidden = false
     errorLine.hidden = true
@@ -135,7 +141,9 @@ export function initUpload(
       e.preventDefault()
       zone.classList.add('drop-zone--dragover')
     })
-    zone.addEventListener('dragleave', () => zone.classList.remove('drop-zone--dragover'))
+    zone.addEventListener('dragleave', () =>
+      zone.classList.remove('drop-zone--dragover'),
+    )
     zone.addEventListener('drop', (e) => {
       e.preventDefault()
       zone.classList.remove('drop-zone--dragover')
@@ -199,23 +207,28 @@ export function initUpload(
   btnReplaceOpt.addEventListener('click', showOptIdle)
 
   // ---- Register module-level reset ----
-  _resetFn = () => { showTspIdle(); showOptIdle() }
+  _resetFn = () => {
+    showTspIdle()
+    showOptIdle()
+  }
 
   // ---- Wire example dataset buttons ----
 
-  document.querySelectorAll<HTMLButtonElement>('[data-example]').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const name = btn.dataset.example!
-      try {
-        const resp = await fetch(exampleUrl(name))
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-        const text = await resp.text()
-        await loadTspText(`${name}.tsp`, text)
-      } catch (err) {
-        showError(err instanceof Error ? err.message : String(err))
-      }
+  document
+    .querySelectorAll<HTMLButtonElement>('[data-example]')
+    .forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const name = btn.dataset.example!
+        try {
+          const resp = await fetch(exampleUrl(name))
+          if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+          const text = await resp.text()
+          await loadTspText(`${name}.tsp`, text)
+        } catch (err) {
+          showError(err instanceof Error ? err.message : String(err))
+        }
+      })
     })
-  })
 
   // ---- Auto-load dataset from ?dataset= query param ----
   const params = new URLSearchParams(window.location.search)
@@ -244,11 +257,15 @@ export function initUpload(
             const route = parseOptTour(optText)
             onOptTourLoaded?.(route)
           }
-        } catch { /* opt tour not available, ignore */ }
+        } catch {
+          /* opt tour not available, ignore */
+        }
 
         // Auto-navigate to step 2 (configure solver)
         setTimeout(() => {
-          const btnContinue = document.getElementById('btn-continue') as HTMLButtonElement | null
+          const btnContinue = document.getElementById(
+            'btn-continue',
+          ) as HTMLButtonElement | null
           btnContinue?.click()
         }, 100)
       } catch (err) {

--- a/teeline-web/src/wasm-types.ts
+++ b/teeline-web/src/wasm-types.ts
@@ -1,2 +1,3 @@
 export type { AlgorithmInfo, ParamSpec } from 'teeline-wasm'
-export type SolverKind = 'exact' | 'constructive' | 'local-search' | 'metaheuristic' | 'utility'
+export type SolverKind =
+  'exact' | 'constructive' | 'local-search' | 'metaheuristic' | 'utility'

--- a/teeline-web/src/webmcp.ts
+++ b/teeline-web/src/webmcp.ts
@@ -32,65 +32,79 @@ function wireSolveTSP(worker: Worker): void {
     const ae = e as AgentSubmitEvent
     if (typeof ae.respondWith !== 'function') return
     e.preventDefault()
-    ae.respondWith(new Promise((resolve, reject) => {
-      const data = new FormData(form)
-      const id = crypto.randomUUID()
-      const options: Partial<SolveOptions> = {}
-      const epochs = data.get('epochs')
-      if (epochs !== null && epochs !== '') options.epochs = parseInt(epochs as string, 10)
-      const maxTemp = data.get('max_temperature')
-      if (maxTemp !== null && maxTemp !== '') options.maxTemperature = parseFloat(maxTemp as string)
-      const mutProb = data.get('mutation_probability')
-      if (mutProb !== null && mutProb !== '') options.mutationProbability = parseFloat(mutProb as string)
-      const nNearest = data.get('n_nearest')
-      if (nNearest !== null && nNearest !== '') options.nNearest = parseInt(nNearest as string, 10)
-      const alpha = data.get('alpha')
-      if (alpha !== null && alpha !== '') options.alpha = parseFloat(alpha as string)
-      const beta = data.get('beta')
-      if (beta !== null && beta !== '') options.beta = parseFloat(beta as string)
-      const evaporationRate = data.get('evaporation_rate')
-      if (evaporationRate !== null && evaporationRate !== '') options.evaporationRate = parseFloat(evaporationRate as string)
-      const numAnts = data.get('num_ants')
-      if (numAnts !== null && numAnts !== '') options.numAnts = parseInt(numAnts as string, 10)
+    ae.respondWith(
+      new Promise((resolve, reject) => {
+        const data = new FormData(form)
+        const id = crypto.randomUUID()
+        const options: Partial<SolveOptions> = {}
+        const epochs = data.get('epochs')
+        if (epochs !== null && epochs !== '')
+          options.epochs = parseInt(epochs as string, 10)
+        const maxTemp = data.get('max_temperature')
+        if (maxTemp !== null && maxTemp !== '')
+          options.maxTemperature = parseFloat(maxTemp as string)
+        const mutProb = data.get('mutation_probability')
+        if (mutProb !== null && mutProb !== '')
+          options.mutationProbability = parseFloat(mutProb as string)
+        const nNearest = data.get('n_nearest')
+        if (nNearest !== null && nNearest !== '')
+          options.nNearest = parseInt(nNearest as string, 10)
+        const alpha = data.get('alpha')
+        if (alpha !== null && alpha !== '')
+          options.alpha = parseFloat(alpha as string)
+        const beta = data.get('beta')
+        if (beta !== null && beta !== '')
+          options.beta = parseFloat(beta as string)
+        const evaporationRate = data.get('evaporation_rate')
+        if (evaporationRate !== null && evaporationRate !== '')
+          options.evaporationRate = parseFloat(evaporationRate as string)
+        const numAnts = data.get('num_ants')
+        if (numAnts !== null && numAnts !== '')
+          options.numAnts = parseInt(numAnts as string, 10)
 
-      const handler = (msg: MessageEvent) => {
-        const res = msg.data as WebMCPSolveResult
-        if (res.type !== 'webmcp-result' || res.id !== id) return
-        worker.removeEventListener('message', handler)
-        if (res.error) reject(new Error(res.error))
-        else resolve(res.solution)
-      }
-      worker.addEventListener('message', handler)
-      worker.postMessage({
-        type: 'webmcp-solve',
-        id,
-        solver: (data.get('algorithm') as string | null) ?? 'lk',
-        input: data.get('problem') as string,
-        options,
-      })
-    }))
+        const handler = (msg: MessageEvent) => {
+          const res = msg.data as WebMCPSolveResult
+          if (res.type !== 'webmcp-result' || res.id !== id) return
+          worker.removeEventListener('message', handler)
+          if (res.error) reject(new Error(res.error))
+          else resolve(res.solution)
+        }
+        worker.addEventListener('message', handler)
+        worker.postMessage({
+          type: 'webmcp-solve',
+          id,
+          solver: (data.get('algorithm') as string | null) ?? 'lk',
+          input: data.get('problem') as string,
+          options,
+        })
+      }),
+    )
   })
 }
 
 function wireListAlgorithms(worker: Worker): void {
-  const form = document.getElementById('webmcp-list-algorithms') as HTMLFormElement | null
+  const form = document.getElementById(
+    'webmcp-list-algorithms',
+  ) as HTMLFormElement | null
   if (!form) return
   form.addEventListener('submit', (e) => {
     const ae = e as AgentSubmitEvent
     if (typeof ae.respondWith !== 'function') return
     e.preventDefault()
-    ae.respondWith(new Promise((resolve, reject) => {
-      const id = crypto.randomUUID()
-      const handler = (msg: MessageEvent) => {
-        const res = msg.data as WebMCPAlgorithmsResult
-        if (res.type !== 'webmcp-algorithms' || res.id !== id) return
-        worker.removeEventListener('message', handler)
-        if (res.error) reject(new Error(res.error))
-        else resolve(res.algorithms)
-      }
-      worker.addEventListener('message', handler)
-      worker.postMessage({ type: 'webmcp-list-algorithms', id })
-    }))
+    ae.respondWith(
+      new Promise((resolve, reject) => {
+        const id = crypto.randomUUID()
+        const handler = (msg: MessageEvent) => {
+          const res = msg.data as WebMCPAlgorithmsResult
+          if (res.type !== 'webmcp-algorithms' || res.id !== id) return
+          worker.removeEventListener('message', handler)
+          if (res.error) reject(new Error(res.error))
+          else resolve(res.algorithms)
+        }
+        worker.addEventListener('message', handler)
+        worker.postMessage({ type: 'webmcp-list-algorithms', id })
+      }),
+    )
   })
 }
 
@@ -101,47 +115,63 @@ function wireParseProblem(worker: Worker): void {
     const ae = e as AgentSubmitEvent
     if (typeof ae.respondWith !== 'function') return
     e.preventDefault()
-    ae.respondWith(new Promise((resolve, reject) => {
-      const data = new FormData(form)
-      const id = crypto.randomUUID()
-      const handler = (msg: MessageEvent) => {
-        const res = msg.data as WebMCPParseResult
-        if (res.type !== 'webmcp-parsed' || res.id !== id) return
-        worker.removeEventListener('message', handler)
-        if (res.error) reject(new Error(res.error))
-        else resolve(res.problem)
-      }
-      worker.addEventListener('message', handler)
-      worker.postMessage({ type: 'webmcp-parse', id, input: data.get('problem') as string })
-    }))
+    ae.respondWith(
+      new Promise((resolve, reject) => {
+        const data = new FormData(form)
+        const id = crypto.randomUUID()
+        const handler = (msg: MessageEvent) => {
+          const res = msg.data as WebMCPParseResult
+          if (res.type !== 'webmcp-parsed' || res.id !== id) return
+          worker.removeEventListener('message', handler)
+          if (res.error) reject(new Error(res.error))
+          else resolve(res.problem)
+        }
+        worker.addEventListener('message', handler)
+        worker.postMessage({
+          type: 'webmcp-parse',
+          id,
+          input: data.get('problem') as string,
+        })
+      }),
+    )
   })
 }
 
 function wireCompareTours(worker: Worker): void {
-  const form = document.getElementById('webmcp-compare') as HTMLFormElement | null
+  const form = document.getElementById(
+    'webmcp-compare',
+  ) as HTMLFormElement | null
   if (!form) return
   form.addEventListener('submit', (e) => {
     const ae = e as AgentSubmitEvent
     if (typeof ae.respondWith !== 'function') return
     e.preventDefault()
-    ae.respondWith(new Promise((resolve, reject) => {
-      const data = new FormData(form)
-      const id = crypto.randomUUID()
-      const handler = (msg: MessageEvent) => {
-        const res = msg.data as CompareToursResult
-        if (res.type !== 'compare-tours-result' || res.id !== id) return
-        worker.removeEventListener('message', handler)
-        if (res.error) reject(new Error(res.error))
-        else resolve(res.stats)
-      }
-      worker.addEventListener('message', handler)
-      worker.postMessage({
-        type: 'compare-tours',
-        id,
-        solverRoute: JSON.parse(data.get('solver_route') as string) as number[],
-        optRoute: JSON.parse(data.get('opt_route') as string) as number[],
-        cities: JSON.parse(data.get('cities') as string) as Array<{ id: number; x: number; y: number }>,
-      })
-    }))
+    ae.respondWith(
+      new Promise((resolve, reject) => {
+        const data = new FormData(form)
+        const id = crypto.randomUUID()
+        const handler = (msg: MessageEvent) => {
+          const res = msg.data as CompareToursResult
+          if (res.type !== 'compare-tours-result' || res.id !== id) return
+          worker.removeEventListener('message', handler)
+          if (res.error) reject(new Error(res.error))
+          else resolve(res.stats)
+        }
+        worker.addEventListener('message', handler)
+        worker.postMessage({
+          type: 'compare-tours',
+          id,
+          solverRoute: JSON.parse(
+            data.get('solver_route') as string,
+          ) as number[],
+          optRoute: JSON.parse(data.get('opt_route') as string) as number[],
+          cities: JSON.parse(data.get('cities') as string) as Array<{
+            id: number
+            x: number
+            y: number
+          }>,
+        })
+      }),
+    )
   })
 }

--- a/teeline-web/src/worker.test.ts
+++ b/teeline-web/src/worker.test.ts
@@ -10,9 +10,15 @@ vi.mock('teeline-wasm', () => ({
   compareToursFromInput: vi.fn(),
 }))
 
-
-
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, compareToursFromInput } from 'teeline-wasm'
+import {
+  solve,
+  parseAndSolve,
+  parse,
+  listAlgorithms,
+  getVersion,
+  compareTours,
+  compareToursFromInput,
+} from 'teeline-wasm'
 import {
   handleMessage,
   type ParseAndSolveRequest,
@@ -49,7 +55,11 @@ describe('handleMessage — solve', () => {
     const req: SolveRequest = {
       type: 'solve',
       solver: 'nn',
-      cities: [{ id: 0, x: 1, y: 2 }, { id: 1, x: 3, y: 4 }, { id: 2, x: 5, y: 6 }],
+      cities: [
+        { id: 0, x: 1, y: 2 },
+        { id: 1, x: 3, y: 4 },
+        { id: 2, x: 5, y: 6 },
+      ],
       options: {},
     }
     const res = handleMessage(req)
@@ -61,8 +71,15 @@ describe('handleMessage — solve', () => {
   })
 
   it('returns SolveError when solve throws', () => {
-    vi.mocked(solve).mockImplementation(() => { throw new Error('solver crashed') })
-    const req: SolveRequest = { type: 'solve', solver: 'nn', cities: [], options: {} }
+    vi.mocked(solve).mockImplementation(() => {
+      throw new Error('solver crashed')
+    })
+    const req: SolveRequest = {
+      type: 'solve',
+      solver: 'nn',
+      cities: [],
+      options: {},
+    }
     const res = handleMessage(req)
     expect(res.type).toBe('error')
     if (res.type === 'error') {
@@ -90,7 +107,9 @@ describe('handleMessage — parse-and-solve', () => {
   })
 
   it('returns SolveError when parseAndSolve throws', () => {
-    vi.mocked(parseAndSolve).mockImplementation(() => { throw new Error('bad TSPLIB input') })
+    vi.mocked(parseAndSolve).mockImplementation(() => {
+      throw new Error('bad TSPLIB input')
+    })
     const req: ParseAndSolveRequest = {
       type: 'parse-and-solve',
       solver: 'nn',
@@ -127,7 +146,9 @@ describe('handleMessage — parse', () => {
   })
 
   it('returns SolveError when parse throws', () => {
-    vi.mocked(parse).mockImplementation(() => { throw new Error('bad input') })
+    vi.mocked(parse).mockImplementation(() => {
+      throw new Error('bad input')
+    })
     const req: ParseRequest = { type: 'parse', input: '' }
     const res = handleMessage(req)
     expect(res.type).toBe('error')
@@ -152,7 +173,9 @@ describe('handleMessage — list-algorithms', () => {
   })
 
   it('returns SolveError when listAlgorithms throws', () => {
-    vi.mocked(listAlgorithms).mockImplementation(() => { throw new Error('wasm init failed') })
+    vi.mocked(listAlgorithms).mockImplementation(() => {
+      throw new Error('wasm init failed')
+    })
     const req: ListAlgorithmsRequest = { type: 'list-algorithms' }
     const res = handleMessage(req)
     expect(res.type).toBe('error')
@@ -175,7 +198,9 @@ describe('handleMessage — get-version', () => {
   })
 
   it('returns SolveError when getVersion throws', () => {
-    vi.mocked(getVersion).mockImplementation(() => { throw new Error('version unavailable') })
+    vi.mocked(getVersion).mockImplementation(() => {
+      throw new Error('version unavailable')
+    })
     const req: GetVersionRequest = { type: 'get-version' }
     const res = handleMessage(req)
     expect(res.type).toBe('error')
@@ -201,7 +226,7 @@ describe('handleMessage — compare-tours', () => {
     { id: 4, x: 0.0, y: 1.0 },
   ]
   const solverRoute = [1, 2, 3, 4]
-  const optRoute    = [1, 2, 4, 3]
+  const optRoute = [1, 2, 4, 3]
 
   it('returns compare-tours-result with stats on success', () => {
     vi.mocked(compareTours).mockReturnValue(mockStats)
@@ -280,7 +305,9 @@ describe('handleMessage — webmcp-solve', () => {
   })
 
   it('echoes id in the error response when parseAndSolve throws', () => {
-    vi.mocked(parseAndSolve).mockImplementation(() => { throw new Error('bad tsplib') })
+    vi.mocked(parseAndSolve).mockImplementation(() => {
+      throw new Error('bad tsplib')
+    })
     const req: WebMCPSolveRequest = {
       type: 'webmcp-solve',
       id: 'webmcp-id-err',
@@ -301,7 +328,10 @@ describe('handleMessage — webmcp-solve', () => {
 describe('handleMessage — webmcp-list-algorithms', () => {
   it('calls listAlgorithms and returns webmcp-algorithms with id', () => {
     vi.mocked(listAlgorithms).mockReturnValue([mockAlgorithm])
-    const req: WebMCPListAlgorithmsRequest = { type: 'webmcp-list-algorithms', id: 'algo-id-1' }
+    const req: WebMCPListAlgorithmsRequest = {
+      type: 'webmcp-list-algorithms',
+      id: 'algo-id-1',
+    }
     const res = handleMessage(req)
     expect(listAlgorithms).toHaveBeenCalledOnce()
     expect(res.type).toBe('webmcp-algorithms')
@@ -314,8 +344,13 @@ describe('handleMessage — webmcp-list-algorithms', () => {
   })
 
   it('echoes id in the error response when listAlgorithms throws', () => {
-    vi.mocked(listAlgorithms).mockImplementation(() => { throw new Error('wasm not ready') })
-    const req: WebMCPListAlgorithmsRequest = { type: 'webmcp-list-algorithms', id: 'algo-id-err' }
+    vi.mocked(listAlgorithms).mockImplementation(() => {
+      throw new Error('wasm not ready')
+    })
+    const req: WebMCPListAlgorithmsRequest = {
+      type: 'webmcp-list-algorithms',
+      id: 'algo-id-err',
+    }
     const res = handleMessage(req)
     expect(res.type).toBe('webmcp-algorithms')
     if (res.type === 'webmcp-algorithms') {
@@ -331,12 +366,19 @@ describe('handleMessage — webmcp-parse', () => {
     name: 'test',
     comment: '',
     distanceType: 'EUC_2D',
-    cities: [{ id: 1, x: 0.0, y: 0.0 }, { id: 2, x: 1.0, y: 0.0 }],
+    cities: [
+      { id: 1, x: 0.0, y: 0.0 },
+      { id: 2, x: 1.0, y: 0.0 },
+    ],
   }
 
   it('calls parse and returns webmcp-parsed with full problem', () => {
     vi.mocked(parse).mockReturnValue(mockProblem)
-    const req: WebMCPParseRequest = { type: 'webmcp-parse', id: 'parse-id-1', input: 'NAME: test\n' }
+    const req: WebMCPParseRequest = {
+      type: 'webmcp-parse',
+      id: 'parse-id-1',
+      input: 'NAME: test\n',
+    }
     const res = handleMessage(req)
     expect(parse).toHaveBeenCalledWith('NAME: test\n')
     expect(res.type).toBe('webmcp-parsed')
@@ -349,8 +391,14 @@ describe('handleMessage — webmcp-parse', () => {
   })
 
   it('echoes id in the error response when parse throws', () => {
-    vi.mocked(parse).mockImplementation(() => { throw new Error('invalid tsplib') })
-    const req: WebMCPParseRequest = { type: 'webmcp-parse', id: 'parse-id-err', input: '' }
+    vi.mocked(parse).mockImplementation(() => {
+      throw new Error('invalid tsplib')
+    })
+    const req: WebMCPParseRequest = {
+      type: 'webmcp-parse',
+      id: 'parse-id-err',
+      input: '',
+    }
     const res = handleMessage(req)
     expect(res.type).toBe('webmcp-parsed')
     if (res.type === 'webmcp-parsed') {
@@ -371,8 +419,9 @@ describe('handleMessage — compare-tours-from-input', () => {
     optimalOnlyEdges: 4,
   }
   const solverRoute = [1, 2, 3]
-  const optRoute    = [1, 3, 2]
-  const tspInput = 'NAME: test\nDIMENSION: 3\nEDGE_WEIGHT_TYPE: EXPLICIT\nNODE_COORD_SECTION\n1 0.0 0.0\n2 1.0 0.0\n3 0.0 1.0\nEOF\n'
+  const optRoute = [1, 3, 2]
+  const tspInput =
+    'NAME: test\nDIMENSION: 3\nEDGE_WEIGHT_TYPE: EXPLICIT\nNODE_COORD_SECTION\n1 0.0 0.0\n2 1.0 0.0\n3 0.0 1.0\nEOF\n'
 
   it('returns compare-tours-result with stats when using raw input', () => {
     vi.mocked(compareToursFromInput).mockReturnValue(mockStats)

--- a/teeline-web/src/worker.ts
+++ b/teeline-web/src/worker.ts
@@ -1,6 +1,15 @@
 /// <reference lib="webworker" />
 
-import { solve, parseAndSolve, parse, listAlgorithms, getVersion, compareTours, compareToursFromInput, type ParsedProblem } from 'teeline-wasm'
+import {
+  solve,
+  parseAndSolve,
+  parse,
+  listAlgorithms,
+  getVersion,
+  compareTours,
+  compareToursFromInput,
+  type ParsedProblem,
+} from 'teeline-wasm'
 import type { AlgorithmInfo } from 'teeline-wasm'
 import { defaultSolveOptions, type SolveOptions } from './solver-options'
 
@@ -129,8 +138,28 @@ export interface WebMCPParseResult {
   error?: string
 }
 
-type WorkerRequest = SolveRequest | ParseAndSolveRequest | ParseRequest | ListAlgorithmsRequest | GetVersionRequest | CompareToursRequest | CompareToursFromInputRequest | WebMCPSolveRequest | WebMCPListAlgorithmsRequest | WebMCPParseRequest
-type WorkerResponse = SolveResult | ParseResult | AlgorithmsResult | VersionResult | SolveError | WorkerReadyMessage | CompareToursResult | WebMCPSolveResult | WebMCPAlgorithmsResult | WebMCPParseResult
+type WorkerRequest =
+  | SolveRequest
+  | ParseAndSolveRequest
+  | ParseRequest
+  | ListAlgorithmsRequest
+  | GetVersionRequest
+  | CompareToursRequest
+  | CompareToursFromInputRequest
+  | WebMCPSolveRequest
+  | WebMCPListAlgorithmsRequest
+  | WebMCPParseRequest
+type WorkerResponse =
+  | SolveResult
+  | ParseResult
+  | AlgorithmsResult
+  | VersionResult
+  | SolveError
+  | WorkerReadyMessage
+  | CompareToursResult
+  | WebMCPSolveResult
+  | WebMCPAlgorithmsResult
+  | WebMCPParseResult
 
 export function handleMessage(data: WorkerRequest): WorkerResponse {
   try {
@@ -148,7 +177,11 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
       const req = data as CompareToursRequest
       try {
         // compareTours returns ComparisonStats directly (jco throws on WIT Err)
-        const s = compareTours(new Uint32Array(req.solverRoute), new Uint32Array(req.optRoute), req.cities)
+        const s = compareTours(
+          new Uint32Array(req.solverRoute),
+          new Uint32Array(req.optRoute),
+          req.cities,
+        )
         return {
           type: 'compare-tours-result',
           id: req.id,
@@ -172,7 +205,11 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
     if (data.type === 'compare-tours-from-input') {
       const req = data as CompareToursFromInputRequest
       try {
-        const s = compareToursFromInput(new Uint32Array(req.solverRoute), new Uint32Array(req.optRoute), req.input)
+        const s = compareToursFromInput(
+          new Uint32Array(req.solverRoute),
+          new Uint32Array(req.optRoute),
+          req.input,
+        )
         return {
           type: 'compare-tours-result',
           id: req.id,
@@ -198,7 +235,11 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
       try {
         const opts = { ...defaultSolveOptions(), ...req.options }
         const raw = parseAndSolve(req.solver, req.input, opts)
-        return { type: 'webmcp-result', id: req.id, solution: { total: raw.total, route: Array.from(raw.route) } }
+        return {
+          type: 'webmcp-result',
+          id: req.id,
+          solution: { total: raw.total, route: Array.from(raw.route) },
+        }
       } catch (e) {
         return { type: 'webmcp-result', id: req.id, error: String(e) }
       }
@@ -206,7 +247,11 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
     if (data.type === 'webmcp-list-algorithms') {
       const req = data as WebMCPListAlgorithmsRequest
       try {
-        return { type: 'webmcp-algorithms', id: req.id, algorithms: listAlgorithms() }
+        return {
+          type: 'webmcp-algorithms',
+          id: req.id,
+          algorithms: listAlgorithms(),
+        }
       } catch (e) {
         return { type: 'webmcp-algorithms', id: req.id, error: String(e) }
       }
@@ -219,7 +264,10 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
         return { type: 'webmcp-parsed', id: req.id, error: String(e) }
       }
     }
-    const mergedOptions: SolveOptions = { ...defaultSolveOptions(), ...data.options }
+    const mergedOptions: SolveOptions = {
+      ...defaultSolveOptions(),
+      ...data.options,
+    }
     let solution: ReturnType<typeof solve>
     if (data.type === 'solve') {
       solution = solve(data.solver, data.cities, mergedOptions)
@@ -230,7 +278,7 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
       type: 'result',
       solution: {
         total: solution.total,
-        route: Array.from(solution.route),  // Uint32Array → plain number[]
+        route: Array.from(solution.route), // Uint32Array → plain number[]
       },
     }
   } catch (err) {
@@ -242,7 +290,10 @@ export function handleMessage(data: WorkerRequest): WorkerResponse {
 }
 
 // Only register in Web Worker context (not during Vitest runs)
-if (typeof DedicatedWorkerGlobalScope !== 'undefined' && self instanceof DedicatedWorkerGlobalScope) {
+if (
+  typeof DedicatedWorkerGlobalScope !== 'undefined' &&
+  self instanceof DedicatedWorkerGlobalScope
+) {
   // Signal readiness BEFORE registering onmessage so main.ts knows WASM is
   // initialized and won't send messages that deadlock the jco task scheduler.
   self.postMessage({ type: 'worker-ready' } satisfies WorkerReadyMessage)

--- a/teeline-web/tests/algorithms-index.spec.ts
+++ b/teeline-web/tests/algorithms-index.spec.ts
@@ -11,21 +11,37 @@ test.describe('algorithms index & topbar nav', () => {
 
     await link.click()
     await expect(page).toHaveURL(/\/algorithms\/$/)
-    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Algorithms')
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+      'Algorithms',
+    )
   })
 
-  test('the index lists the solver groups with explainer links', async ({ page }) => {
+  test('the index lists the solver groups with explainer links', async ({
+    page,
+  }) => {
     await page.goto('/algorithms/')
     // one "▶ interactive" link per explainer (21 at the time of writing)
-    await expect(page.getByRole('link', { name: /Open interactive explainer for/ })).toHaveCount(21)
+    await expect(
+      page.getByRole('link', { name: /Open interactive explainer for/ }),
+    ).toHaveCount(21)
     // a known solver doc link is present
-    await expect(page.getByRole('link', { name: 'Christofides', exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: 'Christofides', exact: true }),
+    ).toBeVisible()
   })
 
-  test('an explainer link from the index opens the explainer page', async ({ page }) => {
+  test('an explainer link from the index opens the explainer page', async ({
+    page,
+  }) => {
     await page.goto('/algorithms/')
-    const christofidesRow = page.getByRole('row').filter({ hasText: 'Christofides' })
-    await christofidesRow.getByRole('link', { name: /Open interactive explainer for Christofides/ }).click()
+    const christofidesRow = page
+      .getByRole('row')
+      .filter({ hasText: 'Christofides' })
+    await christofidesRow
+      .getByRole('link', {
+        name: /Open interactive explainer for Christofides/,
+      })
+      .click()
     await expect(page).toHaveURL(/\/algorithms\/christofides\/explainer\/$/)
     await expect(page.locator('.chr-root')).toBeVisible({ timeout: 10_000 })
   })

--- a/teeline-web/tests/auth/auth-flow.spec.ts
+++ b/teeline-web/tests/auth/auth-flow.spec.ts
@@ -18,18 +18,27 @@ async function setupVirtualAuthenticator(page: Page): Promise<void> {
   })
 }
 
-test('register → mint → show-once → refresh wipes → login → revoke → verify', async ({ page, request }) => {
+test('register → mint → show-once → refresh wipes → login → revoke → verify', async ({
+  page,
+  request,
+}) => {
   await setupVirtualAuthenticator(page)
 
   // ---- anonymous state ----
   await page.goto('/api-key/')
-  await expect(page.getByRole('button', { name: 'Create a passkey' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Sign in with passkey' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Create a passkey' }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Sign in with passkey' }),
+  ).toBeVisible()
 
   // ---- register (open registration: first passkey becomes the account) ----
   await page.getByRole('button', { name: 'Create a passkey' }).click()
   await expect(page.getByRole('heading', { name: 'API keys' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Generate API key' }),
+  ).toBeVisible()
 
   // ---- mint an API key ----
   await page.getByRole('button', { name: 'Generate API key' }).click()
@@ -41,7 +50,9 @@ test('register → mint → show-once → refresh wipes → login → revoke →
   // ---- show-once: a refresh destroys the secret (not persisted) ----
   await page.reload()
   await expect(page.getByTestId('fresh-secret')).toHaveCount(0)
-  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Generate API key' }),
+  ).toBeVisible()
 
   // the key is listed (metadata only)
   await expect(page.locator('tbody tr')).toHaveCount(1)
@@ -52,7 +63,11 @@ test('register → mint → show-once → refresh wipes → login → revoke →
     data: { secret },
   })
   expect(verify.status()).toBe(200)
-  const body = (await verify.json()) as { subject: string; revoked: boolean; expired: boolean }
+  const body = (await verify.json()) as {
+    subject: string
+    revoked: boolean
+    expired: boolean
+  }
   expect(body).toMatchObject({ revoked: false, expired: false })
   expect(typeof body.subject).toBe('string')
 
@@ -65,9 +80,13 @@ test('register → mint → show-once → refresh wipes → login → revoke →
 
   // ---- sign out, sign back in with the same passkey ----
   await page.getByRole('button', { name: 'Sign out' }).click()
-  await expect(page.getByRole('button', { name: 'Sign in with passkey' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Sign in with passkey' }),
+  ).toBeVisible()
   await page.getByRole('button', { name: 'Sign in with passkey' }).click()
-  await expect(page.getByRole('button', { name: 'Generate API key' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Generate API key' }),
+  ).toBeVisible()
   await expect(page.locator('tbody tr')).toHaveCount(1)
 
   // ---- revoke (destructive → confirm dialog) ----

--- a/teeline-web/tests/bhk.spec.ts
+++ b/teeline-web/tests/bhk.spec.ts
@@ -45,11 +45,16 @@ test.describe('bhk explainer', () => {
   test('clicking a cell explains its computation', async ({ page }) => {
     // the first size-2 cell (mask 00011, row 0) exists after one step
     await page.getByRole('button', { name: 'Step' }).click()
-    await page.locator('.bhk-cell', { hasText: /^[0-9]/ }).first().click()
+    await page
+      .locator('.bhk-cell', { hasText: /^[0-9]/ })
+      .first()
+      .click()
     await expect(page.locator('.bhk-cellinfo')).toContainText('dp[')
   })
 
-  test('Run completes the whole DP, then read-back reveals the optimal route', async ({ page }) => {
+  test('Run completes the whole DP, then read-back reveals the optimal route', async ({
+    page,
+  }) => {
     const chip = page.locator('.bhk-chip')
 
     // Run goes all the way through the table and the read-back to Done
@@ -74,7 +79,10 @@ test.describe('bhk explainer', () => {
   })
 
   test('Back restores the previous step', async ({ page }) => {
-    const step = page.locator('.bhk-statgrid').locator('div', { hasText: /^step/ }).locator('.bhk-mono')
+    const step = page
+      .locator('.bhk-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.bhk-mono')
     const back = page.getByRole('button', { name: '⏴ Back' })
 
     await page.getByRole('button', { name: 'Step' }).click()
@@ -86,7 +94,10 @@ test.describe('bhk explainer', () => {
   })
 
   test('scenario buttons restart the run', async ({ page }) => {
-    const step = page.locator('.bhk-statgrid').locator('div', { hasText: /^step/ }).locator('.bhk-mono')
+    const step = page
+      .locator('.bhk-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.bhk-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await expect(step).not.toHaveText('0')

--- a/teeline-web/tests/branch-bound.spec.ts
+++ b/teeline-web/tests/branch-bound.spec.ts
@@ -21,7 +21,9 @@ test.describe('branch & bound explainer', () => {
     await waitHydrated(page)
   })
 
-  test('renders the search tree, city map, stats and scenarios', async ({ page }) => {
+  test('renders the search tree, city map, stats and scenarios', async ({
+    page,
+  }) => {
     await expect(page.locator('.bb-title')).toContainText('Branch & Bound')
     await expect(page.locator('.bb-tree')).toBeVisible()
     await expect(page.locator('.bb-map')).toBeVisible()
@@ -33,14 +35,22 @@ test.describe('branch & bound explainer', () => {
     await expect(stats).toContainText('leaves')
     await expect(stats).toContainText('best')
 
-    for (const label of ['Small grid', 'Good bound', 'Worst case', 'Early best']) {
+    for (const label of [
+      'Small grid',
+      'Good bound',
+      'Worst case',
+      'Early best',
+    ]) {
       await expect(page.getByRole('button', { name: label })).toBeVisible()
     }
   })
 
   test('Step expands the search tree one node at a time', async ({ page }) => {
     const chip = page.locator('.bb-chip')
-    const nodes = page.locator('.bb-statgrid').locator('div', { hasText: /^nodes/ }).locator('.bb-mono')
+    const nodes = page
+      .locator('.bb-statgrid')
+      .locator('div', { hasText: /^nodes/ })
+      .locator('.bb-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await expect(chip).toContainText('Expanded')
@@ -50,7 +60,9 @@ test.describe('branch & bound explainer', () => {
     await expect(chip).toContainText(/Expanded|Leaf|Pruned|Backtracked/)
   })
 
-  test('Run completes the search with the optimal tour; Reset restores', async ({ page }) => {
+  test('Run completes the search with the optimal tour; Reset restores', async ({
+    page,
+  }) => {
     const chip = page.locator('.bb-chip')
 
     await page.getByRole('button', { name: 'Run' }).click()
@@ -61,7 +73,10 @@ test.describe('branch & bound explainer', () => {
   })
 
   test('Back restores the previous step', async ({ page }) => {
-    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+    const step = page
+      .locator('.bb-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.bb-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await page.getByRole('button', { name: 'Step' }).click()
@@ -72,7 +87,10 @@ test.describe('branch & bound explainer', () => {
   })
 
   test('Pause stops the animation mid-run', async ({ page }) => {
-    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+    const step = page
+      .locator('.bb-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.bb-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     await page.getByRole('button', { name: 'Pause' }).click()
@@ -82,7 +100,10 @@ test.describe('branch & bound explainer', () => {
   })
 
   test('scenario buttons restart the run', async ({ page }) => {
-    const step = page.locator('.bb-statgrid').locator('div', { hasText: /^step/ }).locator('.bb-mono')
+    const step = page
+      .locator('.bb-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.bb-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await expect(step).not.toHaveText('0')

--- a/teeline-web/tests/christofides.spec.ts
+++ b/teeline-web/tests/christofides.spec.ts
@@ -23,8 +23,12 @@ test.describe('christofides explainer', () => {
     await waitHydrated(page)
   })
 
-  test('renders the canvas, pipeline stepper, ratio meter, proof and compare panels', async ({ page }) => {
-    await expect(page.locator('.chr-title')).toHaveText('Christofides — a ≤1.5× Approximation')
+  test('renders the canvas, pipeline stepper, ratio meter, proof and compare panels', async ({
+    page,
+  }) => {
+    await expect(page.locator('.chr-title')).toHaveText(
+      'Christofides — a ≤1.5× Approximation',
+    )
     await expect(page.locator('.chr-canvas')).toBeVisible()
 
     // six pipeline phases
@@ -41,7 +45,13 @@ test.describe('christofides explainer', () => {
     await expect(stats).toContainText('tour cost')
     await expect(stats).toContainText('ratio')
 
-    for (const label of ['Balanced', 'Near-optimal', 'Matching-heavy', 'Clustered', 'Worst case']) {
+    for (const label of [
+      'Balanced',
+      'Near-optimal',
+      'Matching-heavy',
+      'Clustered',
+      'Worst case',
+    ]) {
       await expect(page.getByRole('button', { name: label })).toBeVisible()
     }
   })
@@ -69,9 +79,14 @@ test.describe('christofides explainer', () => {
     await expect(page.locator('.chr-meter-value')).toContainText('× optimal')
   })
 
-  test('Run animates through the whole pipeline to Done; Reset restores idle', async ({ page }) => {
+  test('Run animates through the whole pipeline to Done; Reset restores idle', async ({
+    page,
+  }) => {
     const chip = page.locator('.chr-chip')
-    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+    const step = page
+      .locator('.chr-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.chr-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     await expect(chip).toContainText('Done —', { timeout: 20_000 })
@@ -83,7 +98,10 @@ test.describe('christofides explainer', () => {
   })
 
   test('Pause stops the animation mid-run', async ({ page }) => {
-    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+    const step = page
+      .locator('.chr-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.chr-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     await page.getByRole('button', { name: 'Pause' }).click()
@@ -93,7 +111,10 @@ test.describe('christofides explainer', () => {
   })
 
   test('Back restores the previous step', async ({ page }) => {
-    const step = page.locator('.chr-statgrid').locator('div', { hasText: /^step/ }).locator('.chr-mono')
+    const step = page
+      .locator('.chr-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.chr-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await page.getByRole('button', { name: 'Step' }).click()
@@ -103,11 +124,16 @@ test.describe('christofides explainer', () => {
     await expect(step).toHaveText('1')
   })
 
-  test('scenario buttons restart the run with their own ratio', async ({ page }) => {
+  test('scenario buttons restart the run with their own ratio', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: 'Worst case' }).click()
     await page.getByRole('button', { name: 'Done' }).click()
     // worst_case is pinned at ~1.39× — the ratio stat reflects it
-    const ratio = page.locator('.chr-statgrid').locator('div', { hasText: /^ratio/ }).locator('.chr-mono')
+    const ratio = page
+      .locator('.chr-statgrid')
+      .locator('div', { hasText: /^ratio/ })
+      .locator('.chr-mono')
     await expect(ratio).toHaveText('1.39×')
   })
 })

--- a/teeline-web/tests/explainer-stochastic-hill.spec.ts
+++ b/teeline-web/tests/explainer-stochastic-hill.spec.ts
@@ -27,11 +27,15 @@ test.describe('stochastic hill explainer', () => {
   })
 
   test('renders the canvas, stats panel and controls', async ({ page }) => {
-    await expect(page.locator('.shc-title')).toHaveText('Stochastic Hill Climbing')
+    await expect(page.locator('.shc-title')).toHaveText(
+      'Stochastic Hill Climbing',
+    )
     await expect(page.locator('.shc-canvas')).toBeVisible()
     // sparkline section label is present; the line itself appears after the
     // first verdict (needs ≥ 2 cost samples)
-    await expect(page.locator('.shc-section-label', { hasText: 'Best cost over epochs' })).toBeVisible()
+    await expect(
+      page.locator('.shc-section-label', { hasText: 'Best cost over epochs' }),
+    ).toBeVisible()
 
     // stats panel
     const stats = page.locator('.shc-statgrid')
@@ -42,12 +46,18 @@ test.describe('stochastic hill explainer', () => {
     await expect(stats).toContainText('accept rate')
 
     // all three scenario buttons
-    for (const label of ['Quick convergence', 'Rugged landscape', 'Needle in haystack']) {
+    for (const label of [
+      'Quick convergence',
+      'Rugged landscape',
+      'Needle in haystack',
+    ]) {
       await expect(page.getByRole('button', { name: label })).toBeVisible()
     }
   })
 
-  test('Step advances the two-phase machine (propose → verdict)', async ({ page }) => {
+  test('Step advances the two-phase machine (propose → verdict)', async ({
+    page,
+  }) => {
     const chip = page.locator('.shc-chip')
 
     await page.getByRole('button', { name: 'Step' }).click()
@@ -60,13 +70,19 @@ test.describe('stochastic hill explainer', () => {
     await expect(page.locator('.shc-spark')).toBeVisible()
 
     // epoch advanced by exactly one verdict
-    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+    const epoch = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^epoch/ })
+      .locator('.shc-mono')
     await expect(epoch).toHaveText('1')
   })
 
   test('Back restores the previous phase', async ({ page }) => {
     const chip = page.locator('.shc-chip')
-    const stepStat = page.locator('.shc-statgrid').locator('div', { hasText: /^step/ }).locator('.shc-mono')
+    const stepStat = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.shc-mono')
 
     await page.getByRole('button', { name: 'Step' }).click() // propose
     await page.getByRole('button', { name: 'Step' }).click() // verdict
@@ -77,8 +93,13 @@ test.describe('stochastic hill explainer', () => {
     await expect(stepStat).toHaveText('1')
   })
 
-  test('Run animates epochs; Pause and Reset stop and reset', async ({ page }) => {
-    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+  test('Run animates epochs; Pause and Reset stop and reset', async ({
+    page,
+  }) => {
+    const epoch = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^epoch/ })
+      .locator('.shc-mono')
     const run = page.getByRole('button', { name: 'Run' })
 
     await run.click()
@@ -94,9 +115,17 @@ test.describe('stochastic hill explainer', () => {
     await expect(page.locator('.shc-chip')).toContainText('Click Step')
   })
 
-  test('scenario buttons restart the run with their own parameters', async ({ page }) => {
-    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
-    const restarts = page.locator('.shc-statgrid').locator('div', { hasText: /^restarts/ }).locator('.shc-mono')
+  test('scenario buttons restart the run with their own parameters', async ({
+    page,
+  }) => {
+    const epoch = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^epoch/ })
+      .locator('.shc-mono')
+    const restarts = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^restarts/ })
+      .locator('.shc-mono')
 
     await page.getByRole('button', { name: 'Rugged landscape' }).click()
     await expect(epoch).toHaveText('0')
@@ -107,9 +136,14 @@ test.describe('stochastic hill explainer', () => {
     await expect(page.locator('.shc-chip')).toContainText('Candidate')
   })
 
-  test('epochs / restart-patience inputs commit on blur and restart the run', async ({ page }) => {
+  test('epochs / restart-patience inputs commit on blur and restart the run', async ({
+    page,
+  }) => {
     const epochsInput = page.locator('#shc-epochs')
-    const epoch = page.locator('.shc-statgrid').locator('div', { hasText: /^epoch/ }).locator('.shc-mono')
+    const epoch = page
+      .locator('.shc-statgrid')
+      .locator('div', { hasText: /^epoch/ })
+      .locator('.shc-mono')
 
     // advance a few steps first
     await page.getByRole('button', { name: 'Run' }).click()

--- a/teeline-web/tests/or-opt.spec.ts
+++ b/teeline-web/tests/or-opt.spec.ts
@@ -28,7 +28,9 @@ test.describe('or-opt explainer', () => {
   test('renders the canvas, stats panel and controls', async ({ page }) => {
     await expect(page.locator('.or-title')).toHaveText('Or-opt Local Search')
     await expect(page.locator('.or-canvas')).toBeVisible()
-    await expect(page.locator('.or-section-label', { hasText: 'Cost over passes' })).toBeVisible()
+    await expect(
+      page.locator('.or-section-label', { hasText: 'Cost over passes' }),
+    ).toBeVisible()
 
     const stats = page.locator('.or-statgrid')
     await expect(stats).toContainText('pass')
@@ -38,15 +40,28 @@ test.describe('or-opt explainer', () => {
     await expect(stats).toContainText('last Δ')
     await expect(stats).toContainText('step')
 
-    for (const label of ['Single segment', 'Triplet move', 'Already optimal', '2-opt stuck']) {
+    for (const label of [
+      'Single segment',
+      'Triplet move',
+      'Already optimal',
+      '2-opt stuck',
+    ]) {
       await expect(page.getByRole('button', { name: label })).toBeVisible()
     }
   })
 
-  test('Step advances the two-click model (candidate → applied)', async ({ page }) => {
+  test('Step advances the two-click model (candidate → applied)', async ({
+    page,
+  }) => {
     const chip = page.locator('.or-chip')
-    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
-    const moves = page.locator('.or-statgrid').locator('div', { hasText: /^moves/ }).locator('.or-mono')
+    const pass = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.or-mono')
+    const moves = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^moves/ })
+      .locator('.or-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     // single_segment scenario: the best move is an Or-1 relocation of city 8
@@ -64,7 +79,10 @@ test.describe('or-opt explainer', () => {
 
   test('Back restores the previous phase', async ({ page }) => {
     const chip = page.locator('.or-chip')
-    const stepStat = page.locator('.or-statgrid').locator('div', { hasText: /^step/ }).locator('.or-mono')
+    const stepStat = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.or-mono')
 
     await page.getByRole('button', { name: 'Step' }).click() // candidate
     await page.getByRole('button', { name: 'Step' }).click() // applied
@@ -75,14 +93,24 @@ test.describe('or-opt explainer', () => {
     await expect(stepStat).toHaveText('1')
   })
 
-  test('Run animates passes to the local optimum; Reset restores idle', async ({ page }) => {
-    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
-    const moves = page.locator('.or-statgrid').locator('div', { hasText: /^moves/ }).locator('.or-mono')
+  test('Run animates passes to the local optimum; Reset restores idle', async ({
+    page,
+  }) => {
+    const pass = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.or-mono')
+    const moves = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^moves/ })
+      .locator('.or-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     // single_segment converges in one pass — watch it advance and finish
     await expect(pass).not.toHaveText('0', { timeout: 10_000 })
-    await expect(page.locator('.or-chip')).toContainText('Local optimum', { timeout: 10_000 })
+    await expect(page.locator('.or-chip')).toContainText('Local optimum', {
+      timeout: 10_000,
+    })
     // one applied move + the final local-optimum scan
     await expect(pass).toHaveText('2')
     await expect(moves).toHaveText('1')
@@ -93,7 +121,10 @@ test.describe('or-opt explainer', () => {
   })
 
   test('Pause stops the animation mid-run', async ({ page }) => {
-    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+    const pass = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.or-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     // pause immediately — before or during the first tick, pass is 0 or 1
@@ -103,7 +134,9 @@ test.describe('or-opt explainer', () => {
     await expect(pass).toHaveText(paused ?? '')
   })
 
-  test('already_optimal reaches the local optimum in one Step', async ({ page }) => {
+  test('already_optimal reaches the local optimum in one Step', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: 'Already optimal' }).click()
     await expect(page.locator('.or-chip')).toContainText('Click Step')
 
@@ -112,7 +145,10 @@ test.describe('or-opt explainer', () => {
   })
 
   test('scenario buttons restart the run', async ({ page }) => {
-    const pass = page.locator('.or-statgrid').locator('div', { hasText: /^pass/ }).locator('.or-mono')
+    const pass = page
+      .locator('.or-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.or-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await page.getByRole('button', { name: 'Step' }).click()

--- a/teeline-web/tests/three-opt.spec.ts
+++ b/teeline-web/tests/three-opt.spec.ts
@@ -25,7 +25,9 @@ test.describe('3-opt explainer', () => {
     await waitHydrated(page)
   })
 
-  test('renders the canvas, pattern diagram, stats and controls', async ({ page }) => {
+  test('renders the canvas, pattern diagram, stats and controls', async ({
+    page,
+  }) => {
     await expect(page.locator('.t3-title')).toHaveText('3-opt Local Search')
     await expect(page.locator('.t3-canvas')).toBeVisible()
 
@@ -41,15 +43,28 @@ test.describe('3-opt explainer', () => {
     await expect(stats).toContainText('last Δ')
     await expect(stats).toContainText('step')
 
-    for (const label of ['Single 3-opt', 'Beyond 2-opt', 'Already 3-optimal', 'Deep sweep']) {
+    for (const label of [
+      'Single 3-opt',
+      'Beyond 2-opt',
+      'Already 3-optimal',
+      'Deep sweep',
+    ]) {
       await expect(page.getByRole('button', { name: label })).toBeVisible()
     }
   })
 
-  test('Step shows the candidate with the chosen reconnection pattern highlighted, then applies', async ({ page }) => {
+  test('Step shows the candidate with the chosen reconnection pattern highlighted, then applies', async ({
+    page,
+  }) => {
     const chip = page.locator('.t3-chip')
-    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
-    const swaps = page.locator('.t3-statgrid').locator('div', { hasText: /^swaps/ }).locator('.t3-mono')
+    const pass = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.t3-mono')
+    const swaps = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^swaps/ })
+      .locator('.t3-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     // single_3opt scenario: the best move is a case-4 segment swap
@@ -68,7 +83,10 @@ test.describe('3-opt explainer', () => {
 
   test('Back restores the previous phase', async ({ page }) => {
     const chip = page.locator('.t3-chip')
-    const stepStat = page.locator('.t3-statgrid').locator('div', { hasText: /^step/ }).locator('.t3-mono')
+    const stepStat = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^step/ })
+      .locator('.t3-mono')
 
     await page.getByRole('button', { name: 'Step' }).click() // candidate
     await page.getByRole('button', { name: 'Step' }).click() // applied
@@ -79,14 +97,24 @@ test.describe('3-opt explainer', () => {
     await expect(stepStat).toHaveText('1')
   })
 
-  test('Run animates the deep sweep to the local optimum; Reset restores idle', async ({ page }) => {
-    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
-    const swaps = page.locator('.t3-statgrid').locator('div', { hasText: /^swaps/ }).locator('.t3-mono')
+  test('Run animates the deep sweep to the local optimum; Reset restores idle', async ({
+    page,
+  }) => {
+    const pass = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.t3-mono')
+    const swaps = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^swaps/ })
+      .locator('.t3-mono')
 
     await page.getByRole('button', { name: 'Deep sweep' }).click()
     await page.getByRole('button', { name: 'Run' }).click()
     // deep_sweep needs several passes to converge
-    await expect(page.locator('.t3-chip')).toContainText('Local optimum', { timeout: 15_000 })
+    await expect(page.locator('.t3-chip')).toContainText('Local optimum', {
+      timeout: 15_000,
+    })
     await expect(swaps).not.toHaveText('0')
     await expect(pass).not.toHaveText('0')
 
@@ -96,7 +124,10 @@ test.describe('3-opt explainer', () => {
   })
 
   test('Pause stops the animation mid-run', async ({ page }) => {
-    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+    const pass = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.t3-mono')
 
     await page.getByRole('button', { name: 'Run' }).click()
     await page.getByRole('button', { name: 'Pause' }).click()
@@ -105,7 +136,9 @@ test.describe('3-opt explainer', () => {
     await expect(pass).toHaveText(paused ?? '')
   })
 
-  test('already_3optimal reaches the local optimum in one Step', async ({ page }) => {
+  test('already_3optimal reaches the local optimum in one Step', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: 'Already 3-optimal' }).click()
     await expect(page.locator('.t3-chip')).toContainText('Click Step')
 
@@ -114,7 +147,10 @@ test.describe('3-opt explainer', () => {
   })
 
   test('scenario buttons restart the run', async ({ page }) => {
-    const pass = page.locator('.t3-statgrid').locator('div', { hasText: /^pass/ }).locator('.t3-mono')
+    const pass = page
+      .locator('.t3-statgrid')
+      .locator('div', { hasText: /^pass/ })
+      .locator('.t3-mono')
 
     await page.getByRole('button', { name: 'Step' }).click()
     await page.getByRole('button', { name: 'Step' }).click()

--- a/teeline-web/tests/webmcp.spec.ts
+++ b/teeline-web/tests/webmcp.spec.ts
@@ -28,12 +28,16 @@ async function invokeWebMCPTool(
 
       // Fill fields by name
       for (const [name, value] of Object.entries(fields)) {
-        const el = form.elements.namedItem(name) as HTMLInputElement | HTMLTextAreaElement | null
+        const el = form.elements.namedItem(name) as
+          HTMLInputElement | HTMLTextAreaElement | null
         if (el) el.value = value
       }
 
       return new Promise((resolve, reject) => {
-        const event = new Event('submit', { bubbles: true, cancelable: true }) as SubmitEvent & {
+        const event = new Event('submit', {
+          bubbles: true,
+          cancelable: true,
+        }) as SubmitEvent & {
           agentInvoked: boolean
           respondWith(p: Promise<unknown>): void
         }
@@ -49,12 +53,14 @@ async function invokeWebMCPTool(
 }
 
 // DOM test — forms are in the static HTML; no WASM init needed
-test('4 WebMCP forms are present in the DOM with toolname attributes', async ({ page }) => {
+test('4 WebMCP forms are present in the DOM with toolname attributes', async ({
+  page,
+}) => {
   await page.goto('/')
   const forms = await page.locator('form[toolname]').all()
   expect(forms).toHaveLength(4)
 
-  const names = await Promise.all(forms.map(f => f.getAttribute('toolname')))
+  const names = await Promise.all(forms.map((f) => f.getAttribute('toolname')))
   expect(names).toContain('solveTSP')
   expect(names).toContain('listAlgorithms')
   expect(names).toContain('parseProblem')
@@ -68,17 +74,26 @@ test.describe('WebMCP tool invocation', () => {
     await page.waitForSelector('.status-dot--ready', { timeout: 20_000 })
   })
 
-  test('listAlgorithms returns an array of algorithm objects', async ({ page }) => {
-    const result = await invokeWebMCPTool(page, 'webmcp-list-algorithms') as Array<{ id: string; name: string }>
+  test('listAlgorithms returns an array of algorithm objects', async ({
+    page,
+  }) => {
+    const result = (await invokeWebMCPTool(
+      page,
+      'webmcp-list-algorithms',
+    )) as Array<{ id: string; name: string }>
     expect(Array.isArray(result)).toBe(true)
     expect(result.length).toBeGreaterThan(0)
-    const ids = result.map(a => a.id)
+    const ids = result.map((a) => a.id)
     expect(ids).toContain('nn')
     expect(ids).toContain('lk')
   })
 
-  test('parseProblem returns city list for valid TSPLIB input', async ({ page }) => {
-    const result = await invokeWebMCPTool(page, 'webmcp-parse', { problem: SMALL_TSP }) as {
+  test('parseProblem returns city list for valid TSPLIB input', async ({
+    page,
+  }) => {
+    const result = (await invokeWebMCPTool(page, 'webmcp-parse', {
+      problem: SMALL_TSP,
+    })) as {
       name: string
       cities: Array<{ id: number; x: number; y: number }>
     }
@@ -88,27 +103,29 @@ test.describe('WebMCP tool invocation', () => {
   })
 
   test('solveTSP returns tour and cost for valid input', async ({ page }) => {
-    const result = await invokeWebMCPTool(page, 'webmcp-solve', {
+    const result = (await invokeWebMCPTool(page, 'webmcp-solve', {
       problem: SMALL_TSP,
       algorithm: 'nn',
-    }) as { total: number; route: number[] }
+    })) as { total: number; route: number[] }
     expect(typeof result.total).toBe('number')
     expect(result.total).toBeGreaterThan(0)
     expect(result.route).toHaveLength(4)
   })
 
-  test('compareTours returns gap stats for matching city sets', async ({ page }) => {
+  test('compareTours returns gap stats for matching city sets', async ({
+    page,
+  }) => {
     const cities = [
       { id: 1, x: 0, y: 0 },
       { id: 2, x: 1, y: 0 },
       { id: 3, x: 1, y: 1 },
       { id: 4, x: 0, y: 1 },
     ]
-    const result = await invokeWebMCPTool(page, 'webmcp-compare', {
+    const result = (await invokeWebMCPTool(page, 'webmcp-compare', {
       solver_route: JSON.stringify([1, 2, 3, 4]),
       opt_route: JSON.stringify([1, 2, 3, 4]),
       cities: JSON.stringify(cities),
-    }) as { gapPct: number; sharedEdges: number }
+    })) as { gapPct: number; sharedEdges: number }
     expect(result.gapPct).toBe(0)
     expect(result.sharedEdges).toBe(4)
   })


### PR DESCRIPTION
## Summary

Adopts [Prettier](https://prettier.io) for `teeline-web` so JS/TS formatting is enforced instead of hand-maintained. Prompted by hand-formatting drift noticed in #511.

## Config

`.prettierrc` matches the existing hand-maintained style:

```json
{ "semi": false, "singleQuote": true }
```

Prettier's defaults would have added semicolons and switched to double quotes, which the codebase deliberately avoids.

## Tooling

- `teeline-web/.prettierrc`, `teeline-web/.prettierignore`
- `format` / `format:check` npm scripts
- `prettier` added as an explicit devDependency (previously only transitive)
- `.githooks/pre-commit` now checks staged web code
- `.github/workflows/teeline-web.yml` runs `npm run format:check`

## Scope

`.prettierignore` skips `node_modules/`, `dist/`, `.astro/`, `.wrangler/`, `test-results/`, `public/` and `package-lock.json`, plus:

- `*.astro` — needs `prettier-plugin-astro`; deliberately left as a follow-up
- `*.md` / `*.yml` / `*.yaml` — already covered by markdownlint / yamllint

## Verification

Mechanical formatting only (121 files). After `prettier --write`:

- `npm run format:check` ✅
- `npx tsc --noEmit` ✅
- `npx astro check` — 0 errors / warnings / hints ✅
- `npm test` — 468 passed (33 files) ✅
- `npm run build:check` — production build, 164 pages ✅

The pre-commit hook and CI format check both pass on this branch.

## Merge note

This touches `teeline-web/src/upload.ts` and `upload.test.ts`, which #511 also changes — whichever lands second needs a trivial rebase.
