### PR TITLE
fix(web): add creator and license to problem dataset structured data

### DIFF
--- a/docs/problems/a280.md
+++ b/docs/problems/a280.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/a280.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/ali535.md
+++ b/docs/problems/ali535.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/ali535.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/att48.md
+++ b/docs/problems/att48.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/att48.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/att532.md
+++ b/docs/problems/att532.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/att532.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/bayg29.md
+++ b/docs/problems/bayg29.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/bayg29.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/bays29.md
+++ b/docs/problems/bays29.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/bays29.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/berlin52.md
+++ b/docs/problems/berlin52.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/berlin52.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/bier127.md
+++ b/docs/problems/bier127.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/bier127.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/brazil58.md
+++ b/docs/problems/brazil58.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/brazil58.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/brd14051.md
+++ b/docs/problems/brd14051.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/brd14051.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/brg180.md
+++ b/docs/problems/brg180.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/brg180.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/burma14.md
+++ b/docs/problems/burma14.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/burma14.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/ch130.md
+++ b/docs/problems/ch130.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/ch130.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/ch150.md
+++ b/docs/problems/ch150.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/ch150.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d1291.md
+++ b/docs/problems/d1291.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d1291.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d15112.md
+++ b/docs/problems/d15112.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d15112.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d1655.md
+++ b/docs/problems/d1655.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d1655.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d18512.md
+++ b/docs/problems/d18512.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d18512.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d198.md
+++ b/docs/problems/d198.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d198.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d2103.md
+++ b/docs/problems/d2103.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d2103.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d493.md
+++ b/docs/problems/d493.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d493.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/d657.md
+++ b/docs/problems/d657.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/d657.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/dantzig42.md
+++ b/docs/problems/dantzig42.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/dantzig42.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/dsj1000.md
+++ b/docs/problems/dsj1000.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/dsj1000.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/eil101.md
+++ b/docs/problems/eil101.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/eil101.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/eil51.md
+++ b/docs/problems/eil51.md
@@ -9,6 +9,8 @@ optimalCost: 426
 dataUrl: "https://static.tspsolver.com/tsplib/eil51.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/eil76.md
+++ b/docs/problems/eil76.md
@@ -9,6 +9,8 @@ optimalCost: 538
 dataUrl: "https://static.tspsolver.com/tsplib/eil76.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fl1400.md
+++ b/docs/problems/fl1400.md
@@ -9,6 +9,8 @@ optimalCost: 20127
 dataUrl: "https://static.tspsolver.com/tsplib/fl1400.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fl1577.md
+++ b/docs/problems/fl1577.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/fl1577.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fl3795.md
+++ b/docs/problems/fl3795.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/fl3795.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fl417.md
+++ b/docs/problems/fl417.md
@@ -9,6 +9,8 @@ optimalCost: 11861
 dataUrl: "https://static.tspsolver.com/tsplib/fl417.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fnl4461.md
+++ b/docs/problems/fnl4461.md
@@ -9,6 +9,8 @@ optimalCost: 182566
 dataUrl: "https://static.tspsolver.com/tsplib/fnl4461.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/fri26.md
+++ b/docs/problems/fri26.md
@@ -9,6 +9,8 @@ optimalCost: 937
 dataUrl: "https://static.tspsolver.com/tsplib/fri26.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gil262.md
+++ b/docs/problems/gil262.md
@@ -9,6 +9,8 @@ optimalCost: 2378
 dataUrl: "https://static.tspsolver.com/tsplib/gil262.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr120.md
+++ b/docs/problems/gr120.md
@@ -9,6 +9,8 @@ optimalCost: 6942
 dataUrl: "https://static.tspsolver.com/tsplib/gr120.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gr137.md
+++ b/docs/problems/gr137.md
@@ -9,6 +9,8 @@ optimalCost: 69853
 dataUrl: "https://static.tspsolver.com/tsplib/gr137.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr17.md
+++ b/docs/problems/gr17.md
@@ -9,6 +9,8 @@ optimalCost: 2085
 dataUrl: "https://static.tspsolver.com/tsplib/gr17.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gr202.md
+++ b/docs/problems/gr202.md
@@ -9,6 +9,8 @@ optimalCost: 40160
 dataUrl: "https://static.tspsolver.com/tsplib/gr202.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr21.md
+++ b/docs/problems/gr21.md
@@ -9,6 +9,8 @@ optimalCost: 2707
 dataUrl: "https://static.tspsolver.com/tsplib/gr21.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gr229.md
+++ b/docs/problems/gr229.md
@@ -9,6 +9,8 @@ optimalCost: 134602
 dataUrl: "https://static.tspsolver.com/tsplib/gr229.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr24.md
