### PR TITLE
fix(web): serve a real /sitemap.xml and add a 404 page

### DIFF
--- a/teeline-web/package.json
+++ b/teeline-web/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro check && tsc --noEmit && astro build && node scripts/copy-wasm.mjs",
-    "build:check": "astro check && tsc --noEmit && astro build",
+    "build": "astro check && tsc --noEmit && astro build && node scripts/copy-wasm.mjs && node scripts/sitemap-alias.mjs",
+    "build:check": "astro check && tsc --noEmit && astro build && node scripts/sitemap-alias.mjs",
     "preview": "astro preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/teeline-web/public/robots.txt
+++ b/teeline-web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://tspsolver.com/sitemap-index.xml
+Sitemap: https://tspsolver.com/sitemap.xml

--- a/teeline-web/scripts/sitemap-alias.mjs
+++ b/teeline-web/scripts/sitemap-alias.mjs
@@ -1,0 +1,48 @@
+import { copyFileSync, existsSync } from 'fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// @astrojs/sitemap always emits a sitemap *index* at /sitemap-index.xml that
+// points at one or more /sitemap-<n>.xml chunks — there is no option to name
+// the index `sitemap.xml`.
+//
+// /sitemap.xml is the path crawlers, Google Search Console and third-party SEO
+// tools assume by default. Without it the request falls through to Cloudflare
+// Pages' SPA fallback (no top-level 404.html), which answers with the homepage
+// as HTTP 200 HTML — so a submitted /sitemap.xml looks like a valid page that
+// contains no sitemap, and no URLs get discovered.
+//
+// Mirror the generated index to /sitemap.xml so the conventional URL serves a
+// real sitemap document. Copying stays correct no matter how many chunks the
+// integration emits, because the index only lists `sitemap-<n>.xml` URLs.
+
+/**
+ * Copy `<distDir>/sitemap-index.xml` to `<distDir>/sitemap.xml`.
+ *
+ * @param {string} [distDir] Astro build output directory (default: `dist`).
+ * @returns {string} absolute path of the written `/sitemap.xml` alias.
+ */
+export function aliasSitemap(distDir = 'dist') {
+  const indexPath = resolve(distDir, 'sitemap-index.xml')
+  const aliasPath = resolve(distDir, 'sitemap.xml')
+
+  if (!existsSync(indexPath)) {
+    throw new Error(`${indexPath} not found — did astro build run?`)
+  }
+
+  copyFileSync(indexPath, aliasPath)
+  return aliasPath
+}
+
+// CLI entry point: `node scripts/sitemap-alias.mjs` (run by `npm run build`).
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    console.log(`[sitemap-alias] dist/sitemap-index.xml → ${aliasSitemap()}`)
+  } catch (err) {
+    console.error(`[sitemap-alias] ERROR: ${err.message}`)
+    process.exit(1)
+  }
+}

--- a/teeline-web/scripts/sitemap-alias.test.mjs
+++ b/teeline-web/scripts/sitemap-alias.test.mjs
@@ -1,0 +1,36 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { aliasSitemap } from './sitemap-alias.mjs'
+
+const INDEX_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
+  '<sitemap><loc>https://tspsolver.com/sitemap-0.xml</loc></sitemap>' +
+  '</sitemapindex>'
+
+describe('aliasSitemap', () => {
+  let dist
+
+  beforeEach(() => {
+    dist = mkdtempSync(join(tmpdir(), 'sitemap-alias-'))
+  })
+
+  afterEach(() => {
+    rmSync(dist, { recursive: true, force: true })
+  })
+
+  it('copies the generated sitemap index to /sitemap.xml', () => {
+    writeFileSync(join(dist, 'sitemap-index.xml'), INDEX_XML)
+
+    const aliasPath = aliasSitemap(dist)
+
+    expect(aliasPath).toBe(join(dist, 'sitemap.xml'))
+    expect(readFileSync(aliasPath, 'utf8')).toBe(INDEX_XML)
+  })
+
+  it('throws when the build output has no sitemap index', () => {
+    expect(() => aliasSitemap(dist)).toThrow(/sitemap-index\.xml not found/)
+  })
+})

--- a/teeline-web/src/layouts/BaseLayout.astro
+++ b/teeline-web/src/layouts/BaseLayout.astro
@@ -9,13 +9,15 @@ import Topbar from '../components/Topbar.astro'
 interface Props {
   title: string
   description: string
-  path: string
+  // Optional so status pages (404) can omit a canonical URL for a path that
+  // does not exist.
+  path?: string
   ogType?: 'website' | 'article'
   ogDescription?: string
 }
 
 const { title, description, path, ogType = 'website', ogDescription } = Astro.props
-const canonicalUrl = `https://tspsolver.com${path}`
+const canonicalUrl = path ? `https://tspsolver.com${path}` : undefined
 ---
 <html lang="en">
   <head>