+++ b/docs/problems/gr24.md
@@ -9,6 +9,8 @@ optimalCost: 1272
 dataUrl: "https://static.tspsolver.com/tsplib/gr24.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gr431.md
+++ b/docs/problems/gr431.md
@@ -9,6 +9,8 @@ optimalCost: 171414
 dataUrl: "https://static.tspsolver.com/tsplib/gr431.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr48.md
+++ b/docs/problems/gr48.md
@@ -9,6 +9,8 @@ optimalCost: 5046
 dataUrl: "https://static.tspsolver.com/tsplib/gr48.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/gr666.md
+++ b/docs/problems/gr666.md
@@ -9,6 +9,8 @@ optimalCost: 294358
 dataUrl: "https://static.tspsolver.com/tsplib/gr666.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/gr96.md
+++ b/docs/problems/gr96.md
@@ -9,6 +9,8 @@ optimalCost: 55209
 dataUrl: "https://static.tspsolver.com/tsplib/gr96.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/hk48.md
+++ b/docs/problems/hk48.md
@@ -9,6 +9,8 @@ optimalCost: 11461
 dataUrl: "https://static.tspsolver.com/tsplib/hk48.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/kroA100.md
+++ b/docs/problems/kroA100.md
@@ -9,6 +9,8 @@ optimalCost: 21282
 dataUrl: "https://static.tspsolver.com/tsplib/kroA100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroA150.md
+++ b/docs/problems/kroA150.md
@@ -9,6 +9,8 @@ optimalCost: 26524
 dataUrl: "https://static.tspsolver.com/tsplib/kroA150.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroA200.md
+++ b/docs/problems/kroA200.md
@@ -9,6 +9,8 @@ optimalCost: 29368
 dataUrl: "https://static.tspsolver.com/tsplib/kroA200.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroB100.md
+++ b/docs/problems/kroB100.md
@@ -9,6 +9,8 @@ optimalCost: 22141
 dataUrl: "https://static.tspsolver.com/tsplib/kroB100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroB150.md
+++ b/docs/problems/kroB150.md
@@ -9,6 +9,8 @@ optimalCost: 26130
 dataUrl: "https://static.tspsolver.com/tsplib/kroB150.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroB200.md
+++ b/docs/problems/kroB200.md
@@ -9,6 +9,8 @@ optimalCost: 29437
 dataUrl: "https://static.tspsolver.com/tsplib/kroB200.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroC100.md
+++ b/docs/problems/kroC100.md
@@ -9,6 +9,8 @@ optimalCost: 20749
 dataUrl: "https://static.tspsolver.com/tsplib/kroC100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroD100.md
+++ b/docs/problems/kroD100.md
@@ -9,6 +9,8 @@ optimalCost: 21294
 dataUrl: "https://static.tspsolver.com/tsplib/kroD100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/kroE100.md
+++ b/docs/problems/kroE100.md
@@ -9,6 +9,8 @@ optimalCost: 22068
 dataUrl: "https://static.tspsolver.com/tsplib/kroE100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/lin105.md
+++ b/docs/problems/lin105.md
@@ -9,6 +9,8 @@ optimalCost: 14379
 dataUrl: "https://static.tspsolver.com/tsplib/lin105.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/lin318.md
+++ b/docs/problems/lin318.md
@@ -9,6 +9,8 @@ optimalCost: 42029
 dataUrl: "https://static.tspsolver.com/tsplib/lin318.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/linhp318.md
+++ b/docs/problems/linhp318.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/linhp318.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/nrw1379.md
+++ b/docs/problems/nrw1379.md
@@ -9,6 +9,8 @@ optimalCost: 56638
 dataUrl: "https://static.tspsolver.com/tsplib/nrw1379.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/p654.md
+++ b/docs/problems/p654.md
@@ -9,6 +9,8 @@ optimalCost: 34643
 dataUrl: "https://static.tspsolver.com/tsplib/p654.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pa561.md
+++ b/docs/problems/pa561.md
@@ -9,6 +9,8 @@ optimalCost: 2763
 dataUrl: "https://static.tspsolver.com/tsplib/pa561.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/pcb1173.md
+++ b/docs/problems/pcb1173.md
@@ -9,6 +9,8 @@ optimalCost: 56892
 dataUrl: "https://static.tspsolver.com/tsplib/pcb1173.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pcb3038.md
+++ b/docs/problems/pcb3038.md
@@ -9,6 +9,8 @@ optimalCost: 137694
 dataUrl: "https://static.tspsolver.com/tsplib/pcb3038.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pcb442.md
+++ b/docs/problems/pcb442.md
@@ -9,6 +9,8 @@ optimalCost: 50778
 dataUrl: "https://static.tspsolver.com/tsplib/pcb442.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pla33810.md
+++ b/docs/problems/pla33810.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/pla33810.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pla7397.md
+++ b/docs/problems/pla7397.md
@@ -9,6 +9,8 @@ optimalCost: 23260728
 dataUrl: "https://static.tspsolver.com/tsplib/pla7397.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pla85900.md
+++ b/docs/problems/pla85900.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/pla85900.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr1002.md
+++ b/docs/problems/pr1002.md
@@ -9,6 +9,8 @@ optimalCost: 259045
 dataUrl: "https://static.tspsolver.com/tsplib/pr1002.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr107.md
+++ b/docs/problems/pr107.md
@@ -9,6 +9,8 @@ optimalCost: 44303
 dataUrl: "https://static.tspsolver.com/tsplib/pr107.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr124.md
+++ b/docs/problems/pr124.md
@@ -9,6 +9,8 @@ optimalCost: 59030
 dataUrl: "https://static.tspsolver.com/tsplib/pr124.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr136.md
+++ b/docs/problems/pr136.md
@@ -9,6 +9,8 @@ optimalCost: 96772
 dataUrl: "https://static.tspsolver.com/tsplib/pr136.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr144.md
+++ b/docs/problems/pr144.md
@@ -9,6 +9,8 @@ optimalCost: 58537
 dataUrl: "https://static.tspsolver.com/tsplib/pr144.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr152.md
+++ b/docs/problems/pr152.md
@@ -9,6 +9,8 @@ optimalCost: 73682
 dataUrl: "https://static.tspsolver.com/tsplib/pr152.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr226.md
+++ b/docs/problems/pr226.md
@@ -9,6 +9,8 @@ optimalCost: 80369
 dataUrl: "https://static.tspsolver.com/tsplib/pr226.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr2392.md
+++ b/docs/problems/pr2392.md
@@ -9,6 +9,8 @@ optimalCost: 378032
 dataUrl: "https://static.tspsolver.com/tsplib/pr2392.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr264.md
+++ b/docs/problems/pr264.md
@@ -9,6 +9,8 @@ optimalCost: 49135
 dataUrl: "https://static.tspsolver.com/tsplib/pr264.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr299.md
+++ b/docs/problems/pr299.md
@@ -9,6 +9,8 @@ optimalCost: 48191
 dataUrl: "https://static.tspsolver.com/tsplib/pr299.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr439.md
+++ b/docs/problems/pr439.md
@@ -9,6 +9,8 @@ optimalCost: 107217
 dataUrl: "https://static.tspsolver.com/tsplib/pr439.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/pr76.md
+++ b/docs/problems/pr76.md
@@ -9,6 +9,8 @@ optimalCost: 108159
 dataUrl: "https://static.tspsolver.com/tsplib/pr76.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rat195.md
+++ b/docs/problems/rat195.md
@@ -9,6 +9,8 @@ optimalCost: 2323
 dataUrl: "https://static.tspsolver.com/tsplib/rat195.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rat575.md
+++ b/docs/problems/rat575.md
@@ -9,6 +9,8 @@ optimalCost: 6773
 dataUrl: "https://static.tspsolver.com/tsplib/rat575.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rat783.md
+++ b/docs/problems/rat783.md
@@ -9,6 +9,8 @@ optimalCost: 8806
 dataUrl: "https://static.tspsolver.com/tsplib/rat783.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rat99.md
+++ b/docs/problems/rat99.md
@@ -9,6 +9,8 @@ optimalCost: 1211
 dataUrl: "https://static.tspsolver.com/tsplib/rat99.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rd100.md
+++ b/docs/problems/rd100.md
@@ -9,6 +9,8 @@ optimalCost: 7910
 dataUrl: "https://static.tspsolver.com/tsplib/rd100.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rd400.md
+++ b/docs/problems/rd400.md
@@ -9,6 +9,8 @@ optimalCost: 15281
 dataUrl: "https://static.tspsolver.com/tsplib/rd400.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl11849.md
+++ b/docs/problems/rl11849.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/rl11849.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl1304.md
+++ b/docs/problems/rl1304.md
@@ -9,6 +9,8 @@ optimalCost: 252948
 dataUrl: "https://static.tspsolver.com/tsplib/rl1304.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl1323.md
+++ b/docs/problems/rl1323.md
@@ -9,6 +9,8 @@ optimalCost: 270199
 dataUrl: "https://static.tspsolver.com/tsplib/rl1323.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl1889.md