@@ -24,7 +26,7 @@ const canonicalUrl = `https://tspsolver.com${path}`
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta property="og:type" content={ogType} />
-    <meta property="og:url" content={canonicalUrl} />
+    {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
     <meta property="og:title" content={title} />
     <meta property="og:description" content={ogDescription ?? description} />
     <meta property="og:image" content="https://tspsolver.com/og-image.png" />
@@ -36,7 +38,7 @@ const canonicalUrl = `https://tspsolver.com${path}`
     <meta name="twitter:description" content={ogDescription ?? description} />
     <meta name="twitter:image" content="https://tspsolver.com/og-image.png" />
     <meta name="twitter:image:alt" content="teeline — TSPSolver, find your path" />
-    <link rel="canonical" href={canonicalUrl} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <slot name="head" />
   </head>

--- a/teeline-web/src/pages/404.astro
+++ b/teeline-web/src/pages/404.astro
@@ -1,0 +1,47 @@
+---
+// Astro emits this as dist/404.html. Its presence is what stops Cloudflare
+// Pages from assuming the site is a single-page app: without a top-level
+// 404.html, Pages matches every unmatched path to `/` and serves the homepage
+// with HTTP 200, which is exactly how /sitemap.xml used to return HTML
+// instead of XML (and why bogus URLs looked like valid pages to crawlers).
+import BaseLayout from '../layouts/BaseLayout.astro'
+
+const title = 'Page not found — Teeline'
+const description = 'The page you requested does not exist on tspsolver.com.'
+
+const links = [
+  { href: '/', label: 'Solver home' },
+  { href: '/algorithms/', label: 'Algorithms' },
+  { href: '/problems/', label: 'Problems' },
+  { href: '/blog/', label: 'Blog' },
+]
+---
+<BaseLayout title={title} description={description}>
+  <Fragment slot="head">
+    <meta name="robots" content="noindex" />
+  </Fragment>
+  <main class="mx-auto max-w-content px-6 py-16">
+    <p class="font-mono text-sm text-text-dim">404</p>
+    <h1 class="mt-2 text-2xl font-semibold tracking-tight lg:text-3xl">
+      Page not found
+    </h1>
+    <p class="mt-3 max-w-2xl text-text-dim">
+      The page you requested doesn’t exist (or used to live somewhere else). Pick
+      a destination below, or head back to the solver.
+    </p>
+    <ul class="mt-8 flex list-none flex-wrap gap-3 p-0">
+      {
+        links.map(({ href, label }) => (
+          <li>
+            <a
+              href={href}
+              class="inline-block rounded-lg border border-border bg-surface px-4 py-2 font-mono text-sm text-text no-underline transition-colors hover:border-border-hover hover:text-accent"
+            >
+              {label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </main>
+</BaseLayout>

--- a/teeline-web/tests/seo.spec.ts
+++ b/teeline-web/tests/seo.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+// Regression guard for the Cloudflare Pages SPA fallback: with no top-level
+// 404.html, Pages matches every unmatched path to `/` and answers with the
+// homepage as HTTP 200 — which is how /sitemap.xml used to come back as HTML
+// (so Search Console read a "valid" page that contained no sitemap).
+test.describe('not-found handling', () => {
+  test('unknown paths return the 404 page, not the homepage', async ({
+    page,
+  }) => {
+    const response = await page.goto('/this-page-does-not-exist-xyz')
+
+    expect(response?.status()).toBe(404)
+
+    const main = page.getByRole('main')
+    await expect(main.getByRole('heading', { level: 1 })).toHaveText(
+      'Page not found',
+    )
+    await expect(main.getByRole('link', { name: 'Algorithms' })).toBeVisible()
+    await expect(main.getByRole('link', { name: 'Problems' })).toBeVisible()
+  })
+})

--- a/teeline-web/vitest.config.ts
+++ b/teeline-web/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     // node env (default) — tests import only DOM-free modules
     // Playwright tests live in tests/ — excluded by not matching this pattern
     // functions/** tests use miniflare's local D1 emulation (node env)
-    include: ['src/**/*.test.ts', 'functions/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'functions/**/*.test.ts',
+      'scripts/**/*.test.mjs',
+    ],
   },
 })


### PR DESCRIPTION
## Problem

`https://tspsolver.com/sitemap.xml` returned the **homepage as HTML (HTTP 200)**, so Google Search Console read it as a valid page containing no sitemap and never discovered the algorithm/problem pages.

Two things combined to cause this:

1. `@astrojs/sitemap` only emits `/sitemap-index.xml` (+ `/sitemap-0.xml` chunks) — there is no `/sitemap.xml`.
2. The Pages project has no top-level `404.html`, so [Cloudflare Pages assumes an SPA](https://developers.cloudflare.com/pages/configuration/serving-pages/) and matches **every** unmatched path to `/`, answering with the homepage as HTTP 200.

So `/sitemap.xml` didn't 404 — it silently returned a 200 HTML page. `robots.txt` (which pointed at `sitemap-index.xml`) was already valid, but any tool or submission using the conventional `/sitemap.xml` got nothing.

## Changes

- **`scripts/sitemap-alias.mjs`** — post-build step (wired into `build` and `build:check`) that mirrors `dist/sitemap-index.xml` to `dist/sitemap.xml`. Copying the index stays correct no matter how many `sitemap-<n>.xml` chunks the integration emits.
- **`src/pages/404.astro`** — Astro emits `dist/404.html`, which switches Pages off the SPA fallback: unknown URLs now return a real `404` (with a useful page) instead of the homepage with 200. This also removes the soft-404 signal for bogus URLs.
- **`src/layouts/BaseLayout.astro`** — `path` is now optional so the 404 page can omit a canonical URL pointing at a non-existent path; all other pages are unchanged.
- **`public/robots.txt`** — points at the conventional `/sitemap.xml`.
- **Tests** — vitest for the alias script, Playwright for the 404 response.

## Verification

Built with `npm run build`, then served the output with `wrangler pages dev dist/` (which emulates Pages routing/fallback):

| URL | Before | After |
| --- | --- | --- |
| `/sitemap.xml` | `200 text/html` (homepage) | `200 application/xml` (sitemap index → `sitemap-0.xml`) |
| `/sitemap-index.xml` | `200 application/xml` | unchanged |
| `/does-not-exist-xyz` | `200 text/html` (homepage) | `404` + "Page not found" |
| `/`, `/problems/berlin52/` | `200` | unchanged |

`npm test` → 473 passed; new Playwright 404 spec passes; `prettier --check .` clean.

Note: `/sitemap-index.xml` is intentionally left in place, so any existing Search Console submission of it keeps working.