+++ b/docs/problems/rl1889.md
@@ -9,6 +9,8 @@ optimalCost: 316536
 dataUrl: "https://static.tspsolver.com/tsplib/rl1889.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl5915.md
+++ b/docs/problems/rl5915.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/rl5915.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/rl5934.md
+++ b/docs/problems/rl5934.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/rl5934.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/si1032.md
+++ b/docs/problems/si1032.md
@@ -9,6 +9,8 @@ optimalCost: 92650
 dataUrl: "https://static.tspsolver.com/tsplib/si1032.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/si175.md
+++ b/docs/problems/si175.md
@@ -9,6 +9,8 @@ optimalCost: 21407
 dataUrl: "https://static.tspsolver.com/tsplib/si175.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/si535.md
+++ b/docs/problems/si535.md
@@ -9,6 +9,8 @@ optimalCost: 48450
 dataUrl: "https://static.tspsolver.com/tsplib/si535.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/st70.md
+++ b/docs/problems/st70.md
@@ -9,6 +9,8 @@ optimalCost: 675
 dataUrl: "https://static.tspsolver.com/tsplib/st70.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/swiss42.md
+++ b/docs/problems/swiss42.md
@@ -9,6 +9,8 @@ optimalCost: 1273
 dataUrl: "https://static.tspsolver.com/tsplib/swiss42.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 

--- a/docs/problems/ts225.md
+++ b/docs/problems/ts225.md
@@ -9,6 +9,8 @@ optimalCost: 126643
 dataUrl: "https://static.tspsolver.com/tsplib/ts225.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/tsp225.md
+++ b/docs/problems/tsp225.md
@@ -9,6 +9,8 @@ optimalCost: 3919
 dataUrl: "https://static.tspsolver.com/tsplib/tsp225.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u1060.md
+++ b/docs/problems/u1060.md
@@ -9,6 +9,8 @@ optimalCost: 224094
 dataUrl: "https://static.tspsolver.com/tsplib/u1060.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u1432.md
+++ b/docs/problems/u1432.md
@@ -9,6 +9,8 @@ optimalCost: 152970
 dataUrl: "https://static.tspsolver.com/tsplib/u1432.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u159.md
+++ b/docs/problems/u159.md
@@ -9,6 +9,8 @@ optimalCost: 42080
 dataUrl: "https://static.tspsolver.com/tsplib/u159.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u1817.md
+++ b/docs/problems/u1817.md
@@ -9,6 +9,8 @@ optimalCost: 57201
 dataUrl: "https://static.tspsolver.com/tsplib/u1817.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u2152.md
+++ b/docs/problems/u2152.md
@@ -9,6 +9,8 @@ optimalCost: 64253
 dataUrl: "https://static.tspsolver.com/tsplib/u2152.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u2319.md
+++ b/docs/problems/u2319.md
@@ -9,6 +9,8 @@ optimalCost: 234256
 dataUrl: "https://static.tspsolver.com/tsplib/u2319.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u574.md
+++ b/docs/problems/u574.md
@@ -9,6 +9,8 @@ optimalCost: 36905
 dataUrl: "https://static.tspsolver.com/tsplib/u574.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/u724.md
+++ b/docs/problems/u724.md
@@ -9,6 +9,8 @@ optimalCost: 41910
 dataUrl: "https://static.tspsolver.com/tsplib/u724.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/ulysses16.md
+++ b/docs/problems/ulysses16.md
@@ -9,6 +9,8 @@ optimalCost: 6859
 dataUrl: "https://static.tspsolver.com/tsplib/ulysses16.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/ulysses22.md
+++ b/docs/problems/ulysses22.md
@@ -9,6 +9,8 @@ optimalCost: 7013
 dataUrl: "https://static.tspsolver.com/tsplib/ulysses22.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/usa13509.md
+++ b/docs/problems/usa13509.md
@@ -9,6 +9,8 @@ optimalCost: null
 dataUrl: "https://static.tspsolver.com/tsplib/usa13509.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/vm1084.md
+++ b/docs/problems/vm1084.md
@@ -9,6 +9,8 @@ optimalCost: 239297
 dataUrl: "https://static.tspsolver.com/tsplib/vm1084.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/docs/problems/vm1748.md
+++ b/docs/problems/vm1748.md
@@ -9,6 +9,8 @@ optimalCost: 336556
 dataUrl: "https://static.tspsolver.com/tsplib/vm1748.tsp"
 source: "TSPLIB95"
 sourceUrl: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
+creator: "TSPLIB — Gerhard Reinelt, University of Heidelberg"
+license: "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
 ---
 
 <svg viewBox="0 0 340 200" width="100%" style="max-width:340px;border-radius:8px;border:1px solid #d0d7de;background:#f6f8fa;" role="img" aria-label="City map for this problem">

--- a/scripts/gen-problem-pages.mjs
+++ b/scripts/gen-problem-pages.mjs
@@ -12,6 +12,9 @@ const DOCS_DIR = join(import.meta.dirname, '..', 'docs', 'problems')
 const DATA_BASE = 'https://static.tspsolver.com/tsplib'
 const SOURCE = 'TSPLIB95'
 const SOURCE_URL = 'https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/'
+// Dataset structured data (schema.org) needs an explicit creator and license.
+const CREATOR = 'TSPLIB — Gerhard Reinelt, University of Heidelberg'
+const LICENSE = SOURCE_URL
 
 mkdirSync(DOCS_DIR, { recursive: true })
 
@@ -159,6 +162,8 @@ optimalCost: ${optimalCost !== null ? optimalCost : 'null'}
 dataUrl: "${dataUrl}"
 source: "${SOURCE}"
 sourceUrl: "${SOURCE_URL}"
+creator: "${CREATOR}"
+license: "${LICENSE}"
 ---
 
 ${minimap}

--- a/teeline-web/src/content.config.ts
+++ b/teeline-web/src/content.config.ts
@@ -25,6 +25,8 @@ const problems = defineCollection({
     dataUrl: z.string(),
     source: z.string(),
     sourceUrl: z.string(),
+    creator: z.string(),
+    license: z.string(),
   }),
 })
 

--- a/teeline-web/src/pages/problems/[id]/index.astro
+++ b/teeline-web/src/pages/problems/[id]/index.astro
@@ -29,6 +29,12 @@ const jsonLd = {
   description: `${data.description} — ${data.cities} cities, ${data.edgeWeightType}. TSPLIB95 TSP instance.`,
   identifier: data.id,
   url: canonicalUrl,
+  creator: {
+    '@type': 'Organization',
+    name: data.creator,
+    url: data.sourceUrl,
+  },
+  license: data.license,
   size: data.cities,
   variableMeasured: data.edgeWeightType,
   ...(data.optimalCost !== null ? { measurementTechnique: `Optimal tour length: ${data.optimalCost}` } : {}),
@@ -77,6 +83,8 @@ const jsonLd = {
         <tr><td>Optimal tour</td><td><strong>{data.optimalCost.toLocaleString()}</strong></td></tr>
       )}
       <tr><td>Source</td><td><a href={data.sourceUrl} target="_blank" rel="noopener">{data.source}</a></td></tr>
+      <tr><td>Creator</td><td>{data.creator}</td></tr>
+      <tr><td>License</td><td><a href={data.license} target="_blank" rel="noopener">TSPLIB95 terms</a></td></tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
## Why

Google Search Console flagged the problem pages' `Dataset` structured data as missing two recommended fields:

- Missing field "license"
- Missing field "creator"

Both warnings are now resolved by adding the fields to the JSON-LD **and** surfacing them in the visible page content.

## What

- `teeline-web/src/pages/problems/[id]/index.astro`
  - `creator` and `license` added to the `Dataset` JSON-LD.
  - New visible **Creator** and **License** rows in the property table.
- `teeline-web/src/content.config.ts` — `creator` and `license` are now required string fields in the `problems` collection schema.
- `scripts/gen-problem-pages.mjs` — generator writes the two frontmatter fields, so regenerating won't drop them.
- `docs/problems/*.md` — all 111 problem pages regenerated; exactly 2 lines added per file, no other content drift.

## Values

| Field | Value |
| --- | --- |
| `creator` | `TSPLIB — Gerhard Reinelt, University of Heidelberg` (emitted as a schema.org `Organization` with the TSPLIB URL) |
| `license` | `https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/` |

> Note: TSPLIB publishes no formal license document, so `license` points at the collection's terms/source page rather than a dedicated license text.

## Example JSON-LD

```json
"creator": {
  "@type": "Organization",
  "name": "TSPLIB — Gerhard Reinelt, University of Heidelberg",
  "url": "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
},
"license": "https://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/"
```

## Verification

- `astro check` — 0 errors / 0 warnings / 0 hints
- `tsc --noEmit` — clean
- Production build (`npm run build`) — succeeds, 164 pages
- Scripted check of rendered output — **111/111** `dist/problems/*/index.html` contain a valid `Dataset` JSON-LD with `creator.name` and `license`, plus both visible rows
- `vitest run` — 471/471 tests pass

Once merged and deployed, Search Console should clear the two warnings on the next crawl.